### PR TITLE
Update local memory fmp and add asm op for absolute local addr

### DIFF
--- a/assembly/src/parsers/crypto_ops.rs
+++ b/assembly/src/parsers/crypto_ops.rs
@@ -1,4 +1,4 @@
-use super::{validate_op_len, AssemblyError, Felt, Operation, Token};
+use super::{super::validate_operation, AssemblyError, Felt, Operation, Token};
 use vm_core::{utils::PushMany, AdviceInjector};
 
 // HASHING
@@ -30,11 +30,7 @@ const RPHASH_NUM_ELEMENTS: u64 = 8;
 /// - the operation is malformed.
 /// - an unrecognized operation is received (anything other than rphash).
 pub fn parse_rphash(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // validate the operation
-    validate_op_len(op, 1, 0, 0)?;
-    if op.parts()[0] != "rphash" {
-        return Err(AssemblyError::unexpected_token(op, "rphash"));
-    }
+    validate_operation!(op, "rphash", 0);
 
     // Add 4 elements to the stack to prepare the capacity portion for the Rescue Prime permutation
     // The capacity should start at stack[8], and the number of elements to be hashed should
@@ -70,11 +66,7 @@ pub fn parse_rphash(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
 /// - the operation is malformed.
 /// - an unrecognized operation is received (anything other than rpperm).
 pub fn parse_rpperm(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // validate the operation
-    validate_op_len(op, 1, 0, 0)?;
-    if op.parts()[0] != "rpperm" {
-        return Err(AssemblyError::unexpected_token(op, "rpperm"));
-    }
+    validate_operation!(op, "rpperm", 0);
 
     // append the machine op to the span block
     span_ops.push(Operation::RpPerm);
@@ -102,11 +94,7 @@ pub fn parse_rpperm(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
 /// - an unrecognized operation is received (anything other than "mtree" with a valid variant of
 ///   "get", "set", or "cwm").
 pub fn parse_mtree(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // validate operation
-    validate_op_len(op, 2, 0, 0)?;
-    if op.parts()[0] != "mtree" {
-        return Err(AssemblyError::unexpected_token(op, "mtree.{get|set|cwm}"));
-    }
+    validate_operation!(op, "mtree.cwm|get|set", 0);
 
     match op.parts()[1] {
         "get" => mtree_get(span_ops),
@@ -399,7 +387,7 @@ mod tests {
         );
 
         let op_mismatch = Token::new("rpperm.get", op_pos);
-        let expected = AssemblyError::unexpected_token(&op_mismatch, "mtree.{get|set|cwm}");
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "mtree.cwm|get|set");
         assert_eq!(
             parse_mtree(&mut span_ops, &op_mismatch).unwrap_err(),
             expected

--- a/assembly/src/parsers/field_ops.rs
+++ b/assembly/src/parsers/field_ops.rs
@@ -1,5 +1,6 @@
 use super::{
-    parse_element_param, validate_op_len, AssemblyError, Felt, FieldElement, Operation, Token,
+    super::validate_operation, parse_element_param, AssemblyError, Felt, FieldElement, Operation,
+    Token,
 };
 
 // ASSERTIONS AND TESTS
@@ -227,11 +228,7 @@ pub fn parse_neq(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assemb
 /// # Errors
 /// Returns an error if the assembly operation token is malformed or incorrect.
 pub fn parse_eqw(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // validate operation
-    validate_op_len(op, 1, 0, 0)?;
-    if op.parts()[0] != "eqw" {
-        return Err(AssemblyError::unexpected_token(op, "eqw"));
-    }
+    validate_operation!(op, "eqw", 0);
 
     span_ops.push(Operation::Eqw);
 
@@ -247,11 +244,7 @@ pub fn parse_eqw(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assemb
 /// # Errors
 /// Returns an error if the assembly operation token is malformed or incorrect.
 pub fn parse_lt(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // validate operation
-    validate_op_len(op, 1, 0, 0)?;
-    if op.parts()[0] != "lt" {
-        return Err(AssemblyError::unexpected_token(op, "lt"));
-    }
+    validate_operation!(op, "lt", 0);
 
     // Split both elements into high and low bits
     // 3 cycles
@@ -282,11 +275,7 @@ pub fn parse_lt(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assembl
 /// # Errors
 /// Returns an error if the assembly operation token is malformed or incorrect.
 pub fn parse_lte(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // validate operation
-    validate_op_len(op, 1, 0, 0)?;
-    if op.parts()[0] != "lte" {
-        return Err(AssemblyError::unexpected_token(op, "lte"));
-    }
+    validate_operation!(op, "lte", 0);
 
     // Split both elements into high and low bits
     // 3 cycles
@@ -317,11 +306,7 @@ pub fn parse_lte(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assemb
 /// # Errors
 /// Returns an error if the assembly operation token is malformed or incorrect.
 pub fn parse_gt(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // validate operation
-    validate_op_len(op, 1, 0, 0)?;
-    if op.parts()[0] != "gt" {
-        return Err(AssemblyError::unexpected_token(op, "gt"));
-    }
+    validate_operation!(op, "gt", 0);
 
     // Split both elements into high and low bits
     // 3 cycles
@@ -352,11 +337,7 @@ pub fn parse_gt(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assembl
 /// # Errors
 /// Returns an error if the assembly operation token is malformed or incorrect.
 pub fn parse_gte(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // validate operation
-    validate_op_len(op, 1, 0, 0)?;
-    if op.parts()[0] != "gte" {
-        return Err(AssemblyError::unexpected_token(op, "gte"));
-    }
+    validate_operation!(op, "gte", 0);
 
     // Split both elements into high and low bits
     // 3 cycles

--- a/assembly/src/parsers/io_ops/adv_ops.rs
+++ b/assembly/src/parsers/io_ops/adv_ops.rs
@@ -1,4 +1,4 @@
-use super::{parse_int_param, validate_op_len, AssemblyError, Operation, Token};
+use super::{parse_int_param, validate_operation, AssemblyError, Operation, Token};
 use vm_core::utils::PushMany;
 
 // CONSTANTS
@@ -21,11 +21,7 @@ const ADVICE_READ_LIMIT: u32 = 16;
 /// parameter, or does not match the expected operation. Returns an `invalid_param` `AssemblyError`
 /// if the parameter for `push.adv` is not a decimal value.
 pub fn parse_push_adv(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // do basic validation common to all advice operations
-    validate_op_len(op, 2, 1, 1)?;
-    if op.parts()[1] != "adv" {
-        return Err(AssemblyError::unexpected_token(op, "push.adv.n"));
-    }
+    validate_operation!(op, "push.adv", 1);
 
     // parse and validate the parameter as the number of items to read from the advice tape
     // it must be between 1 and ADVICE_READ_LIMIT, inclusive, since adv.push.0 is a no-op
@@ -40,10 +36,7 @@ pub fn parse_push_adv(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), A
 /// Reads a word from the advice tape and overwrites the top 4 elements of the stack with it. After
 /// validation, this operation uses the ```READW``` machine operation directly.
 pub fn parse_loadw_adv(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // ensure that no parameter exists
-    if op.num_parts() > 2 {
-        return Err(AssemblyError::extra_param(op));
-    }
+    validate_operation!(op, "loadw.adv", 0);
 
     // load a word from the advice tape
     span_ops.push(Operation::ReadW);

--- a/assembly/src/parsers/io_ops/constant_ops.rs
+++ b/assembly/src/parsers/io_ops/constant_ops.rs
@@ -1,5 +1,5 @@
 use super::{
-    parse_decimal_param, parse_element_param, parse_hex_param, push_value, validate_op_len,
+    parse_decimal_param, parse_element_param, parse_hex_param, push_value, validate_operation,
     AssemblyError, Felt, Operation, Token,
 };
 
@@ -36,9 +36,9 @@ const HEX_CHUNK_SIZE: usize = 16;
 /// invalid. It will also return an error if the op token is malformed or doesn't match the expected
 /// instruction.
 pub fn parse_push_constant(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    let param_idx = 1;
-    validate_op_len(op, param_idx, 1, MAX_CONST_INPUTS)?;
+    validate_operation!(op, "push", 1..MAX_CONST_INPUTS);
 
+    let param_idx = 1;
     let param_count = op.num_parts() - param_idx;
     // for multiple input parameters, parse & push each one onto the stack in order, then return
     if param_count > 1 {

--- a/assembly/src/parsers/io_ops/env_ops.rs
+++ b/assembly/src/parsers/io_ops/env_ops.rs
@@ -1,4 +1,4 @@
-use super::{validate_op_len, AssemblyError, Operation, Token};
+use super::{validate_operation, AssemblyError, Operation, Token};
 
 // ENVIRONMENT INPUTS
 // ================================================================================================
@@ -15,11 +15,7 @@ use super::{validate_op_len, AssemblyError, Operation, Token};
 /// be handled. It will return an error if the assembly instruction is malformed or the environment
 /// input is unrecognized.
 pub fn parse_push_env(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    // validate the operation
-    validate_op_len(op, 3, 0, 0)?;
-    if op.parts()[1] != "env" {
-        return Err(AssemblyError::unexpected_token(op, "push.env.{var}"));
-    }
+    validate_operation!(op, "push.env.sdepth", 0);
 
     // update the span block
     match op.parts()[2] {
@@ -78,7 +74,7 @@ mod tests {
 
         // invalid env var
         let op_val_invalid = Token::new("push.env.invalid", pos);
-        let expected = AssemblyError::invalid_op(&op_val_invalid);
+        let expected = AssemblyError::unexpected_token(&op_val_invalid, "push.env.sdepth");
         assert_eq!(
             parse_push(&mut span_ops, &op_val_invalid, num_proc_locals).unwrap_err(),
             expected

--- a/assembly/src/parsers/io_ops/env_ops.rs
+++ b/assembly/src/parsers/io_ops/env_ops.rs
@@ -54,6 +54,7 @@ pub fn parse_push_env(
 #[cfg(test)]
 mod tests {
     use super::{
+        super::tests::get_parsing_error,
         super::{super::FieldElement, parse_push, AssemblyError, Felt},
         Operation, Token,
     };
@@ -65,7 +66,7 @@ mod tests {
     fn push_env_sdepth() {
         let num_proc_locals = 0;
 
-        // pushes the current depth of the stack onto the top of the stack
+        // --- pushes the current depth of the stack onto the top of the stack --------------------
         let mut span_ops = vec![Operation::Push(Felt::ONE); 8];
         let op = Token::new("push.env.sdepth", 0);
         let mut expected = span_ops.clone();
@@ -77,14 +78,25 @@ mod tests {
     }
 
     #[test]
+    fn push_env_locaddr() {
+        let asm_op = "push.env.locaddr";
+        let num_proc_locals = 2;
+        let mut span_ops: Vec<Operation> = Vec::new();
+
+        let op_str = format!("{}.{}", asm_op, 1);
+        let op = Token::new(&op_str, 0);
+        assert!(parse_push(&mut span_ops, &op, num_proc_locals).is_ok());
+    }
+
+    #[test]
     fn push_env_invalid() {
         let num_proc_locals = 0;
 
-        // fails when env op variant is invalid or missing or has too many immediate values
+        // --- fails when env op variant is invalid or missing or has too many immediate values ---
         let mut span_ops: Vec<Operation> = Vec::new();
         let pos = 0;
 
-        // missing env var
+        // --- missing env var --------------------------------------------------------------------
         let op_no_val = Token::new("push.env", pos);
         let expected = AssemblyError::invalid_op(&op_no_val);
         assert_eq!(
@@ -92,20 +104,79 @@ mod tests {
             expected
         );
 
-        // invalid env var
+        // --- invalid env var --------------------------------------------------------------------
         let op_val_invalid = Token::new("push.env.invalid", pos);
-        let expected = AssemblyError::unexpected_token(&op_val_invalid, "push.env.sdepth");
+        let expected = AssemblyError::unexpected_token(&op_val_invalid, "push.env.locaddr|sdepth");
         assert_eq!(
             parse_push(&mut span_ops, &op_val_invalid, num_proc_locals).unwrap_err(),
             expected
         );
 
-        // extra value
+        // --- extra value ------------------------------------------------------------------------
         let op_extra_val = Token::new("push.env.sdepth.0", pos);
         let expected = AssemblyError::extra_param(&op_extra_val);
         assert_eq!(
             parse_push(&mut span_ops, &op_extra_val, num_proc_locals).unwrap_err(),
             expected
         );
+    }
+
+    #[test]
+    fn push_env_sdepth_invalid() {
+        let num_proc_locals = 0;
+
+        // fails when env op variant is invalid or missing or has too many immediate values
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let pos = 0;
+
+        // --- extra param ------------------------------------------------------------------------
+        let op_extra_val = Token::new("push.env.sdepth.0", pos);
+        let expected = AssemblyError::extra_param(&op_extra_val);
+        assert_eq!(
+            parse_push(&mut span_ops, &op_extra_val, num_proc_locals).unwrap_err(),
+            expected
+        );
+    }
+
+    #[test]
+    fn push_env_locaddr_invalid() {
+        let asm_op = "push.env.locaddr";
+        let num_proc_locals = 2;
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let pos = 0;
+
+        // --- missing param ----------------------------------------------------------------------
+        let op_missing_param = Token::new(asm_op, pos);
+        let expected = AssemblyError::missing_param(&op_missing_param);
+        assert_eq!(
+            parse_push(&mut span_ops, &op_missing_param, num_proc_locals).unwrap_err(),
+            expected
+        );
+
+        // --- provided local index is outside of the declared bounds of the procedure locals -----
+        let op_str = format!("{}.{}", asm_op, 2);
+        let op_val_invalid = Token::new(&op_str, pos);
+        let expected = AssemblyError::invalid_param_with_reason(
+            &op_val_invalid,
+            3,
+            format!(
+                "parameter value must be greater than or equal to 0 and less than or equal to {}",
+                num_proc_locals - 1
+            )
+            .as_str(),
+        );
+        assert_eq!(
+            get_parsing_error("push", &op_val_invalid, num_proc_locals),
+            expected
+        );
+
+        // --- no procedure locals in context -----------------------------------------------------
+        let op_str = format!("{}.{}", asm_op, 1);
+        let op_context_invalid = Token::new(&op_str, pos);
+        let expected = AssemblyError::invalid_op_with_reason(
+            &op_context_invalid,
+            "no procedure locals available in current context",
+        );
+        assert_eq!(get_parsing_error("push", &op_context_invalid, 0), expected);
     }
 }

--- a/assembly/src/parsers/io_ops/env_ops.rs
+++ b/assembly/src/parsers/io_ops/env_ops.rs
@@ -8,7 +8,9 @@ use super::{
 /// Appends machine operations to the current span block according to the requested environment
 /// assembly instruction.
 ///
-/// `push.env.sdepth` pushes the current depth of the stack onto the top of the stack, which is
+/// - `push.env.locaddr.i` pushes the absolute address of the local variable at index `i` onto the
+/// stack.
+/// - `push.env.sdepth` pushes the current depth of the stack onto the top of the stack, which is
 /// handled directly by the `SDEPTH` operation.
 ///
 /// # Errors

--- a/assembly/src/parsers/io_ops/local_ops.rs
+++ b/assembly/src/parsers/io_ops/local_ops.rs
@@ -1,4 +1,6 @@
-use super::{parse_int_param, push_value, validate_op_len, AssemblyError, Felt, Operation, Token};
+use super::{
+    parse_int_param, push_value, validate_operation, AssemblyError, Felt, Operation, Token,
+};
 use vm_core::utils::PushMany;
 
 // LOCAL MEMORY FOR PROCEDURE VARIABLES
@@ -11,7 +13,7 @@ pub fn parse_push_local(
     op: &Token,
     num_proc_locals: u32,
 ) -> Result<(), AssemblyError> {
-    validate_op_len(op, 2, 1, 1)?;
+    validate_operation!(op, "push.local", 1);
 
     parse_read_local(span_ops, op, num_proc_locals, false)?;
 
@@ -27,7 +29,7 @@ pub fn parse_pop_local(
     op: &Token,
     num_proc_locals: u32,
 ) -> Result<(), AssemblyError> {
-    validate_op_len(op, 2, 1, 1)?;
+    validate_operation!(op, "pop.local", 1);
 
     // pad to word length before calling STOREW
     span_ops.push_many(Operation::Pad, 3);
@@ -53,10 +55,7 @@ pub fn parse_read_local(
     num_proc_locals: u32,
     overwrite_stack_top: bool,
 ) -> Result<(), AssemblyError> {
-    // check for parameter
-    if op.num_parts() < 3 {
-        return Err(AssemblyError::missing_param(op));
-    }
+    validate_operation!(@only_params op, "pushw|loadw.local", 1);
 
     if !overwrite_stack_top {
         // make space for the new elements
@@ -86,10 +85,7 @@ pub fn parse_write_local(
     num_proc_locals: u32,
     retain_stack_top: bool,
 ) -> Result<(), AssemblyError> {
-    // check for parameter
-    if op.num_parts() < 3 {
-        return Err(AssemblyError::missing_param(op));
-    }
+    validate_operation!(@only_params op, "popw|storew.local", 1);
 
     push_local_addr(span_ops, op, num_proc_locals)?;
     span_ops.push(Operation::StoreW);

--- a/assembly/src/parsers/io_ops/mem_ops.rs
+++ b/assembly/src/parsers/io_ops/mem_ops.rs
@@ -1,4 +1,4 @@
-use super::{parse_element_param, validate_op_len, AssemblyError, Operation, Token};
+use super::{parse_element_param, validate_operation, AssemblyError, Operation, Token};
 use vm_core::utils::PushMany;
 
 // RANDOM ACCESS MEMORY
@@ -7,7 +7,7 @@ use vm_core::utils::PushMany;
 /// Pushes the first element of the word at the specified memory address onto the stack. The
 /// memory address may be provided directly as an immediate value or via the stack.
 pub fn parse_push_mem(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    validate_op_len(op, 2, 0, 1)?;
+    validate_operation!(op, "push.mem", 0..1);
 
     // read from memory with overwrite_stack_top set to false so the rest of the stack is kept
     parse_read_mem(span_ops, op, false)?;
@@ -20,7 +20,7 @@ pub fn parse_push_mem(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), A
 /// Pops the top element off the stack and saves it at the specified memory address. The memory
 /// address may be provided directly as an immediate value or via the stack.
 pub fn parse_pop_mem(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    validate_op_len(op, 2, 0, 1)?;
+    validate_operation!(op, "pop.mem", 0..1);
 
     // pad to word length before calling STOREW
     span_ops.push_many(Operation::Pad, 3);
@@ -56,6 +56,8 @@ pub fn parse_read_mem(
     op: &Token,
     overwrite_stack_top: bool,
 ) -> Result<(), AssemblyError> {
+    validate_operation!(@only_params op, "push|pushw|loadw.mem", 0..1);
+
     if !overwrite_stack_top {
         // make space for the new elements
         span_ops.push_many(Operation::Pad, 4);
@@ -100,6 +102,8 @@ pub fn parse_write_mem(
     op: &Token,
     retain_stack_top: bool,
 ) -> Result<(), AssemblyError> {
+    validate_operation!(@only_params op, "pop|popw|storew.mem", 0..1);
+
     if op.num_parts() == 3 {
         push_mem_addr(span_ops, op)?;
     }

--- a/assembly/src/parsers/io_ops/mod.rs
+++ b/assembly/src/parsers/io_ops/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    parse_decimal_param, parse_element_param, parse_hex_param, parse_int_param, push_value,
-    validate_op_len, AssemblyError, Felt, Operation, Token,
+    super::validate_operation, parse_decimal_param, parse_element_param, parse_hex_param,
+    parse_int_param, push_value, AssemblyError, Felt, Operation, Token,
 };
 
 mod adv_ops;
@@ -92,14 +92,7 @@ pub fn parse_pushw(
     op: &Token,
     num_proc_locals: u32,
 ) -> Result<(), AssemblyError> {
-    // validate op
-    validate_op_len(op, 2, 0, 1)?;
-    if op.parts()[0] != "pushw" {
-        return Err(AssemblyError::unexpected_token(
-            op,
-            "pushw.{mem|mem.a|local.i}",
-        ));
-    }
+    validate_operation!(op, "pushw.local|mem");
 
     match op.parts()[1] {
         // read from mem with overwrite_stack_top set to false so the rest of the stack is kept
@@ -131,12 +124,7 @@ pub fn parse_pop(
     op: &Token,
     num_proc_locals: u32,
 ) -> Result<(), AssemblyError> {
-    if op.num_parts() < 2 {
-        return Err(AssemblyError::invalid_op(op));
-    }
-    if op.parts()[0] != "pop" {
-        return Err(AssemblyError::unexpected_token(op, "pop.{mem|mem.a}"));
-    }
+    validate_operation!(op, "pop.local|mem");
 
     match op.parts()[1] {
         "local" => parse_pop_local(span_ops, op, num_proc_locals),
@@ -167,14 +155,7 @@ pub fn parse_popw(
     op: &Token,
     num_proc_locals: u32,
 ) -> Result<(), AssemblyError> {
-    // validate op
-    validate_op_len(op, 2, 0, 1)?;
-    if op.parts()[0] != "popw" {
-        return Err(AssemblyError::unexpected_token(
-            op,
-            "popw.{mem|mem.a|local.i}",
-        ));
-    }
+    validate_operation!(op, "popw.local|mem");
 
     match op.parts()[1] {
         // write to mem with retain_stack_top set to false so the 4 elements are dropped after writing
@@ -215,14 +196,7 @@ pub fn parse_loadw(
     op: &Token,
     num_proc_locals: u32,
 ) -> Result<(), AssemblyError> {
-    // validate op
-    validate_op_len(op, 2, 0, 1)?;
-    if op.parts()[0] != "loadw" {
-        return Err(AssemblyError::unexpected_token(
-            op,
-            "loadw.{adv|mem|mem.a|local.i}",
-        ));
-    }
+    validate_operation!(op, "loadw.adv|local|mem");
 
     match op.parts()[1] {
         "adv" => parse_loadw_adv(span_ops, op),
@@ -260,14 +234,7 @@ pub fn parse_storew(
     op: &Token,
     num_proc_locals: u32,
 ) -> Result<(), AssemblyError> {
-    // validate op
-    validate_op_len(op, 2, 0, 1)?;
-    if op.parts()[0] != "storew" {
-        return Err(AssemblyError::unexpected_token(
-            op,
-            "storew.{mem|mem.a|local.i}",
-        ));
-    }
+    validate_operation!(op, "storew.local|mem");
 
     match op.parts()[1] {
         // write to mem with retain_stack_top set to true so the 4 elements are left on the stack
@@ -292,7 +259,7 @@ mod tests {
 
     #[test]
     fn pushw_invalid() {
-        test_parsew_base("pushw", "pushw.{mem|mem.a|local.i}");
+        test_parsew_base("pushw", "pushw.local|mem");
     }
 
     // TESTS FOR REMOVING VALUES FROM THE STACK (POP)
@@ -300,7 +267,7 @@ mod tests {
 
     #[test]
     fn popw_invalid() {
-        test_parsew_base("popw", "popw.{mem|mem.a|local.i}");
+        test_parsew_base("popw", "popw.local|mem");
     }
 
     // TESTS FOR OVERWRITING VALUES ON THE STACK (LOAD)
@@ -308,7 +275,7 @@ mod tests {
 
     #[test]
     fn loadw_invalid() {
-        test_parsew_base("loadw", "loadw.{adv|mem|mem.a|local.i}");
+        test_parsew_base("loadw", "loadw.adv|local|mem");
     }
 
     // TESTS FOR SAVING STACK VALUES WITHOUT REMOVING THEM (STORE)
@@ -316,7 +283,7 @@ mod tests {
 
     #[test]
     fn storew_invalid() {
-        test_parsew_base("storew", "storew.{mem|mem.a|local.i}");
+        test_parsew_base("storew", "storew.local|mem");
     }
 
     // TEST HELPERS
@@ -342,7 +309,7 @@ mod tests {
         // invalid variant
         let op_str = format!("{}.invalid", base_op);
         let op_invalid = Token::new(&op_str, pos);
-        let expected = AssemblyError::invalid_op(&op_invalid);
+        let expected = AssemblyError::unexpected_token(&op_invalid, expected_token);
         assert_eq!(
             get_parsing_error(base_op, &op_invalid, num_proc_locals),
             expected

--- a/assembly/src/parsers/io_ops/mod.rs
+++ b/assembly/src/parsers/io_ops/mod.rs
@@ -64,7 +64,7 @@ pub fn parse_push(
 
     match op.parts()[1] {
         "adv" => parse_push_adv(span_ops, op),
-        "env" => parse_push_env(span_ops, op),
+        "env" => parse_push_env(span_ops, op, num_proc_locals),
         "local" => parse_push_local(span_ops, op, num_proc_locals),
         "mem" => parse_push_mem(span_ops, op),
         _ => parse_push_constant(span_ops, op),

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -207,41 +207,6 @@ fn parse_int_param(
     Ok(result)
 }
 
-/// This is a helper function that validates the length of an assembly instruction and returns
-/// an error if the instruction is too short or too long.
-///
-/// `instr_parts` expects the number of non-parameter parts in the instruction, e.g. 2 for the
-/// "mem.pop" instruction. `min_params` and `max_params` expect the minimum and maximum number of
-/// parameters accepted by the operation respectively.
-///
-/// # Errors
-///
-/// This function will return an AssemblyError if the instruction part of the operation is
-/// too short or if too many or too few parameters are provided.
-fn validate_op_len(
-    op: &Token,
-    instr_parts: usize,
-    min_params: usize,
-    max_params: usize,
-) -> Result<(), AssemblyError> {
-    let num_parts = op.num_parts();
-
-    // token has too few parts to contain the full instruction
-    if num_parts < instr_parts {
-        return Err(AssemblyError::invalid_op(op));
-    }
-    // token has too few parts to contain the required parameters
-    if num_parts < instr_parts + min_params {
-        return Err(AssemblyError::missing_param(op));
-    }
-    // token has more than the maximum number of parts
-    if num_parts > instr_parts + max_params {
-        return Err(AssemblyError::extra_param(op));
-    }
-
-    Ok(())
-}
-
 /// This is a helper function that appends a PUSH operation to the span block which puts the
 /// provided value parameter onto the stack.
 ///
@@ -256,4 +221,83 @@ fn push_value(span_ops: &mut Vec<Operation>, value: Felt) {
     } else {
         span_ops.push(Operation::Push(value));
     }
+}
+
+/// Validates an op Token against a provided instruction string and/or an expected number of
+/// parameter inputs and returns an appropriate AssemblyError if the operation Token is invalid.
+///
+/// * To fully validate an operation, pass all of the following:
+/// - the parsed operation Token
+/// - a string describing a valid instruction, with variants separated by '|' and parameters
+///   excluded.
+/// - an integer or range for the number of allowed parameters
+/// This will attempt to fully validate the operation, so a full-length instruction must be
+/// described. For example, `popw.mem` accepts 0 or 1 inputs and can be validated by:
+/// ```validate_operation!(op_token, "popw.mem", 0..1)```
+///
+/// * To validate only the operation parameters, specify @only_params before passing the same inputs
+/// used for full validation (above). This will skip validating each part of the instruction.
+/// For example, to validate only the parameters of `popw.mem` use:
+/// ```validate_operation!(@only_params op_token, "popw.mem", 0..1)```
+///
+/// * To validate only the instruction portion of the operation, exclude the specification for the
+/// number of parameters. This will only validate up to the number of parts in the provided
+/// instruction string. For example, `pop.local` and `pop.mem` are the two valid instruction
+/// variants for `pop`, so the first 2 parts of `pop` can be validated by:
+/// ```validate_operation!(op_token, "pop.local|mem")```
+/// or the first part can be validated by:
+/// ```validate_operation!(op_token, "pop")```
+#[macro_export]
+macro_rules! validate_operation {
+    // validate that the number of parameters is within the allowed range
+    (@only_params $token:expr, $instr:literal, $min_params:literal..$max_params:expr ) => {
+        let num_parts = $token.num_parts();
+        let num_instr_parts = $instr.split(".").count();
+
+        // token has too few parts to contain the required parameters
+        if num_parts < num_instr_parts + $min_params {
+            return Err(AssemblyError::missing_param($token));
+        }
+        // token has more than the maximum number of parts
+        if num_parts > num_instr_parts + $max_params {
+            return Err(AssemblyError::extra_param($token));
+        }
+    };
+    // validate the exact number of parameters
+    (@only_params $token:expr, $instr:literal, $num_params:literal) => {
+        validate_operation!(@only_params $token, $instr, $num_params..$num_params);
+    };
+
+    // validate the instruction string and an optional parameter range
+    ($token:expr, $instr:literal $(, $min_params:literal..$max_params:expr)?) => {
+        // split the expected instruction into a vector of parts
+        let instr_parts: Vec<Vec<&str>> = $instr
+            .split(".")
+            .map(|part| part.split("|").collect())
+            .collect();
+
+        let num_parts = $token.num_parts();
+        let num_instr_parts = instr_parts.len();
+
+        // token has too few parts to contain the full instruction
+        if num_parts < num_instr_parts {
+            return Err(AssemblyError::invalid_op($token));
+        }
+
+        // compare the parts to make sure they match
+        for (part_variants, token_part) in instr_parts.iter().zip($token.parts()) {
+            if !part_variants.contains(token_part) {
+                return Err(AssemblyError::unexpected_token($token, $instr));
+            }
+        }
+
+        $(
+            // validate the parameter range, if provided
+            validate_operation!(@only_params $token, $instr, $min_params..$max_params);
+        )?
+    };
+    // validate the instruction string and an exact number of parameters
+    ($token:expr, $instr:literal, $num_params:literal) => {
+        validate_operation!($token, $instr, $num_params..$num_params);
+    };
 }

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -1,4 +1,7 @@
-use super::{ExecutionError, Felt, FieldElement, Process, StarkField};
+use super::{
+    super::system::{FMP_MAX, FMP_MIN},
+    ExecutionError, Felt, FieldElement, Process, StarkField,
+};
 
 // SYSTEM OPERATIONS
 // ================================================================================================
@@ -50,7 +53,7 @@ impl Process {
         let fmp = self.system.fmp();
 
         let new_fmp = fmp + offset;
-        if new_fmp.as_int() > u32::MAX as u64 {
+        if new_fmp.as_int() < FMP_MIN || new_fmp.as_int() > FMP_MAX {
             return Err(ExecutionError::InvalidFmpValue(fmp, new_fmp));
         }
 

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -71,42 +71,42 @@ impl Process {
 mod tests {
     use super::{
         super::{init_stack_with, Operation},
-        Felt, FieldElement, Process,
+        Felt, FieldElement, Process, FMP_MAX, FMP_MIN,
     };
 
     #[test]
     fn op_fmpupdate() {
         let mut process = Process::new_dummy();
 
-        // initial value of fmp register should be zero
-        assert_eq!(Felt::ZERO, process.system.fmp());
+        // initial value of fmp register should be 2^30
+        assert_eq!(Felt::new(2_u64.pow(30)), process.system.fmp());
 
         // increment fmp register
         process.execute_op(Operation::Push(Felt::new(2))).unwrap();
         process.execute_op(Operation::FmpUpdate).unwrap();
-        assert_eq!(Felt::new(2), process.system.fmp());
+        assert_eq!(Felt::new(FMP_MIN + 2), process.system.fmp());
 
         // increment fmp register again
         process.execute_op(Operation::Push(Felt::new(3))).unwrap();
         process.execute_op(Operation::FmpUpdate).unwrap();
-        assert_eq!(Felt::new(5), process.system.fmp());
+        assert_eq!(Felt::new(FMP_MIN + 5), process.system.fmp());
 
         // decrement fmp register
         process.execute_op(Operation::Push(-Felt::new(3))).unwrap();
         process.execute_op(Operation::FmpUpdate).unwrap();
-        assert_eq!(Felt::new(2), process.system.fmp());
+        assert_eq!(Felt::new(FMP_MIN + 2), process.system.fmp());
 
-        // decrementing beyond zero should be an error
+        // decrementing beyond the minimum fmp value should be an error
         process.execute_op(Operation::Push(-Felt::new(3))).unwrap();
         assert!(process.execute_op(Operation::FmpUpdate).is_err());
 
-        // going up to u32::MAX should be OK
+        // going up to the max fmp value should be OK
         let mut process = Process::new_dummy();
         process
             .execute_op(Operation::Push(Felt::new(u32::MAX as u64)))
             .unwrap();
         process.execute_op(Operation::FmpUpdate).unwrap();
-        assert_eq!(Felt::new(u32::MAX as u64), process.system.fmp());
+        assert_eq!(Felt::new(FMP_MAX), process.system.fmp());
 
         // but going beyond that should be an error
         let mut process = Process::new_dummy();
@@ -136,14 +136,14 @@ mod tests {
         process.execute_op(Operation::Push(-Felt::new(1))).unwrap();
         process.execute_op(Operation::FmpAdd).unwrap();
 
-        let expected = build_expected(&[1]);
+        let expected = build_expected(&[FMP_MIN + 1]);
         assert_eq!(expected, process.stack.trace_state());
 
         // compute address of second local (also make sure that rest of stack is not affected)
         process.execute_op(Operation::Push(-Felt::new(2))).unwrap();
         process.execute_op(Operation::FmpAdd).unwrap();
 
-        let expected = build_expected(&[0, 1]);
+        let expected = build_expected(&[FMP_MIN, FMP_MIN + 1]);
         assert_eq!(expected, process.stack.trace_state());
     }
 

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -1,5 +1,13 @@
 use super::{Felt, FieldElement};
 
+// CONSTANTS
+// ================================================================================================
+
+// Memory addresses for procedure locals should start at 2^30 and not go below.
+pub const FMP_MIN: u64 = 2_u64.pow(30);
+// The total number of locals available to all procedures at runtime must be smaller than 2^32.
+pub const FMP_MAX: u64 = FMP_MIN + u32::MAX as u64;
+
 // SYSTEM INFO
 // ================================================================================================
 
@@ -17,11 +25,12 @@ impl System {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new [System] struct with execution traces instantiated with the specified length.
+    /// Initializes the free memory pointer `fmp` used for local memory offsets to 2^30.
     pub fn new(init_trace_length: usize) -> Self {
         Self {
             clk: 0,
             clk_trace: vec![Felt::ZERO; init_trace_length],
-            fmp: Felt::ZERO,
+            fmp: Felt::new(FMP_MIN),
             fmp_trace: vec![Felt::ZERO; init_trace_length],
         }
     }

--- a/processor/src/tests/io_ops/env_ops.rs
+++ b/processor/src/tests/io_ops/env_ops.rs
@@ -1,10 +1,11 @@
-use super::test_op_execution;
+use super::{compile, test_op_execution, test_script_execution};
+use crate::system::FMP_MIN;
 
 // PUSHING VALUES ONTO THE STACK (PUSH)
 // ================================================================================================
 
 #[test]
-fn push_env() {
+fn push_env_sdepth() {
     let test_op = "push.env.sdepth";
 
     // --- empty stack ----------------------------------------------------------------------------
@@ -20,5 +21,104 @@ fn push_env() {
         format!("{} {}", setup_ops, test_op).as_str(),
         &[0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7],
         &[18, 1, 1, 7, 6, 5, 4, 3, 2, 1, 0, 7, 6, 5, 4, 3],
+    );
+}
+
+#[test]
+fn push_env_locaddr() {
+    // --- locaddr returns expected address -------------------------------------------------------
+    let script = compile(
+        "
+        proc.foo.2
+            push.env.locaddr.0
+            push.env.locaddr.1
+        end
+        begin
+            exec.foo
+        end",
+    );
+    test_script_execution(&script, &[10], &[FMP_MIN + 1, FMP_MIN + 2, 10]);
+
+    // --- accessing mem via locaddr updates the correct variables --------------------------------
+    let script = compile(
+        "
+        proc.foo.2
+            push.env.locaddr.0
+            pop.mem
+            push.env.locaddr.1
+            popw.mem
+            push.local.0
+            pushw.local.1
+        end
+        begin
+            exec.foo
+        end",
+    );
+    test_script_execution(&script, &[10, 1, 2, 3, 4, 5], &[4, 3, 2, 1, 5, 10]);
+
+    // --- locaddr returns expected addresses in nested procedures --------------------------------
+    let script = compile(
+        "
+        proc.foo.3
+            push.env.locaddr.0
+            push.env.locaddr.1
+            push.env.locaddr.2
+        end
+        proc.bar.2
+            push.env.locaddr.0
+            exec.foo
+            push.env.locaddr.1
+        end
+        begin
+            exec.bar
+            exec.foo
+        end",
+    );
+
+    test_script_execution(
+        &script,
+        &[10],
+        &[
+            FMP_MIN + 1,
+            FMP_MIN + 2,
+            FMP_MIN + 3,
+            FMP_MIN + 1,
+            FMP_MIN + 3,
+            FMP_MIN + 4,
+            FMP_MIN + 5,
+            FMP_MIN + 2,
+            10,
+        ],
+    );
+
+    // --- accessing mem via locaddr in nested procedures updates the correct variables -----------
+    let script = compile(
+        "
+        proc.foo.2
+            push.env.locaddr.0
+            pop.mem
+            push.env.locaddr.1
+            popw.mem
+            pushw.local.1
+            push.local.0
+        end
+        proc.bar.2
+            push.env.locaddr.0
+            pop.mem
+            pop.local.1
+            exec.foo
+            push.env.locaddr.1
+            push.mem
+            push.local.0
+        end
+        begin
+            exec.bar
+        end",
+    );
+
+    test_script_execution(
+        &script,
+        &[10, 1, 2, 3, 4, 5, 6, 7],
+        &[7, 6, 5, 4, 3, 2, 1, 10],
     );
 }


### PR DESCRIPTION
This PR addresses #118 and #105.

- updates `fmp` max and min values for local memory addressing
- updates unit tests for `fmpadd` and `fmpupdate`
- adds new op `push.env.locaddr.i` to push the absolute address of the local at index `i` onto the stack
- updates unit & integration tests for env io ops
- refactors assembly op validation to a macro for greater flexibility and to reduce repeated code in op parsers