### PR TITLE
Implement processing of advice ops

### DIFF
--- a/core/src/v1/program/inputs.rs
+++ b/core/src/v1/program/inputs.rs
@@ -3,14 +3,18 @@ use super::{super::STACK_TOP_SIZE, BaseElement};
 // PROGRAM INPUTS
 // ================================================================================================
 
+/// TODO: add docs
 #[derive(Clone, Debug)]
 pub struct ProgramInputs {
     stack_init: Vec<BaseElement>,
+    advice_tape: Vec<BaseElement>,
 }
 
 impl ProgramInputs {
-    // TODO: add comments
-    pub fn new(stack_init: &[u64]) -> ProgramInputs {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+    /// TODO: add comments
+    pub fn new(stack_init: &[u64], advice_tape: &[u64]) -> ProgramInputs {
         assert!(
             stack_init.len() <= STACK_TOP_SIZE,
             "expected no more than {} initial stack values, but received {}",
@@ -21,6 +25,7 @@ impl ProgramInputs {
         // TODO: make sure there is no overflow
         ProgramInputs {
             stack_init: stack_init.iter().map(|&v| BaseElement::new(v)).collect(),
+            advice_tape: advice_tape.iter().map(|&v| BaseElement::new(v)).collect(),
         }
     }
 
@@ -28,16 +33,25 @@ impl ProgramInputs {
     pub fn none() -> ProgramInputs {
         ProgramInputs {
             stack_init: Vec::new(),
+            advice_tape: Vec::new(),
         }
     }
 
     /// Returns `ProgramInputs` initialized with the provided initial stack values.
     pub fn from_public(stack_init: &[u64]) -> ProgramInputs {
-        Self::new(stack_init)
+        Self::new(stack_init, &[])
     }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
 
     /// Returns initial stack values.
     pub fn stack_init(&self) -> &[BaseElement] {
         &self.stack_init
+    }
+
+    /// Returns a reference to the advice tape.
+    pub fn advice_tape(&self) -> &[BaseElement] {
+        &self.advice_tape
     }
 }

--- a/processor/src/v1/advice/mod.rs
+++ b/processor/src/v1/advice/mod.rs
@@ -1,0 +1,64 @@
+use super::{BaseElement, ExecutionError, ProgramInputs, Word};
+
+pub struct AdviceProvider {
+    step: usize,
+    tape: Vec<BaseElement>,
+}
+
+impl AdviceProvider {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// TODO: add docs
+    pub fn new(inputs: &ProgramInputs) -> Self {
+        // the advice tape is reversed so that we can pop elements off the end
+        Self {
+            step: 0,
+            tape: inputs.advice_tape().iter().rev().cloned().collect(),
+        }
+    }
+
+    // ADVICE TAPE
+    // --------------------------------------------------------------------------------------------
+
+    /// Removes the next element from the advice tape and returns it.
+    ///
+    /// # Errors
+    /// Returns an error if the advice tape is empty.
+    pub fn read_tape(&mut self) -> Result<BaseElement, ExecutionError> {
+        self.tape
+            .pop()
+            .ok_or(ExecutionError::EmptyAdviceTape(self.step))
+    }
+
+    // MERKLE PATHS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a Merkle path to a leaf at the specified index in a Merkle tree with the specified
+    /// root.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * A Merkle path provider for the specified root cannot be found in this advice provider.
+    /// * The specified depth is greater than the depth of the Merkle tree identified by the
+    ///   specified root.
+    /// * The Merkle path provider for the specified root does not contain a Merkle path for a
+    ///   leaf at the specified depth and index.
+    #[allow(unused)]
+    pub fn get_merkle_path(
+        &mut self,
+        _root: Word,
+        _depth: BaseElement,
+        _index: BaseElement,
+    ) -> Result<Vec<Word>, ExecutionError> {
+        // TODO: implement
+        unimplemented!()
+    }
+
+    // CONTEXT MANAGEMENT
+    // --------------------------------------------------------------------------------------------
+
+    /// Increments the clock cycle.
+    pub fn advance_clock(&mut self) {
+        self.step += 1;
+    }
+}

--- a/processor/src/v1/errors.rs
+++ b/processor/src/v1/errors.rs
@@ -11,4 +11,5 @@ pub enum ExecutionError {
     StackUnderflow(&'static str, usize),
     DivideByZero(usize),
     FailedAssertion(usize),
+    EmptyAdviceTape(usize),
 }

--- a/processor/src/v1/memory/mod.rs
+++ b/processor/src/v1/memory/mod.rs
@@ -48,7 +48,7 @@ impl Memory {
         self.state.insert(int_addr, value);
     }
 
-    // Increments the clock cycle.
+    /// Increments the clock cycle.
     pub fn advance_clock(&mut self) {
         self.step += 1;
     }

--- a/processor/src/v1/mod.rs
+++ b/processor/src/v1/mod.rs
@@ -17,6 +17,9 @@ use stack::Stack;
 mod memory;
 use memory::Memory;
 
+mod advice;
+use advice::AdviceProvider;
+
 mod trace;
 pub use trace::ExecutionTrace;
 
@@ -51,6 +54,7 @@ struct Process {
     decoder: Decoder,
     stack: Stack,
     memory: Memory,
+    advice: AdviceProvider,
 }
 
 impl Process {
@@ -60,6 +64,7 @@ impl Process {
             decoder: Decoder::new(),
             stack: Stack::new(&inputs, 4),
             memory: Memory::new(),
+            advice: AdviceProvider::new(&inputs),
         }
     }
 

--- a/processor/src/v1/operations/io_ops.rs
+++ b/processor/src/v1/operations/io_ops.rs
@@ -30,7 +30,7 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than five elements.
     pub(super) fn op_loadw(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(5, "LOAD")?;
+        self.stack.check_depth(5, "LOADW")?;
 
         // get the address from the stack and read the word from memory
         let addr = self.stack.get(0);
@@ -57,7 +57,7 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than five elements.
     pub(super) fn op_storew(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(5, "STORE")?;
+        self.stack.check_depth(5, "STOREW")?;
 
         // get the address from the stack and build the word to be saved from the stack values
         let addr = self.stack.get(0);
@@ -79,6 +79,44 @@ impl Process {
 
         Ok(())
     }
+
+    // ADVICE OPERATIONS
+    // --------------------------------------------------------------------------------------------
+
+    /// Removes the next element from the advice tape and pushes onto the stack.
+    ///
+    /// # Errors
+    /// Returns an error if the advice tape is empty.
+    pub(super) fn op_read(&mut self) -> Result<(), ExecutionError> {
+        let value = self.advice.read_tape()?;
+        self.stack.set(0, value);
+        self.stack.shift_right(0);
+        Ok(())
+    }
+
+    /// Removes a word (4 elements) from the advice tape and overwrites the top four stack
+    /// elements with it.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * The stack contains fewer than four elements.
+    /// * The advice tape contains fewer than four elements.
+    pub(super) fn op_readw(&mut self) -> Result<(), ExecutionError> {
+        self.stack.check_depth(4, "READW")?;
+
+        let a = self.advice.read_tape()?;
+        let b = self.advice.read_tape()?;
+        let c = self.advice.read_tape()?;
+        let d = self.advice.read_tape()?;
+
+        self.stack.set(0, d);
+        self.stack.set(1, c);
+        self.stack.set(2, b);
+        self.stack.set(3, a);
+        self.stack.copy_state(4);
+
+        Ok(())
+    }
 }
 
 // TESTS
@@ -93,31 +131,31 @@ mod tests {
 
     #[test]
     fn op_push() {
-        let mut processor = Process::new_dummy();
-        assert_eq!(0, processor.stack.depth());
-        assert_eq!(0, processor.stack.current_step());
-        assert_eq!([BaseElement::ZERO; 16], processor.stack.trace_state());
+        let mut process = Process::new_dummy();
+        assert_eq!(0, process.stack.depth());
+        assert_eq!(0, process.stack.current_step());
+        assert_eq!([BaseElement::ZERO; 16], process.stack.trace_state());
 
         // push one item onto the stack
         let op = Operation::Push(BaseElement::ONE);
-        processor.execute_op(op).unwrap();
+        process.execute_op(op).unwrap();
         let mut expected = [BaseElement::ZERO; 16];
         expected[0] = BaseElement::ONE;
 
-        assert_eq!(1, processor.stack.depth());
-        assert_eq!(1, processor.stack.current_step());
-        assert_eq!(expected, processor.stack.trace_state());
+        assert_eq!(1, process.stack.depth());
+        assert_eq!(1, process.stack.current_step());
+        assert_eq!(expected, process.stack.trace_state());
 
         // push another item onto the stack
         let op = Operation::Push(BaseElement::new(3));
-        processor.execute_op(op).unwrap();
+        process.execute_op(op).unwrap();
         let mut expected = [BaseElement::ZERO; 16];
         expected[0] = BaseElement::new(3);
         expected[1] = BaseElement::ONE;
 
-        assert_eq!(2, processor.stack.depth());
-        assert_eq!(2, processor.stack.current_step());
-        assert_eq!(expected, processor.stack.trace_state());
+        assert_eq!(2, process.stack.depth());
+        assert_eq!(2, process.stack.current_step());
+        assert_eq!(expected, process.stack.trace_state());
     }
 
     // MEMORY OPERATION TESTS
@@ -125,8 +163,8 @@ mod tests {
 
     #[test]
     fn op_storew() {
-        let mut processor = Process::new_dummy();
-        assert_eq!(0, processor.memory.size());
+        let mut process = Process::new_dummy();
+        assert_eq!(0, process.memory.size());
 
         // push the first word onto the stack and save it at address 0
         let word1 = [
@@ -135,19 +173,15 @@ mod tests {
             BaseElement::new(5),
             BaseElement::new(7),
         ];
-        store_value(&mut processor, 0, word1);
+        store_value(&mut process, 0, word1);
 
         // check stack state
-        let mut expected_stack = [BaseElement::ZERO; 16];
-        expected_stack[0] = BaseElement::new(7);
-        expected_stack[1] = BaseElement::new(5);
-        expected_stack[2] = BaseElement::new(3);
-        expected_stack[3] = BaseElement::new(1);
-        assert_eq!(expected_stack, processor.stack.trace_state());
+        let expected_stack = build_expected_stack(&[7, 5, 3, 1]);
+        assert_eq!(expected_stack, process.stack.trace_state());
 
         // check memory state
-        assert_eq!(1, processor.memory.size());
-        assert_eq!(word1, processor.memory.get_value(0).unwrap());
+        assert_eq!(1, process.memory.size());
+        assert_eq!(word1, process.memory.get_value(0).unwrap());
 
         // push the second word onto the stack and save it at address 3
         let word2 = [
@@ -156,30 +190,22 @@ mod tests {
             BaseElement::new(6),
             BaseElement::new(8),
         ];
-        store_value(&mut processor, 3, word2);
+        store_value(&mut process, 3, word2);
 
         // check stack state
-        let mut expected_stack = [BaseElement::ZERO; 16];
-        expected_stack[0] = BaseElement::new(8);
-        expected_stack[1] = BaseElement::new(6);
-        expected_stack[2] = BaseElement::new(4);
-        expected_stack[3] = BaseElement::new(2);
-        expected_stack[4] = BaseElement::new(7);
-        expected_stack[5] = BaseElement::new(5);
-        expected_stack[6] = BaseElement::new(3);
-        expected_stack[7] = BaseElement::new(1);
-        assert_eq!(expected_stack, processor.stack.trace_state());
+        let expected_stack = build_expected_stack(&[8, 6, 4, 2, 7, 5, 3, 1]);
+        assert_eq!(expected_stack, process.stack.trace_state());
 
         // check memory state
-        assert_eq!(2, processor.memory.size());
-        assert_eq!(word1, processor.memory.get_value(0).unwrap());
-        assert_eq!(word2, processor.memory.get_value(3).unwrap());
+        assert_eq!(2, process.memory.size());
+        assert_eq!(word1, process.memory.get_value(0).unwrap());
+        assert_eq!(word2, process.memory.get_value(3).unwrap());
     }
 
     #[test]
     fn op_loadw() {
-        let mut processor = Process::new_dummy();
-        assert_eq!(0, processor.memory.size());
+        let mut process = Process::new_dummy();
+        assert_eq!(0, process.memory.size());
 
         // push a word onto the stack and save it at address 1
         let word = [
@@ -188,43 +214,90 @@ mod tests {
             BaseElement::new(5),
             BaseElement::new(7),
         ];
-        store_value(&mut processor, 1, word);
+        store_value(&mut process, 1, word);
 
         // push four zeros onto the stack
         for _ in 0..4 {
-            processor.execute_op(Operation::Pad).unwrap();
+            process.execute_op(Operation::Pad).unwrap();
         }
 
         // push the address onto the stack and load the word
-        processor
+        process
             .execute_op(Operation::Push(BaseElement::ONE))
             .unwrap();
-        processor.execute_op(Operation::LoadW).unwrap();
+        process.execute_op(Operation::LoadW).unwrap();
 
-        let mut expected_stack = [BaseElement::ZERO; 16];
-        expected_stack[0] = BaseElement::new(7);
-        expected_stack[1] = BaseElement::new(5);
-        expected_stack[2] = BaseElement::new(3);
-        expected_stack[3] = BaseElement::new(1);
-        expected_stack[4] = BaseElement::new(7);
-        expected_stack[5] = BaseElement::new(5);
-        expected_stack[6] = BaseElement::new(3);
-        expected_stack[7] = BaseElement::new(1);
-        assert_eq!(expected_stack, processor.stack.trace_state());
+        let expected_stack = build_expected_stack(&[7, 5, 3, 1, 7, 5, 3, 1]);
+        assert_eq!(expected_stack, process.stack.trace_state());
 
         // check memory state
-        assert_eq!(1, processor.memory.size());
-        assert_eq!(word, processor.memory.get_value(1).unwrap());
+        assert_eq!(1, process.memory.size());
+        assert_eq!(word, process.memory.get_value(1).unwrap());
+    }
+
+    // ADVICE TAPE OPERATION TESTS
+    // --------------------------------------------------------------------------------------------
+
+    #[test]
+    fn op_read() {
+        // reading from tape should push the value onto the stack
+        let mut process = Process::new_dummy_with_advice_tape(&[3]);
+        process
+            .execute_op(Operation::Push(BaseElement::ONE))
+            .unwrap();
+        process.execute_op(Operation::Read).unwrap();
+        let expected = build_expected_stack(&[3, 1]);
+        assert_eq!(expected, process.stack.trace_state());
+
+        // reading again should result in an error because advice tape is empty
+        assert!(process.execute_op(Operation::Read).is_err());
+    }
+
+    #[test]
+    fn op_readw() {
+        // reading from tape should overwrite top 4 values
+        let mut process = Process::new_dummy_with_advice_tape(&[3, 4, 5, 6]);
+        process
+            .execute_op(Operation::Push(BaseElement::ONE))
+            .unwrap();
+        process.execute_op(Operation::Pad).unwrap();
+        process.execute_op(Operation::Pad).unwrap();
+        process.execute_op(Operation::Pad).unwrap();
+        process.execute_op(Operation::Pad).unwrap();
+        process.execute_op(Operation::ReadW).unwrap();
+        let expected = build_expected_stack(&[6, 5, 4, 3, 1]);
+        assert_eq!(expected, process.stack.trace_state());
+
+        // reading again should result in an error because advice tape is empty
+        assert!(process.execute_op(Operation::ReadW).is_err());
+
+        // should return an error if the stack has fewer than 4 values
+        let mut process = Process::new_dummy_with_advice_tape(&[3, 4, 5, 6]);
+        process
+            .execute_op(Operation::Push(BaseElement::ONE))
+            .unwrap();
+        process.execute_op(Operation::Pad).unwrap();
+        process.execute_op(Operation::Pad).unwrap();
+        assert!(process.execute_op(Operation::ReadW).is_err());
     }
 
     // HELPER METHODS
     // --------------------------------------------------------------------------------------------
-    fn store_value(processor: &mut Process, addr: u64, value: [BaseElement; 4]) {
+
+    fn store_value(process: &mut Process, addr: u64, value: [BaseElement; 4]) {
         for &value in value.iter() {
-            processor.execute_op(Operation::Push(value)).unwrap();
+            process.execute_op(Operation::Push(value)).unwrap();
         }
         let addr = BaseElement::new(addr);
-        processor.execute_op(Operation::Push(addr)).unwrap();
-        processor.execute_op(Operation::StoreW).unwrap();
+        process.execute_op(Operation::Push(addr)).unwrap();
+        process.execute_op(Operation::StoreW).unwrap();
+    }
+
+    fn build_expected_stack(values: &[u64]) -> [BaseElement; 16] {
+        let mut expected = [BaseElement::ZERO; 16];
+        for (&value, result) in values.iter().zip(expected.iter_mut()) {
+            *result = BaseElement::new(value);
+        }
+        expected
     }
 }

--- a/processor/src/v1/operations/mod.rs
+++ b/processor/src/v1/operations/mod.rs
@@ -110,8 +110,8 @@ impl Process {
             // ----- input / output ---------------------------------------------------------------
             Operation::Push(value) => self.op_push(value)?,
 
-            Operation::Read => unimplemented!(),
-            Operation::ReadW => unimplemented!(),
+            Operation::Read => self.op_read()?,
+            Operation::ReadW => self.op_readw()?,
 
             Operation::LoadW => self.op_loadw()?,
             Operation::StoreW => self.op_storew()?,
@@ -129,11 +129,12 @@ impl Process {
         Ok(())
     }
 
-    /// Increments the clock cycle for all components of the processor.
+    /// Increments the clock cycle for all components of the process.
     fn advance_clock(&mut self) {
         self.step += 1;
         self.stack.advance_clock();
         self.memory.advance_clock();
+        self.advice.advance_clock();
     }
 
     /// Makes sure there is enough memory allocated for the trace to accommodate a new clock cycle.
@@ -144,10 +145,17 @@ impl Process {
     // TEST METHODS
     // --------------------------------------------------------------------------------------------
 
-    /// Instantiates a new processor for testing purposes.
+    /// Instantiates a new blank process for testing purposes.
     #[cfg(test)]
     fn new_dummy() -> Self {
         Self::new(super::ProgramInputs::none())
+    }
+
+    /// Instantiates a new process with an advice tape for testing purposes.
+    #[cfg(test)]
+    fn new_dummy_with_advice_tape(advice_tape: &[u64]) -> Self {
+        let inputs = super::ProgramInputs::new(&[], advice_tape);
+        Self::new(inputs)
     }
 }
 

--- a/processor/src/v1/stack/mod.rs
+++ b/processor/src/v1/stack/mod.rs
@@ -188,7 +188,7 @@ impl Stack {
         self.depth += 1;
     }
 
-    // Increments the clock cycle.
+    /// Increments the clock cycle.
     pub fn advance_clock(&mut self) {
         self.step += 1;
     }

--- a/processor/src/v1/trace.rs
+++ b/processor/src/v1/trace.rs
@@ -22,6 +22,7 @@ impl ExecutionTrace {
             decoder: _,
             stack,
             memory: _,
+            advice: _,
         } = process;
 
         let mut stack_trace = stack.into_trace();


### PR DESCRIPTION
This PR implements handling of advice ops in the processor. The ops are: `read` and `readw`.

Also, as a part of this PR basic structure for `AdviceProvider` struct is implemented.