### PR TITLE
BLAKE3 using Miden Assembly

### DIFF
--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -30,3 +30,4 @@ assembly = { package = "miden-assembly", path = "../assembly", version = "0.2", 
 logtest = { version = "2.0.0", default-features = false  }
 proptest = "1.0.0"
 rand-utils = { package = "winter-rand-utils", version = "0.3" }
+blake3 = "1.3.1"

--- a/processor/src/tests/stdlib/crypto/blake3.rs
+++ b/processor/src/tests/stdlib/crypto/blake3.rs
@@ -1,0 +1,80 @@
+use crate::{execute, Felt, FieldElement, ProgramInputs, Script, STACK_TOP_SIZE};
+use vm_core::utils::IntoBytes;
+
+#[test]
+fn blake3_2_to_1_hash() {
+    let script = compile(
+        "
+    use.std::crypto::hashes::blake3
+
+    begin
+        exec.blake3::hash
+    end
+    ",
+    );
+
+    // prepare random input byte array
+    let i_digest_0: [u8; 32] = rand_utils::rand_array::<Felt, 4>().into_bytes();
+    let i_digest_1: [u8; 32] = rand_utils::rand_array::<Felt, 4>().into_bytes();
+
+    let mut i_digest = [0u8; 64];
+    i_digest[..32].copy_from_slice(&i_digest_0);
+    i_digest[32..].copy_from_slice(&i_digest_1);
+
+    // allocate space on stack so that bytes can be converted to blake3 words
+    let mut i_words = [0u64; STACK_TOP_SIZE];
+
+    // convert each of four consecutive little endian bytes (of input) to blake3 words
+    for i in 0..STACK_TOP_SIZE {
+        i_words[i] = from_le_bytes_to_words(&i_digest[i * 4..(i + 1) * 4]) as u64;
+    }
+    i_words.reverse();
+
+    // use blake3 crate to compute 2-to-1 digest of byte array
+    let digest = blake3::hash(&i_digest);
+
+    // prepare digest in desired blake3 word form so that assertion writing becomes easier
+    let digest_bytes = digest.as_bytes();
+    let mut digest_words = [0u64; STACK_TOP_SIZE >> 1];
+
+    // convert each of four consecutive little endian bytes (of digest) to blake3 words
+    for i in 0..(STACK_TOP_SIZE >> 1) {
+        digest_words[i] = from_le_bytes_to_words(&digest_bytes[i * 4..(i + 1) * 4]) as u64;
+    }
+
+    // finally execute miden program on VM
+    let inputs = ProgramInputs::new(&i_words, &[], Vec::new()).unwrap();
+    let trace = execute(&script, &inputs).unwrap();
+    let last_state = trace.last_stack_state();
+
+    // first 8 elements of stack top holds blake3 digest, while remaining 8 elements
+    // are zeroed
+    let digest_on_stack = convert_to_stack(&digest_words);
+    assert_eq!(digest_on_stack, last_state);
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn compile(source: &str) -> Script {
+    let assembler = assembly::Assembler::new();
+    assembler.compile_script(source).unwrap()
+}
+
+/// Takes an array of u64 values and builds a stack, perserving their order and converting them to
+/// field elements.
+fn convert_to_stack(values: &[u64]) -> [Felt; STACK_TOP_SIZE] {
+    let mut result = [Felt::ZERO; STACK_TOP_SIZE];
+    for (&value, result) in values.iter().zip(result.iter_mut()) {
+        *result = Felt::new(value);
+    }
+    result
+}
+
+/// Given a slice of four consecutive little endian bytes, interprets them as 32 -bit unsigned integer
+fn from_le_bytes_to_words(le_bytes: &[u8]) -> u32 {
+    ((le_bytes[3] as u32) << 24)
+        | ((le_bytes[2] as u32) << 16)
+        | ((le_bytes[1] as u32) << 8)
+        | ((le_bytes[0] as u32) << 0)
+}

--- a/processor/src/tests/stdlib/crypto/mod.rs
+++ b/processor/src/tests/stdlib/crypto/mod.rs
@@ -1,0 +1,1 @@
+mod blake3;

--- a/processor/src/tests/stdlib/mod.rs
+++ b/processor/src/tests/stdlib/mod.rs
@@ -1,3 +1,4 @@
 use super::{compile, test_script_execution};
 
+mod crypto;
 mod u64_mod;

--- a/stdlib/asm/crypto/hashes/blake3.masm
+++ b/stdlib/asm/crypto/hashes/blake3.masm
@@ -1,0 +1,962 @@
+proc.from_mem_to_stack.1
+    storew.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    pushw.mem # = b #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    pushw.mem # = a #
+end
+
+# initial hash state of blake3 when computing 2-to-1 hash i.e. two blake3 digests are being merged into single digest of 32 -bytes #
+# see https://github.com/itzmeanjan/blake3/blob/f07d32ec10cbc8a10663b7e6539e0b1dab3e453b/include/blake3.hpp#L1709-L1713 #
+proc.initialize_hash_state.1
+    popw.local.0
+
+    # blake3 initial values #
+    # see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792d8094f35c05c41c9aeb5dfe4aa67ca1ac/reference_impl/reference_impl.rs#L36-L38 #
+    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+
+    popw.mem
+
+    push.0x5BE0CD19.0x1F83D9AB.0x9B05688C.0x510E527F
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+
+    popw.mem
+
+    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+
+    popw.mem
+
+    # blake3 hash constants https://github.com/itzmeanjan/blake3/blob/1c58f6a343baee52ba1fe7fc98bfb280b6d567da/include/blake3_consts.hpp#L16-L20 #
+    push.11.64.0.0
+
+    pushw.local.0
+    drop
+    drop
+    drop
+
+    popw.mem
+end
+
+# permutes ordered message words, kept on stack top ( = sixteen 32 -bit BLAKE3 words ) #
+# such that next round of mixing can be applied #
+# after completion of permutation, message words are transferred back to stack top, in ordered form #
+# see https://github.com/itzmeanjan/blake3/blob/f07d32ec10cbc8a10663b7e6539e0b1dab3e453b/include/blake3.hpp#L1623-L1639 #
+proc.blake3_msg_words_permute.3
+    movup.2
+    movup.6
+    swap
+    movup.4
+    movup.10
+    swap
+    movup.3
+    movup.3
+
+    push.env.locaddr.0
+    popw.mem
+
+    movup.4
+    movup.3
+    movup.9
+    swap
+    movup.3
+    movup.3
+
+    push.env.locaddr.1
+    popw.mem
+
+    movup.4
+    swap
+    movup.5
+    movdn.2
+
+    push.env.locaddr.2
+    popw.mem
+
+    movdn.3
+
+    # bring message words back to stack, from local memory #
+    push.env.locaddr.2
+    pushw.mem
+    push.env.locaddr.1
+    pushw.mem
+    push.env.locaddr.0
+    pushw.mem
+end
+
+# this function computes final 32 -bytes digest from first 8 blake3 words of hash state, #
+# which is here represented as stack top of Miden VM i.e. top 8 elements of stack #
+# ( read top two words) are to be manipulated in this function so that after completion of #
+# execution of this function, first 8 elements of stack should hold desired blake3 hash #
+# #
+# see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#L116-L119 #
+# you'll notice I've skipped executing second statement in loop body of above hyperlinked implementation, #
+# that's because it doesn't dictate what output of 2-to-1 hash will be #
+proc.prepare_digest.0
+    dup.8
+    u32xor
+
+    dup.9
+    movup.2
+    u32xor
+    swap
+
+    dup.10
+    movup.3
+    u32xor
+    movdn.2
+
+    dup.11
+    movup.4
+    u32xor
+    movdn.3
+
+    dup.12
+    movup.5
+    u32xor
+    movdn.4
+
+    dup.13
+    movup.6
+    u32xor
+    movdn.5
+
+    dup.14
+    movup.7
+    u32xor
+    movdn.6
+
+    dup.15
+    movup.8
+    u32xor
+    movdn.7
+end
+
+# column-wise mixing #
+# see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792d8094f35c05c41c9aeb5dfe4aa67ca1ac/reference_impl/reference_impl.rs#L55-L59 #
+proc.columnar_mixing.1
+    pushw.mem
+    popw.local.0
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    pushw.mem # = b #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    pushw.mem # = a #
+
+    dup.4
+    movup.9
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+
+    dup.1
+    dup.6
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.2
+    drop
+
+    dup.2
+    dup.7
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.8
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    dupw.1    # copy a #
+
+    movup.4
+    u32xor
+    u32rotr.16
+    
+    swap
+    movup.4
+    u32xor
+    u32rotr.16
+    swap
+    
+    movup.2
+    movup.4
+    u32xor
+    u32rotr.16
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32xor
+    u32rotr.16
+    movdn.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    dupw.1    # copy d #
+
+    movup.4
+    u32add.unsafe
+    drop
+
+    swap
+    movup.4
+    u32add.unsafe
+    drop
+    swap
+    
+    movup.2
+    movup.4
+    u32add.unsafe
+    drop
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32add.unsafe
+    drop
+    movdn.3
+
+    # --- #
+
+    movupw.3
+    dupw.1
+    
+    movup.4
+    u32xor
+    u32rotr.12
+    
+    swap
+    movup.4
+    u32xor
+    u32rotr.12
+    swap
+    
+    movup.2
+    movup.4
+    u32xor
+    u32rotr.12
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32xor
+    u32rotr.12
+    movdn.3
+    
+    movdnw.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    popw.mem # = c #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    popw.mem # = d #
+
+    # --- #
+
+    dup.4
+    movup.9
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    
+    dup.1
+    dup.6
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.2
+    drop
+    
+    dup.2
+    dup.7
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+    
+    dup.3
+    dup.8
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    dupw.1        # copy a #
+    
+    movup.4
+    u32xor
+    u32rotr.8
+    
+    swap
+    movup.4
+    u32xor
+    u32rotr.8
+    swap
+    
+    movup.2
+    movup.4
+    u32xor
+    u32rotr.8
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32xor
+    u32rotr.8
+    movdn.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    dupw.1        # copy d #
+    
+    movup.4
+    u32add.unsafe
+    drop
+    
+    swap
+    movup.4
+    u32add.unsafe
+    drop
+    swap
+    
+    movup.2
+    movup.4
+    u32add.unsafe
+    drop
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32add.unsafe
+    drop
+    movdn.3
+
+    # --- #
+
+    movupw.3
+    dupw.1
+
+    movup.4
+    u32xor
+    u32rotr.7
+
+    swap
+    movup.4
+    u32xor
+    u32rotr.7
+    swap
+
+    movup.2
+    movup.4
+    u32xor
+    u32rotr.7
+    movdn.2
+
+    movup.3
+    movup.4
+    u32xor
+    u32rotr.7
+    movdn.3
+
+    movdnw.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    popw.mem # = c #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    popw.mem # = d #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    popw.mem # = a #
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    popw.mem # = b #
+end
+
+# diagonal-wise mixing #
+# see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792d8094f35c05c41c9aeb5dfe4aa67ca1ac/reference_impl/reference_impl.rs#L60-L64 #
+proc.diagonal_mixing.1
+    pushw.mem
+    popw.local.0
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    pushw.mem # = b #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    pushw.mem # = a #
+
+    dup.5
+    movup.9
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+
+    dup.1
+    dup.7
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.2
+    drop
+
+    dup.2
+    dup.8
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    dup.3
+    dup.5
+    u32xor
+    u32rotr.16
+    swap.4
+    drop
+
+    dup.5
+    u32xor
+    u32rotr.16
+
+    swap
+    dup.6
+    u32xor
+    u32rotr.16
+    swap
+
+    dup.2
+    dup.8
+    u32xor
+    u32rotr.16
+    swap.3
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    dup.2
+    dup.8
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    dup.5
+    u32add.unsafe
+    drop
+
+    swap
+    dup.6
+    u32add.unsafe
+    drop
+    swap
+
+    # --- #
+
+    movupw.3
+
+    swap
+    dup.6
+    u32xor
+    u32rotr.12
+    swap
+
+    dup.2
+    dup.8
+    u32xor
+    u32rotr.12
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    u32xor
+    u32rotr.12
+    swap.4
+    drop
+
+    dup.5
+    u32xor
+    u32rotr.12
+
+    movdnw.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    popw.mem # = c #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    popw.mem # = d #
+
+    # --- #
+
+    dup.5
+    movup.9
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+
+    dup.1
+    dup.7
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.2
+    drop
+
+    dup.2
+    dup.8
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    dup.3
+    dup.5
+    u32xor
+    u32rotr.8
+    swap.4
+    drop
+
+    dup.5
+    u32xor
+    u32rotr.8
+
+    swap
+    dup.6
+    u32xor
+    u32rotr.8
+    swap
+
+    dup.2
+    dup.8
+    u32xor
+    u32rotr.8
+    swap.3
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    dup.2
+    dup.8
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    dup.5
+    u32add.unsafe
+    drop
+
+    swap
+    dup.6
+    u32add.unsafe
+    drop
+    swap
+
+    # --- #
+
+    movupw.3
+
+    swap
+    dup.6
+    u32xor
+    u32rotr.7
+    swap
+
+    dup.2
+    dup.8
+    u32xor
+    u32rotr.7
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    u32xor
+    u32rotr.7
+    swap.4
+    drop
+
+    dup.5
+    u32xor
+    u32rotr.7
+
+    movdnw.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    popw.mem # = c #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    popw.mem # = d #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    popw.mem # = a #
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    popw.mem # = b #
+end
+
+proc.prepare_columnar_mixing_in_words.0
+    dupw.1
+    dupw.1
+
+    movup.6
+    movup.5
+    movup.4
+    movup.3
+end
+
+proc.prepare_diagonal_mixing_in_words.0
+    dupw.3
+    dupw.3
+
+    movup.6
+    movup.5
+    movup.4
+    movup.3
+end
+
+# see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#L54-L65 #
+proc.round.1
+    pushw.mem
+    popw.local.0
+
+    # --- columnar mixing --- #
+    # equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#L55-L59 #
+    exec.prepare_columnar_mixing_in_words
+    push.env.locaddr.0
+    exec.columnar_mixing
+
+    # --- diagonal mixing --- #
+    # equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#L60-L64 #
+    exec.prepare_diagonal_mixing_in_words
+    push.env.locaddr.0
+    exec.diagonal_mixing
+end
+
+# see https://github.com/itzmeanjan/blake3/blob/f07d32e/include/blake3.hpp#L1705-L1759 #
+proc.compress.1
+    popw.local.0
+
+    # round 0 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 1 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 2 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 3 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 4 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 5 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 6 #
+    push.env.locaddr.0
+    exec.round
+    # no permutation required after last round of mixing #
+end
+
+# blake3 2-to-1 hash function
+
+Input: First 16 elements of stack ( i.e. stack top ) holds 64 -bytes input digest, 
+  which is two blake3 digests concatenated next to each other
+  
+Output: First 8 elements of stack holds 32 -bytes blake3 digest, 
+  while remaining 8 elements of stack top are zeroed #
+export.hash.4
+    # initializing blake3 hash state for 2-to-1 hashing #
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.initialize_hash_state
+
+    # chunk compression, note only one chunk with one message block ( = 64 -bytes ) #
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.compress
+
+    # dropping mixed/ permuted input message words from stack top #
+    dropw
+    dropw
+    dropw
+    dropw
+
+    # bringing latest blake3 hash state from memory to stack #
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.from_mem_to_stack
+
+    # now preparing top 8 elements of stack, so that they contains #
+    # blake3 digest on input words #
+    exec.prepare_digest
+
+    movupw.3
+    movupw.3
+    dropw
+    dropw
+end

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -6,7 +6,969 @@
 #[rustfmt::skip]
 pub const MODULES: [(&str, &str); 3] = [
 // ----- std::crypto::hashes::blake3 --------------------------------------------------------------
-("std::crypto::hashes::blake3", ""),
+("std::crypto::hashes::blake3", "proc.from_mem_to_stack.1
+    storew.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    pushw.mem # = b #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    pushw.mem # = a #
+end
+
+# initial hash state of blake3 when computing 2-to-1 hash i.e. two blake3 digests are being merged into single digest of 32 -bytes #
+# see https://github.com/itzmeanjan/blake3/blob/f07d32ec10cbc8a10663b7e6539e0b1dab3e453b/include/blake3.hpp#L1709-L1713 #
+proc.initialize_hash_state.1
+    popw.local.0
+
+    # blake3 initial values #
+    # see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792d8094f35c05c41c9aeb5dfe4aa67ca1ac/reference_impl/reference_impl.rs#L36-L38 #
+    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+
+    popw.mem
+
+    push.0x5BE0CD19.0x1F83D9AB.0x9B05688C.0x510E527F
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+
+    popw.mem
+
+    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+
+    popw.mem
+
+    # blake3 hash constants https://github.com/itzmeanjan/blake3/blob/1c58f6a343baee52ba1fe7fc98bfb280b6d567da/include/blake3_consts.hpp#L16-L20 #
+    push.11.64.0.0
+
+    pushw.local.0
+    drop
+    drop
+    drop
+
+    popw.mem
+end
+
+# permutes ordered message words, kept on stack top ( = sixteen 32 -bit BLAKE3 words ) #
+# such that next round of mixing can be applied #
+# after completion of permutation, message words are transferred back to stack top, in ordered form #
+# see https://github.com/itzmeanjan/blake3/blob/f07d32ec10cbc8a10663b7e6539e0b1dab3e453b/include/blake3.hpp#L1623-L1639 #
+proc.blake3_msg_words_permute.3
+    movup.2
+    movup.6
+    swap
+    movup.4
+    movup.10
+    swap
+    movup.3
+    movup.3
+
+    push.env.locaddr.0
+    popw.mem
+
+    movup.4
+    movup.3
+    movup.9
+    swap
+    movup.3
+    movup.3
+
+    push.env.locaddr.1
+    popw.mem
+
+    movup.4
+    swap
+    movup.5
+    movdn.2
+
+    push.env.locaddr.2
+    popw.mem
+
+    movdn.3
+
+    # bring message words back to stack, from local memory #
+    push.env.locaddr.2
+    pushw.mem
+    push.env.locaddr.1
+    pushw.mem
+    push.env.locaddr.0
+    pushw.mem
+end
+
+# this function computes final 32 -bytes digest from first 8 blake3 words of hash state, #
+# which is here represented as stack top of Miden VM i.e. top 8 elements of stack #
+# ( read top two words) are to be manipulated in this function so that after completion of #
+# execution of this function, first 8 elements of stack should hold desired blake3 hash #
+# #
+# see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#L116-L119 #
+# you'll notice I've skipped executing second statement in loop body of above hyperlinked implementation, #
+# that's because it doesn't dictate what output of 2-to-1 hash will be #
+proc.prepare_digest.0
+    dup.8
+    u32xor
+
+    dup.9
+    movup.2
+    u32xor
+    swap
+
+    dup.10
+    movup.3
+    u32xor
+    movdn.2
+
+    dup.11
+    movup.4
+    u32xor
+    movdn.3
+
+    dup.12
+    movup.5
+    u32xor
+    movdn.4
+
+    dup.13
+    movup.6
+    u32xor
+    movdn.5
+
+    dup.14
+    movup.7
+    u32xor
+    movdn.6
+
+    dup.15
+    movup.8
+    u32xor
+    movdn.7
+end
+
+# column-wise mixing #
+# see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792d8094f35c05c41c9aeb5dfe4aa67ca1ac/reference_impl/reference_impl.rs#L55-L59 #
+proc.columnar_mixing.1
+    pushw.mem
+    popw.local.0
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    pushw.mem # = b #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    pushw.mem # = a #
+
+    dup.4
+    movup.9
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+
+    dup.1
+    dup.6
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.2
+    drop
+
+    dup.2
+    dup.7
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.8
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    dupw.1    # copy a #
+
+    movup.4
+    u32xor
+    u32rotr.16
+    
+    swap
+    movup.4
+    u32xor
+    u32rotr.16
+    swap
+    
+    movup.2
+    movup.4
+    u32xor
+    u32rotr.16
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32xor
+    u32rotr.16
+    movdn.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    dupw.1    # copy d #
+
+    movup.4
+    u32add.unsafe
+    drop
+
+    swap
+    movup.4
+    u32add.unsafe
+    drop
+    swap
+    
+    movup.2
+    movup.4
+    u32add.unsafe
+    drop
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32add.unsafe
+    drop
+    movdn.3
+
+    # --- #
+
+    movupw.3
+    dupw.1
+    
+    movup.4
+    u32xor
+    u32rotr.12
+    
+    swap
+    movup.4
+    u32xor
+    u32rotr.12
+    swap
+    
+    movup.2
+    movup.4
+    u32xor
+    u32rotr.12
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32xor
+    u32rotr.12
+    movdn.3
+    
+    movdnw.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    popw.mem # = c #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    popw.mem # = d #
+
+    # --- #
+
+    dup.4
+    movup.9
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    
+    dup.1
+    dup.6
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.2
+    drop
+    
+    dup.2
+    dup.7
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+    
+    dup.3
+    dup.8
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    dupw.1        # copy a #
+    
+    movup.4
+    u32xor
+    u32rotr.8
+    
+    swap
+    movup.4
+    u32xor
+    u32rotr.8
+    swap
+    
+    movup.2
+    movup.4
+    u32xor
+    u32rotr.8
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32xor
+    u32rotr.8
+    movdn.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    dupw.1        # copy d #
+    
+    movup.4
+    u32add.unsafe
+    drop
+    
+    swap
+    movup.4
+    u32add.unsafe
+    drop
+    swap
+    
+    movup.2
+    movup.4
+    u32add.unsafe
+    drop
+    movdn.2
+    
+    movup.3
+    movup.4
+    u32add.unsafe
+    drop
+    movdn.3
+
+    # --- #
+
+    movupw.3
+    dupw.1
+
+    movup.4
+    u32xor
+    u32rotr.7
+
+    swap
+    movup.4
+    u32xor
+    u32rotr.7
+    swap
+
+    movup.2
+    movup.4
+    u32xor
+    u32rotr.7
+    movdn.2
+
+    movup.3
+    movup.4
+    u32xor
+    u32rotr.7
+    movdn.3
+
+    movdnw.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    popw.mem # = c #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    popw.mem # = d #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    popw.mem # = a #
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    popw.mem # = b #
+end
+
+# diagonal-wise mixing #
+# see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792d8094f35c05c41c9aeb5dfe4aa67ca1ac/reference_impl/reference_impl.rs#L60-L64 #
+proc.diagonal_mixing.1
+    pushw.mem
+    popw.local.0
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    pushw.mem # = b #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    pushw.mem # = a #
+
+    dup.5
+    movup.9
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+
+    dup.1
+    dup.7
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.2
+    drop
+
+    dup.2
+    dup.8
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    dup.3
+    dup.5
+    u32xor
+    u32rotr.16
+    swap.4
+    drop
+
+    dup.5
+    u32xor
+    u32rotr.16
+
+    swap
+    dup.6
+    u32xor
+    u32rotr.16
+    swap
+
+    dup.2
+    dup.8
+    u32xor
+    u32rotr.16
+    swap.3
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    dup.2
+    dup.8
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    dup.5
+    u32add.unsafe
+    drop
+
+    swap
+    dup.6
+    u32add.unsafe
+    drop
+    swap
+
+    # --- #
+
+    movupw.3
+
+    swap
+    dup.6
+    u32xor
+    u32rotr.12
+    swap
+
+    dup.2
+    dup.8
+    u32xor
+    u32rotr.12
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    u32xor
+    u32rotr.12
+    swap.4
+    drop
+
+    dup.5
+    u32xor
+    u32rotr.12
+
+    movdnw.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    popw.mem # = c #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    popw.mem # = d #
+
+    # --- #
+
+    dup.5
+    movup.9
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+
+    dup.1
+    dup.7
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.2
+    drop
+
+    dup.2
+    dup.8
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    movup.10
+    u32add.unsafe
+    drop
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    pushw.mem # = d #
+
+    dup.3
+    dup.5
+    u32xor
+    u32rotr.8
+    swap.4
+    drop
+
+    dup.5
+    u32xor
+    u32rotr.8
+
+    swap
+    dup.6
+    u32xor
+    u32rotr.8
+    swap
+
+    dup.2
+    dup.8
+    u32xor
+    u32rotr.8
+    swap.3
+    drop
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    pushw.mem # = c #
+
+    dup.2
+    dup.8
+    u32add.unsafe
+    drop
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    u32add.unsafe
+    drop
+    swap.4
+    drop
+
+    dup.5
+    u32add.unsafe
+    drop
+
+    swap
+    dup.6
+    u32add.unsafe
+    drop
+    swap
+
+    # --- #
+
+    movupw.3
+
+    swap
+    dup.6
+    u32xor
+    u32rotr.7
+    swap
+
+    dup.2
+    dup.8
+    u32xor
+    u32rotr.7
+    swap.3
+    drop
+
+    dup.3
+    dup.5
+    u32xor
+    u32rotr.7
+    swap.4
+    drop
+
+    dup.5
+    u32xor
+    u32rotr.7
+
+    movdnw.3
+
+    # --- #
+
+    pushw.local.0
+    drop
+    drop
+    swap
+    drop
+    popw.mem # = c #
+
+    pushw.local.0
+    drop
+    drop
+    drop
+    popw.mem # = d #
+
+    pushw.local.0
+    repeat.3
+        swap
+        drop
+    end
+    popw.mem # = a #
+
+    pushw.local.0
+    drop
+    repeat.2
+        swap
+        drop
+    end
+    popw.mem # = b #
+end
+
+proc.prepare_columnar_mixing_in_words.0
+    dupw.1
+    dupw.1
+
+    movup.6
+    movup.5
+    movup.4
+    movup.3
+end
+
+proc.prepare_diagonal_mixing_in_words.0
+    dupw.3
+    dupw.3
+
+    movup.6
+    movup.5
+    movup.4
+    movup.3
+end
+
+# see https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#L54-L65 #
+proc.round.1
+    pushw.mem
+    popw.local.0
+
+    # --- columnar mixing --- #
+    # equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#L55-L59 #
+    exec.prepare_columnar_mixing_in_words
+    push.env.locaddr.0
+    exec.columnar_mixing
+
+    # --- diagonal mixing --- #
+    # equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#L60-L64 #
+    exec.prepare_diagonal_mixing_in_words
+    push.env.locaddr.0
+    exec.diagonal_mixing
+end
+
+# see https://github.com/itzmeanjan/blake3/blob/f07d32e/include/blake3.hpp#L1705-L1759 #
+proc.compress.1
+    popw.local.0
+
+    # round 0 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 1 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 2 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 3 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 4 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 5 #
+    push.env.locaddr.0
+    exec.round
+    exec.blake3_msg_words_permute
+
+    # round 6 #
+    push.env.locaddr.0
+    exec.round
+    # no permutation required after last round of mixing #
+end
+
+# blake3 2-to-1 hash function
+
+Input: First 16 elements of stack ( i.e. stack top ) holds 64 -bytes input digest, 
+  which is two blake3 digests concatenated next to each other
+  
+Output: First 8 elements of stack holds 32 -bytes blake3 digest, 
+  while remaining 8 elements of stack top are zeroed #
+export.hash.4
+    # initializing blake3 hash state for 2-to-1 hashing #
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.initialize_hash_state
+
+    # chunk compression, note only one chunk with one message block ( = 64 -bytes ) #
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.compress
+
+    # dropping mixed/ permuted input message words from stack top #
+    dropw
+    dropw
+    dropw
+    dropw
+
+    # bringing latest blake3 hash state from memory to stack #
+    push.env.locaddr.3
+    push.env.locaddr.2
+    push.env.locaddr.1
+    push.env.locaddr.0
+
+    exec.from_mem_to_stack
+
+    # now preparing top 8 elements of stack, so that they contains #
+    # blake3 digest on input words #
+    exec.prepare_digest
+
+    movupw.3
+    movupw.3
+    dropw
+    dropw
+end
+"),
 // ----- std::math::u256 --------------------------------------------------------------------------
 ("std::math::u256", "export.add_unsafe
     swapw.3


### PR DESCRIPTION
This PR implements BLAKE3 2-to-1 hash function for Miden `stdlib`. I'm using BLAKE3 reference [implementation](https://github.com/BLAKE3-team/BLAKE3/blob/da4c792d8094f35c05c41c9aeb5dfe4aa67ca1ac/reference_impl/reference_impl.rs), along with Miden Assembly [specification](https://hackmd.io/YDbjUVHTRn64F4LPelC-NA#Stack-manipulation), as guide.