### PR TITLE
Add u64 multiplication procedure to standard library

### DIFF
--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod crypto_ops;
 mod field_ops;
 mod flow_control;
 mod io_ops;
+mod stdlib;
 mod u32_ops;
 
 // TESTS

--- a/processor/src/tests/stdlib/mod.rs
+++ b/processor/src/tests/stdlib/mod.rs
@@ -1,0 +1,3 @@
+use super::{compile, test_script_execution};
+
+mod u64_mod;

--- a/processor/src/tests/stdlib/u64_mod.rs
+++ b/processor/src/tests/stdlib/u64_mod.rs
@@ -1,0 +1,52 @@
+use super::{compile, test_script_execution};
+use rand_utils::rand_value;
+
+#[test]
+fn add_unsafe() {
+    let a: u64 = rand_value();
+    let b: u64 = rand_value();
+    let c = a.wrapping_add(b);
+
+    let script = compile(
+        "
+        use.std::math::u64
+        begin
+            exec.u64::add_unsafe
+        end",
+    );
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c1, c0) = split_u64(c);
+
+    test_script_execution(&script, &[a0, a1, b0, b1], &[c1, c0]);
+}
+
+#[test]
+fn mul_unsafe() {
+    let a: u64 = rand_value();
+    let b: u64 = rand_value();
+    let c = a.wrapping_mul(b);
+
+    let script = compile(
+        "
+        use.std::math::u64
+        begin
+            exec.u64::mul_unsafe
+        end",
+    );
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c1, c0) = split_u64(c);
+
+    test_script_execution(&script, &[a0, a1, b0, b1], &[c1, c0]);
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Split the provided u64 value into 32 hight and low bits.
+fn split_u64(value: u64) -> (u64, u64) {
+    (value >> 32, value as u32 as u64)
+}

--- a/stdlib/asm/math/u256.masm
+++ b/stdlib/asm/math/u256.masm
@@ -147,7 +147,7 @@ export.or
     u32or
 end
 
-export.u256xor
+export.xor
     swapw.3
     movup.3
     movup.7

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -1,3 +1,7 @@
+# Performs addition of two unsigned 64 bit integers discarding the overflow. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64 #
 export.add_unsafe
     swap
     movup.3
@@ -5,5 +9,23 @@ export.add_unsafe
     movup.3
     movup.3
     u32addc
+    drop
+end
+
+# Performs multiplication of two unsigned 64 bit integers discarding the overflow. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64 #
+export.mul_unsafe
+    dup.3
+    dup.2
+    u32mul.unsafe
+    movup.4
+    movup.4
+    u32madd
+    drop
+    movup.3
+    movup.3
+    u32madd
     drop
 end

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -157,7 +157,7 @@ export.or
     u32or
 end
 
-export.u256xor
+export.xor
     swapw.3
     movup.3
     movup.7
@@ -209,13 +209,35 @@ export.eq_unsafe
     and
 end"),
 // ----- std::math::u64 ---------------------------------------------------------------------------
-("std::math::u64", "export.add_unsafe
+("std::math::u64", "# Performs addition of two unsigned 64 bit integers discarding the overflow. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64 #
+export.add_unsafe
     swap
     movup.3
     u32add.unsafe
     movup.3
     movup.3
     u32addc
+    drop
+end
+
+# Performs multiplication of two unsigned 64 bit integers discarding the overflow. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64 #
+export.mul_unsafe
+    dup.3
+    dup.2
+    u32mul.unsafe
+    movup.4
+    movup.4
+    u32madd
+    drop
+    movup.3
+    movup.3
+    u32madd
     drop
 end"),
 ];


### PR DESCRIPTION
This PR adds multiplication procedure to `std::math::u64` module. It also adds simple tests for u64 addition and multiplication.

Related to #131 