### PR TITLE
Refactor processor integration tests

### DIFF
--- a/processor/src/tests/aux_table_trace.rs
+++ b/processor/src/tests/aux_table_trace.rs
@@ -1,38 +1,31 @@
 use super::{
     super::{
         bitwise::BITWISE_OR,
+        build_op_test, build_test,
         hasher::{LINEAR_HASH, RETURN_STATE},
-        AuxiliaryTableTrace, ExecutionTrace, FieldElement, Process,
+        AuxiliaryTableTrace, FieldElement,
     },
-    build_inputs, compile, Felt,
+    Felt,
 };
 
 #[test]
 fn trace_len() {
     // --- final trace lengths are equal when stack trace is longer than aux trace ----------------
-    let script = compile("begin popw.mem.2 end");
-    let inputs = build_inputs(&[1, 2, 3, 4]);
-    let mut process = Process::new(inputs);
-    process.execute_code_block(script.root()).unwrap();
-    let trace = ExecutionTrace::new(process);
+    let test = build_op_test!("popw.mem.2", &[1, 2, 3, 4]);
+    let trace = test.execute().unwrap();
 
     assert_eq!(trace.aux_table()[0].len(), trace.stack()[0].len());
 
     // --- final trace lengths are equal when aux trace is longer than stack trace ----------------
-    let script = compile("begin u32and end");
-    let inputs = build_inputs(&[4, 8]);
-    let mut process = Process::new(inputs);
-    process.execute_code_block(script.root()).unwrap();
-    let trace = ExecutionTrace::new(process);
+    let test = build_op_test!("u32and", &[4, 8]);
+    let trace = test.execute().unwrap();
 
     assert_eq!(trace.aux_table()[0].len(), trace.stack()[0].len());
 
     // --- stack and aux trace lengths are equal after multi-processor aux trace ------------------
-    let script = compile("begin u32and pop.mem.0 u32or end");
-    let inputs = build_inputs(&[1, 2, 3, 4]);
-    let mut process = Process::new(inputs);
-    process.execute_code_block(script.root()).unwrap();
-    let trace = ExecutionTrace::new(process);
+    let source = "begin u32and pop.mem.0 u32or end";
+    let test = build_test!(source, &[1, 2, 3, 4]);
+    let trace = test.execute().unwrap();
 
     assert_eq!(trace.aux_table()[0].len(), trace.stack()[0].len());
 
@@ -43,12 +36,8 @@ fn trace_len() {
 #[test]
 fn hasher_aux_trace() {
     // --- single hasher permutation with no stack manipulation -----------------------------------
-    let script = compile("begin rpperm end");
-    let inputs = build_inputs(&[2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]);
-    let mut process = Process::new(inputs);
-
-    process.execute_code_block(script.root()).unwrap();
-    let trace = ExecutionTrace::new(process);
+    let test = build_op_test!("rpperm", &[2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]);
+    let trace = test.execute().unwrap();
     let aux_table = trace.aux_table();
 
     let expected_len = 8;
@@ -62,12 +51,8 @@ fn hasher_aux_trace() {
 #[test]
 fn bitwise_aux_trace() {
     // --- single bitwise operation with no stack manipulation ------------------------------------
-    let script = compile("begin u32or end");
-    let inputs = build_inputs(&[4, 8]);
-    let mut process = Process::new(inputs);
-
-    process.execute_code_block(script.root()).unwrap();
-    let trace = ExecutionTrace::new(process);
+    let test = build_op_test!("u32or", &[4, 8]);
+    let trace = test.execute().unwrap();
     let aux_table = trace.aux_table();
 
     let expected_len = 8;
@@ -81,12 +66,8 @@ fn bitwise_aux_trace() {
 #[test]
 fn memory_aux_trace() {
     // --- single memory operation with no stack manipulation -------------------------------------
-    let script = compile("begin storew.mem.2 end");
-    let inputs = build_inputs(&[1, 2, 3, 4]);
-    let mut process = Process::new(inputs);
-
-    process.execute_code_block(script.root()).unwrap();
-    let trace = ExecutionTrace::new(process);
+    let test = build_op_test!("storew.mem.2", &[1, 2, 3, 4]);
+    let trace = test.execute().unwrap();
     let aux_table = trace.aux_table();
 
     // the memory trace is only one row, so the length should match the stack trace length
@@ -106,12 +87,9 @@ fn memory_aux_trace() {
 #[test]
 fn stacked_aux_trace() {
     // --- operations in hasher, bitwise, and memory processors without stack manipulation --------
-    let script = compile("begin u32or storew.mem.0 rpperm end");
-    let inputs = build_inputs(&[8, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 1]);
-    let mut process = Process::new(inputs);
-
-    process.execute_code_block(script.root()).unwrap();
-    let trace = ExecutionTrace::new(process);
+    let source = "begin u32or storew.mem.0 rpperm end";
+    let test = build_test!(source, &[8, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 1]);
+    let trace = test.execute().unwrap();
     let aux_table = trace.aux_table();
 
     // expect 8 rows of hasher trace

--- a/processor/src/tests/crypto_ops.rs
+++ b/processor/src/tests/crypto_ops.rs
@@ -1,8 +1,8 @@
-use super::{build_inputs, compile, execute, push_to_stack, Felt, FieldElement, Word};
+use super::{super::build_op_test, Felt, FieldElement, Word};
 use rand_utils::rand_vector;
 use vm_core::{
     hasher::{apply_permutation, hash_elements, STATE_WIDTH},
-    AdviceSet, ProgramInputs, StarkField,
+    AdviceSet, StarkField,
 };
 
 // TESTS
@@ -10,25 +10,26 @@ use vm_core::{
 
 #[test]
 fn rpperm() {
-    let script = compile("begin rpperm end");
+    let asm_op = "rpperm";
+
     // --- test hashing [ONE, ONE] ----------------------------------------------------------------
     let values: Vec<u64> = vec![2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0];
-    let inputs = build_inputs(&values);
     let expected = build_expected_perm(&values);
 
-    let trace = execute(&script, &inputs).unwrap();
-    let last_state = trace.last_stack_state();
+    let test = build_op_test!(asm_op, &values);
+    let last_state = test.get_last_stack_state();
+
     assert_eq!(expected, &last_state[0..12]);
 
     // --- test hashing 8 random values -----------------------------------------------------------
     let mut values = rand_vector::<u64>(8);
     let capacity: Vec<u64> = vec![0, 0, 0, 8];
     values.extend_from_slice(&capacity);
-    let inputs = build_inputs(&values);
     let expected = build_expected_perm(&values);
 
-    let trace = execute(&script, &inputs).unwrap();
-    let last_state = trace.last_stack_state();
+    let test = build_op_test!(asm_op, &values);
+    let last_state = test.get_last_stack_state();
+
     assert_eq!(expected, &last_state[0..12]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
@@ -41,33 +42,33 @@ fn rpperm() {
 
     let values_to_hash: Vec<u64> = vec![2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0];
     stack_inputs.extend_from_slice(&values_to_hash);
-    let inputs = build_inputs(&stack_inputs);
 
-    let trace = execute(&script, &inputs).unwrap();
-    let last_state = trace.last_stack_state();
+    let test = build_op_test!(asm_op, &stack_inputs);
+    let last_state = test.get_last_stack_state();
+
     assert_eq!(expected_stack_slice, &last_state[12..16]);
 }
 
 #[test]
 fn rphash() {
-    let script = compile("begin rphash end");
+    let asm_op = "rphash";
 
     // --- test hashing [ONE, ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO] ----------------------------
     let values = [1, 1, 0, 0, 0, 0, 0, 0];
-    let inputs = build_inputs(&values);
     let expected = build_expected_hash(&values);
 
-    let trace = execute(&script, &inputs).unwrap();
-    let last_state = trace.last_stack_state();
+    let test = build_op_test!(asm_op, &values);
+    let last_state = test.get_last_stack_state();
+
     assert_eq!(expected, &last_state[..4]);
 
     // --- test hashing 8 random values -----------------------------------------------------------
     let values = rand_vector::<u64>(8);
-    let inputs = build_inputs(&values);
     let expected = build_expected_hash(&values);
 
-    let trace = execute(&script, &inputs).unwrap();
-    let last_state = trace.last_stack_state();
+    let test = build_op_test!(asm_op, &values);
+    let last_state = test.get_last_stack_state();
+
     assert_eq!(expected, &last_state[..4]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
@@ -80,16 +81,16 @@ fn rphash() {
 
     let values_to_hash: Vec<u64> = vec![1, 1, 0, 0, 0, 0, 0, 0];
     stack_inputs.extend_from_slice(&values_to_hash);
-    let inputs = build_inputs(&stack_inputs);
 
-    let trace = execute(&script, &inputs).unwrap();
-    let last_state = trace.last_stack_state();
+    let test = build_op_test!(asm_op, &stack_inputs);
+    let last_state = test.get_last_stack_state();
+
     assert_eq!(expected_stack_slice, &last_state[4..8]);
 }
 
 #[test]
 fn mtree_get() {
-    let script = compile("begin mtree.get end");
+    let asm_op = "mtree.get";
 
     let index = 3usize;
     let leaves = init_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
@@ -104,30 +105,23 @@ fn mtree_get() {
         tree.depth() as u64,
     ];
 
-    let inputs = ProgramInputs::new(&stack_inputs, &[], vec![tree.clone()]).unwrap();
-
-    let trace = execute(&script, &inputs).unwrap();
-    let last_state = trace.last_stack_state();
-
-    let expected_stack = push_to_stack(&[
-        tree.root()[0].as_int(),
-        tree.root()[1].as_int(),
-        tree.root()[2].as_int(),
-        tree.root()[3].as_int(),
-        leaves[index][0].as_int(),
-        leaves[index][1].as_int(),
-        leaves[index][2].as_int(),
+    let final_stack = [
         leaves[index][3].as_int(),
-    ]);
-    assert_eq!(expected_stack, last_state);
+        leaves[index][2].as_int(),
+        leaves[index][1].as_int(),
+        leaves[index][0].as_int(),
+        tree.root()[3].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[0].as_int(),
+    ];
+
+    let test = build_op_test!(asm_op, &stack_inputs, &[], vec![tree]);
+    test.expect_stack(&final_stack);
 }
 
 #[test]
 fn mtree_update() {
-    // --- mtree.set ----------------------------------------------------------------------
-    // update a node value and replace the old root
-    let script = compile("begin mtree.set end");
-
     let index = 5usize;
     let leaves = init_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
     let tree = AdviceSet::new_merkle_tree(leaves.clone()).unwrap();
@@ -150,48 +144,47 @@ fn mtree_update() {
         tree.depth() as u64,
     ];
 
-    let inputs = ProgramInputs::new(&stack_inputs, &[], vec![tree.clone()]).unwrap();
-    let trace = execute(&script, &inputs).unwrap();
-    let last_state = trace.last_stack_state();
+    // --- mtree.set ----------------------------------------------------------------------
+    // update a node value and replace the old root
+    let asm_op = "mtree.set";
 
     // expected state has the new leaf and the new root of the tree
-    let expected_stack = push_to_stack(&[
-        new_tree.root()[0].as_int(),
-        new_tree.root()[1].as_int(),
-        new_tree.root()[2].as_int(),
-        new_tree.root()[3].as_int(),
-        new_node[0].as_int(),
-        new_node[1].as_int(),
-        new_node[2].as_int(),
+    let final_stack = [
         new_node[3].as_int(),
-    ]);
+        new_node[2].as_int(),
+        new_node[1].as_int(),
+        new_node[0].as_int(),
+        new_tree.root()[3].as_int(),
+        new_tree.root()[2].as_int(),
+        new_tree.root()[1].as_int(),
+        new_tree.root()[0].as_int(),
+    ];
 
-    assert_eq!(expected_stack, last_state);
+    let test = build_op_test!(asm_op, &stack_inputs, &[], vec![tree.clone()]);
+    test.expect_stack(&final_stack);
 
     // --- mtree.cwm ----------------------------------------------------------------------
     // update a node value and replace the old root
-    let script = compile("begin mtree.cwm end");
-    let inputs = ProgramInputs::new(&stack_inputs, &[], vec![tree.clone()]).unwrap();
-    let trace = execute(&script, &inputs).unwrap();
-    let last_state = trace.last_stack_state();
+    let asm_op = "mtree.cwm";
 
     // expected state has the new leaf, the new root of the tree, and the root of the old tree
-    let expected_stack = push_to_stack(&[
-        tree.root()[0].as_int(),
-        tree.root()[1].as_int(),
-        tree.root()[2].as_int(),
-        tree.root()[3].as_int(),
-        new_tree.root()[0].as_int(),
-        new_tree.root()[1].as_int(),
-        new_tree.root()[2].as_int(),
-        new_tree.root()[3].as_int(),
-        new_node[0].as_int(),
-        new_node[1].as_int(),
-        new_node[2].as_int(),
+    let final_stack = [
         new_node[3].as_int(),
-    ]);
+        new_node[2].as_int(),
+        new_node[1].as_int(),
+        new_node[0].as_int(),
+        new_tree.root()[3].as_int(),
+        new_tree.root()[2].as_int(),
+        new_tree.root()[1].as_int(),
+        new_tree.root()[0].as_int(),
+        tree.root()[3].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[0].as_int(),
+    ];
 
-    assert_eq!(expected_stack, last_state);
+    let test = build_op_test!(asm_op, &stack_inputs, &[], vec![tree]);
+    test.expect_stack(&final_stack);
 }
 
 // HELPER FUNCTIONS

--- a/processor/src/tests/io_ops/adv_ops.rs
+++ b/processor/src/tests/io_ops/adv_ops.rs
@@ -1,4 +1,4 @@
-use super::{compile, execute, push_to_stack, test_execution_failure, ProgramInputs};
+use super::{build_op_test, build_test, TestError};
 use rand_utils::rand_value;
 
 // PUSHING VALUES ONTO THE STACK (PUSH)
@@ -6,33 +6,30 @@ use rand_utils::rand_value;
 
 #[test]
 fn push_adv() {
+    let asm_op = "push.adv";
     let advice_tape = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    let test_n = |n: usize| {
+        let source = format!("{}.{}", asm_op, n);
+        let mut final_stack = vec![0; n];
+        final_stack.copy_from_slice(&advice_tape[..n]);
+        final_stack.reverse();
+
+        let test = build_op_test!(source, &[], &advice_tape, vec![]);
+        test.expect_stack(&final_stack);
+    };
 
     // --- push 1 ---------------------------------------------------------------------------------
-    let n = 1;
-    let script = compile(format!("begin push.adv.{} end", n).as_str());
-
-    let inputs = ProgramInputs::new(&[], &advice_tape, vec![]).unwrap();
-    let trace = execute(&script, &inputs).unwrap();
-    let expected = push_to_stack(&advice_tape[..n]);
-
-    assert_eq!(expected, trace.last_stack_state());
+    test_n(1);
 
     // --- push max -------------------------------------------------------------------------------
-    let n = 16;
-    let script = compile(format!("begin push.adv.{} end", n).as_str());
-
-    let inputs = ProgramInputs::new(&[], &advice_tape, vec![]).unwrap();
-    let trace = execute(&script, &inputs).unwrap();
-    let expected = push_to_stack(&advice_tape[..n]);
-
-    assert_eq!(expected, trace.last_stack_state());
+    test_n(16);
 }
 
 #[test]
 fn push_adv_invalid() {
     // attempting to read from empty advice tape should throw an error
-    test_execution_failure("push.adv.1", &[], "EmptyAdviceTape");
+    let test = build_op_test!("push.adv.1");
+    test.expect_error(TestError::ExecutionError("EmptyAdviceTape"));
 }
 
 // OVERWRITING VALUES ON THE STACK (LOAD)
@@ -40,20 +37,20 @@ fn push_adv_invalid() {
 
 #[test]
 fn loadw_adv() {
-    let script = compile("begin loadw.adv end");
+    let asm_op = "loadw.adv";
     let advice_tape = [1, 2, 3, 4];
+    let mut final_stack = advice_tape;
+    final_stack.reverse();
 
-    let inputs = ProgramInputs::new(&[8, 7, 6, 5], &advice_tape, vec![]).unwrap();
-    let trace = execute(&script, &inputs).unwrap();
-    let expected = push_to_stack(&advice_tape);
-
-    assert_eq!(expected, trace.last_stack_state());
+    let test = build_op_test!(asm_op, &[8, 7, 6, 5], &advice_tape, vec![]);
+    test.expect_stack(&final_stack);
 }
 
 #[test]
 fn loadw_adv_invalid() {
     // attempting to read from empty advice tape should throw an error
-    test_execution_failure("loadw.adv", &[0, 0, 0, 0], "EmptyAdviceTape");
+    let test = build_op_test!("loadw.adv", &[0, 0, 0, 0]);
+    test.expect_error(TestError::ExecutionError("EmptyAdviceTape"));
 }
 
 // ADVICE INJECTORS
@@ -61,7 +58,7 @@ fn loadw_adv_invalid() {
 
 #[test]
 fn adv_inject_u64div() {
-    let script = compile("begin adv.u64div push.adv.4 end");
+    let source = "begin adv.u64div push.adv.4 end";
 
     // get two random 64-bit integers and split them into 32-bit limbs
     let a = rand_value::<u64>();
@@ -83,9 +80,7 @@ fn adv_inject_u64div() {
     let r_lo = r as u32 as u64;
 
     // inject a/b into the advice tape and then read these values from the tape
-    let inputs = ProgramInputs::new(&[a_lo, a_hi, b_lo, b_hi], &[], vec![]).unwrap();
-    let trace = execute(&script, &inputs).unwrap();
-
-    let expected = push_to_stack(&[a_lo, a_hi, b_lo, b_hi, q_lo, q_hi, r_lo, r_hi]);
-    assert_eq!(expected, trace.last_stack_state());
+    let test = build_test!(source, &[a_lo, a_hi, b_lo, b_hi]);
+    let expected = [r_hi, r_lo, q_hi, q_lo, b_hi, b_lo, a_hi, a_lo];
+    test.expect_stack(&expected);
 }

--- a/processor/src/tests/io_ops/constant_ops.rs
+++ b/processor/src/tests/io_ops/constant_ops.rs
@@ -1,86 +1,88 @@
-use super::test_op_execution;
+use super::build_op_test;
 
 // PUSHING VALUES ONTO THE STACK (PUSH)
 // ================================================================================================
 
 #[test]
 fn push_one() {
-    let asm_op = "push";
+    let asm_op_base = "push";
 
     // --- test zero ------------------------------------------------------------------------------
-    test_op_execution(format!("{}.{}", asm_op, "0").as_str(), &[], &[0]);
+    let asm_op = format!("{}.{}", asm_op_base, "0");
+    let test = build_op_test!(&asm_op);
+    test.expect_stack(&[0]);
 
     // --- single decimal input -------------------------------------------------------------------
-    test_op_execution(format!("{}.{}", asm_op, "5").as_str(), &[], &[5]);
+    let asm_op = format!("{}.{}", asm_op_base, "5");
+    let test = build_op_test!(&asm_op);
+    test.expect_stack(&[5]);
 
     // --- single hexadecimal input ---------------------------------------------------------------
-    test_op_execution(format!("{}.{}", asm_op, "0xAF").as_str(), &[], &[175]);
+    let asm_op = format!("{}.{}", asm_op_base, "0xAF");
+    let test = build_op_test!(&asm_op);
+    test.expect_stack(&[175]);
 }
 
 #[test]
 fn push_many() {
-    let asm_op = "push";
+    let base_op = "push";
 
     // --- multiple values with separators --------------------------------------------------------
-    test_op_execution(
-        format!("{}.17.0x13.23", asm_op).as_str(),
-        &[],
-        &[23, 19, 17],
-    );
+    let asm_op = format!("{}.17.0x13.23", base_op);
+    let test = build_op_test!(asm_op);
+    test.expect_stack(&[23, 19, 17]);
 
     // --- push the maximum number of decimal values (16) -------------------------------------
+    let asm_op = format!(
+        "{}.16.17.18.19.20.21.22.23.24.25.26.27.28.29.30.31",
+        base_op
+    );
     let mut expected = Vec::with_capacity(16);
     for i in (16..32).rev() {
         expected.push(i);
     }
-    test_op_execution(
-        format!("{}.16.17.18.19.20.21.22.23.24.25.26.27.28.29.30.31", asm_op).as_str(),
-        &[],
-        &expected,
-    );
+
+    let test = build_op_test!(asm_op);
+    test.expect_stack(&expected);
 
     // --- push hexadecimal values with period separators between values ----------------------
+    let asm_op = format!("{}.0xA.0x64.0x3E8.0x2710.0x186A0", base_op);
     let mut expected = Vec::with_capacity(5);
     for i in (1..=5).rev() {
         expected.push(10_u64.pow(i));
     }
-    test_op_execution(
-        format!("{}.0xA.0x64.0x3E8.0x2710.0x186A0", asm_op).as_str(),
-        &[],
-        &expected,
-    );
+
+    let test = build_op_test!(asm_op);
+    test.expect_stack(&expected);
 
     // --- push a mixture of decimal and single-element hexadecimal values --------------------
+    let asm_op = format!("{}.2.4.8.0x10.0x20.0x40.128.0x100", base_op);
     let mut expected = Vec::with_capacity(8);
     for i in (1_u32..=8).rev() {
         expected.push(2_u64.pow(i));
     }
-    test_op_execution(
-        format!("{}.2.4.8.0x10.0x20.0x40.128.0x100", asm_op).as_str(),
-        &[],
-        &expected,
-    );
+
+    let test = build_op_test!(asm_op);
+    test.expect_stack(&expected);
 }
 
 #[test]
 fn push_without_separator() {
-    let asm_op = "push";
+    let base_op = "push";
 
     // --- multiple values as a hexadecimal string ------------------------------------------------
-    test_op_execution(
-        format!("{}.0x0000000000004321000000000000dcba", asm_op).as_str(),
-        &[],
-        &[56506, 17185],
-    );
+    let asm_op = format!("{}.0x0000000000004321000000000000dcba", base_op);
+
+    let test = build_op_test!(asm_op);
+    test.expect_stack(&[56506, 17185]);
 
     // --- push the maximum number of hexadecimal values without separators (16) ------------------
+    let asm_op =    format!("{}.0x0000000000000000000000000000000100000000000000020000000000000003000000000000000400000000000000050000000000000006000000000000000700000000000000080000000000000009000000000000000A000000000000000B000000000000000C000000000000000D000000000000000E000000000000000F", base_op);
     let mut expected = Vec::with_capacity(16);
     for i in (0..16).rev() {
         expected.push(i);
     }
-    test_op_execution(
-        format!("{}.0x0000000000000000000000000000000100000000000000020000000000000003000000000000000400000000000000050000000000000006000000000000000700000000000000080000000000000009000000000000000A000000000000000B000000000000000C000000000000000D000000000000000E000000000000000F", asm_op).as_str(),
-        &[],
-        &expected,
-    )
+
+    let test = build_op_test!(asm_op);
+    test.expect_stack(&expected);
 }

--- a/processor/src/tests/io_ops/mem_ops.rs
+++ b/processor/src/tests/io_ops/mem_ops.rs
@@ -1,4 +1,4 @@
-use super::{compile, test_execution_failure, test_memory_write, test_script_execution};
+use super::{build_op_test, build_test, TestError};
 
 // PUSHING VALUES ONTO THE STACK (PUSH)
 // ================================================================================================
@@ -9,15 +9,17 @@ fn push_mem() {
     let asm_op = "push.mem";
 
     // --- read from uninitialized memory - address provided via the stack ------------------------
-    let script = compile(format!("begin {} end", asm_op).as_str());
-    test_script_execution(&script, &[addr], &[0]);
+    let test = build_op_test!(asm_op, &[addr]);
+    test.expect_stack(&[0]);
 
     // --- read from uninitialized memory - address provided as a parameter -----------------------
-    let script = compile(format!("begin {}.{} end", asm_op, addr).as_str());
-    test_script_execution(&script, &[], &[0]);
+    let asm_op = format!("{}.{}", asm_op, addr);
+    let test = build_op_test!(&asm_op);
+    test.expect_stack(&[0]);
 
     // --- the rest of the stack is unchanged -----------------------------------------------------
-    test_script_execution(&script, &[1, 2, 3, 4], &[0, 4, 3, 2, 1]);
+    let test = build_op_test!(&asm_op, &[1, 2, 3, 4]);
+    test.expect_stack(&[0, 4, 3, 2, 1]);
 }
 
 #[test]
@@ -26,15 +28,18 @@ fn pushw_mem() {
     let asm_op = "pushw.mem";
 
     // --- read from uninitialized memory - address provided via the stack ------------------------
-    let script = compile(format!("begin {} end", asm_op).as_str());
-    test_script_execution(&script, &[addr], &[0, 0, 0, 0]);
+    let test = build_op_test!(asm_op, &[addr]);
+    test.expect_stack(&[0, 0, 0, 0]);
 
     // --- read from uninitialized memory - address provided as a parameter -----------------------
-    let script = compile(format!("begin {}.{} end", asm_op, addr).as_str());
-    test_script_execution(&script, &[], &[0, 0, 0, 0]);
+    let asm_op = format!("{}.{}", asm_op, addr);
+
+    let test = build_op_test!(asm_op);
+    test.expect_stack(&[0, 0, 0, 0]);
 
     // --- the rest of the stack is unchanged -----------------------------------------------------
-    test_script_execution(&script, &[1, 2, 3, 4], &[0, 0, 0, 0, 4, 3, 2, 1]);
+    let test = build_op_test!(asm_op, &[1, 2, 3, 4]);
+    test.expect_stack(&[0, 0, 0, 0, 4, 3, 2, 1]);
 }
 
 // REMOVING VALUES FROM THE STACK (POP)
@@ -46,18 +51,13 @@ fn pop_mem() {
     let addr = 0;
 
     // --- address provided via the stack ---------------------------------------------------------
-    let script = compile(format!("begin {} end", asm_op).as_str());
-    test_memory_write(
-        &script,
-        &[1, 2, 3, 4, addr],
-        &[3, 2, 1],
-        addr,
-        &[4, 0, 0, 0],
-    );
+    let test = build_op_test!(asm_op, &[1, 2, 3, 4, addr]);
+    test.expect_stack_and_memory(&[3, 2, 1], addr, &[4, 0, 0, 0]);
 
     // --- address provided as a parameter --------------------------------------------------------
-    let script = compile(format!("begin {}.{} end", asm_op, addr).as_str());
-    test_memory_write(&script, &[1, 2, 3, 4], &[3, 2, 1], addr, &[4, 0, 0, 0]);
+    let asm_op = format!("{}.{}", asm_op, addr);
+    let test = build_op_test!(&asm_op, &[1, 2, 3, 4]);
+    test.expect_stack_and_memory(&[3, 2, 1], addr, &[4, 0, 0, 0]);
 }
 
 #[test]
@@ -65,7 +65,8 @@ fn pop_mem_invalid() {
     let asm_op = "pop.mem.0";
 
     // --- pop fails when stack is empty ----------------------------------------------------------
-    test_execution_failure(asm_op, &[], "StackUnderflow");
+    let test = build_op_test!(asm_op);
+    test.expect_error(TestError::ExecutionError("StackUnderflow"));
 }
 
 #[test]
@@ -74,16 +75,17 @@ fn popw_mem() {
     let addr = 0;
 
     // --- address provided via the stack ---------------------------------------------------------
-    let script = compile(format!("begin {} end", asm_op).as_str());
-    test_memory_write(&script, &[1, 2, 3, 4, addr], &[], addr, &[1, 2, 3, 4]);
+    let test = build_op_test!(asm_op, &[1, 2, 3, 4, addr]);
+    test.expect_stack_and_memory(&[], addr, &[1, 2, 3, 4]);
 
     // --- address provided as a parameter --------------------------------------------------------
-    let script = compile(format!("begin {}.{} end", asm_op, addr).as_str());
-    test_memory_write(&script, &[1, 2, 3, 4], &[], addr, &[1, 2, 3, 4]);
+    let asm_op = format!("{}.{}", asm_op, addr);
+    let test = build_op_test!(&asm_op, &[1, 2, 3, 4]);
+    test.expect_stack_and_memory(&[], addr, &[1, 2, 3, 4]);
 
     // --- the rest of the stack is unchanged -----------------------------------------------------
-    let script = compile(format!("begin {}.{} end", asm_op, addr).as_str());
-    test_memory_write(&script, &[0, 1, 2, 3, 4], &[0], addr, &[1, 2, 3, 4]);
+    let test = build_op_test!(&asm_op, &[0, 1, 2, 3, 4]);
+    test.expect_stack_and_memory(&[0], addr, &[1, 2, 3, 4]);
 }
 
 #[test]
@@ -91,7 +93,8 @@ fn popw_mem_invalid() {
     let asm_op = "popw.mem.0";
 
     // --- popw fails when the stack doesn't contain a full word ----------------------------------------------------------
-    test_execution_failure(asm_op, &[1, 2], "StackUnderflow");
+    let test = build_op_test!(asm_op, &[1, 2]);
+    test.expect_error(TestError::ExecutionError("StackUnderflow"));
 }
 
 // OVERWRITING VALUES ON THE STACK (LOAD)
@@ -103,19 +106,19 @@ fn loadw_mem() {
     let asm_op = "loadw.mem";
 
     // --- read from uninitialized memory - address provided via the stack ------------------------
-    let script = compile(format!("begin {} end", asm_op).as_str());
-    test_script_execution(&script, &[addr, 5, 6, 7, 8], &[0, 0, 0, 0]);
+    let test = build_op_test!(asm_op, &[addr, 5, 6, 7, 8]);
+    test.expect_stack(&[0, 0, 0, 0]);
 
     // --- read from uninitialized memory - address provided as a parameter -----------------------
-    let script = compile(format!("begin {}.{} end", asm_op, addr).as_str());
-    test_script_execution(&script, &[5, 6, 7, 8], &[0, 0, 0, 0]);
+    let asm_op = format!("{}.{}", asm_op, addr);
+
+    let test = build_op_test!(asm_op, &[5, 6, 7, 8]);
+    test.expect_stack(&[0, 0, 0, 0]);
 
     // --- the rest of the stack is unchanged -----------------------------------------------------
-    test_script_execution(
-        &script,
-        &[1, 2, 3, 4, 5, 6, 7, 8],
-        &[0, 0, 0, 0, 4, 3, 2, 1],
-    );
+
+    let test = build_op_test!(asm_op, &[1, 2, 3, 4, 5, 6, 7, 8]);
+    test.expect_stack(&[0, 0, 0, 0, 4, 3, 2, 1]);
 }
 
 // SAVING STACK VALUES WITHOUT REMOVING THEM (STORE)
@@ -127,28 +130,17 @@ fn storew_mem() {
     let addr = 0;
 
     // --- address provided via the stack ---------------------------------------------------------
-    let script = compile(format!("begin {} end", asm_op).as_str());
-    test_memory_write(
-        &script,
-        &[1, 2, 3, 4, addr],
-        &[4, 3, 2, 1],
-        addr,
-        &[1, 2, 3, 4],
-    );
+    let test = build_op_test!(asm_op, &[1, 2, 3, 4, addr]);
+    test.expect_stack_and_memory(&[4, 3, 2, 1], addr, &[1, 2, 3, 4]);
 
     // --- address provided as a parameter --------------------------------------------------------
-    let script = compile(format!("begin {}.{} end", asm_op, addr).as_str());
-    test_memory_write(&script, &[1, 2, 3, 4], &[4, 3, 2, 1], addr, &[1, 2, 3, 4]);
+    let asm_op = format!("{}.{}", asm_op, addr);
+    let test = build_op_test!(&asm_op, &[1, 2, 3, 4]);
+    test.expect_stack_and_memory(&[4, 3, 2, 1], addr, &[1, 2, 3, 4]);
 
     // --- the rest of the stack is unchanged -----------------------------------------------------
-    let script = compile(format!("begin {}.{} end", asm_op, addr).as_str());
-    test_memory_write(
-        &script,
-        &[0, 1, 2, 3, 4],
-        &[4, 3, 2, 1, 0],
-        addr,
-        &[1, 2, 3, 4],
-    );
+    let test = build_op_test!(&asm_op, &[0, 1, 2, 3, 4]);
+    test.expect_stack_and_memory(&[4, 3, 2, 1, 0], addr, &[1, 2, 3, 4]);
 }
 
 // PAIRED OPERATIONS - ABSOLUTE MEMORY (push/pop, pushw/popw, loadw/storew)
@@ -157,8 +149,7 @@ fn storew_mem() {
 #[test]
 fn inverse_operations() {
     // --- pop and push are inverse operations, so the stack should be left unchanged -------------
-    let script = compile(
-        "
+    let source = "
         begin
             push.0
             pop.mem
@@ -166,17 +157,17 @@ fn inverse_operations() {
             push.1
             push.mem
             push.mem.0
-        end",
-    );
+        end";
+
     let inputs = [0, 1, 2, 3, 4];
     let mut final_stack = inputs;
     final_stack.reverse();
 
-    test_script_execution(&script, &inputs, &final_stack);
+    let test = build_test!(source, &inputs);
+    test.expect_stack(&final_stack);
 
     // --- popw and pushw are inverse operations, so the stack should be left unchanged -----------
-    let script = compile(
-        "
+    let source = "
         begin
             push.0
             popw.mem
@@ -184,17 +175,17 @@ fn inverse_operations() {
             push.1
             pushw.mem
             pushw.mem.0
-        end",
-    );
+        end";
+
     let inputs = [0, 1, 2, 3, 4, 5, 6, 7, 8];
     let mut final_stack = inputs;
     final_stack.reverse();
 
-    test_script_execution(&script, &inputs, &final_stack);
+    let test = build_test!(source, &inputs);
+    test.expect_stack(&final_stack);
 
     // --- storew and loadw are inverse operations, so the stack should be left unchanged ---------
-    let script = compile(
-        "
+    let source = "
         begin
             push.0
             storew.mem
@@ -202,26 +193,27 @@ fn inverse_operations() {
             push.1
             loadw.mem
             loadw.mem.0
-        end",
-    );
+        end";
+
     let inputs = [0, 1, 2, 3, 4];
     let mut final_stack = inputs;
     final_stack.reverse();
 
-    test_script_execution(&script, &inputs, &final_stack);
+    let test = build_test!(source, &inputs);
+    test.expect_stack(&final_stack);
 }
 
 #[test]
 fn read_after_write() {
     // --- write to memory first, then test read with push --------------------------------------
-    let script = compile("begin storew.mem.0 push.mem.0 end");
-    test_script_execution(&script, &[1, 2, 3, 4], &[1, 4, 3, 2, 1]);
+    let test = build_op_test!("storew.mem.0 push.mem.0", &[1, 2, 3, 4]);
+    test.expect_stack(&[1, 4, 3, 2, 1]);
 
     // --- write to memory first, then test read with pushw --------------------------------------
-    let script = compile("begin storew.mem.0 pushw.mem.0 end");
-    test_script_execution(&script, &[1, 2, 3, 4], &[4, 3, 2, 1, 4, 3, 2, 1]);
+    let test = build_op_test!("storew.mem.0 pushw.mem.0", &[1, 2, 3, 4]);
+    test.expect_stack(&[4, 3, 2, 1, 4, 3, 2, 1]);
 
     // --- write to memory first, then test read with loadw --------------------------------------
-    let script = compile("begin popw.mem.0 loadw.mem.0 end");
-    test_script_execution(&script, &[1, 2, 3, 4, 5, 6, 7, 8], &[8, 7, 6, 5]);
+    let test = build_op_test!("popw.mem.0 loadw.mem.0", &[1, 2, 3, 4, 5, 6, 7, 8]);
+    test.expect_stack(&[8, 7, 6, 5]);
 }

--- a/processor/src/tests/io_ops/mod.rs
+++ b/processor/src/tests/io_ops/mod.rs
@@ -1,7 +1,6 @@
 use super::{
-    super::ExecutionTrace, super::Process, super::ProgramInputs, super::Script, build_inputs,
-    compile, convert_to_stack, execute, push_to_stack, test_execution_failure, test_op_execution,
-    test_script_execution, test_script_execution_failure, Felt,
+    super::{build_op_test, build_test},
+    TestError,
 };
 
 mod adv_ops;
@@ -9,30 +8,3 @@ mod constant_ops;
 mod env_ops;
 mod local_ops;
 mod mem_ops;
-
-// HELPER FUNCTIONS
-// ================================================================================================
-
-fn test_memory_write(
-    script: &Script,
-    stack_inputs: &[u64],
-    final_stack: &[u64],
-    mem_addr: u64,
-    expected_mem: &[u64],
-) {
-    let inputs = build_inputs(stack_inputs);
-    let mut process = Process::new(inputs);
-
-    // execute the test
-    process.execute_code_block(script.root()).unwrap();
-
-    // validate the memory state
-    let mem_state = process.memory.get_value(mem_addr).unwrap();
-    let expected_mem: Vec<Felt> = expected_mem.iter().map(|&v| Felt::new(v)).collect();
-    assert_eq!(expected_mem, mem_state);
-
-    // validate the stack state
-    let stack_state = ExecutionTrace::new(process).last_stack_state();
-    let expected_stack = convert_to_stack(final_stack);
-    assert_eq!(expected_stack, stack_state);
-}

--- a/processor/src/tests/stdlib/mod.rs
+++ b/processor/src/tests/stdlib/mod.rs
@@ -1,4 +1,4 @@
-use super::{compile, test_script_execution};
+use super::super::build_test;
 
 mod crypto;
 mod u64_mod;

--- a/processor/src/tests/stdlib/u64_mod.rs
+++ b/processor/src/tests/stdlib/u64_mod.rs
@@ -1,4 +1,4 @@
-use super::{compile, test_script_execution};
+use super::build_test;
 use rand_utils::rand_value;
 
 #[test]
@@ -7,19 +7,18 @@ fn add_unsafe() {
     let b: u64 = rand_value();
     let c = a.wrapping_add(b);
 
-    let script = compile(
-        "
+    let source = "
         use.std::math::u64
         begin
             exec.u64::add_unsafe
-        end",
-    );
+        end";
 
     let (a1, a0) = split_u64(a);
     let (b1, b0) = split_u64(b);
     let (c1, c0) = split_u64(c);
 
-    test_script_execution(&script, &[a0, a1, b0, b1], &[c1, c0]);
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[c1, c0]);
 }
 
 #[test]
@@ -28,19 +27,18 @@ fn mul_unsafe() {
     let b: u64 = rand_value();
     let c = a.wrapping_mul(b);
 
-    let script = compile(
-        "
+    let source = "
         use.std::math::u64
         begin
             exec.u64::mul_unsafe
-        end",
-    );
+        end";
 
     let (a1, a0) = split_u64(a);
     let (b1, b0) = split_u64(b);
     let (c1, c0) = split_u64(c);
 
-    test_script_execution(&script, &[a0, a1, b0, b1], &[c1, c0]);
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[c1, c0]);
 }
 
 #[test]
@@ -49,23 +47,24 @@ fn div_unsafe() {
     let b: u64 = rand_value();
     let c = a / b;
 
-    let script = compile(
-        "
+    let source = "
         use.std::math::u64
         begin
             exec.u64::div_unsafe
-        end",
-    );
+        end";
 
     let (a1, a0) = split_u64(a);
     let (b1, b0) = split_u64(b);
     let (c1, c0) = split_u64(c);
 
-    test_script_execution(&script, &[a0, a1, b0, b1], &[c1, c0]);
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[c1, c0]);
 
     let d = a / b0;
     let (d1, d0) = split_u64(d);
-    test_script_execution(&script, &[a0, a1, b0, 0], &[d1, d0]);
+
+    let test = build_test!(source, &[a0, a1, b0, 0]);
+    test.expect_stack(&[d1, d0]);
 }
 
 // HELPER FUNCTIONS

--- a/processor/src/tests/u32_ops/bitwise_ops.rs
+++ b/processor/src/tests/u32_ops/bitwise_ops.rs
@@ -1,6 +1,5 @@
 use super::{
-    test_execution_failure, test_input_out_of_bounds, test_op_execution,
-    test_op_execution_proptest, test_param_out_of_bounds, U32_BOUND,
+    build_op_test, test_input_out_of_bounds, test_param_out_of_bounds, TestError, U32_BOUND,
 };
 use proptest::prelude::*;
 use rand_utils::rand_value;
@@ -13,24 +12,31 @@ fn u32and() {
     let asm_op = "u32and";
 
     // --- simple cases ---------------------------------------------------------------------------
-    test_op_execution(asm_op, &[1, 1], &[1]);
-    test_op_execution(asm_op, &[0, 1], &[0]);
-    test_op_execution(asm_op, &[1, 0], &[0]);
-    test_op_execution(asm_op, &[0, 0], &[0]);
+    let test = build_op_test!(asm_op, &[1, 1]);
+    test.expect_stack(&[1]);
+
+    let test = build_op_test!(asm_op, &[0, 1]);
+    test.expect_stack(&[0]);
+
+    let test = build_op_test!(asm_op, &[1, 0]);
+    test.expect_stack(&[0]);
+
+    let test = build_op_test!(asm_op, &[0, 0]);
+    test.expect_stack(&[0]);
 
     // --- random u32 values ----------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = rand_value::<u64>() as u32;
-    test_op_execution(asm_op, &[a as u64, b as u64], &[(a & b) as u64]);
+
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[(a & b) as u64]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
     let c = rand_value::<u64>() as u32;
     let d = rand_value::<u64>() as u32;
-    test_op_execution(
-        asm_op,
-        &[c as u64, d as u64, a as u64, b as u64],
-        &[(a & b) as u64, d as u64, c as u64],
-    );
+
+    let test = build_op_test!(asm_op, &[c as u64, d as u64, a as u64, b as u64]);
+    test.expect_stack(&[(a & b) as u64, d as u64, c as u64]);
 }
 
 #[test]
@@ -38,8 +44,11 @@ fn u32and() {
 fn u32and_fail() {
     let asm_op = "u32and";
 
-    test_execution_failure(asm_op, &[U32_BOUND, 0], "NotU32Value");
-    test_execution_failure(asm_op, &[0, U32_BOUND], "NotU32Value");
+    let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
+
+    let test = build_op_test!(asm_op, &[0, U32_BOUND]);
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -47,24 +56,31 @@ fn u32or() {
     let asm_op = "u32or";
 
     // --- simple cases ---------------------------------------------------------------------------
-    test_op_execution(asm_op, &[1, 1], &[1]);
-    test_op_execution(asm_op, &[0, 1], &[1]);
-    test_op_execution(asm_op, &[1, 0], &[1]);
-    test_op_execution(asm_op, &[0, 0], &[0]);
+    let test = build_op_test!(asm_op, &[1, 1]);
+    test.expect_stack(&[1]);
+
+    let test = build_op_test!(asm_op, &[0, 1]);
+    test.expect_stack(&[1]);
+
+    let test = build_op_test!(asm_op, &[1, 0]);
+    test.expect_stack(&[1]);
+
+    let test = build_op_test!(asm_op, &[0, 0]);
+    test.expect_stack(&[0]);
 
     // --- random u32 values ----------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = rand_value::<u64>() as u32;
-    test_op_execution(asm_op, &[a as u64, b as u64], &[(a | b) as u64]);
+
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[(a | b) as u64]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
     let c = rand_value::<u64>() as u32;
     let d = rand_value::<u64>() as u32;
-    test_op_execution(
-        asm_op,
-        &[c as u64, d as u64, a as u64, b as u64],
-        &[(a | b) as u64, d as u64, c as u64],
-    );
+
+    let test = build_op_test!(asm_op, &[c as u64, d as u64, a as u64, b as u64]);
+    test.expect_stack(&[(a | b) as u64, d as u64, c as u64]);
 }
 
 #[test]
@@ -72,8 +88,11 @@ fn u32or() {
 fn u32or_fail() {
     let asm_op = "u32or";
 
-    test_execution_failure(asm_op, &[U32_BOUND, 0], "NotU32Value");
-    test_execution_failure(asm_op, &[0, U32_BOUND], "NotU32Value");
+    let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
+
+    let test = build_op_test!(asm_op, &[0, U32_BOUND]);
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -81,24 +100,30 @@ fn u32xor() {
     let asm_op = "u32xor";
 
     // --- simple cases ---------------------------------------------------------------------------
-    test_op_execution(asm_op, &[1, 1], &[0]);
-    test_op_execution(asm_op, &[0, 1], &[1]);
-    test_op_execution(asm_op, &[1, 0], &[1]);
-    test_op_execution(asm_op, &[0, 0], &[0]);
+    let test = build_op_test!(asm_op, &[1, 1]);
+    test.expect_stack(&[0]);
+
+    let test = build_op_test!(asm_op, &[0, 1]);
+    test.expect_stack(&[1]);
+
+    let test = build_op_test!(asm_op, &[1, 0]);
+    test.expect_stack(&[1]);
+
+    let test = build_op_test!(asm_op, &[0, 0]);
+    test.expect_stack(&[0]);
 
     // --- random u32 values ----------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = rand_value::<u64>() as u32;
-    test_op_execution(asm_op, &[a as u64, b as u64], &[(a ^ b) as u64]);
+
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[(a ^ b) as u64]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
     let c = rand_value::<u64>() as u32;
     let d = rand_value::<u64>() as u32;
-    test_op_execution(
-        asm_op,
-        &[c as u64, d as u64, a as u64, b as u64],
-        &[(a ^ b) as u64, d as u64, c as u64],
-    );
+    let test = build_op_test!(asm_op, &[c as u64, d as u64, a as u64, b as u64]);
+    test.expect_stack(&[(a ^ b) as u64, d as u64, c as u64]);
 }
 
 #[test]
@@ -106,8 +131,11 @@ fn u32xor() {
 fn u32xor_fail() {
     let asm_op = "u32xor";
 
-    test_execution_failure(asm_op, &[U32_BOUND, 0], "NotU32Value");
-    test_execution_failure(asm_op, &[0, U32_BOUND], "NotU32Value");
+    let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
+
+    let test = build_op_test!(asm_op, &[0, U32_BOUND]);
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -115,16 +143,23 @@ fn u32not() {
     let asm_op = "u32not";
 
     // --- simple cases ---------------------------------------------------------------------------
-    test_op_execution(asm_op, &[U32_BOUND - 1], &[0]);
-    test_op_execution(asm_op, &[0], &[U32_BOUND - 1]);
+    let test = build_op_test!(asm_op, &[U32_BOUND - 1]);
+    test.expect_stack(&[0]);
+
+    let test = build_op_test!(asm_op, &[0]);
+    test.expect_stack(&[U32_BOUND - 1]);
 
     // --- random u32 values ----------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
-    test_op_execution(asm_op, &[a as u64], &[!a as u64]);
+
+    let test = build_op_test!(asm_op, &[a as u64]);
+    test.expect_stack(&[!a as u64]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
     let b = rand_value::<u64>() as u32;
-    test_op_execution(asm_op, &[b as u64, a as u64], &[!a as u64, b as u64]);
+
+    let test = build_op_test!(asm_op, &[b as u64, a as u64]);
+    test.expect_stack(&[!a as u64, b as u64]);
 }
 
 #[test]
@@ -142,34 +177,29 @@ fn u32shl() {
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u32;
     let b = 1_u32;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[2]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[2]);
 
     // --- test max values of a and b -------------------------------------------------------------
     let a = (U32_BOUND - 1) as u32;
     let b = 31;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[U32_BOUND - 1],
-        &[a.wrapping_shl(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shl(b) as u64]);
 
     // --- test b = 0 -----------------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = 0;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[a as u64],
-        &[a.wrapping_shl(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shl(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = (rand_value::<u64>() % 32) as u32;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[a as u64],
-        &[a.wrapping_shl(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shl(b) as u64]);
 }
 
 #[test]
@@ -189,34 +219,29 @@ fn u32shr() {
     // --- test simple case -----------------------------------------------------------------------
     let a = 4_u32;
     let b = 2_u32;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[1]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[1]);
 
     // --- test max values of a and b -------------------------------------------------------------
     let a = (U32_BOUND - 1) as u32;
     let b = 31;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[U32_BOUND - 1],
-        &[a.wrapping_shr(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shr(b) as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = 0;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[a as u64],
-        &[a.wrapping_shr(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shr(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = (rand_value::<u64>() % 32) as u32;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[a as u64],
-        &[a.wrapping_shr(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shr(b) as u64]);
 }
 
 #[test]
@@ -236,40 +261,40 @@ fn u32rotl() {
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u32;
     let b = 1_u32;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[2]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[2]);
 
     // --- test simple wraparound case with large a -----------------------------------------------
     let a = (1_u64 << 31) as u32;
     let b: u32 = 1;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[1]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[1]);
 
     // --- test simple case wraparound case with max b --------------------------------------------
     let a = 2_u32;
     let b: u32 = 31;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[1]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[1]);
 
     // --- no change when a is max value (all 1s) -------------------------------------------------
     let a = (U32_BOUND - 1) as u32;
     let b = 2;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[a as u64]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = 0;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[a as u64],
-        &[a.rotate_left(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.rotate_left(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = (rand_value::<u64>() % 32) as u32;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[a as u64],
-        &[a.rotate_left(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.rotate_left(b) as u64]);
 }
 
 #[test]
@@ -289,40 +314,40 @@ fn u32rotr() {
     // --- test simple case -----------------------------------------------------------------------
     let a = 2_u32;
     let b = 1_u32;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[1]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[1]);
 
     // --- test simple wraparound case with small a -----------------------------------------------
     let a = 1_u32;
     let b = 1_u32;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[U32_BOUND >> 1]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[U32_BOUND >> 1]);
 
     // --- test simple case wraparound case with max b --------------------------------------------
     let a = 1_u32;
     let b: u32 = 31;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[2]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[2]);
 
     // --- no change when a is max value (all 1s) -------------------------------------------------
     let a = (U32_BOUND - 1) as u32;
     let b = 2;
-    test_op_execution(get_asm_op(b).as_str(), &[a as u64], &[a as u64]);
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = 0;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[a as u64],
-        &[a.rotate_right(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.rotate_right(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
     let a = rand_value::<u64>() as u32;
     let b = (rand_value::<u64>() % 32) as u32;
-    test_op_execution(
-        get_asm_op(b).as_str(),
-        &[a as u64],
-        &[a.rotate_right(b) as u64],
-    );
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.rotate_right(b) as u64]);
 }
 
 #[test]
@@ -344,7 +369,8 @@ proptest! {
         // should result in bitwise AND
         let expected = (a & b) as u64;
 
-        test_op_execution_proptest(asm_opcode, &values, &[expected])?;
+        let test = build_op_test!(asm_opcode, &values);
+        test.prop_expect_stack(&[expected])?;
     }
 
     #[test]
@@ -354,7 +380,8 @@ proptest! {
         // should result in bitwise OR
         let expected = (a | b) as u64;
 
-        test_op_execution_proptest(asm_opcode, &values, &[expected])?;
+        let test = build_op_test!(asm_opcode, &values);
+        test.prop_expect_stack(&[expected])?;
     }
 
     #[test]
@@ -364,7 +391,8 @@ proptest! {
         // should result in bitwise XOR
         let expected = (a ^ b) as u64;
 
-        test_op_execution_proptest(asm_opcode, &values, &[expected])?;
+        let test = build_op_test!(asm_opcode, &values);
+        test.prop_expect_stack(&[expected])?;
     }
 
     #[test]
@@ -372,7 +400,8 @@ proptest! {
         let asm_opcode = "u32not";
 
         // should result in bitwise NOT
-        test_op_execution_proptest(asm_opcode, &[value as u64], &[!value as u64])?;
+        let test = build_op_test!(asm_opcode, &[value as u64]);
+        test.prop_expect_stack(&[!value as u64])?;
     }
 
     #[test]
@@ -381,7 +410,8 @@ proptest! {
 
         // should execute left shift
         let expected =  a << b;
-        test_op_execution_proptest(&asm_opcode, &[a as u64], &[expected as u64])?;
+        let test = build_op_test!(asm_opcode, &[a as u64]);
+        test.prop_expect_stack(&[expected as u64])?;
     }
 
     #[test]
@@ -390,7 +420,8 @@ proptest! {
 
         // should execute right shift
         let expected =  a >> b;
-        test_op_execution_proptest(&asm_opcode, &[a as u64], &[expected as u64])?;
+        let test = build_op_test!(asm_opcode, &[a as u64]);
+        test.prop_expect_stack(&[expected as u64])?;
     }
 
     #[test]
@@ -399,7 +430,8 @@ proptest! {
         let asm_opcode = format!("{}.{}", op_base, b);
 
         // should execute left bit rotation
-        test_op_execution_proptest(&asm_opcode, &[a as u64], &[a.rotate_left(b) as u64])?;
+        let test = build_op_test!(asm_opcode, &[a as u64]);
+        test.prop_expect_stack(&[a.rotate_left(b) as u64])?;
     }
 
     #[test]
@@ -408,6 +440,7 @@ proptest! {
         let asm_opcode = format!("{}.{}", op_base, b);
 
         // should execute right bit rotation
-        test_op_execution_proptest(&asm_opcode, &[a as u64], &[a.rotate_right(b) as u64])?;
+        let test = build_op_test!(asm_opcode, &[a as u64]);
+        test.prop_expect_stack(&[a.rotate_right(b) as u64])?;
     }
 }


### PR DESCRIPTION
This PR refactors the processor integration tests to use macros, making testing patterns more consistent and reducing duplication.