### PR TITLE
Implement bitwise op trace generation

### DIFF
--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -1,5 +1,8 @@
 use super::{ExecutionError, Felt, StarkField, TraceFragment};
 
+#[cfg(test)]
+mod tests;
+
 // CONSTANTS
 // ================================================================================================
 

--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -6,14 +6,43 @@ mod tests;
 // CONSTANTS
 // ================================================================================================
 
-const TRACE_WIDTH: usize = 13;
+/// Number of columns needed to record an execution trace of the bitwise helper.
+const TRACE_WIDTH: usize = 11;
 
-const INIT_TRACE_LEN: usize = 128;
+/// Initial capacity of each column.
+const INIT_TRACE_CAPACITY: usize = 128;
 
 // BITWISE HELPER
 // ================================================================================================
 
-/// TODO: add docs
+/// Bitwise operation helper for the VM.
+///
+/// This component is responsible for computing AND, OR, and XOR bitwise operations on 32-bit
+/// values, as well as for building an execution trace of these operations.
+///
+/// ## Execution trace
+/// Execution trace for each operation consists of 8 rows and 11 columns. At the hight level,
+/// we break input values into 4-bit limbs, apply the bitwise operation to these limbs at every
+/// row starting with the most significant limb, and accumulate the result in the result column.
+///
+/// The layout of the table is illustrated below.
+///
+///    a     b      a0     a1     a2     a3     b0     b1     b2     b3     c
+/// ├─────┴─────┴───────┴──────┴──────┴──────┴──────┴──────┴──────┴──────┴─────┤
+///
+/// In the above, the meaning of the columns is as follows:
+/// - Columns `a` and `b` contain accumulated 4-bit limbs of input values. Specifically, at the
+///   first row, the values of columns `a` and `b` are set to the most significant 4-bit limb
+///   of each input value. With all subsequent rows, the next most significant limb is appended
+///   to each column for the corresponding value. Thus, by the 8th row, columns `a` and `b`
+///   contain full input values for the bitwise operation.
+/// - Columns `a0` through `a3` and `b0` through `b3` contain bits of the least significant 4-bit
+///   limb of the values in `a` and `b` columns respectively.
+/// - Column `c` contains the accumulated result of applying the bitwise operation to 4-bit limbs.
+///   At the first row, column `c` contains the result of bitwise operation applied to the most
+///   significant 4-bit limbs of the input values. With every subsequent row, the next most
+///   significant 4-bit limb of the result is appended to it. Thus, but the 8th row, column `c`
+///   contains the full result of the bitwise operation.
 pub struct Bitwise {
     trace: [Vec<Felt>; TRACE_WIDTH],
 }
