### PR TITLE
Incorrect implementation of parse_u32div for u32div and u32div.b operations #94

### DIFF
--- a/assembly/src/parsers/u32_ops.rs
+++ b/assembly/src/parsers/u32_ops.rs
@@ -259,7 +259,8 @@ pub fn parse_u32div(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
                 false
             }
             _ => {
-                if parse_int_param(op, 1, 0, u32::MAX)? == 0 {
+                let divider: u32 = parse_int_param(op, 1, 0, u32::MAX)?;
+                if divider == 0 {
                     return Err(AssemblyError::invalid_param_with_reason(
                         op,
                         1,
@@ -267,7 +268,8 @@ pub fn parse_u32div(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
                     ));
                 }
 
-                assert_u32_and_push_u32_param(span_ops, op, 0)?;
+                assert_u32(span_ops);
+                push_value(span_ops, Felt::new(divider as u64));
                 true
             }
         },
@@ -303,7 +305,17 @@ pub fn parse_u32mod(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
             _ => {
                 // for u32mod.n (where n is the immediate value), we need to push the immediate
                 // value onto the stack, and make sure both operands are u32 values.
-                assert_u32_and_push_u32_param(span_ops, op, 1)?;
+                let divider: u32 = parse_int_param(op, 1, 0, u32::MAX)?;
+                if divider == 0 {
+                    return Err(AssemblyError::invalid_param_with_reason(
+                        op,
+                        1,
+                        "division by 0",
+                    ));
+                }
+
+                assert_u32(span_ops);
+                push_value(span_ops, Felt::new(divider as u64));
             }
         },
         _ => return Err(AssemblyError::extra_param(op)),
@@ -799,7 +811,7 @@ fn handle_u32_and_unsafe_check(
 ///   - Any number argument gets pushed to the stack, checked if both are u32 and performs the
 ///     operation.
 ///
-/// According to the spec this is currently U32ADD, U32SUB, U32DIV, U32MUL.
+/// According to the spec this is currently U32ADD, U32SUB, U32MUL.
 fn handle_arithmetic_operation(
     span_ops: &mut Vec<Operation>,
     op: &Token,

--- a/assembly/src/parsers/u32_ops.rs
+++ b/assembly/src/parsers/u32_ops.rs
@@ -259,8 +259,8 @@ pub fn parse_u32div(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
                 false
             }
             _ => {
-                let divider: u32 = parse_int_param(op, 1, 0, u32::MAX)?;
-                if divider == 0 {
+                let divisor: u32 = parse_int_param(op, 1, 0, u32::MAX)?;
+                if divisor == 0 {
                     return Err(AssemblyError::invalid_param_with_reason(
                         op,
                         1,
@@ -269,7 +269,7 @@ pub fn parse_u32div(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
                 }
 
                 assert_u32(span_ops);
-                push_value(span_ops, Felt::new(divider as u64));
+                push_value(span_ops, Felt::new(divisor as u64));
                 true
             }
         },
@@ -305,8 +305,8 @@ pub fn parse_u32mod(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
             _ => {
                 // for u32mod.n (where n is the immediate value), we need to push the immediate
                 // value onto the stack, and make sure both operands are u32 values.
-                let divider: u32 = parse_int_param(op, 1, 0, u32::MAX)?;
-                if divider == 0 {
+                let divisor: u32 = parse_int_param(op, 1, 0, u32::MAX)?;
+                if divisor == 0 {
                     return Err(AssemblyError::invalid_param_with_reason(
                         op,
                         1,
@@ -315,7 +315,7 @@ pub fn parse_u32mod(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
                 }
 
                 assert_u32(span_ops);
-                push_value(span_ops, Felt::new(divider as u64));
+                push_value(span_ops, Felt::new(divisor as u64));
             }
         },
         _ => return Err(AssemblyError::extra_param(op)),


### PR DESCRIPTION
Added a division by 0 check for the u32div.b operation, as well as separate processing of the result of the u32div operation when checking for belonging to the u32 type.