### PR TITLE
Implement memory trace generation

### DIFF
--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -26,6 +26,7 @@ use advice::AdviceProvider;
 
 mod trace;
 pub use trace::ExecutionTrace;
+use trace::TraceFragment;
 
 mod errors;
 pub use errors::ExecutionError;

--- a/processor/src/memory/mod.rs
+++ b/processor/src/memory/mod.rs
@@ -1,23 +1,34 @@
-use super::{Felt, FieldElement, StarkField, Word};
-use std::collections::BTreeMap;
+use super::{Felt, FieldElement, StarkField, TraceFragment, Word};
+use winter_utils::collections::BTreeMap;
+
+#[cfg(test)]
+mod tests;
 
 // RANDOM ACCESS MEMORY
 // ================================================================================================
 
 /// TODO: add comments
 pub struct Memory {
-    step: usize,
-    state: BTreeMap<u64, Word>,
+    /// Current clock cycle of the VM.
+    step: u64,
+
+    /// Memory access trace sorted first by address and then by clock cycle.
+    trace: BTreeMap<u64, Vec<(Felt, Word)>>,
+
+    /// Total number of entries in the trace; tracked separately so that we don't have to sum up
+    /// length of all vectors in the trace map all the time.
+    num_trace_rows: usize,
 }
 
 impl Memory {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    /// TODO: add comments
+    /// Returns a new [Memory] initialized with an empty trace.
     pub fn new() -> Self {
         Self {
             step: 0,
-            state: BTreeMap::new(),
+            trace: BTreeMap::new(),
+            num_trace_rows: 0,
         }
     }
 
@@ -25,9 +36,14 @@ impl Memory {
     // --------------------------------------------------------------------------------------------
 
     /// Returns current size of the memory (in words).
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn size(&self) -> usize {
-        self.state.len()
+        self.trace.len()
+    }
+
+    /// Returns length of execution trace required to describe this memory.
+    pub fn trace_len(&self) -> usize {
+        self.num_trace_rows
     }
 
     // TRACE ACCESSORS AND MUTATORS
@@ -35,22 +51,115 @@ impl Memory {
 
     /// Returns a word (4 elements) located in memory at the specified address.
     ///
-    /// If the specified address hasn't been previously written to, 4 ZERO elements are returned.
-    /// This effectively implies that memory is initialized to ZERO.
+    /// If the specified address hasn't been previously written to, four ZERO elements are
+    /// returned. This effectively implies that memory is initialized to ZERO.
     pub fn read(&mut self, addr: Felt) -> Word {
-        let int_addr = addr.as_int();
-        *self.state.entry(int_addr).or_insert([Felt::ZERO; 4])
+        self.num_trace_rows += 1;
+        let clk = Felt::new(self.step);
+
+        // look up the previous value in the appropriate address trace and add (clk, prev_value)
+        // to it; if this is the first time we access this address, create address trace for it
+        // with entry (clk, [ZERO, 4]). in both cases, return the last value in the address trace.
+        self.trace
+            .entry(addr.as_int())
+            .and_modify(|addr_trace| {
+                let last_value = addr_trace.last().expect("empty address trace").1;
+                addr_trace.push((clk, last_value));
+            })
+            .or_insert_with(|| vec![(clk, [Felt::ZERO; 4])])
+            .last()
+            .expect("empty address trace")
+            .1
     }
 
     /// Writes the provided words (4 elements) at the specified address.
     pub fn write(&mut self, addr: Felt, value: Word) {
-        let int_addr = addr.as_int();
-        self.state.insert(int_addr, value);
+        self.num_trace_rows += 1;
+        let clk = Felt::new(self.step);
+
+        // add a tuple (clk, value) to the appropriate address trace; if this is the first time
+        // we access this address, initialize address trace.
+        self.trace
+            .entry(addr.as_int())
+            .and_modify(|addr_trace| addr_trace.push((clk, value)))
+            .or_insert_with(|| vec![(clk, value)]);
     }
+
+    // CONTEXT MANAGEMENT
+    // --------------------------------------------------------------------------------------------
 
     /// Increments the clock cycle.
     pub fn advance_clock(&mut self) {
         self.step += 1;
+    }
+
+    // TRACE COMPLETION
+    // --------------------------------------------------------------------------------------------
+
+    /// Fills the provide trace fragment with trace data from this memory instance.
+    #[allow(dead_code)]
+    pub fn fill_trace(self, trace: &mut TraceFragment) {
+        debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace_length");
+
+        // set the pervious address and clock cycle to the first address and clock cycle of the
+        // trace; we also adjust the clock cycle so that delta value for the first row would end
+        // up being ZERO. if the trace is empty, return without any further processing.
+        let (mut prev_addr, mut prev_clk) = match self.get_first_row_info() {
+            Some((addr, clk)) => (addr, clk - Felt::ONE),
+            None => return,
+        };
+
+        // iterate through addresses in ascending order, and write trace row for each memory access
+        // into the trace. we expect the trace to be 14 columns wide.
+        let mut i = 0;
+        for (addr, addr_trace) in self.trace {
+            // when we start a new address, we set the previous value to all zeros. the effect of
+            // this is that memory is always initialized to zero.
+            let addr = Felt::new(addr);
+            let mut prev_value = [Felt::ZERO; 4];
+            for (clk, value) in addr_trace {
+                trace.set(i, 0, Felt::ZERO); // ctx
+                trace.set(i, 1, addr);
+                trace.set(i, 2, clk);
+                trace.set(i, 3, prev_value[0]);
+                trace.set(i, 4, prev_value[1]);
+                trace.set(i, 5, prev_value[2]);
+                trace.set(i, 6, prev_value[3]);
+                trace.set(i, 7, value[0]);
+                trace.set(i, 8, value[1]);
+                trace.set(i, 9, value[2]);
+                trace.set(i, 10, value[3]);
+
+                // compute delta as difference either between addresses or clock cycles
+                let delta = if prev_addr != addr {
+                    addr - prev_addr
+                } else {
+                    clk - prev_clk - Felt::ONE
+                };
+
+                let (delta_hi, delta_lo) = split_u32_into_u16(delta);
+                trace.set(i, 11, delta_lo);
+                trace.set(i, 12, delta_hi);
+                trace.set(i, 13, delta.inv());
+
+                // update values for the next iteration of the loop
+                i += 1;
+                prev_clk = clk;
+                prev_value = value;
+            }
+            prev_addr = addr;
+        }
+    }
+
+    /// Returns the address and clock cycle of the first trace row, or None if the trace is empty.
+    fn get_first_row_info(&self) -> Option<(Felt, Felt)> {
+        match self.trace.iter().next() {
+            Some((&addr, addr_trace)) => {
+                let clk = addr_trace[0].0;
+                Some((Felt::new(addr), clk))
+            }
+            None => None,
+        }
     }
 
     // TEST METHODS
@@ -59,6 +168,24 @@ impl Memory {
     /// Instantiates a new processor for testing purposes.
     #[cfg(test)]
     pub fn get_value(&self, addr: u64) -> Option<Word> {
-        self.state.get(&addr).copied()
+        match self.trace.get(&addr) {
+            Some(addr_trace) => addr_trace.last().map(|(_, value)| *value),
+            None => None,
+        }
     }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn split_u32_into_u16(value: Felt) -> (Felt, Felt) {
+    const U32MAX: u64 = u32::MAX as u64;
+
+    let value = value.as_int();
+    assert!(value <= U32MAX, "not a 32-bit value");
+
+    let lo = (value as u16) as u64;
+    let hi = value >> 16;
+
+    (Felt::new(hi), Felt::new(lo))
 }

--- a/processor/src/memory/mod.rs
+++ b/processor/src/memory/mod.rs
@@ -143,11 +143,11 @@ impl Memory {
                 trace.set(i, 13, delta.inv());
 
                 // update values for the next iteration of the loop
-                i += 1;
+                prev_addr = addr;
                 prev_clk = clk;
                 prev_value = value;
+                i += 1;
             }
-            prev_addr = addr;
         }
     }
 

--- a/processor/src/memory/tests.rs
+++ b/processor/src/memory/tests.rs
@@ -1,0 +1,116 @@
+use super::{Felt, FieldElement, Memory, TraceFragment, Word};
+
+#[test]
+fn mem_init() {
+    let mem = Memory::new();
+    assert_eq!(0, mem.size());
+    assert_eq!(0, mem.trace_len());
+}
+
+#[test]
+fn mem_read() {
+    let mut mem = Memory::new();
+    mem.advance_clock();
+
+    // read a value from address 0; clk = 1
+    let addr0 = Felt::new(0);
+    let value = mem.read(addr0);
+    assert_eq!([Felt::ZERO; 4], value);
+    assert_eq!(1, mem.size());
+    assert_eq!(1, mem.trace_len());
+
+    // read a value from address 3; clk = 2
+    mem.advance_clock();
+    let addr3 = Felt::new(3);
+    let value = mem.read(addr3);
+    assert_eq!([Felt::ZERO; 4], value);
+    assert_eq!(2, mem.size());
+    assert_eq!(2, mem.trace_len());
+
+    // read a value from address 0 again; clk = 3
+    mem.advance_clock();
+    let value = mem.read(addr0);
+    assert_eq!([Felt::ZERO; 4], value);
+    assert_eq!(2, mem.size());
+    assert_eq!(3, mem.trace_len());
+
+    // read a value from address 2; clk = 4
+    mem.advance_clock();
+    let addr2 = Felt::new(2);
+    let value = mem.read(addr2);
+    assert_eq!([Felt::ZERO; 4], value);
+    assert_eq!(3, mem.size());
+    assert_eq!(4, mem.trace_len());
+
+    // check generated trace; rows should be sorted by address and then clock cycle
+    let num_rows = 4;
+    let mut trace = (0..14)
+        .map(|_| vec![Felt::ZERO; num_rows])
+        .collect::<Vec<_>>();
+    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
+
+    mem.fill_trace(&mut fragment);
+
+    // address 0
+    let expected = build_trace_row(addr0, 1, [Felt::ZERO; 4], [Felt::ZERO; 4], [Felt::ZERO; 14]);
+    assert_eq!(expected, read_trace_row(&trace, 0));
+    let expected = build_trace_row(addr0, 3, [Felt::ZERO; 4], [Felt::ZERO; 4], expected);
+    assert_eq!(expected, read_trace_row(&trace, 1));
+
+    // address 2
+    let expected = build_trace_row(addr2, 4, [Felt::ZERO; 4], [Felt::ZERO; 4], expected);
+    assert_eq!(expected, read_trace_row(&trace, 2));
+
+    // address 3
+    let expected = build_trace_row(addr3, 2, [Felt::ZERO; 4], [Felt::ZERO; 4], expected);
+    assert_eq!(expected, read_trace_row(&trace, 3));
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn read_trace_row(trace: &[Vec<Felt>], step: usize) -> [Felt; 14] {
+    let mut row = [Felt::ZERO; 14];
+    for (value, column) in row.iter_mut().zip(trace) {
+        *value = column[step];
+    }
+    row
+}
+
+fn build_trace_row(
+    addr: Felt,
+    clk: u64,
+    old_val: Word,
+    new_val: Word,
+    prev_row: [Felt; 14],
+) -> [Felt; 14] {
+    let mut row = [Felt::ZERO; 14];
+    row[0] = Felt::ZERO; // ctx
+    row[1] = addr;
+    row[2] = Felt::new(clk);
+    row[3] = old_val[0];
+    row[4] = old_val[1];
+    row[5] = old_val[2];
+    row[6] = old_val[3];
+    row[7] = new_val[0];
+    row[8] = new_val[1];
+    row[9] = new_val[2];
+    row[10] = new_val[3];
+
+    if prev_row != [Felt::ZERO; 14] {
+        let delta = if row[0] != prev_row[0] {
+            row[0] - prev_row[0]
+        } else if row[1] != prev_row[1] {
+            row[1] - prev_row[1]
+        } else {
+            row[2] - prev_row[2] - Felt::ONE
+        };
+
+        let (hi, lo) = super::split_u32_into_u16(delta);
+        row[11] = lo;
+        row[12] = hi;
+        row[13] = delta.inv();
+    }
+
+    row
+}

--- a/processor/src/memory/tests.rs
+++ b/processor/src/memory/tests.rs
@@ -1,4 +1,4 @@
-use super::{Felt, FieldElement, Memory, TraceFragment, Word};
+use super::{Felt, FieldElement, Memory, StarkField, TraceFragment, Word};
 
 #[test]
 fn mem_init() {
@@ -10,9 +10,9 @@ fn mem_init() {
 #[test]
 fn mem_read() {
     let mut mem = Memory::new();
-    mem.advance_clock();
 
     // read a value from address 0; clk = 1
+    mem.advance_clock();
     let addr0 = Felt::new(0);
     let value = mem.read(addr0);
     assert_eq!([Felt::ZERO; 4], value);
@@ -64,6 +64,147 @@ fn mem_read() {
     // address 3
     let expected = build_trace_row(addr3, 2, [Felt::ZERO; 4], [Felt::ZERO; 4], expected);
     assert_eq!(expected, read_trace_row(&trace, 3));
+}
+
+#[test]
+fn mem_write() {
+    let mut mem = Memory::new();
+
+    // write a value into address 0; clk = 1
+    mem.advance_clock();
+    let addr0 = Felt::new(0);
+    let value1 = [Felt::ONE, Felt::ZERO, Felt::ZERO, Felt::ZERO];
+    mem.write(addr0, value1);
+    assert_eq!(value1, mem.get_value(addr0.as_int()).unwrap());
+    assert_eq!(1, mem.size());
+    assert_eq!(1, mem.trace_len());
+
+    // write a value into address 2; clk = 2
+    mem.advance_clock();
+    let addr2 = Felt::new(2);
+    let value5 = [Felt::new(5), Felt::ZERO, Felt::ZERO, Felt::ZERO];
+    mem.write(addr2, value5);
+    assert_eq!(value5, mem.get_value(addr2.as_int()).unwrap());
+    assert_eq!(2, mem.size());
+    assert_eq!(2, mem.trace_len());
+
+    // write a value into address 1; clk = 3
+    mem.advance_clock();
+    let addr1 = Felt::new(1);
+    let value7 = [Felt::new(7), Felt::ZERO, Felt::ZERO, Felt::ZERO];
+    mem.write(addr1, value7);
+    assert_eq!(value7, mem.get_value(addr1.as_int()).unwrap());
+    assert_eq!(3, mem.size());
+    assert_eq!(3, mem.trace_len());
+
+    // write a value into address 0; clk = 4
+    mem.advance_clock();
+    let value9 = [Felt::new(9), Felt::ZERO, Felt::ZERO, Felt::ZERO];
+    mem.write(addr0, value9);
+    assert_eq!(value7, mem.get_value(addr1.as_int()).unwrap());
+    assert_eq!(3, mem.size());
+    assert_eq!(4, mem.trace_len());
+
+    // check generated trace; rows should be sorted by address and then clock cycle
+    let num_rows = 4;
+    let mut trace = (0..14)
+        .map(|_| vec![Felt::ZERO; num_rows])
+        .collect::<Vec<_>>();
+    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
+
+    mem.fill_trace(&mut fragment);
+
+    // address 0
+    let expected = build_trace_row(addr0, 1, [Felt::ZERO; 4], value1, [Felt::ZERO; 14]);
+    assert_eq!(expected, read_trace_row(&trace, 0));
+    let expected = build_trace_row(addr0, 4, value1, value9, expected);
+    assert_eq!(expected, read_trace_row(&trace, 1));
+
+    // address 1
+    let expected = build_trace_row(addr1, 3, [Felt::ZERO; 4], value7, expected);
+    assert_eq!(expected, read_trace_row(&trace, 2));
+
+    // address 2
+    let expected = build_trace_row(addr2, 2, [Felt::ZERO; 4], value5, expected);
+    assert_eq!(expected, read_trace_row(&trace, 3));
+}
+
+#[test]
+fn mem_write_read() {
+    let mut mem = Memory::new();
+
+    // write 1 into address 5; clk = 1
+    mem.advance_clock();
+    let addr5 = Felt::new(5);
+    let value1 = [Felt::ONE, Felt::ZERO, Felt::ZERO, Felt::ZERO];
+    mem.write(addr5, value1);
+
+    // write 4 into address 2; clk = 2
+    mem.advance_clock();
+    let addr2 = Felt::new(2);
+    let value4 = [Felt::new(4), Felt::ZERO, Felt::ZERO, Felt::ZERO];
+    mem.write(addr2, value4);
+
+    // read a value from address 5; clk = 3
+    mem.advance_clock();
+    let _ = mem.read(addr5);
+
+    // write 2 into address 5; clk = 4
+    mem.advance_clock();
+    let value2 = [Felt::new(2), Felt::ZERO, Felt::ZERO, Felt::ZERO];
+    mem.write(addr5, value2);
+
+    // read a value from address 2; clk = 5
+    mem.advance_clock();
+    let _ = mem.read(addr2);
+
+    // write 7 into address 2; clk = 6
+    mem.advance_clock();
+    let value7 = [Felt::new(7), Felt::ZERO, Felt::ZERO, Felt::ZERO];
+    mem.write(addr2, value7);
+
+    // read a value from address 5; clk = 7
+    mem.advance_clock();
+    let _ = mem.read(addr5);
+
+    // read a value from address 2; clk = 8
+    mem.advance_clock();
+    let _ = mem.read(addr2);
+
+    // read a value from address 5; clk = 9
+    mem.advance_clock();
+    let _ = mem.read(addr5);
+
+    // check generated trace; rows should be sorted by address and then clock cycle
+    let num_rows = 9;
+    let mut trace = (0..14)
+        .map(|_| vec![Felt::ZERO; num_rows])
+        .collect::<Vec<_>>();
+    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
+
+    mem.fill_trace(&mut fragment);
+
+    // address 2
+    let expected = build_trace_row(addr2, 2, [Felt::ZERO; 4], value4, [Felt::ZERO; 14]);
+    assert_eq!(expected, read_trace_row(&trace, 0));
+    let expected = build_trace_row(addr2, 5, value4, value4, expected);
+    assert_eq!(expected, read_trace_row(&trace, 1));
+    let expected = build_trace_row(addr2, 6, value4, value7, expected);
+    assert_eq!(expected, read_trace_row(&trace, 2));
+    let expected = build_trace_row(addr2, 8, value7, value7, expected);
+    assert_eq!(expected, read_trace_row(&trace, 3));
+
+    // address 5
+    let expected = build_trace_row(addr5, 1, [Felt::ZERO; 4], value1, expected);
+    assert_eq!(expected, read_trace_row(&trace, 4));
+    let expected = build_trace_row(addr5, 3, value1, value1, expected);
+    assert_eq!(expected, read_trace_row(&trace, 5));
+    let expected = build_trace_row(addr5, 4, value1, value2, expected);
+    assert_eq!(expected, read_trace_row(&trace, 6));
+    let expected = build_trace_row(addr5, 7, value2, value2, expected);
+    assert_eq!(expected, read_trace_row(&trace, 7));
+    let expected = build_trace_row(addr5, 9, value2, value2, expected);
+    assert_eq!(expected, read_trace_row(&trace, 8));
 }
 
 // HELPER FUNCTIONS

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -87,6 +87,45 @@ impl Trace for ExecutionTrace {
     }
 }
 
+// TRACE FRAGMENT
+// ================================================================================================
+
+/// TODO: add docs
+pub struct TraceFragment<'a> {
+    data: Vec<&'a mut [Felt]>,
+}
+
+impl<'a> TraceFragment<'a> {
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the number of rows in this execution trace fragment.
+    pub fn len(&self) -> usize {
+        self.data[0].len()
+    }
+
+    // DATA MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Updates a single cell in this fragment with provided value.
+    #[inline(always)]
+    pub fn set(&mut self, row_idx: usize, col_idx: usize, value: Felt) {
+        self.data[col_idx][row_idx] = value;
+    }
+
+    // TEST METHODS
+    // --------------------------------------------------------------------------------------------
+
+    #[cfg(test)]
+    pub fn trace_to_fragment(trace: &'a mut [Vec<Felt>]) -> Self {
+        let mut data = Vec::new();
+        for column in trace.iter_mut() {
+            data.push(column.as_mut_slice());
+        }
+        Self { data }
+    }
+}
+
 // HELPER FUNCTIONS
 // ================================================================================================
 


### PR DESCRIPTION
This PR implements execution trace generation for memory accesses (reads and writes). It also introduces a `TraceFragment` struct which will be useful in other contexts.

- [x] Implement trace generation
- [x] Add tests
- [x] Write docs