### PR TITLE
Processor refactoring

### DIFF
--- a/processor/src/v1/mod.rs
+++ b/processor/src/v1/mod.rs
@@ -35,14 +35,14 @@ type StackTrace = [Vec<BaseElement>; STACK_TOP_SIZE];
 // PROCESSOR
 // ================================================================================================
 
-pub struct Processor {
+pub struct Process {
     step: usize,
     decoder: Decoder,
     stack: Stack,
     memory: Memory,
 }
 
-impl Processor {
+impl Process {
     pub fn new(inputs: ProgramInputs) -> Self {
         Self {
             step: 0,
@@ -62,9 +62,6 @@ impl Processor {
 
         Ok(trace)
     }
-
-    // PUBLIC ACCESSORS
-    // --------------------------------------------------------------------------------------------
 
     // CODE BLOCK EXECUTORS
     // --------------------------------------------------------------------------------------------

--- a/processor/src/v1/mod.rs
+++ b/processor/src/v1/mod.rs
@@ -32,10 +32,21 @@ mod tests;
 type Word = [BaseElement; 4];
 type StackTrace = [Vec<BaseElement>; STACK_TOP_SIZE];
 
-// PROCESSOR
+// EXECUTOR
 // ================================================================================================
 
-pub struct Process {
+/// Returns an execution trace resulting from executing the provided script against the provided
+/// inputs.
+pub fn execute(script: &Script, inputs: &ProgramInputs) -> Result<ExecutionTrace, ExecutionError> {
+    let mut process = Process::new(inputs.clone());
+    process.execute_code_block(script.root())?;
+    Ok(ExecutionTrace::new(process))
+}
+
+// PROCESS
+// ================================================================================================
+
+struct Process {
     step: usize,
     decoder: Decoder,
     stack: Stack,
@@ -50,17 +61,6 @@ impl Process {
             stack: Stack::new(&inputs, 4),
             memory: Memory::new(),
         }
-    }
-
-    pub fn execute(&mut self, script: &Script) -> Result<ExecutionTrace, ExecutionError> {
-        self.execute_code_block(script.root())?;
-
-        self.stack.finalize();
-
-        // TODO: get rid of cloning
-        let trace = ExecutionTrace::new(self.stack.trace().clone());
-
-        Ok(trace)
     }
 
     // CODE BLOCK EXECUTORS

--- a/processor/src/v1/operations/field_ops.rs
+++ b/processor/src/v1/operations/field_ops.rs
@@ -1,9 +1,9 @@
-use super::{utils::assert_binary, BaseElement, ExecutionError, FieldElement, Processor};
+use super::{utils::assert_binary, BaseElement, ExecutionError, FieldElement, Process};
 
 // FIELD OPERATIONS
 // ================================================================================================
 
-impl Processor {
+impl Process {
     // ARITHMETIC OPERATIONS
     // --------------------------------------------------------------------------------------------
     /// Pops two elements off the stack, adds them together, and pushes the result back onto the
@@ -219,7 +219,7 @@ impl Processor {
 mod tests {
     use super::{
         super::{BaseElement, FieldElement, Operation},
-        Processor,
+        Process,
     };
     use rand_utils::rand_value;
 
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn op_add() {
         // initialize the stack with a few values
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         let (c, b, a) = init_stack_rand(&mut processor);
 
         // add the top two values
@@ -244,7 +244,7 @@ mod tests {
     #[test]
     fn op_neg() {
         // initialize the stack with a few values
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         let (c, b, a) = init_stack_rand(&mut processor);
 
         // negate the top value
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn op_mul() {
         // initialize the stack with a few values
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         let (c, b, a) = init_stack_rand(&mut processor);
 
         // add the top two values
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn op_inv() {
         // initialize the stack with a few values
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         let (c, b, a) = init_stack_rand(&mut processor);
 
         // invert the top value
@@ -295,7 +295,7 @@ mod tests {
     #[test]
     fn op_incr() {
         // initialize the stack with a few values
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         let (c, b, a) = init_stack_rand(&mut processor);
 
         // negate the top value
@@ -313,7 +313,7 @@ mod tests {
     #[test]
     fn op_and() {
         // --- test 0 AND 0 ---------------------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[2, 0, 0]);
 
         processor.execute_op(Operation::And).unwrap();
@@ -321,7 +321,7 @@ mod tests {
         assert_eq!(expected, processor.stack.trace_state());
 
         // --- test 1 AND 0 ---------------------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[2, 0, 1]);
 
         processor.execute_op(Operation::And).unwrap();
@@ -329,7 +329,7 @@ mod tests {
         assert_eq!(expected, processor.stack.trace_state());
 
         // --- test 0 AND 1 ---------------------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[2, 1, 0]);
 
         processor.execute_op(Operation::And).unwrap();
@@ -337,7 +337,7 @@ mod tests {
         assert_eq!(expected, processor.stack.trace_state());
 
         // --- test 1 AND 0 ---------------------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[2, 1, 1]);
 
         processor.execute_op(Operation::And).unwrap();
@@ -345,12 +345,12 @@ mod tests {
         assert_eq!(expected, processor.stack.trace_state());
 
         // --- first operand is not binary ------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[2, 1, 2]);
         assert!(processor.execute_op(Operation::And).is_err());
 
         // --- second operand is not binary ------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[2, 2, 1]);
         assert!(processor.execute_op(Operation::And).is_err());
     }
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn op_not() {
         // --- test NOT 0 -----------------------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[2, 0]);
 
         processor.execute_op(Operation::Not).unwrap();
@@ -366,7 +366,7 @@ mod tests {
         assert_eq!(expected, processor.stack.trace_state());
 
         // --- test NOT 1 ----------------------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[2, 1]);
 
         processor.execute_op(Operation::Not).unwrap();
@@ -374,7 +374,7 @@ mod tests {
         assert_eq!(expected, processor.stack.trace_state());
 
         // --- operand is not binary ------------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[2, 2]);
         assert!(processor.execute_op(Operation::Not).is_err());
     }
@@ -385,7 +385,7 @@ mod tests {
     #[test]
     fn op_eq() {
         // --- test when top two values are equal -----------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[3, 7, 7]);
 
         processor.execute_op(Operation::Eq).unwrap();
@@ -393,7 +393,7 @@ mod tests {
         assert_eq!(expected, processor.stack.trace_state());
 
         // --- test when top two values are not equal -------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[3, 5, 7]);
 
         processor.execute_op(Operation::Eq).unwrap();
@@ -404,7 +404,7 @@ mod tests {
     #[test]
     fn op_eqz() {
         // --- test when top is zero ------------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[3, 0]);
 
         processor.execute_op(Operation::Eqz).unwrap();
@@ -412,7 +412,7 @@ mod tests {
         assert_eq!(expected, processor.stack.trace_state());
 
         // --- test when top is not zero --------------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         init_stack_with(&mut processor, &[3, 4]);
 
         processor.execute_op(Operation::Eqz).unwrap();
@@ -423,7 +423,7 @@ mod tests {
     #[test]
     fn op_eqw() {
         // --- test when top two words are equal ------------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         let mut values = init_stack_with(&mut processor, &[1, 2, 3, 4, 5, 2, 3, 4, 5]);
 
         processor.execute_op(Operation::Eqw).unwrap();
@@ -432,7 +432,7 @@ mod tests {
         assert_eq!(expected, processor.stack.trace_state());
 
         // --- test when top two words are not equal --------------------------
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         let mut values = init_stack_with(&mut processor, &[1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
         processor.execute_op(Operation::Eqw).unwrap();
@@ -444,7 +444,7 @@ mod tests {
     // HELPER FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
-    fn init_stack_rand(processor: &mut Processor) -> (BaseElement, BaseElement, BaseElement) {
+    fn init_stack_rand(processor: &mut Process) -> (BaseElement, BaseElement, BaseElement) {
         // push values a and b onto the stack
         let a = rand_value();
         let b = rand_value();
@@ -453,7 +453,7 @@ mod tests {
         (values[2], values[1], values[0])
     }
 
-    fn init_stack_with(processor: &mut Processor, values: &[u64]) -> Vec<BaseElement> {
+    fn init_stack_with(processor: &mut Process, values: &[u64]) -> Vec<BaseElement> {
         let mut result = Vec::with_capacity(values.len());
         for value in values.iter().map(|&v| BaseElement::new(v)) {
             processor.execute_op(Operation::Push(value)).unwrap();

--- a/processor/src/v1/operations/io_ops.rs
+++ b/processor/src/v1/operations/io_ops.rs
@@ -1,9 +1,9 @@
-use super::{BaseElement, ExecutionError, Processor};
+use super::{BaseElement, ExecutionError, Process};
 
 // INPUT / OUTPUT OPERATIONS
 // ================================================================================================
 
-impl Processor {
+impl Process {
     /// Pushes the provided value onto the stack.
     ///
     /// The original stack is shifted to the right by one item.
@@ -88,12 +88,12 @@ impl Processor {
 mod tests {
     use super::{
         super::{FieldElement, Operation},
-        BaseElement, Processor,
+        BaseElement, Process,
     };
 
     #[test]
     fn op_push() {
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         assert_eq!(0, processor.stack.depth());
         assert_eq!(0, processor.stack.current_step());
         assert_eq!([BaseElement::ZERO; 16], processor.stack.trace_state());
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn op_storew() {
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         assert_eq!(0, processor.memory.size());
 
         // push the first word onto the stack and save it at address 0
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn op_loadw() {
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
         assert_eq!(0, processor.memory.size());
 
         // push a word onto the stack and save it at address 1
@@ -219,7 +219,7 @@ mod tests {
 
     // HELPER METHODS
     // --------------------------------------------------------------------------------------------
-    fn store_value(processor: &mut Processor, addr: u64, value: [BaseElement; 4]) {
+    fn store_value(processor: &mut Process, addr: u64, value: [BaseElement; 4]) {
         for &value in value.iter() {
             processor.execute_op(Operation::Push(value)).unwrap();
         }

--- a/processor/src/v1/operations/mod.rs
+++ b/processor/src/v1/operations/mod.rs
@@ -1,4 +1,4 @@
-use super::{BaseElement, ExecutionError, FieldElement, Operation, Processor};
+use super::{BaseElement, ExecutionError, FieldElement, Operation, Process};
 
 mod field_ops;
 mod io_ops;
@@ -10,7 +10,7 @@ mod utils;
 // OPERATION DISPATCHER
 // ================================================================================================
 
-impl Processor {
+impl Process {
     /// Executes the specified operation.
     pub(super) fn execute_op(&mut self, op: Operation) -> Result<(), ExecutionError> {
         // make sure there is enough memory allocated to hold the execution trace

--- a/processor/src/v1/operations/stack_ops.rs
+++ b/processor/src/v1/operations/stack_ops.rs
@@ -1,6 +1,6 @@
-use super::{BaseElement, ExecutionError, FieldElement, Processor};
+use super::{BaseElement, ExecutionError, FieldElement, Process};
 
-impl Processor {
+impl Process {
     // STACK MANIPULATION
     // --------------------------------------------------------------------------------------------
     /// Pushes a ZERO onto the processor.stack.
@@ -140,13 +140,13 @@ impl Processor {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{FieldElement, Operation, Processor},
+        super::{FieldElement, Operation, Process},
         BaseElement,
     };
 
     #[test]
     fn op_pad() {
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
 
         // push one item onto the stack
         processor
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn op_drop() {
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
 
         // push one item onto the stack
         processor
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn op_dup() {
-        let mut processor = Processor::new_dummy();
+        let mut processor = Process::new_dummy();
 
         // calling DUP on an empty stack should be an error
         assert!(processor.execute_op(Operation::Dup0).is_err());

--- a/processor/src/v1/operations/sys_ops.rs
+++ b/processor/src/v1/operations/sys_ops.rs
@@ -1,9 +1,9 @@
-use super::{BaseElement, ExecutionError, FieldElement, Processor};
+use super::{BaseElement, ExecutionError, FieldElement, Process};
 
 // INPUT OPERATIONS
 // ================================================================================================
 
-impl Processor {
+impl Process {
     /// Pushes the provided value onto the stack.
     ///
     /// The original stack is shifted to the right by one item.

--- a/processor/src/v1/operations/u32_ops.rs
+++ b/processor/src/v1/operations/u32_ops.rs
@@ -1,6 +1,6 @@
-use super::{ExecutionError, Processor};
+use super::{ExecutionError, Process};
 
-impl Processor {
+impl Process {
     // CASTING OPERATIONS
     // --------------------------------------------------------------------------------------------
     pub(super) fn op_u32split(&mut self) -> Result<(), ExecutionError> {

--- a/processor/src/v1/stack/mod.rs
+++ b/processor/src/v1/stack/mod.rs
@@ -81,9 +81,9 @@ impl Stack {
         result
     }
 
-    /// TODO: probably replace with into_trace()?
-    pub fn trace(&self) -> &StackTrace {
-        &self.trace
+    /// TODO: add docs
+    pub fn into_trace(self) -> StackTrace {
+        self.trace
     }
 
     // TRACE ACCESSORS AND MUTATORS
@@ -191,13 +191,6 @@ impl Stack {
     // Increments the clock cycle.
     pub fn advance_clock(&mut self) {
         self.step += 1;
-    }
-
-    pub fn finalize(&mut self) {
-        for _ in self.step..self.trace_length() - 1 {
-            self.copy_state(0);
-            self.advance_clock();
-        }
     }
 
     // UTILITY METHODS

--- a/processor/src/v1/tests/mod.rs
+++ b/processor/src/v1/tests/mod.rs
@@ -1,4 +1,4 @@
-use super::{BaseElement, FieldElement, Process, ProgramInputs, STACK_TOP_SIZE};
+use super::{BaseElement, FieldElement, ProgramInputs, STACK_TOP_SIZE};
 
 #[test]
 fn simple_program() {
@@ -8,9 +8,7 @@ fn simple_program() {
         .unwrap();
 
     let inputs = ProgramInputs::none();
-    let mut processor = Process::new(inputs);
-
-    let trace = processor.execute(&script).unwrap();
+    let trace = super::execute(&script, &inputs).unwrap();
 
     let last_state = trace.last_stack_state();
     let expected_state = build_stack_state(&[3]);

--- a/processor/src/v1/tests/mod.rs
+++ b/processor/src/v1/tests/mod.rs
@@ -1,4 +1,4 @@
-use super::{BaseElement, FieldElement, Processor, ProgramInputs, STACK_TOP_SIZE};
+use super::{BaseElement, FieldElement, Process, ProgramInputs, STACK_TOP_SIZE};
 
 #[test]
 fn simple_program() {
@@ -8,7 +8,7 @@ fn simple_program() {
         .unwrap();
 
     let inputs = ProgramInputs::none();
-    let mut processor = Processor::new(inputs);
+    let mut processor = Process::new(inputs);
 
     let trace = processor.execute(&script).unwrap();
 

--- a/processor/src/v1/trace.rs
+++ b/processor/src/v1/trace.rs
@@ -1,4 +1,4 @@
-use super::{BaseElement, StackTrace, STACK_TOP_SIZE};
+use super::{BaseElement, Process, StackTrace, STACK_TOP_SIZE};
 use vm_core::FieldElement;
 use winterfell::Trace;
 
@@ -13,12 +13,30 @@ pub struct ExecutionTrace {
 }
 
 impl ExecutionTrace {
-    pub fn new(stack_trace: StackTrace) -> Self {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Builds an execution trace for the provided process.
+    pub(super) fn new(process: Process) -> Self {
+        let Process {
+            step,
+            decoder: _,
+            stack,
+            memory: _,
+        } = process;
+
+        let mut stack_trace = stack.into_trace();
+        for column in stack_trace.iter_mut() {
+            finalize_column(column, step);
+        }
+
         Self {
             meta: Vec::new(),
             stack: stack_trace,
         }
     }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
 
     /// TODO: add docs
     pub fn init_stack_state(&self) -> [BaseElement; STACK_TOP_SIZE] {
@@ -66,4 +84,12 @@ impl Trace for ExecutionTrace {
     fn into_columns(self) -> Vec<Vec<Self::BaseField>> {
         self.stack.into()
     }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn finalize_column(column: &mut Vec<BaseElement>, step: usize) {
+    let last_value = column[step];
+    column[step..].fill(last_value);
 }


### PR DESCRIPTION
This PR refactors processor structure in the following ways:

- `Processor` struct is renamed to `Process` struct
- `execute()` function is added. This function instantiates a new process, executes a script against it, and builds an execution trace from the final state of the process.