### PR TITLE
Refactor asm io ops to what.where format

### DIFF
--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -96,9 +96,9 @@ fn parse_op_token(op: &Token, span_ops: &mut Vec<Operation>) -> Result<(), Assem
         // ----- input / output operations --------------------------------------------------------
         "push" => io_ops::parse_push(span_ops, op),
         "pushw" => io_ops::parse_pushw(span_ops, op),
-        "env" => io_ops::parse_env(span_ops, op),
-        "adv" => io_ops::parse_adv(span_ops, op),
-        "mem" => io_ops::parse_mem(span_ops, op),
+        "popw" => io_ops::parse_popw(span_ops, op),
+        "loadw" => io_ops::parse_loadw(span_ops, op),
+        "storew" => io_ops::parse_storew(span_ops, op),
 
         // ----- cryptographic operations ---------------------------------------------------------
         "rphash" => crypto_ops::parse_rphash(span_ops, op),


### PR DESCRIPTION
This PR addresses the first stage of #84 and refactors all assembly i/o operations and tests to the new "what.where" format as outlined in the new [specs](https://hackmd.io/YDbjUVHTRn64F4LPelC-NA#Input--output-operations). It does not update the `push` operation for constants to the new spec, although it does remove `pushw` for constants to update the `pushw` parser to the new format.

Updated ops include:
- all mem ops
- all adv ops
- all env ops
- `pushw` operation for constants removed
- handling for local memory ops is stubbed out