### PR TITLE
Implement assembly io advice ops

### DIFF
--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -4,6 +4,7 @@ use core::fmt;
 // ASSEMBLY ERROR
 // ================================================================================================
 
+#[derive(PartialEq)]
 pub struct AssemblyError {
     message: String,
     step: usize,

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -4,7 +4,7 @@ use core::fmt;
 // ASSEMBLY ERROR
 // ================================================================================================
 
-#[derive(PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct AssemblyError {
     message: String,
     step: usize,

--- a/assembly/src/parsers/io_ops.rs
+++ b/assembly/src/parsers/io_ops.rs
@@ -259,16 +259,33 @@ mod tests {
         let param_idx = 0;
 
         // value missing
-        let op_no_val = Token::new("pushw", param_idx);
-        assert!(parse_push(&mut span_ops, &op_no_val).is_err());
+        let op_no_val = Token::new("push", param_idx);
+        let expected = AssemblyError::missing_param(&op_no_val);
+        assert_eq!(parse_push(&mut span_ops, &op_no_val).unwrap_err(), expected);
 
         // invalid value
         let op_val_invalid = Token::new("push.abc", param_idx);
-        assert!(parse_push(&mut span_ops, &op_val_invalid).is_err());
+        let expected = AssemblyError::invalid_param(&op_val_invalid, 1);
+        assert_eq!(
+            parse_push(&mut span_ops, &op_val_invalid).unwrap_err(),
+            expected
+        );
 
         // extra value
-        let op_extra_val = Token::new("pushw.0.1", param_idx);
-        assert!(parse_push(&mut span_ops, &op_extra_val).is_err());
+        let op_extra_val = Token::new("push.0.1", param_idx);
+        let expected = AssemblyError::extra_param(&op_extra_val);
+        assert_eq!(
+            parse_push(&mut span_ops, &op_extra_val).unwrap_err(),
+            expected
+        );
+
+        // wrong operation passed to parsing function
+        let op_mismatch = Token::new("pushw.0", param_idx);
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "push.{param}");
+        assert_eq!(
+            parse_push(&mut span_ops, &op_mismatch).unwrap_err(),
+            expected
+        )
     }
 
     #[test]
@@ -296,19 +313,44 @@ mod tests {
 
         // no values
         let op_no_vals = Token::new("pushw", param_idx);
-        assert!(parse_pushw(&mut span_ops, &op_no_vals).is_err());
+        let expected = AssemblyError::missing_param(&op_no_vals);
+        assert_eq!(
+            parse_pushw(&mut span_ops, &op_no_vals).unwrap_err(),
+            expected
+        );
 
         // insufficient values provided
         let op_val_missing = Token::new("pushw.0.1.2", param_idx);
-        assert!(parse_pushw(&mut span_ops, &op_val_missing).is_err());
+        let expected = AssemblyError::missing_param(&op_val_missing);
+        assert_eq!(
+            parse_pushw(&mut span_ops, &op_val_missing).unwrap_err(),
+            expected
+        );
 
         // invalid value
-        let op_val_invalid = Token::new("push.0.1.2.abc", param_idx);
-        assert!(parse_pushw(&mut span_ops, &op_val_invalid).is_err());
+        let op_val_invalid = Token::new("pushw.0.1.2.abc", param_idx);
+        let expected = AssemblyError::invalid_param(&op_val_invalid, 4);
+        assert_eq!(
+            parse_pushw(&mut span_ops, &op_val_invalid).unwrap_err(),
+            expected
+        );
 
         // extra value
         let op_extra_val = Token::new("pushw.0.1.2.3.4", param_idx);
-        assert!(parse_pushw(&mut span_ops, &op_extra_val).is_err());
+        let expected = AssemblyError::extra_param(&op_extra_val);
+        assert_eq!(
+            parse_pushw(&mut span_ops, &op_extra_val).unwrap_err(),
+            expected
+        );
+
+        // wrong operation passed to parsing function
+        let op_mismatch = Token::new("push.0.1.2.3", param_idx);
+        let expected =
+            AssemblyError::unexpected_token(&op_mismatch, "pushw.{param}.{param}.{param}.{param}");
+        assert_eq!(
+            parse_pushw(&mut span_ops, &op_mismatch).unwrap_err(),
+            expected
+        )
     }
 
     #[test]
