### PR TITLE
WIP: implement comment parsing

### DIFF
--- a/assembly/src/v1/errors.rs
+++ b/assembly/src/v1/errors.rs
@@ -144,6 +144,14 @@ impl AssemblyError {
         }
     }
 
+    pub fn unmatched_comment(step: usize) -> Self {
+        AssemblyError {
+            message: "# comment delimiter without matching #".to_string(),
+            step,
+            op: "".to_string(),
+        }
+    }
+
     // SCRIPT
     // --------------------------------------------------------------------------------------------
 

--- a/assembly/src/v1/tokens/stream.rs
+++ b/assembly/src/v1/tokens/stream.rs
@@ -20,7 +20,23 @@ impl<'a> TokenStream<'a> {
         if source.is_empty() {
             return Err(AssemblyError::empty_source());
         }
-        let tokens = source.split_whitespace().collect::<Vec<_>>();
+
+        let mut in_comment = false;
+        let tokens = source
+            .split_whitespace()
+            .filter(|&token| {
+                if token == "#" {
+                    in_comment = !in_comment;
+                } else if !in_comment {
+                    return true;
+                }
+                false
+            })
+            .collect::<Vec<_>>();
+
+        if in_comment {
+            return Err(AssemblyError::unmatched_comment(tokens.len()));
+        }
         if tokens.is_empty() {
             return Err(AssemblyError::empty_source());
         }


### PR DESCRIPTION
This PR implements the comment parsing #10 

I have 2 questions:

1. I've left #token and token# as invalid_op errors rather than comment errors. Would you prefer for these to give invalid comment errors?
2. There are quite a few “TODO: add comments” instructions throughout. All of the cases seem to be covered by implementing the parsing in TokenStream, but before removing them I wanted to check if there’s something else you intended in those spots or with this implementation in general