### PR TITLE
PR: assembly parser io ops tests + parse_mem implementation

### DIFF
--- a/assembly/src/v1/parsers/io_ops.rs
+++ b/assembly/src/v1/parsers/io_ops.rs
@@ -54,3 +54,149 @@ pub fn parse_readw(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), As
 pub fn parse_mem(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
     unimplemented!()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push() {
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_0 = Token::new("push.0", 0);
+        let op_1 = Token::new("push.1", 0);
+        let op_other = Token::new("push.2", 0);
+        let expected = vec![
+            Operation::Pad,
+            Operation::Pad,
+            Operation::Incr,
+            Operation::Push(BaseElement::new(2)),
+        ];
+
+        parse_push(&mut span_ops, &op_0).expect("Failed to parse push.0");
+        parse_push(&mut span_ops, &op_1).expect("Failed to parse push.1");
+        parse_push(&mut span_ops, &op_other).expect("Failed to parse push.2");
+
+        assert_eq!(span_ops, expected);
+    }
+
+    #[test]
+    fn mem_pop() {
+        // stores the top 4 elements of the stack in memory
+        // then removes those 4 elements from the top of the stack
+
+        // test pop with memory address on top of the stack
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_mem_pop = Token::new("mem.pop", 0);
+        let expected = vec![
+            Operation::StoreW,
+            Operation::Drop,
+            Operation::Drop,
+            Operation::Drop,
+            Operation::Drop,
+        ];
+        parse_mem(&mut span_ops, &op_mem_pop).expect("Failed to parse mem.pop");
+        assert_eq!(&span_ops, &expected);
+
+        // test pop with memory address provided directly (address 0)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_pop_addr = Token::new("mem.pop.0", 0);
+        let expected_addr = vec![
+            Operation::Push(BaseElement::ZERO),
+            Operation::StoreW,
+            Operation::Drop,
+            Operation::Drop,
+            Operation::Drop,
+            Operation::Drop,
+        ];
+
+        parse_mem(&mut span_ops_addr, &op_pop_addr).expect("Failed to parse mem.pop.0");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+    }
+
+    #[test]
+    fn mem_store() {
+        // stores the top 4 elements of the stack in memory
+
+        // test store with memory address on top of the stack
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_store = Token::new("mem.store", 0);
+        let expected = vec![Operation::StoreW];
+
+        parse_mem(&mut span_ops, &op_store).expect("Failed to parse mem.store");
+
+        assert_eq!(&span_ops, &expected);
+
+        // test store with memory address provided directly (address 0)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_store_addr = Token::new("mem.store.0", 0);
+        let expected_addr = vec![Operation::Push(BaseElement::ZERO), Operation::StoreW];
+
+        parse_mem(&mut span_ops_addr, &op_store_addr)
+            .expect("Failed to parse mem.store.0 with adddress (address provided by op)");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+    }
+
+    #[test]
+    fn mem_push() {
+        // reads a word from memory and pushes it onto the stack
+
+        // test push with memory address on top of stack
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_push = Token::new("mem.push", 0);
+        let expected = vec![
+            Operation::Pad,
+            Operation::Pad,
+            Operation::Pad,
+            Operation::Pad,
+            Operation::MovUp4,
+            Operation::LoadW,
+        ];
+
+        parse_mem(&mut span_ops, &op_push).expect("Failed to parse mem.push");
+
+        assert_eq!(&span_ops, &expected);
+
+        // test push with memory address provided directly (address 0)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_push_addr = Token::new("mem.push.0", 0);
+        let expected_addr = vec![
+            Operation::Pad,
+            Operation::Pad,
+            Operation::Pad,
+            Operation::Pad,
+            Operation::Push(BaseElement::ZERO),
+            Operation::LoadW,
+        ];
+
+        parse_mem(&mut span_ops_addr, &op_push_addr)
+            .expect("Failed to parse mem.push.0 (address provided by op)");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+    }
+
+    #[test]
+    fn mem_load() {
+        // reads a word from memory and overwrites the top 4 stack elements
+
+        // test load with memory address on top of stack
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_push = Token::new("mem.load", 0);
+        let expected = vec![Operation::LoadW];
+
+        parse_mem(&mut span_ops, &op_push).expect("Failed to parse mem.load");
+
+        assert_eq!(&span_ops, &expected);
+
+        // test load with memory address provided directly (address 0)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_load_addr = Token::new("mem.load.0", 0);
+        let expected_addr = vec![Operation::Push(BaseElement::ZERO), Operation::LoadW];
+
+        parse_mem(&mut span_ops_addr, &op_load_addr)
+            .expect("Failed to parse mem.load.0 (address provided by op)");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+    }
+}


### PR DESCRIPTION
Hi Bobbin,

I added some tests to get my bearings. Please let me know if you prefer unit tests more or less collapsed (i.e. all mem variants in one test or splitting the 2 methods of providing address into their own tests).

Hopefully I'm on the right track here!