@@ -331,15 +373,32 @@ mod tests {
 
         // missing env var
         let op_no_val = Token::new("env", param_idx);
-        assert!(parse_mem(&mut span_ops, &op_no_val).is_err());
+        let expected = AssemblyError::invalid_op(&op_no_val);
+        assert_eq!(parse_env(&mut span_ops, &op_no_val).unwrap_err(), expected);
 
         // invalid env var
         let op_val_invalid = Token::new("env.invalid", param_idx);
-        assert!(parse_push(&mut span_ops, &op_val_invalid).is_err());
+        let expected = AssemblyError::invalid_op(&op_val_invalid);
+        assert_eq!(
+            parse_env(&mut span_ops, &op_val_invalid).unwrap_err(),
+            expected
+        );
 
         // extra value
         let op_extra_val = Token::new("env.sdepth.0", param_idx);
-        assert!(parse_push(&mut span_ops, &op_extra_val).is_err());
+        let expected = AssemblyError::extra_param(&op_extra_val);
+        assert_eq!(
+            parse_env(&mut span_ops, &op_extra_val).unwrap_err(),
+            expected
+        );
+
+        // wrong operation passed to parsing function
+        let op_mismatch = Token::new("push.sdepth", param_idx);
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "env.{param}");
+        assert_eq!(
+            parse_env(&mut span_ops, &op_mismatch).unwrap_err(),
+            expected
+        )
     }
 
     #[test]
@@ -470,15 +529,37 @@ mod tests {
         let param_idx = 0;
 
         // missing variant
-        let op_no_val = Token::new("mem", param_idx);
-        assert!(parse_mem(&mut span_ops, &op_no_val).is_err());
+        let op_missing = Token::new("mem", param_idx);
+        let expected = AssemblyError::invalid_op(&op_missing);
+        assert_eq!(parse_mem(&mut span_ops, &op_missing).unwrap_err(), expected);
 
         // invalid variant
-        let op_val_invalid = Token::new("mem.abc", param_idx);
-        assert!(parse_push(&mut span_ops, &op_val_invalid).is_err());
+        let op_invalid = Token::new("mem.abc", param_idx);
+        let expected = AssemblyError::invalid_op(&op_invalid);
+        assert_eq!(parse_mem(&mut span_ops, &op_invalid).unwrap_err(), expected);
+
+        // invalid param
+        let op_val_invalid = Token::new("mem.push.a", param_idx);
+        let expected = AssemblyError::invalid_param(&op_val_invalid, 2);
+        assert_eq!(
+            parse_mem(&mut span_ops, &op_val_invalid).unwrap_err(),
+            expected
+        );
 
         // extra value
         let op_extra_val = Token::new("mem.push.0.1", param_idx);
-        assert!(parse_push(&mut span_ops, &op_extra_val).is_err());
+        let expected = AssemblyError::extra_param(&op_extra_val);
+        assert_eq!(
+            parse_mem(&mut span_ops, &op_extra_val).unwrap_err(),
+            expected
+        );
+
+        // wrong operation passed to parsing function
+        let op_mismatch = Token::new("adv.push.0", param_idx);
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "mem.{push|load|pop|store}");
+        assert_eq!(
+            parse_mem(&mut span_ops, &op_mismatch).unwrap_err(),
+            expected
+        );
     }
 }

