### PR TITLE
Implement minimum stack depth

### DIFF
--- a/core/src/inputs/mod.rs
+++ b/core/src/inputs/mod.rs
@@ -2,7 +2,7 @@ use super::{
     errors::{AdviceSetError, InputError},
     hasher,
     utils::IntoBytes,
-    Felt, FieldElement, Word, STACK_TOP_SIZE,
+    Felt, FieldElement, Word, MIN_STACK_DEPTH,
 };
 use core::convert::TryInto;
 use winter_utils::collections::{BTreeMap, Vec};
@@ -49,9 +49,9 @@ impl ProgramInputs {
         advice_tape: &[u64],
         advice_sets: Vec<AdviceSet>,
     ) -> Result<Self, InputError> {
-        if stack_init.len() > STACK_TOP_SIZE {
+        if stack_init.len() > MIN_STACK_DEPTH {
             return Err(InputError::TooManyStackValues(
-                STACK_TOP_SIZE,
+                MIN_STACK_DEPTH,
                 stack_init.len(),
             ));
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,5 +19,6 @@ pub type Word = [Felt; 4];
 // CONSTANTS
 // ================================================================================================
 
-/// Number of stack registers which can be accesses by the VM directly.
-pub const STACK_TOP_SIZE: usize = 16;
+/// The minimum stack depth enforced by the VM. This is also the number of stack registers which can
+/// be accessed by the VM directly.
+pub const MIN_STACK_DEPTH: usize = 16;

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -8,7 +8,6 @@ pub enum ExecutionError {
     UnsupportedCodeBlock(CodeBlock),
     UnexecutableCodeBlock(CodeBlock),
     NotBinaryValue(Felt),
-    StackUnderflow(&'static str, usize),
     DivideByZero(usize),
     FailedAssertion(usize),
     EmptyAdviceTape(usize),

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -17,8 +17,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than 12 elements.
     pub(super) fn op_rpperm(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(12, "RPPERM")?;
-
         let input_state = [
             self.stack.get(11),
             self.stack.get(10),
@@ -69,8 +67,6 @@ impl Process {
     ///   identified by the specified root.
     /// - Path to the node at the specified depth and index is not known to the advice provider.
     pub(super) fn op_mpverify(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(10, "MPVERIFY")?;
-
         // read depth, index, node value, and root value from the stack
         let depth = self.stack.get(0);
         let index = self.stack.get(1);
@@ -147,8 +143,6 @@ impl Process {
     ///   identified by the specified root.
     /// - Path to the node at the specified depth and index is not known to the advice provider.
     pub(super) fn op_mrupdate(&mut self, copy: bool) -> Result<(), ExecutionError> {
-        self.stack.check_depth(14, "MRUPDATE")?;
-
         // read depth, index, old and new node values, and tree root value from the stack
         let depth = self.stack.get(0);
         let index = self.stack.get(1);

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -13,9 +13,6 @@ impl Process {
     /// word follows, with the number of elements to be hashed at the deepest position in stack[11].
     /// For a Rescue Prime permutation of [A, B, C] where A is the capacity, the stack should be
     /// arranged (from the top) as [C, B, A, ...].
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than 12 elements.
     pub(super) fn op_rpperm(&mut self) -> Result<(), ExecutionError> {
         let input_state = [
             self.stack.get(11),
@@ -61,7 +58,6 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - The stack contains fewer than 10 elements.
     /// - Merkle tree for the specified root cannot be found in the advice provider.
     /// - The specified depth is either zero or greater than the depth of the Merkle tree
     ///   identified by the specified root.
@@ -137,7 +133,6 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - The stack contains fewer than 14 elements.
     /// - Merkle tree for the specified root cannot be found in the advice provider.
     /// - The specified depth is either zero or greater than the depth of the Merkle tree
     ///   identified by the specified root.

--- a/processor/src/operations/decorators/debug_tests.rs
+++ b/processor/src/operations/decorators/debug_tests.rs
@@ -1,7 +1,7 @@
 use crate::{Felt, Operation, Process};
 use core::cmp;
 use logtest::Logger;
-use vm_core::{DebugOptions, ProgramInputs};
+use vm_core::{DebugOptions, ProgramInputs, MIN_STACK_DEPTH};
 
 #[test]
 fn test_debug() {
@@ -121,7 +121,7 @@ fn test_print_mem(logger: &mut Logger) {
 
 fn assert_stack(size: usize, depth: usize, expected_stack: &[u64], logger: &mut Logger) {
     assert_eq!(logger.len(), 2);
-    let top_size = cmp::min(size, 16);
+    let top_size = cmp::min(size, MIN_STACK_DEPTH);
 
     // build the expected debug string from the expected stack
     let mut expected = expected_stack
@@ -159,7 +159,10 @@ fn test_print_stack(logger: &mut Logger) {
     // values are pushed onto the stack when ProgramInputs are created, so we expect them to be on
     // the stack in reverse order from the original input order
     stack_inputs.reverse();
-    assert_stack(4, 4, &stack_inputs, logger);
+    // expect the stack to be padded with 0s if the number of inputs is less than min depth
+    let depth = cmp::max(stack_inputs.len(), MIN_STACK_DEPTH);
+    stack_inputs.resize(depth, 0);
+    assert_stack(depth, depth, &stack_inputs, logger);
 
     stack_inputs = (1..=16).collect::<Vec<_>>();
     inputs = ProgramInputs::new(&stack_inputs, &[], vec![]).unwrap();

--- a/processor/src/operations/decorators/mod.rs
+++ b/processor/src/operations/decorators/mod.rs
@@ -125,8 +125,6 @@ impl Process {
     ///   identified by the specified root.
     /// - Value of the node at the specified depth and index is not known to the advice provider.
     fn inject_merkle_node(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(6, "INJMKNODE")?;
-
         // read node depth, node index, and tree root from the stack
         let depth = self.stack.get(0);
         let index = self.stack.get(1);

--- a/processor/src/operations/decorators/mod.rs
+++ b/processor/src/operations/decorators/mod.rs
@@ -119,7 +119,6 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - The stack contains fewer than 6 elements.
     /// - Merkle tree for the specified root cannot be found in the advice provider.
     /// - The specified depth is either zero or greater than the depth of the Merkle tree
     ///   identified by the specified root.

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -8,9 +8,6 @@ impl Process {
     // --------------------------------------------------------------------------------------------
     /// Pops two elements off the stack, adds them together, and pushes the result back onto the
     /// stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_add(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
@@ -21,9 +18,6 @@ impl Process {
 
     /// Pops an element off the stack, computes its additive inverse, and pushes the result back
     /// onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack is empty.
     pub(super) fn op_neg(&mut self) -> Result<(), ExecutionError> {
         let a = self.stack.get(0);
         self.stack.set(0, -a);
@@ -33,9 +27,6 @@ impl Process {
 
     /// Pops two elements off the stack, multiplies them, and pushes the result back onto the
     /// stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_mul(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
@@ -48,9 +39,7 @@ impl Process {
     /// back onto the stack.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// * The stack is empty.
-    /// * The value on the top of the stack is ZERO.
+    /// Returns an error if the value on the top of the stack is ZERO.
     pub(super) fn op_inv(&mut self) -> Result<(), ExecutionError> {
         let a = self.stack.get(0);
         if a == Felt::ZERO {
@@ -63,9 +52,6 @@ impl Process {
     }
 
     /// Pops an element off the stack, adds ONE to it, and pushes the result back onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack is empty.
     pub(super) fn op_incr(&mut self) -> Result<(), ExecutionError> {
         let a = self.stack.get(0);
         self.stack.set(0, a + Felt::ONE);
@@ -80,9 +66,8 @@ impl Process {
     /// onto the stack.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// * The stack contains fewer than two elements.
-    /// * Either of the two elements on the top of the stack is not a binary value.
+    /// Returns an error if either of the two elements on the top of the stack is not a binary
+    /// value.
     pub(super) fn op_and(&mut self) -> Result<(), ExecutionError> {
         let b = assert_binary(self.stack.get(0))?;
         let a = assert_binary(self.stack.get(1))?;
@@ -99,9 +84,8 @@ impl Process {
     /// onto the stack.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// * The stack contains fewer than two elements.
-    /// * Either of the two elements on the top of the stack is not a binary value.
+    /// Returns an error if either of the two elements on the top of the stack is not a binary
+    /// value.
     pub(super) fn op_or(&mut self) -> Result<(), ExecutionError> {
         let b = assert_binary(self.stack.get(0))?;
         let a = assert_binary(self.stack.get(1))?;
@@ -118,9 +102,7 @@ impl Process {
     /// the stack.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// * The stack is empty.
-    /// * The value on the top of the stack is not a binary value.
+    /// Returns an error if the value on the top of the stack is not a binary value.
     pub(super) fn op_not(&mut self) -> Result<(), ExecutionError> {
         let a = assert_binary(self.stack.get(0))?;
         self.stack.set(0, Felt::ONE - a);
@@ -133,9 +115,6 @@ impl Process {
 
     /// Pops two elements off the stack and compares them. If the elements are equal, pushes ONE
     /// onto the stack, otherwise pushes ZERO onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_eq(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
@@ -150,9 +129,6 @@ impl Process {
 
     /// Pops an element off the stack and compares it to ZERO. If the element is ZERO, pushes ONE
     /// onto the stack, otherwise pushes ZERO onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack is empty.
     pub(super) fn op_eqz(&mut self) -> Result<(), ExecutionError> {
         let a = self.stack.get(0);
         if a == Felt::ZERO {
@@ -166,9 +142,6 @@ impl Process {
 
     /// Compares the first word (four elements) with the second word on the stack, if the words are
     /// equal, pushes ONE onto the stack, otherwise pushes ZERO onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than 8 elements.
     pub(super) fn op_eqw(&mut self) -> Result<(), ExecutionError> {
         let b3 = self.stack.get(0);
         let b2 = self.stack.get(1);

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -12,8 +12,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_add(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "ADD")?;
-
         let b = self.stack.get(0);
         let a = self.stack.get(1);
         self.stack.set(0, a + b);
@@ -27,8 +25,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack is empty.
     pub(super) fn op_neg(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "NEG")?;
-
         let a = self.stack.get(0);
         self.stack.set(0, -a);
         self.stack.copy_state(1);
@@ -41,8 +37,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_mul(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "MUL")?;
-
         let b = self.stack.get(0);
         let a = self.stack.get(1);
         self.stack.set(0, a * b);
@@ -58,8 +52,6 @@ impl Process {
     /// * The stack is empty.
     /// * The value on the top of the stack is ZERO.
     pub(super) fn op_inv(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "INV")?;
-
         let a = self.stack.get(0);
         if a == Felt::ZERO {
             return Err(ExecutionError::DivideByZero(self.system.clk()));
@@ -75,8 +67,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack is empty.
     pub(super) fn op_incr(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "INCR")?;
-
         let a = self.stack.get(0);
         self.stack.set(0, a + Felt::ONE);
         self.stack.copy_state(1);
@@ -94,8 +84,6 @@ impl Process {
     /// * The stack contains fewer than two elements.
     /// * Either of the two elements on the top of the stack is not a binary value.
     pub(super) fn op_and(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "AND")?;
-
         let b = assert_binary(self.stack.get(0))?;
         let a = assert_binary(self.stack.get(1))?;
         if a == Felt::ONE && b == Felt::ONE {
@@ -115,8 +103,6 @@ impl Process {
     /// * The stack contains fewer than two elements.
     /// * Either of the two elements on the top of the stack is not a binary value.
     pub(super) fn op_or(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "OR")?;
-
         let b = assert_binary(self.stack.get(0))?;
         let a = assert_binary(self.stack.get(1))?;
         if a == Felt::ONE || b == Felt::ONE {
@@ -136,8 +122,6 @@ impl Process {
     /// * The stack is empty.
     /// * The value on the top of the stack is not a binary value.
     pub(super) fn op_not(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "NOT")?;
-
         let a = assert_binary(self.stack.get(0))?;
         self.stack.set(0, Felt::ONE - a);
         self.stack.copy_state(1);
@@ -153,8 +137,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_eq(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "EQ")?;
-
         let b = self.stack.get(0);
         let a = self.stack.get(1);
         if a == b {
@@ -172,8 +154,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack is empty.
     pub(super) fn op_eqz(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "EQZ")?;
-
         let a = self.stack.get(0);
         if a == Felt::ZERO {
             self.stack.set(0, Felt::ONE);
@@ -190,8 +170,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than 8 elements.
     pub(super) fn op_eqw(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(8, "EQW")?;
-
         let b3 = self.stack.get(0);
         let b2 = self.stack.get(1);
         let b1 = self.stack.get(2);

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -33,8 +33,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than five elements.
     pub(super) fn op_loadw(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(5, "LOADW")?;
-
         // get the address from the stack and read the word from memory
         let addr = self.stack.get(0);
         let word = self.memory.read(addr);
@@ -60,8 +58,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than five elements.
     pub(super) fn op_storew(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(5, "STOREW")?;
-
         // get the address from the stack and build the word to be saved from the stack values
         let addr = self.stack.get(0);
         let word = [
@@ -105,8 +101,6 @@ impl Process {
     /// * The stack contains fewer than four elements.
     /// * The advice tape contains fewer than four elements.
     pub(super) fn op_readw(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(4, "READW")?;
-
         let a = self.advice.read_tape()?;
         let b = self.advice.read_tape()?;
         let c = self.advice.read_tape()?;

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -29,9 +29,6 @@ impl Process {
     /// - The top four elements of the stack are overwritten with values retried from memory.
     ///
     /// Thus, the net result of the operation is that the stack is shifted left by one item.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than five elements.
     pub(super) fn op_loadw(&mut self) -> Result<(), ExecutionError> {
         // get the address from the stack and read the word from memory
         let addr = self.stack.get(0);
@@ -54,9 +51,6 @@ impl Process {
     ///   removed from the stack.
     ///
     /// Thus, the net result of the operation is that the stack is shifted left by one item.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than five elements.
     pub(super) fn op_storew(&mut self) -> Result<(), ExecutionError> {
         // get the address from the stack and build the word to be saved from the stack values
         let addr = self.stack.get(0);
@@ -97,9 +91,7 @@ impl Process {
     /// elements with it.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// * The stack contains fewer than four elements.
-    /// * The advice tape contains fewer than four elements.
+    /// Returns an error if the advice tape contains fewer than four elements.
     pub(super) fn op_readw(&mut self) -> Result<(), ExecutionError> {
         let a = self.advice.read_tape()?;
         let b = self.advice.read_tape()?;

--- a/processor/src/operations/stack_ops.rs
+++ b/processor/src/operations/stack_ops.rs
@@ -1,4 +1,4 @@
-use super::{super::STACK_TOP_SIZE, ExecutionError, Felt, FieldElement, Process, StarkField};
+use super::{super::MIN_STACK_DEPTH, ExecutionError, Felt, FieldElement, Process, StarkField};
 
 impl Process {
     // STACK MANIPULATION
@@ -15,7 +15,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack is empty.
     pub(super) fn op_drop(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "DROP")?;
         self.stack.shift_left(1);
         Ok(())
     }
@@ -25,7 +24,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than n + 1 values.
     pub(super) fn op_dup(&mut self, n: usize) -> Result<(), ExecutionError> {
-        self.stack.check_depth(n + 1, "DUP")?;
         let value = self.stack.get(n);
         self.stack.set(0, value);
         self.stack.shift_right(0);
@@ -37,7 +35,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_swap(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "SWAP")?;
         let a = self.stack.get(0);
         let b = self.stack.get(1);
         self.stack.set(0, b);
@@ -51,8 +48,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than 8 elements.
     pub(super) fn op_swapw(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(8, "SWAPW")?;
-
         let a0 = self.stack.get(0);
         let a1 = self.stack.get(1);
         let a2 = self.stack.get(2);
@@ -80,8 +75,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than 12 elements.
     pub(super) fn op_swapw2(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(12, "SWAPW2")?;
-
         let a0 = self.stack.get(0);
         let a1 = self.stack.get(1);
         let a2 = self.stack.get(2);
@@ -117,8 +110,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than 16 elements.
     pub(super) fn op_swapw3(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(16, "SWAPW3")?;
-
         let a0 = self.stack.get(0);
         let a1 = self.stack.get(1);
         let a2 = self.stack.get(2);
@@ -163,8 +154,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than n + 1 values.
     pub(super) fn op_movup(&mut self, n: usize) -> Result<(), ExecutionError> {
-        self.stack.check_depth(n + 1, "MOVUP")?;
-
         // move the nth value to the top of the stack
         let value = self.stack.get(n);
         self.stack.set(0, value);
@@ -176,7 +165,7 @@ impl Process {
         }
 
         // all other items on the stack remain in place
-        if (n + 1) < STACK_TOP_SIZE {
+        if (n + 1) < MIN_STACK_DEPTH {
             self.stack.copy_state(n + 1);
         }
         Ok(())
@@ -189,8 +178,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than n + 1 values.
     pub(super) fn op_movdn(&mut self, n: usize) -> Result<(), ExecutionError> {
-        self.stack.check_depth(n + 1, "MOVDN")?;
-
         // move the value at the top of the stack to the nth position
         let value = self.stack.get(0);
         self.stack.set(n, value);
@@ -202,7 +189,7 @@ impl Process {
         }
 
         // all other items on the stack remain in place
-        if (n + 1) < STACK_TOP_SIZE {
+        if (n + 1) < MIN_STACK_DEPTH {
             self.stack.copy_state(n + 1);
         }
         Ok(())
@@ -219,7 +206,6 @@ impl Process {
     /// - The stack contains fewer than 3 elements.
     /// - The top element of the stack is neither 0 nor 1.
     pub(super) fn op_cswap(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(3, "CSWAP")?;
         let c = self.stack.get(0);
         let b = self.stack.get(1);
         let a = self.stack.get(2);
@@ -248,7 +234,6 @@ impl Process {
     /// - The stack contains fewer than 9 elements.
     /// - The top element of the stack is neither 0 nor 1.
     pub(super) fn op_cswapw(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(9, "CSWAPW")?;
         let c = self.stack.get(0);
         let b0 = self.stack.get(1);
         let b1 = self.stack.get(2);

--- a/processor/src/operations/stack_ops.rs
+++ b/processor/src/operations/stack_ops.rs
@@ -11,18 +11,12 @@ impl Process {
     }
 
     /// Removes the top element off the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack is empty.
     pub(super) fn op_drop(&mut self) -> Result<(), ExecutionError> {
         self.stack.shift_left(1);
         Ok(())
     }
 
     /// Pushes the copy the n-th item onto the stack. n is 0-based.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than n + 1 values.
     pub(super) fn op_dup(&mut self, n: usize) -> Result<(), ExecutionError> {
         let value = self.stack.get(n);
         self.stack.set(0, value);
@@ -31,9 +25,6 @@ impl Process {
     }
 
     /// Swaps stack elements 0 and 1.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_swap(&mut self) -> Result<(), ExecutionError> {
         let a = self.stack.get(0);
         let b = self.stack.get(1);
@@ -44,9 +35,6 @@ impl Process {
     }
 
     /// Swaps stack elements 0, 1, 2, and 3 with elements 4, 5, 6, and 7.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than 8 elements.
     pub(super) fn op_swapw(&mut self) -> Result<(), ExecutionError> {
         let a0 = self.stack.get(0);
         let a1 = self.stack.get(1);
@@ -71,9 +59,6 @@ impl Process {
     }
 
     /// Swaps stack elements 0, 1, 2, and 3 with elements 8, 9, 10, and 11.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than 12 elements.
     pub(super) fn op_swapw2(&mut self) -> Result<(), ExecutionError> {
         let a0 = self.stack.get(0);
         let a1 = self.stack.get(1);
@@ -106,9 +91,6 @@ impl Process {
     }
 
     /// Swaps stack elements 0, 1, 2, and 3, with elements 12, 13, 14, and 15.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than 16 elements.
     pub(super) fn op_swapw3(&mut self) -> Result<(), ExecutionError> {
         let a0 = self.stack.get(0);
         let a1 = self.stack.get(1);
@@ -150,9 +132,6 @@ impl Process {
     /// Moves n-th element to the top of the stack. n is 0-based.
     ///
     /// Elements between 0 and n are shifted right by one slot.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than n + 1 values.
     pub(super) fn op_movup(&mut self, n: usize) -> Result<(), ExecutionError> {
         // move the nth value to the top of the stack
         let value = self.stack.get(n);
@@ -174,9 +153,6 @@ impl Process {
     /// Moves element 0 to the n-th position on the stack. n is 0-based.
     ///
     /// Elements between 0 and n are shifted left by one slot.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than n + 1 values.
     pub(super) fn op_movdn(&mut self, n: usize) -> Result<(), ExecutionError> {
         // move the value at the top of the stack to the nth position
         let value = self.stack.get(0);
@@ -202,9 +178,7 @@ impl Process {
     /// stack. If the popped element is 0, the stack remains unchanged.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// - The stack contains fewer than 3 elements.
-    /// - The top element of the stack is neither 0 nor 1.
+    /// Returns an error if the top element of the stack is neither 0 nor 1.
     pub(super) fn op_cswap(&mut self) -> Result<(), ExecutionError> {
         let c = self.stack.get(0);
         let b = self.stack.get(1);
@@ -230,9 +204,7 @@ impl Process {
     /// elements 4, 5, 6, and 7. If the popped element is 0, the stack remains unchanged.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// - The stack contains fewer than 9 elements.
-    /// - The top element of the stack is neither 0 nor 1.
+    /// Returns an error if the top element of the stack is neither 0 nor 1.
     pub(super) fn op_cswapw(&mut self) -> Result<(), ExecutionError> {
         let c = self.stack.get(0);
         let b0 = self.stack.get(1);

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -65,6 +65,17 @@ mod tests {
     };
 
     #[test]
+    fn op_assert() {
+        // calling assert with a minimum stack should be an ok, as long as the top value is ONE
+        let mut process = Process::new_dummy();
+        process.execute_op(Operation::Push(Felt::ONE)).unwrap();
+        process.execute_op(Operation::Swap).unwrap();
+        process.execute_op(Operation::Drop).unwrap();
+
+        assert!(process.execute_op(Operation::Assert).is_ok());
+    }
+
+    #[test]
     fn op_fmpupdate() {
         let mut process = Process::new_dummy();
 
@@ -112,6 +123,10 @@ mod tests {
 
         let expected = build_expected(&[2]);
         assert_eq!(expected, process.stack.trace_state());
+
+        // calling fmpupdate with a minimum stack should be ok
+        let mut process = Process::new_dummy();
+        assert!(process.execute_op(Operation::FmpUpdate).is_ok());
     }
 
     #[test]

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -12,7 +12,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the popped value is not ONE.
     pub(super) fn op_assert(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "ASSERT")?;
         if self.stack.get(0) != Felt::ONE {
             return Err(ExecutionError::FailedAssertion(self.system.clk()));
         }
@@ -29,8 +28,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack is empty.
     pub(super) fn op_fmpadd(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "FMPADD")?;
-
         let offset = self.stack.get(0);
         let fmp = self.system.fmp();
 
@@ -47,8 +44,6 @@ impl Process {
     /// * The stack is empty.
     /// * New value of `fmp` register is greater than or equal to 2^32.
     pub(super) fn op_fmpupdate(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "FMPUPDATE")?;
-
         let offset = self.stack.get(0);
         let fmp = self.system.fmp();
 

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -24,9 +24,6 @@ impl Process {
 
     /// Pops an element off the stack, adds the current value of the `fmp` register to it, and
     /// pushes the result back onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack is empty.
     pub(super) fn op_fmpadd(&mut self) -> Result<(), ExecutionError> {
         let offset = self.stack.get(0);
         let fmp = self.system.fmp();
@@ -40,9 +37,7 @@ impl Process {
     /// Pops an element off the stack and adds it to the current value of `fmp` register.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// * The stack is empty.
-    /// * New value of `fmp` register is greater than or equal to 2^32.
+    /// Returns an error if the new value of `fmp` register is greater than or equal to 2^32.
     pub(super) fn op_fmpupdate(&mut self) -> Result<(), ExecutionError> {
         let offset = self.stack.get(0);
         let fmp = self.system.fmp();

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -6,9 +6,6 @@ impl Process {
 
     /// Pops the top element off the stack, splits it into low and high 32-bit values, and pushes
     /// these values back onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack is empty.
     pub(super) fn op_u32split(&mut self) -> Result<(), ExecutionError> {
         let a = self.stack.get(0);
         let (lo, hi) = split_element(a);
@@ -25,9 +22,6 @@ impl Process {
 
     /// Pops two elements off the stack, adds them, splits the result into low and high 32-bit
     /// values, and pushes these values back onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_u32add(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
@@ -44,9 +38,7 @@ impl Process {
     /// values, and pushes these values back onto the stack.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// * The stack contains fewer than three elements.
-    /// * The third element from the top fo the stack is not a binary value.
+    /// Returns an error if the third element from the top fo the stack is not a binary value.
     pub(super) fn op_u32addc(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
@@ -63,9 +55,6 @@ impl Process {
     /// Pops two elements off the stack, subtracts the top element from the second element, and
     /// pushes the result as well as a flag indicating whether there was underflow back onto the
     /// stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_u32sub(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
@@ -79,9 +68,6 @@ impl Process {
 
     /// Pops two elements off the stack, multiplies them, splits the result into low and high
     /// 32-bit values, and pushes these values back onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_u32mul(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
@@ -97,9 +83,6 @@ impl Process {
     /// Pops three elements off the stack, multiplies the first two and adds the third element to
     /// the result, splits the result into low and high 32-bit values, and pushes these values
     /// back onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than three elements.
     pub(super) fn op_u32madd(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
@@ -117,9 +100,7 @@ impl Process {
     /// the quotient and the remainder back onto the stack.
     ///
     /// # Errors
-    /// Returns an error if:
-    /// * The stack contains fewer than two elements.
-    /// * The divisor is ZERO.
+    /// Returns an error if the divisor is ZERO.
     pub(super) fn op_u32div(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
@@ -140,11 +121,8 @@ impl Process {
     // BITWISE OPERATIONS
     // --------------------------------------------------------------------------------------------
 
-    /// Pops two elements off the stack, computes their bitwise AND, splits the result into low and
-    /// high 32-bit values, and pushes these values back onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
+    /// Pops two elements off the stack, computes their bitwise AND, and pushes the result back
+    /// onto the stack.
     pub(super) fn op_u32and(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
@@ -155,11 +133,8 @@ impl Process {
         Ok(())
     }
 
-    /// Pops two elements off the stack, computes their bitwise OR, splits the result into low and
-    /// high 32-bit values, and pushes these values back onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
+    /// Pops two elements off the stack, computes their bitwise OR, and pushes the result back onto
+    /// the stack.
     pub(super) fn op_u32or(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
@@ -170,11 +145,8 @@ impl Process {
         Ok(())
     }
 
-    /// Pops two elements off the stack, computes their bitwise XOR, splits the result into low and
-    /// high 32-bit values, and pushes these values back onto the stack.
-    ///
-    /// # Errors
-    /// Returns an error if the stack contains fewer than two elements.
+    /// Pops two elements off the stack, computes their bitwise XOR, and pushes the result back onto
+    /// the stack.
     pub(super) fn op_u32xor(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -10,8 +10,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack is empty.
     pub(super) fn op_u32split(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(1, "U32SPLIT")?;
-
         let a = self.stack.get(0);
         let (lo, hi) = split_element(a);
 
@@ -31,8 +29,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_u32add(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "U32ADD")?;
-
         let b = self.stack.get(0);
         let a = self.stack.get(1);
         let result = a + b;
@@ -52,8 +48,6 @@ impl Process {
     /// * The stack contains fewer than three elements.
     /// * The third element from the top fo the stack is not a binary value.
     pub(super) fn op_u32addc(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(3, "U32ADDC")?;
-
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
         let c = assert_binary(self.stack.get(2))?.as_int();
@@ -73,8 +67,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_u32sub(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "U32SUB")?;
-
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
         let result = a.wrapping_sub(b);
@@ -91,8 +83,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_u32mul(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "U32MUL")?;
-
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
         let result = Felt::new(a * b);
@@ -111,8 +101,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than three elements.
     pub(super) fn op_u32madd(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(3, "U32MADD")?;
-
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
         let c = self.stack.get(2).as_int();
@@ -133,8 +121,6 @@ impl Process {
     /// * The stack contains fewer than two elements.
     /// * The divisor is ZERO.
     pub(super) fn op_u32div(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "U32DIV")?;
-
         let b = self.stack.get(0).as_int();
         let a = self.stack.get(1).as_int();
 
@@ -160,8 +146,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_u32and(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "U32AND")?;
-
         let b = self.stack.get(0);
         let a = self.stack.get(1);
         let result = self.bitwise.u32and(a, b)?;
@@ -177,8 +161,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_u32or(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "U32OR")?;
-
         let b = self.stack.get(0);
         let a = self.stack.get(1);
         let result = self.bitwise.u32or(a, b)?;
@@ -194,8 +176,6 @@ impl Process {
     /// # Errors
     /// Returns an error if the stack contains fewer than two elements.
     pub(super) fn op_u32xor(&mut self) -> Result<(), ExecutionError> {
-        self.stack.check_depth(2, "U32XOR")?;
-
         let b = self.stack.get(0);
         let a = self.stack.get(1);
         let result = self.bitwise.u32xor(a, b)?;

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -268,6 +268,10 @@ mod tests {
         let mut process = Process::new_dummy();
         init_stack_with(&mut process, &[c, b, a]);
         assert!(process.execute_op(Operation::U32addc).is_err());
+
+        // --- test with minimum stack depth ----------------------------------
+        let mut process = Process::new_dummy();
+        assert!(process.execute_op(Operation::U32addc).is_ok());
     }
 
     #[test]
@@ -318,6 +322,10 @@ mod tests {
         process.execute_op(Operation::U32madd).unwrap();
         let expected = build_expected(&[hi, lo, d]);
         assert_eq!(expected, process.stack.trace_state());
+
+        // --- test with minimum stack depth ----------------------------------
+        let mut process = Process::new_dummy();
+        assert!(process.execute_op(Operation::U32madd).is_ok());
     }
 
     #[test]
@@ -343,6 +351,10 @@ mod tests {
         process.execute_op(Operation::U32and).unwrap();
         let expected = build_expected(&[a & b, c, d]);
         assert_eq!(expected, process.stack.trace_state());
+
+        // --- test with minimum stack depth ----------------------------------
+        let mut process = Process::new_dummy();
+        assert!(process.execute_op(Operation::U32and).is_ok());
     }
 
     #[test]
@@ -353,6 +365,10 @@ mod tests {
         process.execute_op(Operation::U32or).unwrap();
         let expected = build_expected(&[a | b, c, d]);
         assert_eq!(expected, process.stack.trace_state());
+
+        // --- test with minimum stack depth ----------------------------------
+        let mut process = Process::new_dummy();
+        assert!(process.execute_op(Operation::U32or).is_ok());
     }
 
     #[test]
@@ -363,6 +379,10 @@ mod tests {
         process.execute_op(Operation::U32xor).unwrap();
         let expected = build_expected(&[a ^ b, c, d]);
         assert_eq!(expected, process.stack.trace_state());
+
+        // --- test with minimum stack depth ----------------------------------
+        let mut process = Process::new_dummy();
+        assert!(process.execute_op(Operation::U32xor).is_ok());
     }
 
     // HELPER FUNCTIONS

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -128,9 +128,6 @@ impl Stack {
     ///
     /// If the stack depth is greater than 16, an item is moved from the overflow stack to the
     /// "in-memory" portion of the stack.
-    ///
-    /// # Panics
-    /// Panics if the resulting stack depth would be less than the minimum stack depth.
     pub fn shift_left(&mut self, start_pos: usize) {
         debug_assert!(start_pos > 0, "start position must be greater than 0");
         debug_assert!(

--- a/processor/src/tests/io_ops/env_ops.rs
+++ b/processor/src/tests/io_ops/env_ops.rs
@@ -1,4 +1,4 @@
-use super::{build_op_test, build_test};
+use super::{build_op_test, build_test, MIN_STACK_DEPTH};
 use crate::system::FMP_MIN;
 
 // PUSHING VALUES ONTO THE STACK (PUSH)
@@ -10,11 +10,11 @@ fn push_env_sdepth() {
 
     // --- empty stack ----------------------------------------------------------------------------
     let test = build_op_test!(test_op);
-    test.expect_stack(&[0]);
+    test.expect_stack(&[MIN_STACK_DEPTH as u64]);
 
     // --- multi-element stack --------------------------------------------------------------------
     let test = build_op_test!(test_op, &[2, 4, 6, 8, 10]);
-    test.expect_stack(&[5, 10, 8, 6, 4, 2]);
+    test.expect_stack(&[MIN_STACK_DEPTH as u64, 10, 8, 6, 4, 2]);
 
     // --- overflowed stack -----------------------------------------------------------------------
     // push 2 values to increase the lenth of the stack beyond 16

--- a/processor/src/tests/io_ops/local_ops.rs
+++ b/processor/src/tests/io_ops/local_ops.rs
@@ -1,4 +1,4 @@
-use super::{build_test, TestError};
+use super::build_test;
 
 // PUSHING VALUES ONTO THE STACK (PUSH)
 // ================================================================================================
@@ -78,21 +78,6 @@ fn pop_local() {
 }
 
 #[test]
-fn pop_local_invalid() {
-    let source = "
-        proc.foo.1 
-            pop.local.0
-        end 
-        begin
-            exec.foo
-        end";
-
-    // --- pop fails when stack is empty ----------------------------------------------------------
-    let test = build_test!(source);
-    test.expect_error(TestError::ExecutionError("StackUnderflow"));
-}
-
-#[test]
 fn popw_local() {
     // --- test write to local memory -------------------------------------------------------------
     let source = "
@@ -123,21 +108,6 @@ fn popw_local() {
 
     let test = build_test!(source, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     test.expect_stack_and_memory(&[], mem_addr, &[5, 6, 7, 8]);
-}
-
-#[test]
-fn popw_local_invalid() {
-    let source = "
-        proc.foo.1 
-            popw.local.0
-        end 
-        begin
-            exec.foo
-        end";
-
-    // --- pop fails when stack is empty ----------------------------------------------------------
-    let test = build_test!(source, &[1, 2]);
-    test.expect_error(TestError::ExecutionError("StackUnderflow"));
 }
 
 // OVERWRITING VALUES ON THE STACK (LOAD)
@@ -198,21 +168,6 @@ fn storew_local() {
 
     let test = build_test!(source, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     test.expect_stack_and_memory(&[4, 3, 2, 1], mem_addr, &[5, 6, 7, 8]);
-}
-
-#[test]
-fn storew_local_invalid() {
-    let source = "
-        proc.foo.1 
-            storew.local.0
-        end 
-        begin
-            exec.foo
-        end";
-
-    // --- pop fails when stack is empty ----------------------------------------------------------
-    let test = build_test!(source, &[1, 2]);
-    test.expect_error(TestError::ExecutionError("StackUnderflow"));
 }
 
 // NESTED PROCEDURES & PAIRED OPERATIONS (push/pop, pushw/popw, loadw/storew)

--- a/processor/src/tests/io_ops/mem_ops.rs
+++ b/processor/src/tests/io_ops/mem_ops.rs
@@ -1,4 +1,4 @@
-use super::{build_op_test, build_test, TestError};
+use super::{build_op_test, build_test};
 
 // PUSHING VALUES ONTO THE STACK (PUSH)
 // ================================================================================================
@@ -61,15 +61,6 @@ fn pop_mem() {
 }
 
 #[test]
-fn pop_mem_invalid() {
-    let asm_op = "pop.mem.0";
-
-    // --- pop fails when stack is empty ----------------------------------------------------------
-    let test = build_op_test!(asm_op);
-    test.expect_error(TestError::ExecutionError("StackUnderflow"));
-}
-
-#[test]
 fn popw_mem() {
     let asm_op = "popw.mem";
     let addr = 0;
@@ -86,15 +77,6 @@ fn popw_mem() {
     // --- the rest of the stack is unchanged -----------------------------------------------------
     let test = build_op_test!(&asm_op, &[0, 1, 2, 3, 4]);
     test.expect_stack_and_memory(&[0], addr, &[1, 2, 3, 4]);
-}
-
-#[test]
-fn popw_mem_invalid() {
-    let asm_op = "popw.mem.0";
-
-    // --- popw fails when the stack doesn't contain a full word ----------------------------------------------------------
-    let test = build_op_test!(asm_op, &[1, 2]);
-    test.expect_error(TestError::ExecutionError("StackUnderflow"));
 }
 
 // OVERWRITING VALUES ON THE STACK (LOAD)

--- a/processor/src/tests/io_ops/mod.rs
+++ b/processor/src/tests/io_ops/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{build_op_test, build_test},
+    super::{build_op_test, build_test, MIN_STACK_DEPTH},
     TestError,
 };
 

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     execute, ExecutionError, ExecutionTrace, Felt, FieldElement, Process, ProgramInputs, Script,
-    Word, STACK_TOP_SIZE,
+    Word, MIN_STACK_DEPTH,
 };
 use proptest::prelude::*;
 
@@ -152,7 +152,7 @@ impl Test {
     }
 
     /// Returns the last state of the stack after executing a test.
-    fn get_last_stack_state(&self) -> [Felt; STACK_TOP_SIZE] {
+    fn get_last_stack_state(&self) -> [Felt; MIN_STACK_DEPTH] {
         let trace = self.execute().unwrap();
 
         trace.last_stack_state()
@@ -164,8 +164,8 @@ impl Test {
 
 /// Takes an array of u64 values and builds a stack, perserving their order and converting them to
 /// field elements.
-fn convert_to_stack(values: &[u64]) -> [Felt; STACK_TOP_SIZE] {
-    let mut result = [Felt::ZERO; STACK_TOP_SIZE];
+fn convert_to_stack(values: &[u64]) -> [Felt; MIN_STACK_DEPTH] {
+    let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
     for (&value, result) in values.iter().zip(result.iter_mut()) {
         *result = Felt::new(value);
     }

--- a/processor/src/tests/stdlib/crypto/blake3.rs
+++ b/processor/src/tests/stdlib/crypto/blake3.rs
@@ -1,4 +1,4 @@
-use crate::{execute, Felt, FieldElement, ProgramInputs, Script, STACK_TOP_SIZE};
+use crate::{execute, Felt, FieldElement, ProgramInputs, Script, MIN_STACK_DEPTH};
 use vm_core::utils::IntoBytes;
 
 #[test]
@@ -22,10 +22,10 @@ fn blake3_2_to_1_hash() {
     i_digest[32..].copy_from_slice(&i_digest_1);
 
     // allocate space on stack so that bytes can be converted to blake3 words
-    let mut i_words = [0u64; STACK_TOP_SIZE];
+    let mut i_words = [0u64; MIN_STACK_DEPTH];
 
     // convert each of four consecutive little endian bytes (of input) to blake3 words
-    for i in 0..STACK_TOP_SIZE {
+    for i in 0..MIN_STACK_DEPTH {
         i_words[i] = from_le_bytes_to_words(&i_digest[i * 4..(i + 1) * 4]) as u64;
     }
     i_words.reverse();
@@ -35,10 +35,10 @@ fn blake3_2_to_1_hash() {
 
     // prepare digest in desired blake3 word form so that assertion writing becomes easier
     let digest_bytes = digest.as_bytes();
-    let mut digest_words = [0u64; STACK_TOP_SIZE >> 1];
+    let mut digest_words = [0u64; MIN_STACK_DEPTH >> 1];
 
     // convert each of four consecutive little endian bytes (of digest) to blake3 words
-    for i in 0..(STACK_TOP_SIZE >> 1) {
+    for i in 0..(MIN_STACK_DEPTH >> 1) {
         digest_words[i] = from_le_bytes_to_words(&digest_bytes[i * 4..(i + 1) * 4]) as u64;
     }
 
@@ -63,8 +63,8 @@ fn compile(source: &str) -> Script {
 
 /// Takes an array of u64 values and builds a stack, perserving their order and converting them to
 /// field elements.
-fn convert_to_stack(values: &[u64]) -> [Felt; STACK_TOP_SIZE] {
-    let mut result = [Felt::ZERO; STACK_TOP_SIZE];
+fn convert_to_stack(values: &[u64]) -> [Felt; MIN_STACK_DEPTH] {
+    let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
     for (&value, result) in values.iter().zip(result.iter_mut()) {
         *result = Felt::new(value);
     }

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -1,6 +1,6 @@
 use super::{
     AuxiliaryTableTrace, Bitwise, Felt, FieldElement, Hasher, Memory, Process, StackTrace,
-    AUXILIARY_TABLE_WIDTH, STACK_TOP_SIZE,
+    AUXILIARY_TABLE_WIDTH, MIN_STACK_DEPTH,
 };
 use core::slice;
 use winterfell::Trace;
@@ -71,15 +71,15 @@ impl ExecutionTrace {
     // --------------------------------------------------------------------------------------------
 
     /// TODO: add docs
-    pub fn init_stack_state(&self) -> [Felt; STACK_TOP_SIZE] {
-        let mut result = [Felt::ZERO; STACK_TOP_SIZE];
+    pub fn init_stack_state(&self) -> [Felt; MIN_STACK_DEPTH] {
+        let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
         self.read_row_into(0, &mut result);
         result
     }
 
     /// TODO: add docs
-    pub fn last_stack_state(&self) -> [Felt; STACK_TOP_SIZE] {
-        let mut result = [Felt::ZERO; STACK_TOP_SIZE];
+    pub fn last_stack_state(&self) -> [Felt; MIN_STACK_DEPTH] {
+        let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
         self.read_row_into(self.length() - 1, &mut result);
         result
     }


### PR DESCRIPTION
This PR addresses #65 by enforcing a minimum stack depth of 16 and removing the concept of stack underflow.

- updates the initial stack depth & left shift handling
- removes stack depth checks from all operations in the processor
- removes the StackUnderflow ExecutionError
- resolves processor unit test errors introduced by the change
- resolves processor integration test errors introduced by the change and removes irrelevant tests
- updates the docs to reflect the min stack depth and StackUnderflow changes & their effect on processor operation Errors