### PR TITLE
Implement assembly comparison operations for field elements

### DIFF
--- a/assembly/src/parsers/field_ops.rs
+++ b/assembly/src/parsers/field_ops.rs
@@ -242,3 +242,104 @@ pub fn parse_gt(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), Assem
 pub fn parse_gte(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
     unimplemented!()
 }
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eqw() {
+        // parse_eqw should return an error if called with an invalid or incorrect operation
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_pos = 0;
+
+        let op_too_long = Token::new("eqw.12", op_pos);
+        let expected = AssemblyError::extra_param(&op_too_long);
+        assert_eq!(
+            parse_eqw(&mut span_ops, &op_too_long).unwrap_err(),
+            expected
+        );
+
+        let op_mismatch = Token::new("eq", op_pos);
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "eqw");
+        assert_eq!(
+            parse_eqw(&mut span_ops, &op_mismatch).unwrap_err(),
+            expected
+        );
+    }
+
+    #[test]
+    fn lt() {
+        // parse_lt should return an error if called with an invalid or incorrect operation
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_pos = 0;
+
+        let op_too_long = Token::new("lt.1", op_pos);
+        let expected = AssemblyError::extra_param(&op_too_long);
+        assert_eq!(parse_lt(&mut span_ops, &op_too_long).unwrap_err(), expected);
+
+        let op_mismatch = Token::new("eq", op_pos);
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "lt");
+        assert_eq!(parse_lt(&mut span_ops, &op_mismatch).unwrap_err(), expected);
+    }
+
+    #[test]
+    fn lte() {
+        // parse_lte should return an error if called with an invalid or incorrect operation
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_pos = 0;
+
+        let op_too_long = Token::new("lte.5", op_pos);
+        let expected = AssemblyError::extra_param(&op_too_long);
+        assert_eq!(
+            parse_lte(&mut span_ops, &op_too_long).unwrap_err(),
+            expected
+        );
+
+        let op_mismatch = Token::new("lt", op_pos);
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "lte");
+        assert_eq!(
+            parse_lte(&mut span_ops, &op_mismatch).unwrap_err(),
+            expected
+        );
+    }
+
+    #[test]
+    fn gt() {
+        // parse_gt should return an error if called with an invalid or incorrect operation
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_pos = 0;
+
+        let op_too_long = Token::new("gt.0x10", op_pos);
+        let expected = AssemblyError::extra_param(&op_too_long);
+        assert_eq!(parse_gt(&mut span_ops, &op_too_long).unwrap_err(), expected);
+
+        let op_mismatch = Token::new("lt", op_pos);
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "gt");
+        assert_eq!(parse_gt(&mut span_ops, &op_mismatch).unwrap_err(), expected);
+    }
+
+    #[test]
+    fn gte() {
+        // parse_gte should return an error if called with an invalid or incorrect operation
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_pos = 0;
+
+        let op_too_long = Token::new("gte.25", op_pos);
+        let expected = AssemblyError::extra_param(&op_too_long);
+        assert_eq!(
+            parse_gte(&mut span_ops, &op_too_long).unwrap_err(),
+            expected
+        );
+
+        let op_mismatch = Token::new("lt", op_pos);
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "gte");
+        assert_eq!(
+            parse_gte(&mut span_ops, &op_mismatch).unwrap_err(),
+            expected
+        );
+    }
+}

--- a/assembly/src/parsers/field_ops.rs
+++ b/assembly/src/parsers/field_ops.rs
@@ -1,4 +1,7 @@
-use super::{parse_element_param, AssemblyError, BaseElement, FieldElement, Operation, Token};
+use super::{
+    parse_element_param, validate_op_len, AssemblyError, BaseElement, FieldElement, Operation,
+    Token,
+};
 
 // ASSERTIONS AND TESTS
 // ================================================================================================
@@ -218,29 +221,333 @@ pub fn parse_neq(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assemb
     Ok(())
 }
 
