### PR TITLE
Update Winterfell Rp64_256 version to improve hash op consistency

### DIFF
--- a/assembly/src/parsers/crypto_ops.rs
+++ b/assembly/src/parsers/crypto_ops.rs
@@ -377,33 +377,6 @@ mod tests {
     }
 
     #[test]
-    fn rphash() {
-        // adds a word to the stack specifying the number of elements to be hashed (8)
-        // does a rescue prime permutation
-        // keeps the top word as the result but drops the other 8 elements
-        let mut span_ops: Vec<Operation> = Vec::new();
-        let op = Token::new("rphash", 0);
-
-        // state of stack before permutation
-        let mut expected = vec![
-            Operation::Pad,
-            Operation::Pad,
-            Operation::Pad,
-            Operation::Push(BaseElement::new(8)),
-        ];
-        // rp permutation leaves stack as [A, B, C,...]
-        expected.push(Operation::RpPerm);
-        // swap A and C, since A is the result we want --> gives [C, B, A, ...]
-        expected.push(Operation::SwapW2);
-        // drop C, B
-        let drop8 = vec![Operation::Drop; 8];
-        expected.extend_from_slice(&drop8);
-
-        parse_rphash(&mut span_ops, &op).expect("Failed to parse rphash");
-        assert_eq!(span_ops, expected);
-    }
-
-    #[test]
     fn rphash_invalid() {
         // parse_rphash should return an error if called with an invalid or incorrect operation
         let mut span_ops: Vec<Operation> = Vec::new();

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,6 @@ default = ["std"]
 std = ["math/std", "winter-utils/std"]
 
 [dependencies]
-crypto = { package = "winter-crypto", version = "0.3.1", default-features = false }
+crypto = { package = "winter-crypto", version = "0.3.2", default-features = false }
 math = { package = "winter-math", version = "0.3", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.3", default-features = false }

--- a/core/src/hasher/mod.rs
+++ b/core/src/hasher/mod.rs
@@ -50,3 +50,9 @@ pub fn hash_elements(elements: &[Felt]) -> Digest {
 pub fn apply_round(state: &mut [Felt; STATE_WIDTH], round: usize) {
     Rp64_256::apply_round(state, round)
 }
+
+/// Applies Rescue-XLIX permutation (7 rounds) to the provided state.
+#[inline(always)]
+pub fn apply_permutation(state: &mut [Felt; STATE_WIDTH]) {
+    Rp64_256::apply_permutation(state)
+}

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -311,8 +311,10 @@ pub enum Operation {
     SDepth,
 
     // ----- cryptographic operations -------------------------------------------------------------
-    /// Applies Rescue Prime permutation to the top 12 elements of the stack. The outer part of the
-    /// sponge is assumed to be at the top of the stack.
+    /// Applies Rescue Prime permutation to the top 12 elements of the stack. The rate part of the
+    /// sponge is assumed to be on top of the stack, and the capacity is expected to be deepest in
+    /// the stack, starting at stack[8]. For a Rescue Prime permutation of [A, B, C] where A is the
+    /// capacity, the stack should look like [C, B, A, ...] from the top.
     RpPerm,
 
     /// Computes a root of a Merkle path for the specified node. This operation can be used to

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -45,7 +45,7 @@ impl Hasher {
                 // TODO: record state into a trace
                 apply_round(&mut state, i);
             }
-            root = [state[0], state[1], state[2], state[3]];
+            root = [state[4], state[5], state[6], state[7]];
             index >>= 1;
         }
 
@@ -82,8 +82,8 @@ impl Hasher {
                 apply_round(&mut old_state, i);
                 apply_round(&mut new_state, i);
             }
-            old_root = [old_state[0], old_state[1], old_state[2], old_state[3]];
-            new_root = [new_state[0], new_state[1], new_state[2], new_state[3]];
+            old_root = [old_state[4], old_state[5], old_state[6], old_state[7]];
+            new_root = [new_state[4], new_state[5], new_state[6], new_state[7]];
             index >>= 1;
         }
 
@@ -97,6 +97,10 @@ impl Hasher {
 
 fn build_merge_state(a: &Word, b: &Word) -> HasherState {
     [
+        Felt::new(8),
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ZERO,
         a[0],
         a[1],
         a[2],
@@ -105,9 +109,5 @@ fn build_merge_state(a: &Word, b: &Word) -> HasherState {
         b[1],
         b[2],
         b[3],
-        Felt::ZERO,
-        Felt::ZERO,
-        Felt::ZERO,
-        Felt::new(8),
     ]
 }

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -217,29 +217,49 @@ mod tests {
     };
     use crate::Word;
     use rand_utils::rand_vector;
-    use vm_core::{hasher::hash_elements, AdviceSet, ProgramInputs};
+    use vm_core::{
+        hasher::{apply_permutation, STATE_WIDTH},
+        AdviceSet, ProgramInputs,
+    };
 
     #[test]
     fn op_rpperm() {
-        // --- test hashing [ONE, ONE] ----------------------------------------
-        let expected = hash_elements(&[Felt::ONE, Felt::ONE]);
-
+        // --- test hashing [ONE, ONE] ------------------------------------------------------------
         let mut process = Process::new_dummy();
-        init_stack_with(&mut process, &[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1]);
+        let inputs: [u64; STATE_WIDTH] = [2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0];
+        let expected: [Felt; STATE_WIDTH] = build_expected_perm(&inputs);
+
+        init_stack_with(&mut process, &inputs);
         process.execute_op(Operation::RpPerm).unwrap();
-        assert_eq!(expected.as_elements(), &process.stack.trace_state()[..4]);
+        assert_eq!(expected, &process.stack.trace_state()[0..12]);
 
-        // --- test hashing 8 random values -----------------------------------
-        let mut values = rand_vector::<u64>(8);
-        let expected = hash_elements(&values.iter().map(|&v| Felt::new(v)).collect::<Vec<_>>());
-
+        // --- test hashing 8 random values -------------------------------------------------------
         let mut process = Process::new_dummy();
-        values.extend_from_slice(&[0, 0, 0, 8]);
-        // reverse the values so that the outer part of the state is at the top of the stack
-        values.reverse();
-        init_stack_with(&mut process, &values);
+        let values = rand_vector::<u64>(8);
+        // add the capacity to prepare the input vector
+        let mut inputs: Vec<u64> = vec![values.len() as u64, 0, 0, 0];
+        inputs.extend_from_slice(&values);
+        let expected: [Felt; STATE_WIDTH] = build_expected_perm(&inputs);
+
+        init_stack_with(&mut process, &inputs);
         process.execute_op(Operation::RpPerm).unwrap();
-        assert_eq!(expected.as_elements(), &process.stack.trace_state()[..4]);
+
+        assert_eq!(expected, &process.stack.trace_state()[0..12]);
+
+        // --- test that the rest of the stack isn't affected -------------------------------------
+        let mut process = Process::new_dummy();
+        let mut inputs: Vec<u64> = vec![1, 2, 3, 4];
+        let expected = inputs
+            .iter()
+            .rev()
+            .map(|&v| Felt::new(v))
+            .collect::<Vec<Felt>>();
+        let values: Vec<u64> = vec![2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0];
+        inputs.extend_from_slice(&values);
+
+        init_stack_with(&mut process, &inputs);
+        process.execute_op(Operation::RpPerm).unwrap();
+        assert_eq!(expected, &process.stack.trace_state()[12..16]);
     }
 
     #[test]
@@ -409,6 +429,17 @@ mod tests {
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = value;
         }
+        expected
+    }
+
+    fn build_expected_perm(values: &[u64]) -> [Felt; STATE_WIDTH] {
+        let mut expected = [Felt::ZERO; STATE_WIDTH];
+        for (&value, result) in values.iter().zip(expected.iter_mut()) {
+            *result = Felt::new(value);
+        }
+        apply_permutation(&mut expected);
+        expected.reverse();
+
         expected
     }
 }

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -8,8 +8,11 @@ use super::{ExecutionError, Process};
 impl Process {
     // HASHING OPERATIONS
     // --------------------------------------------------------------------------------------------
-    /// Applies Rescue Prime permutation to the top 12 elements of the stack. The outer part of the
-    /// state is assumed to be at the top of the stack.
+    /// Applies Rescue Prime permutation to the top 12 elements of the stack. The stack is assumed
+    /// to be arranged so that the 8 elements of the rate are at the top of the stack. The capacity
+    /// word follows, with the number of elements to be hashed at the deepest position in stack[11].
+    /// For a Rescue Prime permutation of [A, B, C] where A is the capacity, the stack should be
+    /// arranged (from the top) as [C, B, A, ...].
     ///
     /// # Errors
     /// Returns an error if the stack contains fewer than 12 elements.
@@ -17,23 +20,23 @@ impl Process {
         self.stack.check_depth(12, "RPPERM")?;
 
         let input_state = [
-            self.stack.get(0),
-            self.stack.get(1),
-            self.stack.get(2),
-            self.stack.get(3),
-            self.stack.get(4),
-            self.stack.get(5),
-            self.stack.get(6),
-            self.stack.get(7),
-            self.stack.get(8),
-            self.stack.get(9),
-            self.stack.get(10),
             self.stack.get(11),
+            self.stack.get(10),
+            self.stack.get(9),
+            self.stack.get(8),
+            self.stack.get(7),
+            self.stack.get(6),
+            self.stack.get(5),
+            self.stack.get(4),
+            self.stack.get(3),
+            self.stack.get(2),
+            self.stack.get(1),
+            self.stack.get(0),
         ];
 
         let (_addr, output_state) = self.hasher.permute(input_state);
 
-        for (i, &value) in output_state.iter().enumerate() {
+        for (i, &value) in output_state.iter().rev().enumerate() {
             self.stack.set(i, value);
         }
         self.stack.copy_state(12);


### PR DESCRIPTION
Resolve the hash operation inconsistency raised in #52.

- update Winterfell winter-crypto dependency version
- update assembly rphash parser for consistency with new RP hash result position
- update hasher functions used for merkle tree ops in the processor
- update comments/docs for consistency with the new version
- update tests for RPPERM (processor), rpperm/rphash(assembly)