### PR TITLE
Implement stacking of auxiliary traces (hasher, bitwise, memory)

### DIFF
--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -74,7 +74,7 @@ impl Bitwise {
             .map(|_| Vec::with_capacity(INIT_TRACE_CAPACITY))
             .collect::<Vec<_>>()
             .try_into()
-            .unwrap();
+            .expect("failed to convert vector to array");
         Self { trace }
     }
 
@@ -193,7 +193,6 @@ impl Bitwise {
     // --------------------------------------------------------------------------------------------
 
     /// Fills the provide trace fragment with trace data from this bitwise helper instance.
-    #[allow(dead_code)]
     pub fn fill_trace(self, trace: &mut TraceFragment) {
         // make sure fragment dimensions are consistent with the dimensions of this trace
         debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace lengths");

--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -16,13 +16,13 @@ const TRACE_WIDTH: usize = NUM_SELECTORS + 11;
 const INIT_TRACE_CAPACITY: usize = 128;
 
 /// Specifies a bitwise AND operation.
-const BITWISE_AND: Selectors = [Felt::ZERO, Felt::ZERO];
+pub const BITWISE_AND: Selectors = [Felt::ZERO, Felt::ZERO];
 
 /// Specifies a bitwise OR operation.
-const BITWISE_OR: Selectors = [Felt::ZERO, Felt::ONE];
+pub const BITWISE_OR: Selectors = [Felt::ZERO, Felt::ONE];
 
 /// Specifies a bitwise XOR operation.
-const BITWISE_XOR: Selectors = [Felt::ONE, Felt::ZERO];
+pub const BITWISE_XOR: Selectors = [Felt::ONE, Felt::ZERO];
 
 // TYPE ALIASES
 // ================================================================================================

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -24,27 +24,27 @@ const TRACE_WIDTH: usize = NUM_SELECTORS + STATE_WIDTH + 2;
 /// Specifies a start of a new linear hash computation or absorption of new elements into an
 /// executing linear hash computation. These selectors can also be used for a simple 2-to-1 hash
 /// computation.
-const LINEAR_HASH: Selectors = [Felt::ONE, Felt::ZERO, Felt::ZERO];
+pub const LINEAR_HASH: Selectors = [Felt::ONE, Felt::ZERO, Felt::ZERO];
 
 /// Specifies a start of Merkle path verification computation or absorption of a new path node
 /// into the hasher state.
-const MP_VERIFY: Selectors = [Felt::ONE, Felt::ZERO, Felt::ONE];
+pub const MP_VERIFY: Selectors = [Felt::ONE, Felt::ZERO, Felt::ONE];
 
 /// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
 /// state for the "old" node value during Merkle root update computation.
-const MR_UPDATE_OLD: Selectors = [Felt::ONE, Felt::ONE, Felt::ZERO];
+pub const MR_UPDATE_OLD: Selectors = [Felt::ONE, Felt::ONE, Felt::ZERO];
 
 /// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
 /// state for the "new" node value during Merkle root update computation.
-const MR_UPDATE_NEW: Selectors = [Felt::ONE, Felt::ONE, Felt::ONE];
+pub const MR_UPDATE_NEW: Selectors = [Felt::ONE, Felt::ONE, Felt::ONE];
 
 /// Specifies a completion of a computation such that only the hash result (values in h0, h1, h2
 /// h3) is returned.
-const RETURN_HASH: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ZERO];
+pub const RETURN_HASH: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ZERO];
 
 /// Specifies a completion of a computation such that the entire hasher state (values in h0 through
 /// h11) is returned.
