### PR TITLE
Add fmp register to processor and associated operations

### DIFF
--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -17,6 +17,13 @@ pub enum Operation {
     /// Pops the stack; if the popped value is not 1, execution fails.
     Assert,
 
+    /// Pops an element off the stack, adds the current value of the `fmp` register to it, and
+    /// pushes the result back onto the stack.
+    FmpAdd,
+
+    /// Pops an element off the stack and adds it to the current value of `fmp` register.
+    FmpUpdate,
+
     // ----- flow control operations --------------------------------------------------------------
     /// Marks the beginning of a join block.
     Join,
@@ -300,13 +307,6 @@ pub enum Operation {
     /// 4 elements at the top of the stack into memory at the specified address.
     StoreW,
 
-    /// Pops an element off the stack, adds the current value of the `fmp` register to it, and
-    /// pushes the result back onto the stack.
-    FmpAdd,
-
-    /// Pops an element off the stack and adds it to the current value of `fmp` register.
-    FmpUpdate,
-
     /// Pushes the current depth of the stack onto the stack.
     SDepth,
 
@@ -373,6 +373,9 @@ impl Operation {
         match self {
             Self::Noop => Some(0b0000_0000),
             Self::Assert => Some(0b0000_0001),
+
+            Self::FmpAdd => Some(0b0011_1101),
+            Self::FmpUpdate => Some(0b0011_1101),
 
             Self::Push(_) => Some(0b0000_0010),
 
@@ -453,9 +456,6 @@ impl Operation {
             Self::Read => Some(0b0011_1100),
             Self::ReadW => Some(0b0011_1101),
 
-            Self::FmpAdd => Some(0b0011_1101),
-            Self::FmpUpdate => Some(0b0011_1101),
-
             Self::SDepth => Some(0b0011_1101),
 
             Self::RpPerm => Some(0b0011_1111),
@@ -500,6 +500,9 @@ impl fmt::Display for Operation {
             // ----- system operations ------------------------------------------------------------
             Self::Noop => write!(f, "noop"),
             Self::Assert => write!(f, "assert"),
+
+            Self::FmpAdd => write!(f, "fmpadd"),
+            Self::FmpUpdate => write!(f, "fmpupdate"),
 
             // ----- flow control operations ------------------------------------------------------
             Self::Join => write!(f, "join"),
@@ -593,9 +596,6 @@ impl fmt::Display for Operation {
 
             Self::LoadW => write!(f, "loadw"),
             Self::StoreW => write!(f, "storew"),
-
-            Self::FmpAdd => write!(f, "fmpadd"),
-            Self::FmpUpdate => write!(f, "fmpupdate"),
 
             Self::SDepth => write!(f, "sdepth"),
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -15,4 +15,5 @@ pub enum ExecutionError {
     AdviceSetNotFound([u8; 32]),
     AdviceSetLookupFailed(AdviceSetError),
     AdviceSetUpdateFailed(AdviceSetError),
+    InvalidFmpValue(Felt, Felt),
 }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -9,6 +9,9 @@ use vm_core::{
 
 mod operations;
 
+mod system;
+use system::System;
+
 mod decoder;
 use decoder::Decoder;
 
@@ -59,7 +62,7 @@ pub fn execute(script: &Script, inputs: &ProgramInputs) -> Result<ExecutionTrace
 // ================================================================================================
 
 struct Process {
-    step: usize,
+    system: System,
     decoder: Decoder,
     stack: Stack,
     hasher: Hasher,
@@ -71,7 +74,7 @@ struct Process {
 impl Process {
     pub fn new(inputs: ProgramInputs) -> Self {
         Self {
-            step: 0,
+            system: System::new(4),
             decoder: Decoder::new(),
             stack: Stack::new(&inputs, 4),
             hasher: Hasher::new(),

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -62,7 +62,7 @@ impl Process {
 
         let a = self.stack.get(0);
         if a == Felt::ZERO {
-            return Err(ExecutionError::DivideByZero(self.step));
+            return Err(ExecutionError::DivideByZero(self.system.clk()));
         }
 
         self.stack.set(0, a.inv());

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -83,17 +83,6 @@ impl Process {
         Ok(())
     }
 
-    // FREE MEMORY POINTER
-    // --------------------------------------------------------------------------------------------
-
-    pub(super) fn op_fmpadd(&mut self) -> Result<(), ExecutionError> {
-        unimplemented!()
-    }
-
-    pub(super) fn op_fmpupdate(&mut self) -> Result<(), ExecutionError> {
-        unimplemented!()
-    }
-
     // ADVICE INPUTS
     // --------------------------------------------------------------------------------------------
 

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -143,7 +143,7 @@ impl Process {
 
     /// Increments the clock cycle for all components of the process.
     fn advance_clock(&mut self) {
-        self.step += 1;
+        self.system.advance_clock();
         self.stack.advance_clock();
         self.memory.advance_clock();
         self.advice.advance_clock();
@@ -151,6 +151,7 @@ impl Process {
 
     /// Makes sure there is enough memory allocated for the trace to accommodate a new clock cycle.
     fn ensure_trace_capacity(&mut self) {
+        self.system.ensure_trace_capacity();
         self.stack.ensure_trace_capacity();
     }
 

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -50,7 +50,7 @@ impl Process {
         let fmp = self.system.fmp();
 
         let new_fmp = fmp + offset;
-        if new_fmp.as_int() >= u32::MAX as u64 {
+        if new_fmp.as_int() > u32::MAX as u64 {
             return Err(ExecutionError::InvalidFmpValue(fmp, new_fmp));
         }
 
@@ -58,5 +58,100 @@ impl Process {
         self.stack.shift_left(1);
 
         Ok(())
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::{init_stack_with, Operation},
+        Felt, FieldElement, Process,
+    };
+
+    #[test]
+    fn op_fmpupdate() {
+        let mut process = Process::new_dummy();
+
+        // initial value of fmp register should be zero
+        assert_eq!(Felt::ZERO, process.system.fmp());
+
+        // increment fmp register
+        process.execute_op(Operation::Push(Felt::new(2))).unwrap();
+        process.execute_op(Operation::FmpUpdate).unwrap();
+        assert_eq!(Felt::new(2), process.system.fmp());
+
+        // increment fmp register again
+        process.execute_op(Operation::Push(Felt::new(3))).unwrap();
+        process.execute_op(Operation::FmpUpdate).unwrap();
+        assert_eq!(Felt::new(5), process.system.fmp());
+
+        // decrement fmp register
+        process.execute_op(Operation::Push(-Felt::new(3))).unwrap();
+        process.execute_op(Operation::FmpUpdate).unwrap();
+        assert_eq!(Felt::new(2), process.system.fmp());
+
+        // decrementing beyond zero should be an error
+        process.execute_op(Operation::Push(-Felt::new(3))).unwrap();
+        assert!(process.execute_op(Operation::FmpUpdate).is_err());
+
+        // going up to u32::MAX should be OK
+        let mut process = Process::new_dummy();
+        process
+            .execute_op(Operation::Push(Felt::new(u32::MAX as u64)))
+            .unwrap();
+        process.execute_op(Operation::FmpUpdate).unwrap();
+        assert_eq!(Felt::new(u32::MAX as u64), process.system.fmp());
+
+        // but going beyond that should be an error
+        let mut process = Process::new_dummy();
+        process
+            .execute_op(Operation::Push(Felt::new(u32::MAX as u64 + 1)))
+            .unwrap();
+        assert!(process.execute_op(Operation::FmpUpdate).is_err());
+
+        // should not affect the rest of the stack state
+        let mut process = Process::new_dummy();
+        init_stack_with(&mut process, &[2, 3]);
+        process.execute_op(Operation::FmpUpdate).unwrap();
+
+        let expected = build_expected(&[2]);
+        assert_eq!(expected, process.stack.trace_state());
+    }
+
+    #[test]
+    fn op_fmpadd() {
+        let mut process = Process::new_dummy();
+
+        // set value of fmp register
+        process.execute_op(Operation::Push(Felt::new(2))).unwrap();
+        process.execute_op(Operation::FmpUpdate).unwrap();
+
+        // compute address of the first local
+        process.execute_op(Operation::Push(-Felt::new(1))).unwrap();
+        process.execute_op(Operation::FmpAdd).unwrap();
+
+        let expected = build_expected(&[1]);
+        assert_eq!(expected, process.stack.trace_state());
+
+        // compute address of second local (also make sure that rest of stack is not affected)
+        process.execute_op(Operation::Push(-Felt::new(2))).unwrap();
+        process.execute_op(Operation::FmpAdd).unwrap();
+
+        let expected = build_expected(&[0, 1]);
+        assert_eq!(expected, process.stack.trace_state());
+    }
+
+    // HELPER FUNCTIONS
+    // --------------------------------------------------------------------------------------------
+
+    fn build_expected(values: &[u64]) -> [Felt; 16] {
+        let mut expected = [Felt::ZERO; 16];
+        for (&value, result) in values.iter().zip(expected.iter_mut()) {
+            *result = Felt::new(value);
+        }
+        expected
     }
 }

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -1,4 +1,4 @@
-use super::{ExecutionError, Felt, FieldElement, Process};
+use super::{ExecutionError, Felt, FieldElement, Process, StarkField};
 
 // SYSTEM OPERATIONS
 // ================================================================================================
@@ -11,9 +11,52 @@ impl Process {
     pub(super) fn op_assert(&mut self) -> Result<(), ExecutionError> {
         self.stack.check_depth(1, "ASSERT")?;
         if self.stack.get(0) != Felt::ONE {
-            return Err(ExecutionError::FailedAssertion(self.step));
+            return Err(ExecutionError::FailedAssertion(self.system.clk()));
         }
         self.stack.shift_left(1);
+        Ok(())
+    }
+
+    // FREE MEMORY POINTER
+    // --------------------------------------------------------------------------------------------
+
+    /// Pops an element off the stack, adds the current value of the `fmp` register to it, and
+    /// pushes the result back onto the stack.
+    ///
+    /// # Errors
+    /// Returns an error if the stack is empty.
+    pub(super) fn op_fmpadd(&mut self) -> Result<(), ExecutionError> {
+        self.stack.check_depth(1, "FMPADD")?;
+
+        let offset = self.stack.get(0);
+        let fmp = self.system.fmp();
+
+        self.stack.set(0, fmp + offset);
+        self.stack.copy_state(1);
+
+        Ok(())
+    }
+
+    /// Pops an element off the stack and adds it to the current value of `fmp` register.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// * The stack is empty.
+    /// * New value of `fmp` register is greater than or equal to 2^32.
+    pub(super) fn op_fmpupdate(&mut self) -> Result<(), ExecutionError> {
+        self.stack.check_depth(1, "FMPUPDATE")?;
+
+        let offset = self.stack.get(0);
+        let fmp = self.system.fmp();
+
+        let new_fmp = fmp + offset;
+        if new_fmp.as_int() >= u32::MAX as u64 {
+            return Err(ExecutionError::InvalidFmpValue(fmp, new_fmp));
+        }
+
+        self.system.set_fmp(new_fmp);
+        self.stack.shift_left(1);
+
         Ok(())
     }
 }

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -50,7 +50,6 @@ impl Stack {
     }
 
     /// Returns execution trace length for this stack.
-    #[allow(dead_code)]
     pub fn trace_length(&self) -> usize {
         self.trace[0].len()
     }

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -1,0 +1,81 @@
+use super::{Felt, FieldElement};
+
+// SYSTEM INFO
+// ================================================================================================
+
+/// System info container for the VM.
+///
+/// Currently, this keeps track of the clock cycle and free memory pointer registers.
+pub struct System {
+    clk: usize,
+    clk_trace: Vec<Felt>,
+    fmp: Felt,
+    fmp_trace: Vec<Felt>,
+}
+
+impl System {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new [System] struct with execution traces instantiated with the specified length.
+    pub fn new(init_trace_length: usize) -> Self {
+        Self {
+            clk: 0,
+            clk_trace: vec![Felt::ZERO; init_trace_length],
+            fmp: Felt::ZERO,
+            fmp_trace: vec![Felt::ZERO; init_trace_length],
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the current clock cycle of a process.
+    #[inline(always)]
+    pub fn clk(&self) -> usize {
+        self.clk
+    }
+
+    /// Returns the current value of the free memory pointer for a process.
+    #[inline(always)]
+    pub fn fmp(&self) -> Felt {
+        self.fmp
+    }
+
+    /// Returns execution trace length of for a process.
+    #[inline(always)]
+    pub fn trace_length(&self) -> usize {
+        self.clk_trace.len()
+    }
+
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Increments the clock cycle.
+    pub fn advance_clock(&mut self) {
+        self.clk += 1;
+        self.clk_trace[self.clk] = Felt::new(self.clk as u64);
+
+        self.fmp_trace[self.clk] = self.fmp;
+    }
+
+    /// Sets the value of free memory pointer for the next clock cycle.
+    pub fn set_fmp(&mut self, fmp: Felt) {
+        // we set only the current value of fmp here, the trace will be updated with this value
+        // when the clock cycle advances.
+        self.fmp = fmp;
+    }
+
+    // UTILITY METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Makes sure there is enough memory allocated for the trace to accommodate a new row.
+    ///
+    /// Trace length is doubled every time it needs to be increased.
+    pub fn ensure_trace_capacity(&mut self) {
+        if self.clk + 1 >= self.trace_length() {
+            let new_length = self.trace_length() * 2;
+            self.clk_trace.resize(new_length, Felt::ZERO);
+            self.fmp_trace.resize(new_length, Felt::ZERO);
+        }
+    }
+}

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -41,7 +41,7 @@ impl System {
         self.fmp
     }
 
-    /// Returns execution trace length of for a process.
+    /// Returns execution trace length for a process.
     #[inline(always)]
     pub fn trace_length(&self) -> usize {
         self.clk_trace.len()

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -18,7 +18,7 @@ impl ExecutionTrace {
     /// Builds an execution trace for the provided process.
     pub(super) fn new(process: Process) -> Self {
         let Process {
-            step,
+            system,
             decoder: _,
             stack,
             hasher: _,
@@ -27,6 +27,7 @@ impl ExecutionTrace {
             advice: _,
         } = process;
 
+        let step = system.clk();
         let mut stack_trace = stack.into_trace();
         for column in stack_trace.iter_mut() {
             finalize_column(column, step);


### PR DESCRIPTION
This PR addresses #83. Specifically, it implements processing of operations which read/write `fmp` register (`fmpadd` and `fmpupdate`). It also encapsulates system registers in a new `System` struct.

- [x] Implement processing of `fmp` operations
- [x] Add tests