@@ -21,10 +50,10 @@ pub struct Bitwise {
 impl Bitwise {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    /// TODO: add docs
+    /// Returns a new [Bitwise] initialized with an empty trace.
     pub fn new() -> Self {
         let trace = (0..TRACE_WIDTH)
-            .map(|_| Vec::with_capacity(INIT_TRACE_LEN))
+            .map(|_| Vec::with_capacity(INIT_TRACE_CAPACITY))
             .collect::<Vec<_>>()
             .try_into()
             .unwrap();
@@ -34,7 +63,8 @@ impl Bitwise {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// TODO: add docs
+    /// Returns length of execution trace required to describe bitwise operations executed on the
+    /// VM.
     pub fn trace_len(&self) -> usize {
         self.trace[0].len()
     }
@@ -42,111 +72,117 @@ impl Bitwise {
     // TRACE MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// TODO: add docs
-    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
-        let mut a = a.as_int();
-        let mut b = b.as_int();
+    /// Computes a bitwise AND of `a` and `b` and returns the result. We assume that `a` and `b`
+    /// are 32-bit values. If that's not the case, the result of the computation is undefined.
+    ///
+    /// This also adds 8 rows to the internal execution trace table required for computing the
+    /// operation.
+    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
+        let a = a.as_int();
+        let b = b.as_int();
         let mut result = 0u64;
 
-        // record the starting address of the trace table
-        let addr = Felt::new(self.trace_len() as u64);
-
         // append 8 rows to the trace, each row computing bitwise AND in 4 bit limbs starting with
-        // the least significant limb.
-        for bit_offset in (0..32).step_by(4) {
-            // add a new row to the trace table and populate it with binary decomposition of the
-            // lower 4 bits of a and b.
-            self.add_trace_row(a, b, bit_offset);
+        // the most significant limb.
+        for bit_offset in (0..32).step_by(4).rev() {
+            // shift a and b so that the next 4-bit limb is in the least significant position
+            let a = a >> bit_offset;
+            let b = b >> bit_offset;
 
-            // compute bitwise AND of the lower 4 bits of a and b
+            // add a new row to the trace table and populate it with binary decomposition of the 4
+            // least significant bits of a and b.
+            self.add_trace_row(a, b);
+
+            // compute bitwise AND of the 4 least significant bits of a and b
             let result_4_bit = (a & b) & 0xF;
 
             // append the 4 bit result to the result accumulator, and save the current result into
-            // the 13th column of the trace.
-            result |= result_4_bit << bit_offset;
-            self.trace[12].push(Felt::new(result));
-
-            // remove the lower 4 bits from a and b
-            a >>= 4;
-            b >>= 4;
+            // the 11th column of the trace.
+            result = (result << 4) | result_4_bit;
+            self.trace[10].push(Felt::new(result));
         }
 
-        Ok((addr, Felt::new(result)))
+        Ok(Felt::new(result))
     }
 
-    /// TODO: add docs
-    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
-        let mut a = a.as_int();
-        let mut b = b.as_int();
+    /// Computes a bitwise OR of `a` and `b` and returns the result. We assume that `a` and `b`
+    /// are 32-bit values. If that's not the case, the result of the computation is undefined.
+    ///
+    /// This also adds 8 rows to the internal execution trace table required for computing the
+    /// operation.
+    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
+        let a = a.as_int();
+        let b = b.as_int();
         let mut result = 0u64;
 
-        // record the starting address of the trace table
-        let addr = Felt::new(self.trace_len() as u64);
-
         // append 8 rows to the trace, each row computing bitwise OR in 4 bit limbs starting with
-        // the least significant limb.
-        for bit_offset in (0..32).step_by(4) {
-            // add a new row to the trace table and populate it with binary decomposition of the
-            // lower 4 bits of a and b.
-            self.add_trace_row(a, b, bit_offset);
+        // the most significant limb.
+        for bit_offset in (0..32).step_by(4).rev() {
+            // shift a and b so that the next 4-bit limb is in the least significant position
+            let a = a >> bit_offset;
+            let b = b >> bit_offset;
 
-            // compute bitwise OR of the lower 4 bits of a and b
+            // add a new row to the trace table and populate it with binary decomposition of the 4
+            // least significant bits of a and b.
+            self.add_trace_row(a, b);
+
+            // compute bitwise OR of the 4 least significant bits of a and b
             let result_4_bit = (a | b) & 0xF;
 
             // append the 4 bit result to the result accumulator, and save the current result into
-            // the 13th column of the trace.
-            result |= result_4_bit << bit_offset;
-            self.trace[12].push(Felt::new(result));
-
-            // remove the lower 4 bits from a and b
-            a >>= 4;
-            b >>= 4;
+            // the 11th column of the trace.
+            result = (result << 4) | result_4_bit;
+            self.trace[10].push(Felt::new(result));
         }
 
-        Ok((addr, Felt::new(result)))
+        Ok(Felt::new(result))
     }
 
-    /// TODO: add docs
-    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
-        let mut a = a.as_int();
-        let mut b = b.as_int();
+    /// Computes a bitwise XOR of `a` and `b` and returns the result. We assume that `a` and `b`
+    /// are 32-bit values. If that's not the case, the result of the computation is undefined.
+    ///
+    /// This also adds 8 rows to the internal execution trace table required for computing the
+    /// operation.
+    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
+        let a = a.as_int();
+        let b = b.as_int();
         let mut result = 0u64;
 
-        // record the starting address of the trace table
-        let addr = Felt::new(self.trace_len() as u64);
-
         // append 8 rows to the trace, each row computing bitwise XOR in 4 bit limbs starting with
-        // the least significant limb.
-        for bit_offset in (0..32).step_by(4) {
-            // add a new row to the trace table and populate it with binary decomposition of the
-            // lower 4 bits of a and b.
-            self.add_trace_row(a, b, bit_offset);
+        // the most significant limb.
+        for bit_offset in (0..32).step_by(4).rev() {
+            // shift a and b so that the next 4-bit limb is in the least significant position
+            let a = a >> bit_offset;
+            let b = b >> bit_offset;
 
-            // compute bitwise XOR of the lower 4 bits of a and b
+            // add a new row to the trace table and populate it with binary decomposition of the 4
+            // least significant bits of a and b.
+            self.add_trace_row(a, b);
+
+            // compute bitwise XOR of the 4 least significant bits of a and b
             let result_4_bit = (a ^ b) & 0xF;
 
             // append the 4 bit result to the result accumulator, and save the current result into
-            // the 13th column of the trace.
-            result |= result_4_bit << bit_offset;
-            self.trace[12].push(Felt::new(result));
-
-            // remove the lower 4 bits from a and b
-            a >>= 4;
-            b >>= 4;
+            // the 11th column of the trace.
+            result = (result << 4) | result_4_bit;
+            self.trace[10].push(Felt::new(result));
         }
 
-        Ok((addr, Felt::new(result)))
+        Ok(Felt::new(result))
     }
 
     // EXECUTION TRACE GENERATION
     // --------------------------------------------------------------------------------------------
 
-    /// TODO: add docs
+    /// Fills the provide trace fragment with trace data from this bitwise helper instance.
     #[allow(dead_code)]
     pub fn fill_trace(self, trace: &mut TraceFragment) {
+        // make sure fragment dimensions are consistent with the dimensions of this trace
         debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace lengths");
         debug_assert_eq!(TRACE_WIDTH, trace.width(), "inconsistent trace widths");
 
+        // copy trace into the fragment column-by-column
+        // TODO: this can be parallelized to copy columns in multiple threads
         for (out_column, column) in trace.columns().zip(self.trace) {
             out_column.copy_from_slice(&column);
         }
@@ -155,22 +191,23 @@ impl Bitwise {
     // HELPER METHODS
     // --------------------------------------------------------------------------------------------
 
-    /// TODO: add docs
-    fn add_trace_row(&mut self, a: u64, b: u64, bit_offset: u64) {
-        self.trace[0].push(Felt::new(self.trace_len() as u64));
-        self.trace[1].push(Felt::new(a));
-        self.trace[2].push(Felt::new(b));
+    /// Appends a new row to the trace table and populates the first 10 column of trace as follows:
+    /// - Column 0 is set to the current value of `a`.
+    /// - Column 1 is set to the current value of `b`.
+    /// - Columns 2 to 5 are set to the 4 least-significant bits of `a`.
+    /// - Columns 6 to 9 are set to the 4 least-significant bits of `b`.
+    fn add_trace_row(&mut self, a: u64, b: u64) {
+        self.trace[0].push(Felt::new(a));
+        self.trace[1].push(Felt::new(b));
 
-        self.trace[3].push(Felt::new(a & 1));
-        self.trace[4].push(Felt::new((a >> 1) & 1));
-        self.trace[5].push(Felt::new((a >> 2) & 1));
-        self.trace[6].push(Felt::new((a >> 3) & 1));
+        self.trace[2].push(Felt::new(a & 1));
+        self.trace[3].push(Felt::new((a >> 1) & 1));
+        self.trace[4].push(Felt::new((a >> 2) & 1));
+        self.trace[5].push(Felt::new((a >> 3) & 1));
 
-        self.trace[7].push(Felt::new(b & 1));
-        self.trace[8].push(Felt::new((b >> 1) & 1));
-        self.trace[9].push(Felt::new((b >> 2) & 1));
-        self.trace[10].push(Felt::new((b >> 3) & 1));
-
-        self.trace[11].push(Felt::new(1 << bit_offset));
+        self.trace[6].push(Felt::new(b & 1));
+        self.trace[7].push(Felt::new((b >> 1) & 1));
+        self.trace[8].push(Felt::new((b >> 2) & 1));
+        self.trace[9].push(Felt::new((b >> 3) & 1));
     }
 }

--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -1,0 +1,173 @@
+use super::{ExecutionError, Felt, StarkField, TraceFragment};
+
+// CONSTANTS
+// ================================================================================================
+
+const TRACE_WIDTH: usize = 13;
+
+const INIT_TRACE_LEN: usize = 128;
+
+// BITWISE HELPER
+// ================================================================================================
+
+/// TODO: add docs
+pub struct Bitwise {
+    trace: [Vec<Felt>; TRACE_WIDTH],
+}
+
+impl Bitwise {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// TODO: add docs
+    pub fn new() -> Self {
+        let trace = (0..TRACE_WIDTH)
+            .map(|_| Vec::with_capacity(INIT_TRACE_LEN))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        Self { trace }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// TODO: add docs
+    pub fn trace_len(&self) -> usize {
+        self.trace[0].len()
+    }
+
+    // TRACE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// TODO: add docs
+    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
+        let mut a = a.as_int();
+        let mut b = b.as_int();
+        let mut result = 0u64;
+
+        // record the starting address of the trace table
+        let addr = Felt::new(self.trace_len() as u64);
+
+        // append 8 rows to the trace, each row computing bitwise AND in 4 bit limbs starting with
+        // the least significant limb.
+        for bit_offset in (0..32).step_by(4) {
+            // add a new row to the trace table and populate it with binary decomposition of the
+            // lower 4 bits of a and b.
+            self.add_trace_row(a, b, bit_offset);
+
+            // compute bitwise AND of the lower 4 bits of a and b
+            let result_4_bit = (a & b) & 0xF;
+
+            // append the 4 bit result to the result accumulator, and save the current result into
+            // the 13th column of the trace.
+            result |= result_4_bit << bit_offset;
+            self.trace[12].push(Felt::new(result));
+
+            // remove the lower 4 bits from a and b
+            a >>= 4;
+            b >>= 4;
+        }
+
+        Ok((addr, Felt::new(result)))
+    }
+
+    /// TODO: add docs
+    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
+        let mut a = a.as_int();
+        let mut b = b.as_int();
+        let mut result = 0u64;
+
+        // record the starting address of the trace table
+        let addr = Felt::new(self.trace_len() as u64);
+
+        // append 8 rows to the trace, each row computing bitwise OR in 4 bit limbs starting with
+        // the least significant limb.
+        for bit_offset in (0..32).step_by(4) {
+            // add a new row to the trace table and populate it with binary decomposition of the
+            // lower 4 bits of a and b.
+            self.add_trace_row(a, b, bit_offset);
+
+            // compute bitwise OR of the lower 4 bits of a and b
+            let result_4_bit = (a | b) & 0xF;
+
+            // append the 4 bit result to the result accumulator, and save the current result into
+            // the 13th column of the trace.
+            result |= result_4_bit << bit_offset;
+            self.trace[12].push(Felt::new(result));
+
+            // remove the lower 4 bits from a and b
+            a >>= 4;
+            b >>= 4;
+        }
+
+        Ok((addr, Felt::new(result)))
+    }
+
+    /// TODO: add docs
+    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
+        let mut a = a.as_int();
+        let mut b = b.as_int();
+        let mut result = 0u64;
+
+        // record the starting address of the trace table
+        let addr = Felt::new(self.trace_len() as u64);
+
+        // append 8 rows to the trace, each row computing bitwise XOR in 4 bit limbs starting with
+        // the least significant limb.
+        for bit_offset in (0..32).step_by(4) {
+            // add a new row to the trace table and populate it with binary decomposition of the
+            // lower 4 bits of a and b.
+            self.add_trace_row(a, b, bit_offset);
+
+            // compute bitwise XOR of the lower 4 bits of a and b
+            let result_4_bit = (a ^ b) & 0xF;
+
+            // append the 4 bit result to the result accumulator, and save the current result into
+            // the 13th column of the trace.
+            result |= result_4_bit << bit_offset;
+            self.trace[12].push(Felt::new(result));
+
+            // remove the lower 4 bits from a and b
+            a >>= 4;
+            b >>= 4;
+        }
+
+        Ok((addr, Felt::new(result)))
+    }
+
+    // EXECUTION TRACE GENERATION
+    // --------------------------------------------------------------------------------------------
+
+    /// TODO: add docs
+    #[allow(dead_code)]
+    pub fn fill_trace(self, trace: &mut TraceFragment) {
+        debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace lengths");
+        debug_assert_eq!(TRACE_WIDTH, trace.width(), "inconsistent trace widths");
+
+        for (out_column, column) in trace.columns().zip(self.trace) {
+            out_column.copy_from_slice(&column);
+        }
+    }
+
+    // HELPER METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// TODO: add docs
+    fn add_trace_row(&mut self, a: u64, b: u64, bit_offset: u64) {
+        self.trace[0].push(Felt::new(self.trace_len() as u64));
+        self.trace[1].push(Felt::new(a));
+        self.trace[2].push(Felt::new(b));
+
+        self.trace[3].push(Felt::new(a & 1));
+        self.trace[4].push(Felt::new((a >> 1) & 1));
+        self.trace[5].push(Felt::new((a >> 2) & 1));
+        self.trace[6].push(Felt::new((a >> 3) & 1));
+
+        self.trace[7].push(Felt::new(b & 1));
+        self.trace[8].push(Felt::new((b >> 1) & 1));
+        self.trace[9].push(Felt::new((b >> 2) & 1));
+        self.trace[10].push(Felt::new((b >> 3) & 1));
+
+        self.trace[11].push(Felt::new(1 << bit_offset));
+    }
+}

--- a/processor/src/bitwise/tests.rs
+++ b/processor/src/bitwise/tests.rs
@@ -14,13 +14,12 @@ fn bitwise_and() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let (address, result) = bitwise.u32and(a, b).unwrap();
-    assert_eq!(Felt::new(0), address);
+    let result = bitwise.u32and(a, b).unwrap();
     assert_eq!(a.as_int() & b.as_int(), result.as_int());
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
-    let mut trace = (0..13)
+    let mut trace = (0..11)
         .map(|_| vec![Felt::new(0); num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
@@ -28,7 +27,7 @@ fn bitwise_and() {
     bitwise.fill_trace(&mut fragment);
 
     // make sure result and result from the trace are the same
-    assert_eq!(result, trace[12][7]);
+    assert_eq!(result, trace[10][7]);
 
     // make sure values a and b were decomposed correctly
     check_decomposition(&trace, 0, a.as_int(), b.as_int());
@@ -37,14 +36,14 @@ fn bitwise_and() {
     let mut prev_result = Felt::new(0);
 
     for i in 0..8 {
-        let c0 = binary_and(trace[3][i], trace[7][i]);
-        let c1 = binary_and(trace[4][i], trace[8][i]);
-        let c2 = binary_and(trace[5][i], trace[9][i]);
-        let c3 = binary_and(trace[6][i], trace[10][i]);
+        let c0 = binary_and(trace[2][i], trace[6][i]);
+        let c1 = binary_and(trace[3][i], trace[7][i]);
+        let c2 = binary_and(trace[4][i], trace[8][i]);
+        let c3 = binary_and(trace[5][i], trace[9][i]);
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
-        let result = prev_result + result_4_bit * trace[11][i];
-        assert_eq!(result, trace[12][i]);
+        let result = prev_result * Felt::new(16) + result_4_bit;
+        assert_eq!(result, trace[10][i]);
 
         prev_result = result;
     }
@@ -57,13 +56,12 @@ fn bitwise_or() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let (address, result) = bitwise.u32or(a, b).unwrap();
-    assert_eq!(Felt::new(0), address);
+    let result = bitwise.u32or(a, b).unwrap();
     assert_eq!(a.as_int() | b.as_int(), result.as_int());
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
-    let mut trace = (0..13)
+    let mut trace = (0..11)
         .map(|_| vec![Felt::new(0); num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
@@ -71,7 +69,7 @@ fn bitwise_or() {
     bitwise.fill_trace(&mut fragment);
 
     // make sure result and result from the trace are the same
-    assert_eq!(result, trace[12][7]);
+    assert_eq!(result, trace[10][7]);
 
     // make sure values a and b were decomposed correctly
     check_decomposition(&trace, 0, a.as_int(), b.as_int());
@@ -80,14 +78,14 @@ fn bitwise_or() {
     let mut prev_result = Felt::new(0);
 
     for i in 0..8 {
-        let c0 = binary_or(trace[3][i], trace[7][i]);
-        let c1 = binary_or(trace[4][i], trace[8][i]);
-        let c2 = binary_or(trace[5][i], trace[9][i]);
-        let c3 = binary_or(trace[6][i], trace[10][i]);
+        let c0 = binary_or(trace[2][i], trace[6][i]);
+        let c1 = binary_or(trace[3][i], trace[7][i]);
+        let c2 = binary_or(trace[4][i], trace[8][i]);
+        let c3 = binary_or(trace[5][i], trace[9][i]);
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
-        let result = prev_result + result_4_bit * trace[11][i];
-        assert_eq!(result, trace[12][i]);
+        let result = prev_result * Felt::new(16) + result_4_bit;
+        assert_eq!(result, trace[10][i]);
 
         prev_result = result;
     }
@@ -100,13 +98,12 @@ fn bitwise_xor() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let (address, result) = bitwise.u32xor(a, b).unwrap();
-    assert_eq!(Felt::new(0), address);
+    let result = bitwise.u32xor(a, b).unwrap();
     assert_eq!(a.as_int() ^ b.as_int(), result.as_int());
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
-    let mut trace = (0..13)
+    let mut trace = (0..11)
         .map(|_| vec![Felt::new(0); num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
@@ -114,7 +111,7 @@ fn bitwise_xor() {
     bitwise.fill_trace(&mut fragment);
 
     // make sure result and result from the trace are the same
-    assert_eq!(result, trace[12][7]);
+    assert_eq!(result, trace[10][7]);
 
     // make sure values a and b were decomposed correctly
     check_decomposition(&trace, 0, a.as_int(), b.as_int());
@@ -123,14 +120,14 @@ fn bitwise_xor() {
     let mut prev_result = Felt::new(0);
 
     for i in 0..8 {
-        let c0 = binary_xor(trace[3][i], trace[7][i]);
-        let c1 = binary_xor(trace[4][i], trace[8][i]);
-        let c2 = binary_xor(trace[5][i], trace[9][i]);
-        let c3 = binary_xor(trace[6][i], trace[10][i]);
+        let c0 = binary_xor(trace[2][i], trace[6][i]);
+        let c1 = binary_xor(trace[3][i], trace[7][i]);
+        let c2 = binary_xor(trace[4][i], trace[8][i]);
+        let c3 = binary_xor(trace[5][i], trace[9][i]);
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
-        let result = prev_result + result_4_bit * trace[11][i];
-        assert_eq!(result, trace[12][i]);
+        let result = prev_result * Felt::new(16) + result_4_bit;
+        assert_eq!(result, trace[10][i]);
 
         prev_result = result;
     }
@@ -144,28 +141,24 @@ fn bitwise_multiple() {
     let b = [rand_u32(), rand_u32(), rand_u32(), rand_u32()];
 
     // first operation: AND
-    let (address, result0) = bitwise.u32and(a[0], b[0]).unwrap();
-    assert_eq!(Felt::new(0), address);
+    let result0 = bitwise.u32and(a[0], b[0]).unwrap();
     assert_eq!(a[0].as_int() & b[0].as_int(), result0.as_int());
 
     // second operation: OR
-    let (address, result1) = bitwise.u32or(a[1], b[1]).unwrap();
-    assert_eq!(Felt::new(8), address);
+    let result1 = bitwise.u32or(a[1], b[1]).unwrap();
     assert_eq!(a[1].as_int() | b[1].as_int(), result1.as_int());
 
     // third operation: XOR
-    let (address, result2) = bitwise.u32xor(a[2], b[2]).unwrap();
-    assert_eq!(Felt::new(16), address);
+    let result2 = bitwise.u32xor(a[2], b[2]).unwrap();
     assert_eq!(a[2].as_int() ^ b[2].as_int(), result2.as_int());
 
     // fourth operation: AND
-    let (address, result3) = bitwise.u32and(a[3], b[3]).unwrap();
-    assert_eq!(Felt::new(24), address);
+    let result3 = bitwise.u32and(a[3], b[3]).unwrap();
     assert_eq!(a[3].as_int() & b[3].as_int(), result3.as_int());
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 32;
-    let mut trace = (0..13)
+    let mut trace = (0..11)
         .map(|_| vec![Felt::new(0); num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
@@ -173,10 +166,10 @@ fn bitwise_multiple() {
     bitwise.fill_trace(&mut fragment);
 
     // make sure results and results from the trace are the same
-    assert_eq!(result0, trace[12][7]);
-    assert_eq!(result1, trace[12][15]);
-    assert_eq!(result2, trace[12][23]);
-    assert_eq!(result3, trace[12][31]);
+    assert_eq!(result0, trace[10][7]);
+    assert_eq!(result1, trace[10][15]);
+    assert_eq!(result2, trace[10][23]);
+    assert_eq!(result3, trace[10][31]);
 
     // make sure input values were decomposed correctly
     check_decomposition(&trace, 0, a[0].as_int(), b[0].as_int());
@@ -188,56 +181,56 @@ fn bitwise_multiple() {
 
     let mut prev_result = Felt::new(0);
     for i in 0..8 {
-        let c0 = binary_and(trace[3][i], trace[7][i]);
-        let c1 = binary_and(trace[4][i], trace[8][i]);
-        let c2 = binary_and(trace[5][i], trace[9][i]);
-        let c3 = binary_and(trace[6][i], trace[10][i]);
+        let c0 = binary_and(trace[2][i], trace[6][i]);
+        let c1 = binary_and(trace[3][i], trace[7][i]);
+        let c2 = binary_and(trace[4][i], trace[8][i]);
+        let c3 = binary_and(trace[5][i], trace[9][i]);
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
-        let result = prev_result + result_4_bit * trace[11][i];
-        assert_eq!(result, trace[12][i]);
+        let result = prev_result * Felt::new(16) + result_4_bit;
+        assert_eq!(result, trace[10][i]);
 
         prev_result = result;
     }
 
     let mut prev_result = Felt::new(0);
     for i in 8..16 {
-        let c0 = binary_or(trace[3][i], trace[7][i]);
-        let c1 = binary_or(trace[4][i], trace[8][i]);
-        let c2 = binary_or(trace[5][i], trace[9][i]);
-        let c3 = binary_or(trace[6][i], trace[10][i]);
+        let c0 = binary_or(trace[2][i], trace[6][i]);
+        let c1 = binary_or(trace[3][i], trace[7][i]);
+        let c2 = binary_or(trace[4][i], trace[8][i]);
+        let c3 = binary_or(trace[5][i], trace[9][i]);
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
-        let result = prev_result + result_4_bit * trace[11][i];
-        assert_eq!(result, trace[12][i]);
+        let result = prev_result * Felt::new(16) + result_4_bit;
+        assert_eq!(result, trace[10][i]);
 
         prev_result = result;
     }
 
     let mut prev_result = Felt::new(0);
     for i in 16..24 {
-        let c0 = binary_xor(trace[3][i], trace[7][i]);
-        let c1 = binary_xor(trace[4][i], trace[8][i]);
-        let c2 = binary_xor(trace[5][i], trace[9][i]);
-        let c3 = binary_xor(trace[6][i], trace[10][i]);
+        let c0 = binary_xor(trace[2][i], trace[6][i]);
+        let c1 = binary_xor(trace[3][i], trace[7][i]);
+        let c2 = binary_xor(trace[4][i], trace[8][i]);
+        let c3 = binary_xor(trace[5][i], trace[9][i]);
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
-        let result = prev_result + result_4_bit * trace[11][i];
-        assert_eq!(result, trace[12][i]);
+        let result = prev_result * Felt::new(16) + result_4_bit;
+        assert_eq!(result, trace[10][i]);
 
         prev_result = result;
     }
 
     let mut prev_result = Felt::new(0);
     for i in 24..32 {
-        let c0 = binary_and(trace[3][i], trace[7][i]);
-        let c1 = binary_and(trace[4][i], trace[8][i]);
-        let c2 = binary_and(trace[5][i], trace[9][i]);
-        let c3 = binary_and(trace[6][i], trace[10][i]);
+        let c0 = binary_and(trace[2][i], trace[6][i]);
+        let c1 = binary_and(trace[3][i], trace[7][i]);
+        let c2 = binary_and(trace[4][i], trace[8][i]);
+        let c3 = binary_and(trace[5][i], trace[9][i]);
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
-        let result = prev_result + result_4_bit * trace[11][i];
-        assert_eq!(result, trace[12][i]);
+        let result = prev_result * Felt::new(16) + result_4_bit;
+        assert_eq!(result, trace[10][i]);
 
         prev_result = result;
     }
@@ -246,29 +239,27 @@ fn bitwise_multiple() {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-fn check_decomposition(trace: &[Vec<Felt>], start: usize, mut a: u64, mut b: u64) {
-    let mut pow_of_16 = 1;
+fn check_decomposition(trace: &[Vec<Felt>], start: usize, a: u64, b: u64) {
+    let mut bit_offset = 28;
 
     for i in start..start + 8 {
-        assert_eq!(Felt::new(i as u64), trace[0][i]);
-        assert_eq!(Felt::new(a), trace[1][i]);
-        assert_eq!(Felt::new(b), trace[2][i]);
+        let a = a >> bit_offset;
+        let b = b >> bit_offset;
 
-        assert_eq!(Felt::new(a & 1), trace[3][i]);
-        assert_eq!(Felt::new((a >> 1) & 1), trace[4][i]);
-        assert_eq!(Felt::new((a >> 2) & 1), trace[5][i]);
-        assert_eq!(Felt::new((a >> 3) & 1), trace[6][i]);
+        assert_eq!(Felt::new(a), trace[0][i]);
+        assert_eq!(Felt::new(b), trace[1][i]);
 
-        assert_eq!(Felt::new(b & 1), trace[7][i]);
-        assert_eq!(Felt::new((b >> 1) & 1), trace[8][i]);
-        assert_eq!(Felt::new((b >> 2) & 1), trace[9][i]);
-        assert_eq!(Felt::new((b >> 3) & 1), trace[10][i]);
+        assert_eq!(Felt::new(a & 1), trace[2][i]);
+        assert_eq!(Felt::new((a >> 1) & 1), trace[3][i]);
+        assert_eq!(Felt::new((a >> 2) & 1), trace[4][i]);
+        assert_eq!(Felt::new((a >> 3) & 1), trace[5][i]);
 
-        assert_eq!(Felt::new(pow_of_16), trace[11][i]);
+        assert_eq!(Felt::new(b & 1), trace[6][i]);
+        assert_eq!(Felt::new((b >> 1) & 1), trace[7][i]);
+        assert_eq!(Felt::new((b >> 2) & 1), trace[8][i]);
+        assert_eq!(Felt::new((b >> 3) & 1), trace[9][i]);
 
-        a >>= 4;
-        b >>= 4;
-        pow_of_16 <<= 4;
+        bit_offset -= 4;
     }
 }
 

--- a/processor/src/bitwise/tests.rs
+++ b/processor/src/bitwise/tests.rs
@@ -1,0 +1,290 @@
+use super::{Bitwise, Felt, StarkField, TraceFragment};
+use rand_utils::rand_value;
+
+#[test]
+fn bitwise_init() {
+    let bitwise = Bitwise::new();
+    assert_eq!(0, bitwise.trace_len());
+}
+
+#[test]
+fn bitwise_and() {
+    let mut bitwise = Bitwise::new();
+
+    let a = rand_u32();
+    let b = rand_u32();
+
+    let (address, result) = bitwise.u32and(a, b).unwrap();
+    assert_eq!(Felt::new(0), address);
+    assert_eq!(a.as_int() & b.as_int(), result.as_int());
+
+    // --- check generated trace ----------------------------------------------
+    let num_rows = 8;
+    let mut trace = (0..13)
+        .map(|_| vec![Felt::new(0); num_rows])
+        .collect::<Vec<_>>();
+    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
+
+    bitwise.fill_trace(&mut fragment);
+
+    // make sure result and result from the trace are the same
+    assert_eq!(result, trace[12][7]);
+
+    // make sure values a and b were decomposed correctly
+    check_decomposition(&trace, 0, a.as_int(), b.as_int());
+
+    // make sure the result was re-composed correctly
+    let mut prev_result = Felt::new(0);
+
+    for i in 0..8 {
+        let c0 = binary_and(trace[3][i], trace[7][i]);
+        let c1 = binary_and(trace[4][i], trace[8][i]);
+        let c2 = binary_and(trace[5][i], trace[9][i]);
+        let c3 = binary_and(trace[6][i], trace[10][i]);
+
+        let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
+        let result = prev_result + result_4_bit * trace[11][i];
+        assert_eq!(result, trace[12][i]);
+
+        prev_result = result;
+    }
+}
+
+#[test]
+fn bitwise_or() {
+    let mut bitwise = Bitwise::new();
+
+    let a = rand_u32();
+    let b = rand_u32();
+
+    let (address, result) = bitwise.u32or(a, b).unwrap();
+    assert_eq!(Felt::new(0), address);
+    assert_eq!(a.as_int() | b.as_int(), result.as_int());
+
+    // --- check generated trace ----------------------------------------------
+    let num_rows = 8;
+    let mut trace = (0..13)
+        .map(|_| vec![Felt::new(0); num_rows])
+        .collect::<Vec<_>>();
+    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
+
+    bitwise.fill_trace(&mut fragment);
+
+    // make sure result and result from the trace are the same
+    assert_eq!(result, trace[12][7]);
+
+    // make sure values a and b were decomposed correctly
+    check_decomposition(&trace, 0, a.as_int(), b.as_int());
+
+    // make sure the result was re-composed correctly
+    let mut prev_result = Felt::new(0);
+
+    for i in 0..8 {
+        let c0 = binary_or(trace[3][i], trace[7][i]);
+        let c1 = binary_or(trace[4][i], trace[8][i]);
+        let c2 = binary_or(trace[5][i], trace[9][i]);
+        let c3 = binary_or(trace[6][i], trace[10][i]);
+
+        let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
+        let result = prev_result + result_4_bit * trace[11][i];
+        assert_eq!(result, trace[12][i]);
+
+        prev_result = result;
+    }
+}
+
+#[test]
+fn bitwise_xor() {
+    let mut bitwise = Bitwise::new();
+
+    let a = rand_u32();
+    let b = rand_u32();
+
+    let (address, result) = bitwise.u32xor(a, b).unwrap();
+    assert_eq!(Felt::new(0), address);
+    assert_eq!(a.as_int() ^ b.as_int(), result.as_int());
+
+    // --- check generated trace ----------------------------------------------
+    let num_rows = 8;
+    let mut trace = (0..13)
+        .map(|_| vec![Felt::new(0); num_rows])
+        .collect::<Vec<_>>();
+    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
+
+    bitwise.fill_trace(&mut fragment);
+
+    // make sure result and result from the trace are the same
+    assert_eq!(result, trace[12][7]);
+
+    // make sure values a and b were decomposed correctly
+    check_decomposition(&trace, 0, a.as_int(), b.as_int());
+
+    // make sure the result was re-composed correctly
+    let mut prev_result = Felt::new(0);
+
+    for i in 0..8 {
+        let c0 = binary_xor(trace[3][i], trace[7][i]);
+        let c1 = binary_xor(trace[4][i], trace[8][i]);
+        let c2 = binary_xor(trace[5][i], trace[9][i]);
+        let c3 = binary_xor(trace[6][i], trace[10][i]);
+
+        let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
+        let result = prev_result + result_4_bit * trace[11][i];
+        assert_eq!(result, trace[12][i]);
+
+        prev_result = result;
+    }
+}
+
+#[test]
+fn bitwise_multiple() {
+    let mut bitwise = Bitwise::new();
+
+    let a = [rand_u32(), rand_u32(), rand_u32(), rand_u32()];
+    let b = [rand_u32(), rand_u32(), rand_u32(), rand_u32()];
+
+    // first operation: AND
+    let (address, result0) = bitwise.u32and(a[0], b[0]).unwrap();
+    assert_eq!(Felt::new(0), address);
+    assert_eq!(a[0].as_int() & b[0].as_int(), result0.as_int());
+
+    // second operation: OR
+    let (address, result1) = bitwise.u32or(a[1], b[1]).unwrap();
+    assert_eq!(Felt::new(8), address);
+    assert_eq!(a[1].as_int() | b[1].as_int(), result1.as_int());
+
+    // third operation: XOR
+    let (address, result2) = bitwise.u32xor(a[2], b[2]).unwrap();
+    assert_eq!(Felt::new(16), address);
+    assert_eq!(a[2].as_int() ^ b[2].as_int(), result2.as_int());
+
+    // fourth operation: AND
+    let (address, result3) = bitwise.u32and(a[3], b[3]).unwrap();
+    assert_eq!(Felt::new(24), address);
+    assert_eq!(a[3].as_int() & b[3].as_int(), result3.as_int());
+
+    // --- check generated trace ----------------------------------------------
+    let num_rows = 32;
+    let mut trace = (0..13)
+        .map(|_| vec![Felt::new(0); num_rows])
+        .collect::<Vec<_>>();
+    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
+
+    bitwise.fill_trace(&mut fragment);
+
+    // make sure results and results from the trace are the same
+    assert_eq!(result0, trace[12][7]);
+    assert_eq!(result1, trace[12][15]);
+    assert_eq!(result2, trace[12][23]);
+    assert_eq!(result3, trace[12][31]);
+
+    // make sure input values were decomposed correctly
+    check_decomposition(&trace, 0, a[0].as_int(), b[0].as_int());
+    check_decomposition(&trace, 8, a[1].as_int(), b[1].as_int());
+    check_decomposition(&trace, 16, a[2].as_int(), b[2].as_int());
+    check_decomposition(&trace, 24, a[3].as_int(), b[3].as_int());
+
+    // make sure the results was re-composed correctly
+
+    let mut prev_result = Felt::new(0);
+    for i in 0..8 {
+        let c0 = binary_and(trace[3][i], trace[7][i]);
+        let c1 = binary_and(trace[4][i], trace[8][i]);
+        let c2 = binary_and(trace[5][i], trace[9][i]);
+        let c3 = binary_and(trace[6][i], trace[10][i]);
+
+        let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
+        let result = prev_result + result_4_bit * trace[11][i];
+        assert_eq!(result, trace[12][i]);
+
+        prev_result = result;
+    }
+
+    let mut prev_result = Felt::new(0);
+    for i in 8..16 {
+        let c0 = binary_or(trace[3][i], trace[7][i]);
+        let c1 = binary_or(trace[4][i], trace[8][i]);
+        let c2 = binary_or(trace[5][i], trace[9][i]);
+        let c3 = binary_or(trace[6][i], trace[10][i]);
+
+        let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
+        let result = prev_result + result_4_bit * trace[11][i];
+        assert_eq!(result, trace[12][i]);
+
+        prev_result = result;
+    }
+
+    let mut prev_result = Felt::new(0);
+    for i in 16..24 {
+        let c0 = binary_xor(trace[3][i], trace[7][i]);
+        let c1 = binary_xor(trace[4][i], trace[8][i]);
+        let c2 = binary_xor(trace[5][i], trace[9][i]);
+        let c3 = binary_xor(trace[6][i], trace[10][i]);
+
+        let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
+        let result = prev_result + result_4_bit * trace[11][i];
+        assert_eq!(result, trace[12][i]);
+
+        prev_result = result;
+    }
+
+    let mut prev_result = Felt::new(0);
+    for i in 24..32 {
+        let c0 = binary_and(trace[3][i], trace[7][i]);
+        let c1 = binary_and(trace[4][i], trace[8][i]);
+        let c2 = binary_and(trace[5][i], trace[9][i]);
+        let c3 = binary_and(trace[6][i], trace[10][i]);
+
+        let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
+        let result = prev_result + result_4_bit * trace[11][i];
+        assert_eq!(result, trace[12][i]);
+
+        prev_result = result;
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn check_decomposition(trace: &[Vec<Felt>], start: usize, mut a: u64, mut b: u64) {
+    let mut pow_of_16 = 1;
+
+    for i in start..start + 8 {
+        assert_eq!(Felt::new(i as u64), trace[0][i]);
+        assert_eq!(Felt::new(a), trace[1][i]);
+        assert_eq!(Felt::new(b), trace[2][i]);
+
+        assert_eq!(Felt::new(a & 1), trace[3][i]);
+        assert_eq!(Felt::new((a >> 1) & 1), trace[4][i]);
+        assert_eq!(Felt::new((a >> 2) & 1), trace[5][i]);
+        assert_eq!(Felt::new((a >> 3) & 1), trace[6][i]);
+
+        assert_eq!(Felt::new(b & 1), trace[7][i]);
+        assert_eq!(Felt::new((b >> 1) & 1), trace[8][i]);
+        assert_eq!(Felt::new((b >> 2) & 1), trace[9][i]);
+        assert_eq!(Felt::new((b >> 3) & 1), trace[10][i]);
+
+        assert_eq!(Felt::new(pow_of_16), trace[11][i]);
+
+        a >>= 4;
+        b >>= 4;
+        pow_of_16 <<= 4;
+    }
+}
+
+fn binary_and(a: Felt, b: Felt) -> Felt {
+    a * b
+}
+
+fn binary_or(a: Felt, b: Felt) -> Felt {
+    a + b - a * b
+}
+
+fn binary_xor(a: Felt, b: Felt) -> Felt {
+    a + b - Felt::new(2) * a * b
+}
+
+fn rand_u32() -> Felt {
+    let value = rand_value::<u64>() as u32 as u64;
+    Felt::new(value)
+}

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -18,6 +18,9 @@ use stack::Stack;
 mod hasher;
 use hasher::Hasher;
 
+mod bitwise;
+use bitwise::Bitwise;
+
 mod memory;
 use memory::Memory;
 
@@ -58,6 +61,7 @@ struct Process {
     decoder: Decoder,
     stack: Stack,
     hasher: Hasher,
+    bitwise: Bitwise,
     memory: Memory,
     advice: AdviceProvider,
 }
@@ -69,6 +73,7 @@ impl Process {
             decoder: Decoder::new(),
             stack: Stack::new(&inputs, 4),
             hasher: Hasher::new(),
+            bitwise: Bitwise::new(),
             memory: Memory::new(),
             advice: AdviceProvider::new(inputs),
         }

--- a/processor/src/memory/mod.rs
+++ b/processor/src/memory/mod.rs
@@ -30,7 +30,7 @@ const INIT_MEM_VALUE: Word = [Felt::ZERO; 4];
 ///   ctx   addr   clk   u0   u1   u2   u3   v0   v1   v2   v3   d0   d1   d_inv
 /// ├─────┴──────┴─────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴───────┤
 ///
-/// In the above:
+/// In the above, the meaning of the columns is as follows:
 /// - `ctx` contains context ID. Currently, context ID is always set to ZERO.
 /// - `addr` contains memory address. Values in this column must increase monotonically for a
 ///   given context but there can be gaps between two consecutive values of up to 2^32. Also,
@@ -87,7 +87,8 @@ impl Memory {
         self.trace.len()
     }
 
-    /// Returns length of execution trace required to describe this memory.
+    /// Returns length of execution trace required to describe all memory access operations
+    /// executed on the VM.
     pub fn trace_len(&self) -> usize {
         self.num_trace_rows
     }

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -156,7 +156,7 @@ impl Process {
 
         let b = self.stack.get(0);
         let a = self.stack.get(1);
-        let (_addr, result) = self.bitwise.u32and(a, b)?;
+        let result = self.bitwise.u32and(a, b)?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);
@@ -173,7 +173,7 @@ impl Process {
 
         let b = self.stack.get(0);
         let a = self.stack.get(1);
-        let (_addr, result) = self.bitwise.u32or(a, b)?;
+        let result = self.bitwise.u32or(a, b)?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);
@@ -190,7 +190,7 @@ impl Process {
 
         let b = self.stack.get(0);
         let a = self.stack.get(1);
-        let (_addr, result) = self.bitwise.u32xor(a, b)?;
+        let result = self.bitwise.u32xor(a, b)?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -154,9 +154,9 @@ impl Process {
     pub(super) fn op_u32and(&mut self) -> Result<(), ExecutionError> {
         self.stack.check_depth(2, "U32AND")?;
 
-        let b = self.stack.get(0).as_int();
-        let a = self.stack.get(1).as_int();
-        let result = Felt::new(a & b);
+        let b = self.stack.get(0);
+        let a = self.stack.get(1);
+        let (_addr, result) = self.bitwise.u32and(a, b)?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);
@@ -171,9 +171,9 @@ impl Process {
     pub(super) fn op_u32or(&mut self) -> Result<(), ExecutionError> {
         self.stack.check_depth(2, "U32OR")?;
 
-        let b = self.stack.get(0).as_int();
-        let a = self.stack.get(1).as_int();
-        let result = Felt::new(a | b);
+        let b = self.stack.get(0);
+        let a = self.stack.get(1);
+        let (_addr, result) = self.bitwise.u32or(a, b)?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);
@@ -188,9 +188,9 @@ impl Process {
     pub(super) fn op_u32xor(&mut self) -> Result<(), ExecutionError> {
         self.stack.check_depth(2, "U32XOR")?;
 
-        let b = self.stack.get(0).as_int();
-        let a = self.stack.get(1).as_int();
-        let result = Felt::new(a ^ b);
+        let b = self.stack.get(0);
+        let a = self.stack.get(1);
+        let (_addr, result) = self.bitwise.u32xor(a, b)?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -1,4 +1,5 @@
 use super::{Felt, FieldElement, Process, StackTrace, STACK_TOP_SIZE};
+use core::slice;
 use winterfell::Trace;
 
 // VM EXECUTION TRACE
@@ -21,6 +22,7 @@ impl ExecutionTrace {
             decoder: _,
             stack,
             hasher: _,
+            bitwise: _,
             memory: _,
             advice: _,
         } = process;
@@ -99,6 +101,11 @@ impl<'a> TraceFragment<'a> {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
+    /// Returns the number of columns in this execution trace fragment.
+    pub fn width(&self) -> usize {
+        self.data.len()
+    }
+
     /// Returns the number of rows in this execution trace fragment.
     pub fn len(&self) -> usize {
         self.data[0].len()
@@ -111,6 +118,11 @@ impl<'a> TraceFragment<'a> {
     #[inline(always)]
     pub fn set(&mut self, row_idx: usize, col_idx: usize, value: Felt) {
         self.data[col_idx][row_idx] = value;
+    }
+
+    /// Returns a mutable iterator the the columns of this fragment.
+    pub fn columns(&mut self) -> slice::IterMut<'_, &'a mut [Felt]> {
+        self.data.iter_mut()
     }
 
     // TEST METHODS


### PR DESCRIPTION
This PR implements trace generation for `u32` bitwise operations: AND, OR, XOR.

- [x] Implement bitwise operation controller
- [x] Add tests
- [x] Write docs