### PR TITLE
Implement parsing of pushw and env io operations

### DIFF
--- a/assembly/src/v1/parsers/io_ops.rs
+++ b/assembly/src/v1/parsers/io_ops.rs
@@ -18,6 +18,38 @@ pub fn parse_push(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assem
     validate_op_len(op, 2, 2)?;
 
     let value = parse_element_param(op, 1)?;
+    push_value(span_ops, value);
+
+    Ok(())
+}
+
+/// Appends PUSH operations to the span block until all elements of the provided word are pushed
+/// onto the stack.
+///
+/// All immediate values are handled in the same way as for the single element "push" operation.
+///
+/// # Errors
+///
+/// This function expects an assembly op with 4 immediate values that are valid field elements
+/// in decimal or hexadecimal representation. It will return an error if the assembly instruction's
+/// immediate values are invalid.
+pub fn parse_pushw(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+    validate_op_len(op, 5, 5)?;
+
+    for idx in 1..=4 {
+        let value = parse_element_param(op, idx)?;
+        push_value(span_ops, value);
+    }
+
+    Ok(())
+}
+
+/// This is a helper function that appends a PUSH operation to the span block which puts the
+/// provided value parameter onto the stack.
+///
+/// When the value is 0, PUSH operation is replaced with PAD. When the value is 1, PUSH operation
+/// is replaced with PAD INCR because in most cases this will be more efficient than doing a PUSH.
+fn push_value(span_ops: &mut Vec<Operation>, value: BaseElement) {
     if value == BaseElement::ZERO {
         span_ops.push(Operation::Pad);
     } else if value == BaseElement::ONE {
@@ -26,12 +58,6 @@ pub fn parse_push(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assem
     } else {
         span_ops.push(Operation::Push(value));
     }
-    Ok(())
-}
-
-/// TODO: implement
-pub fn parse_pushw(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
-    unimplemented!()
 }
 
 // ENVIRONMENT INPUTS

--- a/assembly/src/v1/parsers/io_ops.rs
+++ b/assembly/src/v1/parsers/io_ops.rs
@@ -8,7 +8,15 @@ use super::{parse_element_param, AssemblyError, BaseElement, FieldElement, Opera
 /// In cases when the immediate value is 0, PUSH operation is replaced with PAD. Also, in cases
 /// when immediate value is 1, PUSH operation is replaced with PAD INCR because in most cases
 /// this will be more efficient than doing a PUSH.
+///
+/// # Errors
+///
+/// This function expects an assembly op with exactly one immediate value that is a valid field
+/// element in decimal or hexadecimal representation. It will return an error if the immediate
+/// value is invalid or missing.
 pub fn parse_push(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+    validate_op_len(op, 2, 2)?;
+
     let value = parse_element_param(op, 1)?;
     if value == BaseElement::ZERO {
         span_ops.push(Operation::Pad);

--- a/assembly/src/v1/parsers/io_ops.rs
+++ b/assembly/src/v1/parsers/io_ops.rs
@@ -63,9 +63,28 @@ fn push_value(span_ops: &mut Vec<Operation>, value: BaseElement) {
 // ENVIRONMENT INPUTS
 // ================================================================================================
 
-/// TODO: implement
-pub fn parse_env(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
-    unimplemented!()
+/// Appends machine operations to the current span block according to the requested environment
+/// assembly instruction.
+///
+/// "env.sdepth" pushes the current depth of the stack onto the top of the stack, which is handled
+/// directly by the SDEPTH operation.
+///
+/// # Errors
+///
+/// This function expects a valid assembly environment op that specifies the environment input to
+/// be handled. It will return an error if the assembly instruction is malformed or the environment
+/// input is unrecognized.
+pub fn parse_env(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+    validate_op_len(op, 2, 2)?;
+
+    match op.parts()[1] {
+        "sdepth" => {
+            span_ops.push(Operation::SDepth);
+        }
+        _ => return Err(AssemblyError::invalid_op(op)),
+    }
+
+    Ok(())
 }
 
 // NON-DETERMINISTIC INPUTS


### PR DESCRIPTION
I added a few tests to check error cases and couldn't assert_eq the exact errors. I guess this is because the PartialEq trait isn't implemented for AssemblyError, but maybe there's another way around this that I'm not aware of yet..? For the moment, I just asserted that the result gave an error without checking to see which one. Let me know if you have any thoughts on this.