-// TODO: implement
-pub fn parse_eqw(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
-    unimplemented!()
+/// Appends the EQW operation to the span block to do an element-wise comparison of the top 2 words
+/// on the stack and push a value of 1 if they're equal or 0 otherwise. The original words are left
+/// on the stack.
+///
+/// # Errors
+/// Returns an error if the assembly operation token is malformed or incorrect.
+pub fn parse_eqw(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+    // validate operation
+    validate_op_len(op, 1, 0, 0)?;
+    if op.parts()[0] != "eqw" {
+        return Err(AssemblyError::unexpected_token(op, "eqw"));
+    }
+
+    span_ops.push(Operation::Eqw);
+
+    Ok(())
 }
 
-// TODO: implement
-pub fn parse_lt(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
-    unimplemented!()
+/// Appends operations to the span block to pop the top 2 elements off the stack and do a "less
+/// than" comparison. The stack is expected to be arranged as [b, a, ...] (from the top). A value
+/// of 1 is pushed onto the stack if a < b. Otherwise, 0 is pushed.
+///
+/// This operation takes 17 VM cycles.
+///
+/// # Errors
+/// Returns an error if the assembly operation token is malformed or incorrect.
+pub fn parse_lt(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+    // validate operation
+    validate_op_len(op, 1, 0, 0)?;
+    if op.parts()[0] != "lt" {
+        return Err(AssemblyError::unexpected_token(op, "lt"));
+    }
+
+    // Split both elements into high and low bits
+    // 3 cycles
+    split_elements(span_ops);
+
+    // compare the high bit values and put comparison result flags on the stack for eq and lt
+    // then reorder in preparation for the low-bit comparison (a_lo < b_lo)
+    // 9 cycles
+    check_lt_high_bits(span_ops);
+
+    // check a_lo < b_lo, resulting in 1 if true and 0 otherwise
+    // 3 cycles
+    check_lt(span_ops);
+
+    // combine low-bit and high-bit results
+    // 2 cycles
+    set_result(span_ops);
+
+    Ok(())
 }
 
-// TODO: implement
-pub fn parse_lte(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
-    unimplemented!()
+/// Appends operations to the span block to pop the top 2 elements off the stack and do a "less
+/// than or equal" comparison. The stack is expected to be arranged as [b, a, ...] (from the top).
+/// A value of 1 is pushed onto the stack if a <= b. Otherwise, 0 is pushed.
+///
+/// This operation takes 18 VM cycles.
+///
+/// # Errors
+/// Returns an error if the assembly operation token is malformed or incorrect.
+pub fn parse_lte(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+    // validate operation
+    validate_op_len(op, 1, 0, 0)?;
+    if op.parts()[0] != "lte" {
+        return Err(AssemblyError::unexpected_token(op, "lte"));
+    }
+
+    // Split both elements into high and low bits
+    // 3 cycles
+    split_elements(span_ops);
+
+    // compare the high bit values and put comparison result flags on the stack for eq and lt
+    // then reorder in preparation for the low-bit comparison (a_lo <= b_lo)
+    // 9 cycles
+    check_lt_high_bits(span_ops);
+
+    // check a_lo <= b_lo, resulting in 1 if true and 0 otherwise
+    // 4 cycles
+    check_lte(span_ops);
+
+    // combine low-bit and high-bit results
+    // 2 cycles
+    set_result(span_ops);
+
+    Ok(())
 }
 
-// TODO: implement
-pub fn parse_gt(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
-    unimplemented!()
+/// Appends operations to the span block to pop the top 2 elements off the stack and do a "greater
+/// than" comparison. The stack is expected to be arranged as [b, a, ...] (from the top). A value
+/// of 1 is pushed onto the stack if a > b. Otherwise, 0 is pushed.
+///
+/// This operation takes 18 VM cycles.
+///
+/// # Errors
+/// Returns an error if the assembly operation token is malformed or incorrect.
+pub fn parse_gt(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+    // validate operation
+    validate_op_len(op, 1, 0, 0)?;
+    if op.parts()[0] != "gt" {
+        return Err(AssemblyError::unexpected_token(op, "gt"));
+    }
+
+    // Split both elements into high and low bits
+    // 3 cycles
+    split_elements(span_ops);
+
+    // compare the high bit values and put comparison result flags on the stack for eq and gt
+    // then reorder in preparation for the low-bit comparison (b_lo < a_lo)
+    // 10 cycles
+    check_gt_high_bits(span_ops);
+
+    // check b_lo < a_lo, resulting in 1 if true and 0 otherwise
+    // 3 cycles
+    check_lt(span_ops);
+
+    // combine low-bit and high-bit results
+    // 2 cycles
+    set_result(span_ops);
+
+    Ok(())
 }
 
-// TODO: implement
-pub fn parse_gte(_span_ops: &mut Vec<Operation>, _op: &Token) -> Result<(), AssemblyError> {
-    unimplemented!()
+/// Appends operations to the span block to pop the top 2 elements off the stack and do a "greater
+/// than or equal" comparison. The stack is expected to be arranged as [b, a, ...] (from the top).
+/// A value of 1 is pushed onto the stack if a >= b. Otherwise, 0 is pushed.
+///
+/// This operation takes 19 VM cycles.
+///
+/// # Errors
+/// Returns an error if the assembly operation token is malformed or incorrect.
+pub fn parse_gte(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+    // validate operation
+    validate_op_len(op, 1, 0, 0)?;
+    if op.parts()[0] != "gte" {
+        return Err(AssemblyError::unexpected_token(op, "gte"));
+    }
+
+    // Split both elements into high and low bits
+    // 3 cycles
+    split_elements(span_ops);
+
+    // compare the high bit values and put comparison result flags on the stack for eq and gt
+    // then reorder in preparation for the low-bit comparison (b_lo <= a_lo)
+    // 10 cycles
+    check_gt_high_bits(span_ops);
+
+    // check b_lo <= a_lo, resulting in 1 if true and 0 otherwise
+    // 4 cycles
+    check_lte(span_ops);
+
+    // combine low-bit and high-bit results
+    // 2 cycles
+    set_result(span_ops);
+
+    Ok(())
+}
+
+// COMPARISON OPERATION HELPER FUNCTIONS
+// ================================================================================================
+
+/// Splits the top 2 elements on the stack into low and high 32-bit values and swaps their order.
+/// The expected starting state of the stack (from the top) is: [b, a, ...].
+///
+/// After these operations, the stack state will be: [a_hi, a_lo, b_hi, b_lo, ...].
+///
+/// This function takes 3 cycles.
+fn split_elements(span_ops: &mut Vec<Operation>) {
+    // stack: [b, a, ...] => [b_hi, b_lo, a, ...]
+    span_ops.push(Operation::U32split);
+    // => [a, b_hi, b_lo, ...]
+    span_ops.push(Operation::MovUp2);
+    // => [a_hi, a_lo, b_hi, b_lo, ...]
+    span_ops.push(Operation::U32split);
+}
+
+/// This is a helper function for comparison operations that perform a less-than check a < b
+/// between two field elements a and b. It expects both elements to be already split into upper and
+/// lower 32-bit values and arranged on the stack (from the top) as:
+/// [a_hi, a_lo, bi_hi, b_lo, ...].
+///
+/// It pops the high bit values of both elements, compares them, and pushes 2 flags: one for
+/// less-than and one for equality. Then it moves the flags down the stack, leaving the low bits at
+/// the top of the stack in the orientation required for a less-than check of the low bit values
+/// (a_lo < b_lo).
+///
+/// After this operation, the stack will look as follows (from the top):
+/// - b_lo
+/// - a_lo
+/// - hi_flag_eq: 1 if the high bit values were equal; 0 otherwise
+/// - hi_flag_lt: 1 if a's high-bit values were less than b's (a_hi < b_hi); 0 otherwise
+///
+/// This function takes 9 cycles.
+fn check_lt_high_bits(span_ops: &mut Vec<Operation>) {
+    // reorder the stack to check a_hi < b_hi
+    span_ops.push(Operation::MovUp2);
+
+    // simultaneously check a_hi < b_hi and a_hi = b_hi, resulting in:
+    // - an equality flag of 1 if a_hi = b_hi and 0 otherwise (at stack[0])
+    // - a less-than flag of 1 if a_hi > b_hi and 0 otherwise (at stack[1])
+    check_lt_and_eq(span_ops);
+
+    // reorder the stack to prepare for low-bit comparison (a_lo < b_lo)
+    span_ops.push(Operation::MovUp2);
+    span_ops.push(Operation::MovUp3);
+}
+
+/// This is a helper function for comparison operations that perform a greater-than check a > b
+/// between two field elements a and b. It expects both elements to be already split into upper and
+/// lower 32-bit values and arranged on the stack (from the top) as:
+/// [a_hi, a_lo, bi_hi, b_lo, ...].
+///
+/// It pops the high bit values of both elements, compares them, and pushes 2 flags: one for
+/// greater-than and one for equality. Then it moves the flags down the stack, leaving the low bits at
+/// the top of the stack in the orientation required for a greater-than check of the low bit values
+/// (a_lo > b_lo).
+///
+/// After this operation, the stack will look as follows (from the top):
+/// - a_lo
+/// - b_lo
+/// - hi_flag_eq: 1 if the high bit values were equal; 0 otherwise
+/// - hi_flag_gt: 1 if a's high-bit values were greater than b's (a_hi > b_hi); 0 otherwise
+///
+/// This function takes 10 cycles.
+fn check_gt_high_bits(span_ops: &mut Vec<Operation>) {
+    // reorder the stack to check b_hi < a_hi
+    span_ops.push(Operation::Swap);
+    span_ops.push(Operation::MovDn2);
+
+    // simultaneously check b_hi < a_hi and b_hi = a_hi, resulting in:
+    // - an equality flag of 1 if a_hi = b_hi and 0 otherwise (at stack[0])
+    // - a greater-than flag of 1 if a_hi > b_hi and 0 otherwise (at stack[1])
+    check_lt_and_eq(span_ops);
+
+    // reorder the stack to prepare for low-bit comparison (b_lo < a_lo)
+    span_ops.push(Operation::MovUp3);
+    span_ops.push(Operation::MovUp3);
+}
+
+/// Appends operations to the span block to emulate a "less than" conditional and check that a < b
+/// for a starting stack of [b, a, ...]. Pops both elements and leaves 1 on the stack if a < b and
+/// 0 otherwise.
+///
+/// This is implemented with the VM's ```U32sub``` op, which performs a subtraction and leaves the
+/// result and an underflow flag on the stack. When a < b, a - b will underflow, so the less-than
+/// condition will be true if the underflow flag is set.
+///
+/// This function takes 3 cycles.
+fn check_lt(span_ops: &mut Vec<Operation>) {
+    // calculate a - b
+    // stack: [b, a, ...] => [underflow_flag, result, ...]
+    span_ops.push(Operation::U32sub);
+
+    // drop the result, since it's not needed
+    span_ops.push(Operation::Swap);
+    span_ops.push(Operation::Drop);
+}
+
+/// Appends operations to the span block to emulate a "less than or equal" conditional and check
+/// that a <= b for a starting stack of [b, a, ...]. Pops both elements and leaves 1 on the stack
+/// if a <= b and 0 otherwise.
+///
+/// This is implemented with the VM's ```U32sub``` op, which performs a subtraction and leaves the
+/// result and an underflow flag on the stack. When a < b, a - b will underflow, so the less-than
+/// condition will be true if the underflow flag is set. The equal condition will be true if
+/// there was no underflow and the result is 0.
+///
+/// This function takes 4 cycles.
+fn check_lte(span_ops: &mut Vec<Operation>) {
+    // calculate a - b
+    // stack: [b, a, ...] => [underflow_flag, result, ...]
+    span_ops.push(Operation::U32sub);
+
+    // check the result
+    span_ops.push(Operation::Swap);
+    span_ops.push(Operation::Eqz);
+
+    // set the lte flag if the underflow flag was set or the result was 0
+    span_ops.push(Operation::Or);
+}
+
+/// Appends operations to the span block to simultaneously check both the "less than" condition
+/// (a < b) and equality (a = b) and push a separate flag onto the stack for each result.
+///
+/// The expected stack (from the top) is: [b, a, ...].
+/// - Pushes 1 on the stack if a < b and 0 otherwise.
+/// - Pushes 1 on the stack if a = b and 0 otherwise.
+///
+/// The resulting stack after this operation is: [eq_flag, lt_flag, ...].
+///
+/// This function takes 6 cycles.
+fn check_lt_and_eq(span_ops: &mut Vec<Operation>) {
+    // calculate a - b
+    // stack: [b, a, ...] => [underflow_flag, result, ...]
+    span_ops.push(Operation::U32sub);
+
+    // Put 1 on the stack if the underflow flag was not set (there was no underflow)
+    span_ops.push(Operation::Dup0);
+    span_ops.push(Operation::Not);
+
+    // move the result to the top of the stack and check if it was zero
+    span_ops.push(Operation::MovUp2);
+    span_ops.push(Operation::Eqz);
+
+    // set the equality flag to 1 if there was no underflow and the result was zero
+    span_ops.push(Operation::And)
+}
+
+/// This is a helper function to combine the high-bit and low-bit comparison checks into a single
+/// result flag.
+///
+/// Since we're working with a 64-bit field modulus, we need to ensure that valid field elements
+/// represented by > 32 bits are still compared properly. High bit comparisons take precedence, so
+/// we only care about the result of the low-bit value comparison when the high bits were equal.
+///
+/// The stack is expected to be arranged as follows (from the top):
+/// - low-bit comparison flag: 1 if the lt/lte/gt/gte condition being checked was true; 0 otherwise
+/// - high-bit equality flag: 1 if the high bits were equal; 0 otherwise
+/// - high-bit comparison flag: 1 if the lt/gt condition being checked was true; 0 otherwise
+///
+/// This function takes 2 cycles.
+fn set_result(span_ops: &mut Vec<Operation>) {
+    // check if high bits are equal AND low bit comparison condition was true
+    span_ops.push(Operation::And);
+
+    // Set the result flag if the above check passed OR the high-bit comparison was true
+    span_ops.push(Operation::Or);
 }
 
 // TESTS

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -27,3 +27,4 @@ winter-utils = { package = "winter-utils", version = "0.3", default-features = f
 [dev-dependencies]
 rand-utils = { package = "winter-rand-utils", version = "0.3" }
 assembly = { package = "miden-assembly", path = "../assembly", version = "0.2", default-features = false }
+proptest = "1.0.0"

--- a/processor/src/tests/field_ops.rs
+++ b/processor/src/tests/field_ops.rs
@@ -1,0 +1,310 @@
+use super::{super::execute, build_inputs, build_stack_state, compile};
+use proptest::prelude::*;
+use vm_core::{Felt, StarkField};
+
+// FIELD OPS COMPARISON - MANUAL TESTS
+// ================================================================================================
+
+#[test]
+fn eq() {
+    let script = compile("begin eq end");
+
+    // --- test when two elements are equal ------------------------------------------------------
+    let inputs = build_inputs(&[100, 100]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    let expected_state = build_stack_state(&[1]);
+    assert_eq!(expected_state, last_state);
+
+    // --- test when two elements are unequal ----------------------------------------------------
+    let inputs = build_inputs(&[100, 25]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    let expected_state = build_stack_state(&[0]);
+    assert_eq!(expected_state, last_state);
+
+    // --- test when two u64s are unequal but their felts are equal ------------------------------
+    let a = Felt::MODULUS + 1;
+    let b = 1;
+
+    let inputs = build_inputs(&[b, a]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    let expected_state = build_stack_state(&[1]);
+    assert_eq!(expected_state, last_state);
+}
+
+#[test]
+fn eqw() {
+    let script = compile("begin eqw end");
+
+    // --- test when top two words are equal ------------------------------------------------------
+    let mut values = vec![2, 3, 4, 5, 2, 3, 4, 5];
+    let inputs = build_inputs(&values);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    values.insert(0, 1);
+    let expected_state = build_stack_state(&values);
+    assert_eq!(expected_state, last_state);
+
+    // --- test when top two words are not equal --------------------------------------------------
+    let mut values = vec![1, 2, 3, 4, 5, 6, 7, 8];
+    let inputs = build_inputs(&values);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    values.insert(0, 0);
+    let expected_state = build_stack_state(&values);
+    assert_eq!(expected_state, last_state);
+}
+
+#[test]
+fn lt() {
+    // Results in 1 if a < b for a starting stack of [b, a, ...] and 0 otherwise
+    test_felt_comparison_op("lt", 1, 0, 0);
+}
+
+#[test]
+fn lte() {
+    // Results in 1 if a <= b for a starting stack of [b, a, ...] and 0 otherwise
+    test_felt_comparison_op("lte", 1, 1, 0);
+}
+
+#[test]
+fn gt() {
+    // Results in 1 if a > b for a starting stack of [b, a, ...] and 0 otherwise
+    test_felt_comparison_op("gt", 0, 0, 1);
+}
+
+#[test]
+fn gte() {
+    // Results in 1 if a >= b for a starting stack of [b, a, ...] and 0 otherwise
+    test_felt_comparison_op("gte", 0, 1, 1);
+}
+
+// HELPER FUNCTIONS FOR MANUAL TESTS
+// ================================================================================================
+
+/// This helper function runs an assembly field comparison operation (lt, lte, gt, gte) against a
+/// variety of field element pairs.
+//
+/// The assembly ops which compare multiple field elements work by splitting both elements and
+/// performing a comparison of the upper and lower 32-bit values for each element.
+/// Since we're working with a 64-bit field modulus, we need to ensure that valid field elements
+/// represented by > 32 bits are still compared properly, with high-bit values prioritized over low
+/// when they disagree.
+//
+/// In order for an encoded 64-bit value to be a valid field element while having bits set in
+/// both the high and low 32 bits, the upper 32 bits must not be all 1s. Therefore, for testing
+/// it's sufficient to use elements with one high bit and one low bit set.
+fn test_felt_comparison_op(asm_op: &str, expect_if_lt: u64, expect_if_eq: u64, expect_if_gt: u64) {
+    let script = compile(format!("begin {} end", asm_op).as_str());
+
+    // prepare the expected states with the provided values
+    let expected_state_lt = build_stack_state(&[expect_if_lt]);
+    let expected_state_eq = build_stack_state(&[expect_if_eq]);
+    let expected_state_gt = build_stack_state(&[expect_if_gt]);
+
+    // create vars with a variety of high and low bit relationships for testing
+    let low_bit = 1;
+    let high_bit = 1 << 48;
+
+    // a smaller field element with both a high and a low bit set
+    let smaller = high_bit + low_bit;
+    // element with high bits equal to "smaller" and low bits bigger
+    let hi_eq_lo_gt = smaller + low_bit;
+    // element with high bits bigger than "smaller" and low bits smaller
+    let hi_gt_lo_lt = high_bit << 1;
+    // element with high bits bigger than "smaller" and low bits equal
+    let hi_gt_lo_eq = hi_gt_lo_lt + low_bit;
+
+    // unequal integers expected to be equal as field elements
+    let a = Felt::MODULUS + 1;
+    let a_mod = 1_u64;
+
+    // --- a < b ----------------------------------------------------------------------------------
+    // a is smaller in the low bits (equal in high bits)
+    let inputs = build_inputs(&[hi_eq_lo_gt, smaller]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_lt, last_state);
+
+    // a is smaller in the high bits and equal in the low bits
+    let inputs = build_inputs(&[hi_gt_lo_eq, smaller]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_lt, last_state);
+
+    // a is smaller in the high bits but bigger in the low bits
+    let inputs = build_inputs(&[hi_gt_lo_lt, smaller]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_lt, last_state);
+
+    // compare values above and below the field modulus
+    let inputs = build_inputs(&[a + 1, a_mod]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_lt, last_state);
+
+    // --- a = b ----------------------------------------------------------------------------------
+    // high and low bits are both set
+    let inputs = build_inputs(&[hi_gt_lo_eq, hi_gt_lo_eq]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_eq, last_state);
+
+    // compare values above and below the field modulus
+    let inputs = build_inputs(&[a, a_mod]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_eq, last_state);
+
+    // --- a > b ----------------------------------------------------------------------------------
+    // a is bigger in the low bits (equal in high bits)
+    let inputs = build_inputs(&[smaller, hi_eq_lo_gt]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_gt, last_state);
+
+    // a is bigger in the high bits and equal in the low bits
+    let inputs = build_inputs(&[smaller, hi_gt_lo_eq]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_gt, last_state);
+
+    // a is bigger in the high bits but smaller in the low bits
+    let inputs = build_inputs(&[smaller, hi_gt_lo_lt]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_gt, last_state);
+
+    // compare values above and below the field modulus
+    let inputs = build_inputs(&[a, a_mod + 1]);
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+    assert_eq!(expected_state_gt, last_state);
+}
+
+// FIELD OPS COMPARISON - RANDOMIZED TESTS
+// ================================================================================================
+
+const WORD_LEN: usize = 4;
+
+// This is a proptest strategy for generating a random word of u64 values.
+fn rand_word() -> impl Strategy<Value = Vec<u64>> {
+    prop::collection::vec(any::<u64>(), WORD_LEN)
+}
+
+proptest! {
+    #[test]
+    fn eq_proptest(a in any::<u64>(), b in any::<u64>()) {
+        // test the eq assembly operation with randomized inputs
+        let script = compile("begin eq end");
+
+        let inputs = build_inputs(&[b, a]);
+        let trace = execute(&script, &inputs).unwrap();
+        let last_state = trace.last_stack_state();
+
+        // compare the random a & b values modulo the field modulus to get the expected result
+        let expected_result = if a % Felt::MODULUS == b % Felt::MODULUS { 1 } else { 0 };
+        let expected_state = build_stack_state(&[expected_result]);
+
+        prop_assert_eq!(expected_state, last_state);
+    }
+
+    #[test]
+    fn eqw_proptest(w1 in rand_word(), w2 in rand_word()) {
+        // test the eqw assembly operation with randomized inputs
+        let script = compile("begin eqw end");
+
+        // 2 words (8 values) for comparison and 1 for the result
+        let mut values = vec![0; 2 * WORD_LEN + 1];
+
+        // check the inputs for equality in the field
+        let mut inputs_equal = true;
+        for (i, (a, b)) in w1.iter().zip(w2.iter()).enumerate() {
+            // if any of the values are unequal in the field, then the words will be unequal
+            if *a % Felt::MODULUS != *b % Felt::MODULUS {
+                inputs_equal = false;
+            }
+            // add the values to the vector
+            values[i] = *a;
+            values[i + WORD_LEN] = *b;
+        }
+
+        let inputs = build_inputs(&values);
+        let trace = execute(&script, &inputs).unwrap();
+        let last_state = trace.last_stack_state();
+
+        // add the expected result to get the expected state
+        let expected_result = if inputs_equal { 1 } else { 0 };
+        values.insert(0, expected_result);
+        let expected_state = build_stack_state(&values);
+
+        prop_assert_eq!(expected_state, last_state);
+    }
+
+    #[test]
+    fn lt_proptest(a in any::<u64>(), b in any::<u64>()) {
+        // test the less-than assembly operation with randomized inputs
+        let script = compile("begin lt end");
+
+        let inputs = build_inputs(&[b, a]);
+        let trace = execute(&script, &inputs).unwrap();
+        let last_state = trace.last_stack_state();
+
+        // compare the random a & b values modulo the field modulus to get the expected result
+        let expected_result = if a % Felt::MODULUS < b % Felt::MODULUS { 1 } else { 0 };
+        let expected_state = build_stack_state(&[expected_result]);
+
+        prop_assert_eq!(expected_state, last_state);
+    }
+
+    #[test]
+    fn lte_proptest(a in any::<u64>(), b in any::<u64>()) {
+        // test the less-than-or-equal assembly operation with randomized inputs
+        let script = compile("begin lte end");
+
+        let inputs = build_inputs(&[b, a]);
+        let trace = execute(&script, &inputs).unwrap();
+        let last_state = trace.last_stack_state();
+
+        // compare the random a & b values modulo the field modulus to get the expected result
+        let expected_result = if a % Felt::MODULUS <= b % Felt::MODULUS { 1 } else { 0 };
+        let expected_state = build_stack_state(&[expected_result]);
+
+        prop_assert_eq!(expected_state, last_state);
+    }
+
+    #[test]
+    fn gt_proptest(a in any::<u64>(), b in any::<u64>()) {
+        // test the greater-than assembly operation with randomized inputs
+        let script = compile("begin gt end");
+
+        let inputs = build_inputs(&[b, a]);
+        let trace = execute(&script, &inputs).unwrap();
+        let last_state = trace.last_stack_state();
+
+        // compare the random a & b values modulo the field modulus to get the expected result
+        let expected_result = if a % Felt::MODULUS > b % Felt::MODULUS { 1 } else { 0 };
+        let expected_state = build_stack_state(&[expected_result]);
+
+        prop_assert_eq!(expected_state, last_state);
+    }
+
+    #[test]
+    fn gte_proptest(a in any::<u64>(), b in any::<u64>()) {
+        // test the greater-than-or-equal assembly operation with randomized inputs
+        let script = compile("begin gte end");
+
+        let inputs = build_inputs(&[b, a]);
+        let trace = execute(&script, &inputs).unwrap();
+        let last_state = trace.last_stack_state();
+
+        // compare the random a & b values modulo the field modulus to get the expected result
+        let expected_result = if a % Felt::MODULUS >= b % Felt::MODULUS { 1 } else { 0 };
+        let expected_state = build_stack_state(&[expected_result]);
+
+        prop_assert_eq!(expected_state, last_state);
+    }
+}

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -2,6 +2,7 @@ use super::{Felt, FieldElement, ProgramInputs, Script, STACK_TOP_SIZE};
 use crate::Word;
 
 mod crypto_ops;
+mod field_ops;
 mod flow_control;
 
 // TESTS


### PR DESCRIPTION
This PR implements the field element comparison operations ```eqw```, ```lt```, ```lte```, ```gt```, ```gte``` and adds unit tests and execution tests in the processor. The cycle cost is higher than I had hoped, so I included the cost for each of the expensive ops in the comments.

The extra cost comes from the need to give precedence to the high bit values when comparisons between the high-bit and low-bit values disagree.

For example, during a less-than check:
- If the low-bit values pass the less-than check, but the high-bit values are greater, then the check should fail. However, if the high-bit values are equal, then the check should pass. In both cases the high-bit less-than check failed, but it leads to 2 different results. 
- Similarly, simply checking LTE for the high-bits is insufficient in the case where the low bits are greater and the high bits were equal.

This means that using 1-bit result flags from each of the 32-bit comparisons and then merging those flags with an ```OR``` or an ```AND``` was insufficient.

Possibly there's still a cheaper way and this just needs fresh eyes :)

