### PR TITLE
Fix u32 assembly parsers for shift/rotate ops to allow b = 0

### DIFF
--- a/assembly/src/parsers/u32_ops.rs
+++ b/assembly/src/parsers/u32_ops.rs
@@ -378,7 +378,7 @@ pub fn parse_u32shl(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
             // assert the top of the stack is a u32 value
             assert_u32(span_ops);
 
-            let x = parse_int_param(op, 1, 1, 31)?;
+            let x = parse_int_param(op, 1, 0, 31)?;
             span_ops.push(Operation::Push(BaseElement::new(2u64.pow(x))));
             span_ops.push(Operation::Mul);
             span_ops.push(Operation::U32split);
@@ -403,7 +403,7 @@ pub fn parse_u32shr(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
             // assert the top of the stack is a u32 value
             assert_u32(span_ops);
 
-            let x = parse_int_param(op, 1, 1, 31)?;
+            let x = parse_int_param(op, 1, 0, 31)?;
             span_ops.push(Operation::Push(BaseElement::new(2u64.pow(x))));
             span_ops.push(Operation::U32div);
             // drop the remainder and keep the quotient
@@ -428,7 +428,7 @@ pub fn parse_u32rotl(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), As
             // assert the top of the stack is a u32 value
             assert_u32(span_ops);
 
-            let x = parse_int_param(op, 1, 1, 31)?;
+            let x = parse_int_param(op, 1, 0, 31)?;
             span_ops.push(Operation::Push(BaseElement::new(2u64.pow(x))));
             span_ops.push(Operation::Mul);
             span_ops.push(Operation::U32split);
@@ -453,7 +453,7 @@ pub fn parse_u32rotr(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), As
             // assert the top of the stack is a u32 value
             assert_u32(span_ops);
 
-            let x = parse_int_param(op, 1, 1, 31)?;
+            let x = parse_int_param(op, 1, 0, 31)?;
             span_ops.push(Operation::Push(BaseElement::new(2u64.pow(32 - x))));
             span_ops.push(Operation::Mul);
             span_ops.push(Operation::U32split);

--- a/processor/src/tests/u32_ops.rs
+++ b/processor/src/tests/u32_ops.rs
@@ -13,6 +13,7 @@ const U32_BOUND: u64 = u32::MAX as u64 + 1;
 const WORD_LEN: usize = 4;
 
 // U32 OPERATIONS TESTS - MANUAL - CONVERSIONS AND TESTS
+
 // ================================================================================================
 
 #[test]
@@ -354,12 +355,13 @@ fn u32not_fail() {
 // https://github.com/maticnetwork/miden/issues/76
 fn u32shl() {
     // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
-    let get_asm_op = |b: u64| format!("u32shl.{}", b);
+    let op_base = "u32shl";
+    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
     let get_result = |a, b| (a << b) % U32_BOUND;
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u64;
-    let b = 1_u64;
+    let b = 1_u32;
     test_execution(get_asm_op(b).as_str(), &[a], &[2]);
 
     // --- test max values of a and b -------------------------------------------------------------
@@ -372,12 +374,17 @@ fn u32shl() {
     );
 
     // --- test b = 0 -----------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u64;
-    test_execution(get_asm_op(0).as_str(), &[a], &[a]);
+    let a = rand_value::<u64>() as u32;
+    let b = 0;
+    test_execution(
+        get_asm_op(b).as_str(),
+        &[a as u64],
+        &[get_result(a as u64, b)],
+    );
 
     // --- test random values ---------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() % 32;
+    let b = (rand_value::<u64>() % 32) as u32;
     test_execution(
         get_asm_op(b).as_str(),
         &[a as u64],
@@ -397,12 +404,13 @@ fn u32shl_fail() {
 // https://github.com/maticnetwork/miden/issues/76
 fn u32shr() {
     // right shift: pops a from the stack and pushes a / 2^b for a provided value b
-    let get_asm_op = |b: u64| format!("u32shr.{}", b);
+    let op_base = "u32shr";
+    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
     let get_result = |a, b| a >> b;
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 4_u64;
-    let b = 2_u64;
+    let b = 2_u32;
     test_execution(get_asm_op(b).as_str(), &[a], &[1]);
 
     // --- test max values of a and b -------------------------------------------------------------
@@ -415,12 +423,17 @@ fn u32shr() {
     );
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u64;
-    test_execution(get_asm_op(0).as_str(), &[a], &[a]);
+    let a = rand_value::<u64>() as u32;
+    let b = 0;
+    test_execution(
+        get_asm_op(b).as_str(),
+        &[a as u64],
+        &[get_result(a as u64, b)],
+    );
 
     // --- test random values ---------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() % 32;
+    let b = (rand_value::<u64>() % 32) as u32;
     test_execution(
         get_asm_op(b).as_str(),
         &[a as u64],
@@ -464,8 +477,13 @@ fn u32rotl() {
     test_execution(get_asm_op(b).as_str(), &[a as u64], &[a as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u64;
-    test_execution(get_asm_op(0).as_str(), &[a], &[a]);
+    let a = rand_value::<u64>() as u32;
+    let b = 0 as u32;
+    test_execution(
+        get_asm_op(b).as_str(),
+        &[a as u64],
+        &[a.rotate_left(b) as u64],
+    );
 
     // --- test random values ---------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
@@ -513,8 +531,13 @@ fn u32rotr() {
     test_execution(get_asm_op(b).as_str(), &[a as u64], &[a as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u64;
-    test_execution(get_asm_op(0).as_str(), &[a], &[a]);
+    let a = rand_value::<u64>() as u32;
+    let b = 0 as u32;
+    test_execution(
+        get_asm_op(b).as_str(),
+        &[a as u64],
+        &[a.rotate_right(b) as u64],
+    );
 
     // --- test random values ---------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;


### PR DESCRIPTION
As described in https://github.com/maticnetwork/miden/issues/76, fix the parsers `parse_u32shl`, `parse_u32shr`, `parse_u32rotl`, `parse_u32rotr` for shift/rotate ops to allow parameter value of **0 <= b <= 31**, according to the [assembly specs](https://hackmd.io/YDbjUVHTRn64F4LPelC-NA?view#Bitwise-operations). Also, adjusted the tests to this parsers added in https://github.com/maticnetwork/miden/pull/75 to validate the ~new~ enforcing parameter bounds.