-const RETURN_STATE: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ONE];
+pub const RETURN_STATE: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ONE];
 
 // TYPE ALIASES
 // ================================================================================================

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -183,7 +183,6 @@ impl Hasher {
     // --------------------------------------------------------------------------------------------
 
     /// Fills the provided trace fragment with trace data from this hasher trace instance.
-    #[cfg(test)]
     pub fn fill_trace(self, trace: &mut TraceFragment) {
         self.trace.fill_trace(trace)
     }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -43,10 +43,15 @@ pub use errors::ExecutionError;
 #[cfg(test)]
 mod tests;
 
+// CONSTANTS
+// ================================================================================================
+const AUXILIARY_TABLE_WIDTH: usize = 18;
+
 // TYPE ALIASES
 // ================================================================================================
 
 type StackTrace = [Vec<Felt>; STACK_TOP_SIZE];
+type AuxiliaryTableTrace = [Vec<Felt>; AUXILIARY_TABLE_WIDTH];
 
 // EXECUTOR
 // ================================================================================================

--- a/processor/src/memory/mod.rs
+++ b/processor/src/memory/mod.rs
@@ -144,7 +144,6 @@ impl Memory {
     // --------------------------------------------------------------------------------------------
 
     /// Fills the provide trace fragment with trace data from this memory instance.
-    #[allow(dead_code)]
     pub fn fill_trace(self, trace: &mut TraceFragment) {
         debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace lengths");
 

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -50,7 +50,7 @@ impl Stack {
     }
 
     /// Returns execution trace length for this stack.
-    pub fn trace_length(&self) -> usize {
+    pub fn trace_len(&self) -> usize {
         self.trace[0].len()
     }
 
@@ -215,8 +215,8 @@ impl Stack {
     ///
     /// Trace length is doubled every time it needs to be increased.
     pub fn ensure_trace_capacity(&mut self) {
-        if self.step + 1 >= self.trace_length() {
-            let new_length = self.trace_length() * 2;
+        if self.step + 1 >= self.trace_len() {
+            let new_length = self.trace_len() * 2;
             for register in self.trace.iter_mut() {
                 register.resize(new_length, Felt::ZERO);
             }

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -43,7 +43,7 @@ impl System {
 
     /// Returns execution trace length for a process.
     #[inline(always)]
-    pub fn trace_length(&self) -> usize {
+    pub fn trace_len(&self) -> usize {
         self.clk_trace.len()
     }
 
@@ -72,8 +72,8 @@ impl System {
     ///
     /// Trace length is doubled every time it needs to be increased.
     pub fn ensure_trace_capacity(&mut self) {
-        if self.clk + 1 >= self.trace_length() {
-            let new_length = self.trace_length() * 2;
+        if self.clk + 1 >= self.trace_len() {
+            let new_length = self.trace_len() * 2;
             self.clk_trace.resize(new_length, Felt::ZERO);
             self.fmp_trace.resize(new_length, Felt::ZERO);
         }

--- a/processor/src/tests/aux_table_trace.rs
+++ b/processor/src/tests/aux_table_trace.rs
@@ -1,0 +1,226 @@
+use super::{
+    super::{
+        bitwise::BITWISE_OR,
+        hasher::{LINEAR_HASH, RETURN_STATE},
+        AuxiliaryTableTrace, ExecutionTrace, FieldElement, Process,
+    },
+    build_inputs, compile, Felt,
+};
+
+#[test]
+fn trace_len() {
+    // --- final trace lengths are equal when stack trace is longer than aux trace ----------------
+    let script = compile("begin popw.mem.2 end");
+    let inputs = build_inputs(&[1, 2, 3, 4]);
+    let mut process = Process::new(inputs);
+    process.execute_code_block(script.root()).unwrap();
+    let trace = ExecutionTrace::new(process);
+
+    assert_eq!(trace.aux_table()[0].len(), trace.stack()[0].len());
+
+    // --- final trace lengths are equal when aux trace is longer than stack trace ----------------
+    let script = compile("begin u32and end");
+    let inputs = build_inputs(&[4, 8]);
+    let mut process = Process::new(inputs);
+    process.execute_code_block(script.root()).unwrap();
+    let trace = ExecutionTrace::new(process);
+
+    assert_eq!(trace.aux_table()[0].len(), trace.stack()[0].len());
+
+    // --- stack and aux trace lengths are equal after multi-processor aux trace ------------------
+    let script = compile("begin u32and pop.mem.0 u32or end");
+    let inputs = build_inputs(&[1, 2, 3, 4]);
+    let mut process = Process::new(inputs);
+    process.execute_code_block(script.root()).unwrap();
+    let trace = ExecutionTrace::new(process);
+
+    assert_eq!(trace.aux_table()[0].len(), trace.stack()[0].len());
+
+    // --- trace len is power of 2 after multi-processor aux trace --------------------------------
+    assert!(trace.aux_table()[0].len().is_power_of_two());
+}
+
+#[test]
+fn hasher_aux_trace() {
+    // --- single hasher permutation with no stack manipulation -----------------------------------
+    let script = compile("begin rpperm end");
+    let inputs = build_inputs(&[2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]);
+    let mut process = Process::new(inputs);
+
+    process.execute_code_block(script.root()).unwrap();
+    let trace = ExecutionTrace::new(process);
+    let aux_table = trace.aux_table();
+
+    let expected_len = 8;
+    validate_hasher_trace(aux_table, 0, expected_len);
+
+    // expect  no bitwise trace and no memory trace
+    // so the trace only consists of the hasher trace with length 8
+    assert_eq!(aux_table[0].len(), expected_len);
+}
+
+#[test]
+fn bitwise_aux_trace() {
+    // --- single bitwise operation with no stack manipulation ------------------------------------
+    let script = compile("begin u32or end");
+    let inputs = build_inputs(&[4, 8]);
+    let mut process = Process::new(inputs);
+
+    process.execute_code_block(script.root()).unwrap();
+    let trace = ExecutionTrace::new(process);
+    let aux_table = trace.aux_table();
+
+    let expected_len = 8;
+    validate_bitwise_trace(aux_table, 0, expected_len);
+
+    // expect no hasher trace and no memory trace,
+    // so the trace only consists of the bitwise trace
+    assert_eq!(aux_table[0].len(), expected_len);
+}
+
+#[test]
+fn memory_aux_trace() {
+    // --- single memory operation with no stack manipulation -------------------------------------
+    let script = compile("begin storew.mem.2 end");
+    let inputs = build_inputs(&[1, 2, 3, 4]);
+    let mut process = Process::new(inputs);
+
+    process.execute_code_block(script.root()).unwrap();
+    let trace = ExecutionTrace::new(process);
+    let aux_table = trace.aux_table();
+
+    // the memory trace is only one row, so the length should match the stack trace length
+    let expected_len = trace.stack()[0].len();
+
+    // check the memory trace
+    validate_memory_trace(aux_table, 0, 1, 2);
+
+    // check that it was padded correctly
+    validate_padding(aux_table, 1, expected_len);
+
+    // expect no bitwise trace and no hasher trace,
+    // so the trace consists of the memory trace and final section of padding
+    assert_eq!(aux_table[0].len(), expected_len);
+}
+
+#[test]
+fn stacked_aux_trace() {
+    // --- operations in hasher, bitwise, and memory processors without stack manipulation --------
+    let script = compile("begin u32or storew.mem.0 rpperm end");
+    let inputs = build_inputs(&[8, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 1]);
+    let mut process = Process::new(inputs);
+
+    process.execute_code_block(script.root()).unwrap();
+    let trace = ExecutionTrace::new(process);
+    let aux_table = trace.aux_table();
+
+    // expect 8 rows of hasher trace
+    validate_hasher_trace(aux_table, 0, 8);
+
+    // expect 8 rows of bitwise trace
+    validate_bitwise_trace(aux_table, 8, 16);
+
+    // expect 1 row of memory trace
+    validate_memory_trace(aux_table, 16, 17, 0);
+
+    // expect 15 rows of padding, to pad to next power of 2
+    validate_padding(aux_table, 17, 32);
+
+    // expect aux table trace length to be 32
+    assert_eq!(aux_table[0].len(), 32);
+
+    // expect the stack trace to be the same
+    assert_eq!(aux_table[0].len(), trace.stack()[0].len());
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Validate the hasher trace output by the rpperm operation. The full hasher trace is tested in
+/// the Hasher module, so this just tests the AuxiliaryTableTrace selectors and the initial columns
+/// of the hasher trace.
+fn validate_hasher_trace(aux_table: &AuxiliaryTableTrace, start: usize, end: usize) {
+    // The selectors should match the hasher selectors
+    for row in start..end {
+        // The selectors should match the selectors for the hasher segment
+        assert_eq!(Felt::ZERO, aux_table[0][row]);
+
+        match row {
+            0 => {
+                // in the first row, the expected start of the trace should hold the initial selectors
+                assert_eq!(
+                    LINEAR_HASH,
+                    [aux_table[1][row], aux_table[2][row], aux_table[3][row]]
+                );
+            }
+            7 => {
+                // in the last row, the expected start of the trace should hold the final selectors
+                assert_eq!(
+                    RETURN_STATE,
+                    [aux_table[1][row], aux_table[2][row], aux_table[3][row]]
+                );
+            }
+            _ => {
+                // in the other rows, the expected start of the trace should hold the mid selectors
+                assert_eq!(
+                    [Felt::ZERO, LINEAR_HASH[1], LINEAR_HASH[2]],
+                    [aux_table[1][row], aux_table[2][row], aux_table[3][row]]
+                );
+            }
+        }
+    }
+}
+
+/// Validate the bitwise trace output by the u32or operation. The full bitwise trace is tested in
+/// the Bitwise module, so this just tests the AuxiliaryTableTrace selectors, the initial columns
+/// of the bitwise trace, and the final columns after the bitwise trace.
+fn validate_bitwise_trace(aux_table: &AuxiliaryTableTrace, start: usize, end: usize) {
+    // The selectors should match the bitwise selectors
+    for row in start..end {
+        // The selectors should match the selectors for the bitwise segment
+        assert_eq!(Felt::ONE, aux_table[0][row]);
+        assert_eq!(Felt::ZERO, aux_table[1][row]);
+
+        // the expected start of the bitwise trace should hold the expected bitwise op selectors
+        assert_eq!(BITWISE_OR, [aux_table[2][row], aux_table[3][row]]);
+
+        // the final columns should be padded
+        assert_eq!(Felt::ZERO, aux_table[15][row]);
+        assert_eq!(Felt::ZERO, aux_table[16][row]);
+        assert_eq!(Felt::ZERO, aux_table[17][row]);
+    }
+}
+
+/// Validate the bitwise trace output by the storew operation. The full memory trace is tested in
+/// the Memory module, so this just tests the AuxiliaryTableTrace selectors, the initial columns
+/// of the memory trace, and the final column after the memory trace.
+fn validate_memory_trace(aux_table: &AuxiliaryTableTrace, start: usize, end: usize, addr: u64) {
+    for row in start..end {
+        // The selectors in the first row should match the memory selectors
+        assert_eq!(Felt::ONE, aux_table[0][row]);
+        assert_eq!(Felt::ONE, aux_table[1][row]);
+        assert_eq!(Felt::ZERO, aux_table[2][row]);
+
+        // the expected start of the memory trace should hold the memory ctx and addr
+        assert_eq!(Felt::ZERO, aux_table[3][row]);
+        assert_eq!(Felt::new(addr), aux_table[4][row]);
+
+        // the final column should be padded
+        assert_eq!(Felt::ZERO, aux_table[17][row]);
+    }
+}
+
+/// Checks that the end of the auxiliary trace table is padded and has the correct selectors.
+fn validate_padding(aux_table: &AuxiliaryTableTrace, start: usize, end: usize) {
+    for row in start..end {
+        // selectors
+        assert_eq!(Felt::ONE, aux_table[0][row]);
+        assert_eq!(Felt::ONE, aux_table[1][row]);
+        assert_eq!(Felt::ONE, aux_table[2][row]);
+
+        // padding
+        aux_table.iter().skip(3).for_each(|column| {
+            assert_eq!(Felt::ZERO, column[row]);
+        });
+    }
+}

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -2,6 +2,7 @@ use super::{execute, Felt, FieldElement, ProgramInputs, Script, STACK_TOP_SIZE};
 use crate::Word;
 use proptest::prelude::*;
 
+mod aux_table_trace;
 mod crypto_ops;
 mod field_ops;
 mod flow_control;

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -83,6 +83,18 @@ impl ExecutionTrace {
         self.read_row_into(self.length() - 1, &mut result);
         result
     }
+
+    // ACCESSORS FOR TESTING
+    // --------------------------------------------------------------------------------------------
+    #[cfg(test)]
+    pub fn aux_table(&self) -> &AuxiliaryTableTrace {
+        &self.aux_table
+    }
+
+    #[cfg(test)]
+    pub fn stack(&self) -> &StackTrace {
+        &self.stack
+    }
 }
 
 // TRACE TRAIT IMPLEMENTATION

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -1,15 +1,20 @@
-use super::{Felt, FieldElement, Process, StackTrace, STACK_TOP_SIZE};
+use super::{
+    AuxiliaryTableTrace, Bitwise, Felt, FieldElement, Hasher, Memory, Process, StackTrace,
+    AUXILIARY_TABLE_WIDTH, STACK_TOP_SIZE,
+};
 use core::slice;
 use winterfell::Trace;
 
 // VM EXECUTION TRACE
 // ================================================================================================
 
-/// TODO: for now this consists only of stack trace, but will need to include decoder trace,
-/// auxiliary table traces etc.
+/// TODO: for now this consists only of stack trace and auxiliary traces, but will need to
+/// include decoder trace, etc.
 pub struct ExecutionTrace {
     meta: Vec<u8>,
     stack: StackTrace,
+    #[allow(dead_code)]
+    aux_table: AuxiliaryTableTrace,
 }
 
 impl ExecutionTrace {
@@ -21,21 +26,44 @@ impl ExecutionTrace {
             system,
             decoder: _,
             stack,
-            hasher: _,
-            bitwise: _,
-            memory: _,
+            hasher,
+            bitwise,
+            memory,
             advice: _,
         } = process;
 
+        // get the length required to hold all execution trace steps
+        let aux_trace_len = hasher.trace_len() + bitwise.trace_len() + memory.trace_len();
+        let mut trace_len = usize::max(stack.trace_len(), aux_trace_len);
+        // pad the trace length to the next power of 2
+        if !trace_len.is_power_of_two() {
+            trace_len = trace_len.next_power_of_two();
+        }
+
+        // allocate columns for the trace of the auxiliary table
+        // note: it may be possible to optimize this by initializing with Felt::zeroed_vector,
+        // depending on how the compiler reduces Felt(0) and whether initializing here + iterating
+        // to update selector values is faster than using resize to initialize all values
+        let mut aux_table_trace: AuxiliaryTableTrace = (0..AUXILIARY_TABLE_WIDTH)
+            .map(|_| Vec::<Felt>::with_capacity(trace_len))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("failed to convert vector to array");
+
+        // fill the aux table with the column selectors and stacked coprocessor traces
+        fill_aux_columns(&mut aux_table_trace, trace_len, hasher, bitwise, memory);
+
+        // finalize stack trace and extend it to match the length of the auxiliary trace, if needed
         let step = system.clk();
         let mut stack_trace = stack.into_trace();
         for column in stack_trace.iter_mut() {
-            finalize_column(column, step);
+            finalize_column(column, step, trace_len);
         }
 
         Self {
             meta: Vec::new(),
             stack: stack_trace,
+            aux_table: aux_table_trace,
         }
     }
 
@@ -99,6 +127,13 @@ pub struct TraceFragment<'a> {
 }
 
 impl<'a> TraceFragment<'a> {
+    /// Creates a new TraceFragment with its data allocated to the specified capacity.
+    pub fn new(capacity: usize) -> Self {
+        TraceFragment {
+            data: Vec::with_capacity(capacity),
+        }
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
@@ -126,6 +161,15 @@ impl<'a> TraceFragment<'a> {
         self.data.iter_mut()
     }
 
+    /// Adds a new column to this fragment by pushing a mutable slice with the first `len`
+    /// elements of the provided column. Returns the rest of the provided column as a separate
+    /// mutable slice.
+    pub fn push_column_slice(&mut self, column: &'a mut [Felt], len: usize) -> &'a mut [Felt] {
+        let (column_fragment, rest) = column.split_at_mut(len);
+        self.data.push(column_fragment);
+        rest
+    }
+
     // TEST METHODS
     // --------------------------------------------------------------------------------------------
 
@@ -142,7 +186,124 @@ impl<'a> TraceFragment<'a> {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-fn finalize_column(column: &mut [Felt], step: usize) {
+/// Copies the final output value down to the end of the stack trace, then extends the column to
+/// the length of the execution trace, if it's longer than the stack trace, and copies the last
+/// value to the end of that as well.
+fn finalize_column(column: &mut Vec<Felt>, step: usize, trace_len: usize) {
     let last_value = column[step];
     column[step..].fill(last_value);
+    column.resize(trace_len, last_value);
+}
+
+/// Fills the provided auxiliary table trace with the stacked execution traces of the Hasher,
+/// Bitwise, and Memory coprocessors, along with selector columns to identify each coprocessor
+/// trace and padding to fill the rest of the table.
+///
+/// The auxiliary trace table can be thought of as 4 stacked segments in the following form:
+/// * Hasher segment: contains the hasher trace and selector *
+/// This segment fills the first rows of the table up to the length of the hasher `trace_len`.
+/// - column 0: selector column with values set to ZERO
+/// - columns 1-17: execution trace of hasher coprocessor
+///
+/// * Bitwise segment: contains the bitwise trace and selectors *
+/// This segment begins at the end of the hasher segment and fills the next rows of the table for
+/// the `trace_len` of the bitwise coprocessor.
+/// - column 0: selector column with values set to ONE
+/// - column 1: selector column with values set to ZERO
+/// - columns 2-14: execution trace of bitwise coprocessor
+/// - columns 15-17: unused columns padded with ZERO
+///
+/// * Memory segment: contains the memory trace and selectors *
+/// This segment begins at the end of the bitwise segment and fills the next rows of the table for
+/// the `trace_len` of the memory coprocessor.
+/// - column 0-1: selector columns with values set to ONE
+/// - column 2: selector column with values set to ZERO
+/// - columns 3-16: execution trace of memory coprocessor
+/// - column 17: unused column padded with ZERO
+///
+/// * Final segment: unused *
+/// This segment begins at the end of the memory segment and fills the rest of the rows in the table
+/// up to the full length of the execution trace.
+/// - columns 0-2: selector columns with values set to ONE
+/// - columns 3-17: unused columns padded with ZERO
+///
+fn fill_aux_columns(
+    aux_table_trace: &mut AuxiliaryTableTrace,
+    trace_len: usize,
+    hasher: Hasher,
+    bitwise: Bitwise,
+    memory: Memory,
+) {
+    // allocate fragments to be filled with the respective execution traces of each coprocessor
+    let mut hasher_fragment = TraceFragment::new(AUXILIARY_TABLE_WIDTH);
+    let mut bitwise_fragment = TraceFragment::new(AUXILIARY_TABLE_WIDTH);
+    let mut memory_fragment = TraceFragment::new(AUXILIARY_TABLE_WIDTH);
+
+    // set the selectors and padding as required by each column and segment
+    // and add the hasher, bitwise, and memory segments to their respective fragments
+    // so they can be filled with the coprocessor traces
+    for (column_num, column) in aux_table_trace.iter_mut().enumerate() {
+        match column_num {
+            0 => {
+                // set the selector value for the hasher segment to ZERO
+                column.resize(hasher.trace_len(), Felt::ZERO);
+                // set the selector value for all other segments ONE
+                column.resize(trace_len, Felt::ONE);
+            }
+            1 => {
+                // initialize hasher segment and set bitwise segment selector value to ZERO
+                column.resize(hasher.trace_len() + bitwise.trace_len(), Felt::ZERO);
+                // set selector value for all other segments to ONE
+                column.resize(trace_len, Felt::ONE);
+                // add hasher segment to the hasher fragment to be filled from the hasher trace
+                hasher_fragment.push_column_slice(column, hasher.trace_len());
+            }
+            2 => {
+                // initialize hasher and bitwise segments and set memory segment selector to ZERO
+                column.resize(
+                    hasher.trace_len() + bitwise.trace_len() + memory.trace_len(),
+                    Felt::ZERO,
+                );
+                // set selector value for the final segment to ONE
+                column.resize(trace_len, Felt::ONE);
+                // add hasher segment to the hasher fragment to be filled from the hasher trace
+                let rest_of_column = hasher_fragment.push_column_slice(column, hasher.trace_len());
+                // add bitwise segment to the bitwise fragment to be filled from the bitwise trace
+                bitwise_fragment.push_column_slice(rest_of_column, bitwise.trace_len());
+            }
+            15 | 16 => {
+                // initialize hasher & memory segments and pad bitwise & final segments with ZERO
+                column.resize(trace_len, Felt::ZERO);
+                // add hasher segment to the hasher fragment to be filled from the hasher trace
+                let rest_of_column = hasher_fragment.push_column_slice(column, hasher.trace_len());
+                // split the column again to skip the bitwise segment, which has already been padded
+                let (_, rest_of_column) = rest_of_column.split_at_mut(bitwise.trace_len());
+                // add memory segment to the memory fragment to be filled from the memory trace
+                memory_fragment.push_column_slice(rest_of_column, memory.trace_len());
+            }
+            17 => {
+                // initialize hasher segment and pad bitwise, memory, and final segments with ZERO
+                column.resize(trace_len, Felt::ZERO);
+                // add hasher segment to the hasher fragment to be filled from the hasher trace
+                hasher_fragment.push_column_slice(column, hasher.trace_len());
+            }
+            _ => {
+                // initialize hasher, bitwise, memory segments and pad the final segment with ZERO
+                column.resize(trace_len, Felt::ZERO);
+                // add hasher segment to the hasher fragment to be filled from the hasher trace
+                let rest_of_column = hasher_fragment.push_column_slice(column, hasher.trace_len());
+                // add bitwise segment to the bitwise fragment to be filled from the bitwise trace
+                let rest_of_column =
+                    bitwise_fragment.push_column_slice(rest_of_column, bitwise.trace_len());
+                // add memory segment to the memory fragment to be filled from the memory trace
+                memory_fragment.push_column_slice(rest_of_column, memory.trace_len());
+            }
+        }
+    }
+
+    // fill the fragments with the execution trace from each coprocessor
+    // TODO: this can be parallelized to fill the traces in multiple threads
+    hasher.fill_trace(&mut hasher_fragment);
+    bitwise.fill_trace(&mut bitwise_fragment);
+    memory.fill_trace(&mut memory_fragment);
 }


### PR DESCRIPTION
This PR implements #114.

- handles stacking of the co-processor traces
- adds basic tests for the stacked trace table
- minor refactors