### PR TITLE
Update u32 proptests in the processor to only test valid u32 values

### DIFF
--- a/assembly/src/parsers/io_ops.rs
+++ b/assembly/src/parsers/io_ops.rs
@@ -543,7 +543,7 @@ mod tests {
 
         // parameter out of bounds
         let reason = format!(
-            "parameter value must be greater than {} and less than than {}",
+            "parameter value must be greater than or equal to {} and less than or equal to {}",
             1, ADVICE_READ_LIMIT
         );
         // less than lower bound

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -180,7 +180,7 @@ fn parse_int_param(
             op,
             param_idx,
             format!(
-                "parameter value must be greater than {} and less than than {}",
+                "parameter value must be greater than or equal to {} and less than or equal to {}",
                 lower_bound, upper_bound
             )
             .as_str(),

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -90,7 +90,7 @@ fn test_param_out_of_bounds(asm_op_base: &str, gt_max_value: u64) {
     test_compilation_failure(build_asm_op(gt_max_value).as_str(), "parameter value");
 }
 
-// This is a proptest strategy for generating a random word of u64 values (4 u64 values).
-fn rand_word() -> impl Strategy<Value = Vec<u64>> {
-    prop::collection::vec(any::<u64>(), 4)
+// This is a proptest strategy for generating a random word with 4 values of type T.
+fn rand_word<T: proptest::arbitrary::Arbitrary>() -> impl Strategy<Value = Vec<T>> {
+    prop::collection::vec(any::<T>(), 4)
 }

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -87,7 +87,7 @@ fn test_compilation_failure(asm_op: &str, err_substr: &str) {
 fn test_param_out_of_bounds(asm_op_base: &str, gt_max_value: u64) {
     let build_asm_op = |param: u64| format!("{}.{}", asm_op_base, param);
 
-    test_compilation_failure(build_asm_op(gt_max_value).as_str(), "parameter value");
+    test_compilation_failure(build_asm_op(gt_max_value).as_str(), "parameter");
 }
 
 // This is a proptest strategy for generating a random word with 4 values of type T.


### PR DESCRIPTION
This PR addresses #79 

- Removes all execution failure checks from proptests in the u32_tests in the processor
- Updates all u32 proptests to generate valid random u32 values