### PR TITLE
Free memory pointer operations

### DIFF
--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -288,7 +288,7 @@ pub enum Operation {
     /// Removes the next element from the advice tape and pushes it onto the stack.
     Read,
 
-    /// Returns a a word (4 elements) from the advice tape and overwrites the top four stack
+    /// Removes a a word (4 elements) from the advice tape and overwrites the top four stack
     /// elements with it.
     ReadW,
 
@@ -299,6 +299,13 @@ pub enum Operation {
     /// Pops an element off the stack, interprets it as a memory address, and writes the remaining
     /// 4 elements at the top of the stack into memory at the specified address.
     StoreW,
+
+    /// Pops an element off the stack, adds the current value of the `fmp` register to it, and
+    /// pushes the result back onto the stack.
+    FmpAdd,
+
+    /// Pops an element off the stack and adds it to the current value of `fmp` register.
+    FmpUpdate,
 
     /// Pushes the current depth of the stack onto the stack.
     SDepth,
@@ -446,6 +453,9 @@ impl Operation {
             Self::Read => Some(0b0011_1100),
             Self::ReadW => Some(0b0011_1101),
 
+            Self::FmpAdd => Some(0b0011_1101),
+            Self::FmpUpdate => Some(0b0011_1101),
+
             Self::SDepth => Some(0b0011_1101),
 
             Self::RpPerm => Some(0b0011_1111),
@@ -583,6 +593,9 @@ impl fmt::Display for Operation {
 
             Self::LoadW => write!(f, "loadw"),
             Self::StoreW => write!(f, "storew"),
+
+            Self::FmpAdd => write!(f, "fmpadd"),
+            Self::FmpUpdate => write!(f, "fmpupdate"),
 
             Self::SDepth => write!(f, "sdepth"),
 

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -83,6 +83,17 @@ impl Process {
         Ok(())
     }
 
+    // FREE MEMORY POINTER
+    // --------------------------------------------------------------------------------------------
+
+    pub(super) fn op_fmpadd(&mut self) -> Result<(), ExecutionError> {
+        unimplemented!()
+    }
+
+    pub(super) fn op_fmpupdate(&mut self) -> Result<(), ExecutionError> {
+        unimplemented!()
+    }
+
     // ADVICE INPUTS
     // --------------------------------------------------------------------------------------------
 

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -118,6 +118,9 @@ impl Process {
             Operation::LoadW => self.op_loadw()?,
             Operation::StoreW => self.op_storew()?,
 
+            Operation::FmpAdd => self.op_fmpadd()?,
+            Operation::FmpUpdate => self.op_fmpupdate()?,
+
             Operation::SDepth => self.op_sdepth()?,
 
             // ----- cryptographic operations -----------------------------------------------------


### PR DESCRIPTION
This PR adds two new processor operations: `fmpadd` and `fmpupdate` and stubs out methods for their handling in the processor.

The operations are needed for easier management of local procedure variables as discussed in #73 