--- a/assembly/src/parsers/io_ops.rs
+++ b/assembly/src/parsers/io_ops.rs
@@ -114,12 +114,7 @@ pub fn parse_env(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assemb
 // ================================================================================================
 
 /// TODO: implement
-pub fn parse_read(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
-    unimplemented!()
-}
-
-/// TODO: implement
-pub fn parse_readw(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
+pub fn parse_adv(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
     unimplemented!()
 }
 

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -96,8 +96,7 @@ fn parse_op_token(op: &Token, span_ops: &mut Vec<Operation>) -> Result<(), Assem
         "push" => io_ops::parse_push(span_ops, op),
         "pushw" => io_ops::parse_pushw(span_ops, op),
         "env" => io_ops::parse_env(span_ops, op),
-        "read" => io_ops::parse_read(span_ops, op),
-        "readw" => io_ops::parse_readw(span_ops, op),
+        "adv" => io_ops::parse_adv(span_ops, op),
         "mem" => io_ops::parse_mem(span_ops, op),
 
         // ----- cryptographic operations ---------------------------------------------------------

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -152,6 +152,43 @@ fn parse_element_param(op: &Token, param_idx: usize) -> Result<BaseElement, Asse
     Ok(BaseElement::new(result))
 }
 
+/// This is a helper function that parses the parameter at the specified op index as an integer and
+/// ensures that it falls within the bounds specified by the caller.
+///
+/// # Errors
+/// Returns an invalid param AssemblyError if:
+/// - the parsing attempt fails.
+/// - the parameter is outside the specified lower and upper bounds.
+fn parse_int_param(
+    op: &Token,
+    param_idx: usize,
+    lower_bound: u32,
+    upper_bound: u32,
+) -> Result<u32, AssemblyError> {
+    let param_value = op.parts()[param_idx];
+
+    // attempt to parse the parameter value as an integer
+    let result = match param_value.parse::<u32>() {
+        Ok(i) => i,
+        Err(_) => return Err(AssemblyError::invalid_param(op, param_idx)),
+    };
+
+    // check that the parameter is within the specified bounds
+    if result < lower_bound || result > upper_bound {
+        return Err(AssemblyError::invalid_param_with_reason(
+            op,
+            param_idx,
+            format!(
+                "parameter value must be greater than {} and less than than {}",
+                lower_bound, upper_bound
+            )
+            .as_str(),
+        ));
+    }
+
+    Ok(result)
+}
+
 /// This is a helper function that validates the length of an assembly instruction and returns
 /// an error if the instruction is too short or too long.
 ///

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -152,3 +152,38 @@ fn parse_element_param(op: &Token, param_idx: usize) -> Result<BaseElement, Asse
 
     Ok(BaseElement::new(result))
 }
+
+/// This is a helper function that validates the length of an assembly instruction and returns
+/// an error if the instruction is too short or too long.
+///
+/// `instr_parts` expects the number of non-parameter parts in the instruction, e.g. 2 for the
+/// "mem.pop" instruction. `min_params` and `max_params` expect the minimum and maximum number of
+/// parameters accepted by the operation respectively.
+///
+/// # Errors
+///
+/// This function will return an AssemblyError if the instruction part of the operation is
+/// too short or if too many or too few parameters are provided.
+fn validate_op_len(
+    op: &Token,
+    instr_parts: usize,
+    min_params: usize,
+    max_params: usize,
+) -> Result<(), AssemblyError> {
+    let num_parts = op.num_parts();
+
+    // token has too few parts to contain the full instruction
+    if num_parts < instr_parts {
+        return Err(AssemblyError::invalid_op(op));
+    }
+    // token has too few parts to contain the required parameters
+    if num_parts < instr_parts + min_params {
+        return Err(AssemblyError::missing_param(op));
+    }
+    // token has more than the maximum number of parts
+    if num_parts > instr_parts + max_params {
+        return Err(AssemblyError::extra_param(op));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I updated the io tests to do exact error checking and then added some additional validation to check the exact op tokens being passed to the parser functions. Let me know if you don't think that belongs here (maybe it's overkill).