### PR TITLE
Implement u64 division in standard library

### DIFF
--- a/assembly/src/parsers/io_ops/mod.rs
+++ b/assembly/src/parsers/io_ops/mod.rs
@@ -247,7 +247,14 @@ pub fn parse_storew(
 // ADVICE INJECTORS
 // ================================================================================================
 
-/// TODO: add doc comments
+/// Appends the appropriate advice injector operation to `span_ops`.
+///
+/// Advice injector operations insert one or more values at the head of the advice tape, but do
+/// not modify the VM state and do not advance the clock cycles. Currently, the following advice
+/// injectors can be invoked explicitly:
+/// - adv.u64div: this operation interprets four elements at the top of the stack as two 64-bit
+///   values (represented by 32-bit limbs), divides one value by another, and injects the quotient
+///   and the remainder into the advice tape.
 pub fn parse_adv_inject(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
     validate_operation!(op, "adv.u64div");
     match op.parts()[1] {

--- a/assembly/src/parsers/io_ops/mod.rs
+++ b/assembly/src/parsers/io_ops/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     super::validate_operation, parse_decimal_param, parse_element_param, parse_hex_param,
-    parse_int_param, push_value, AssemblyError, Felt, Operation, Token,
+    parse_int_param, push_value, AdviceInjector, AssemblyError, Felt, Operation, Token,
 };
 
 mod adv_ops;
@@ -242,6 +242,20 @@ pub fn parse_storew(
         "local" => parse_write_local(span_ops, op, num_proc_locals, true),
         _ => Err(AssemblyError::invalid_op(op)),
     }
+}
+
+// ADVICE INJECTORS
+// ================================================================================================
+
+/// TODO: add doc comments
+pub fn parse_adv_inject(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+    validate_operation!(op, "adv.u64div");
+    match op.parts()[1] {
+        "u64div" => span_ops.push(Operation::Advice(AdviceInjector::DivResultU64)),
+        _ => return Err(AssemblyError::invalid_op(op)),
+    }
+
+    Ok(())
 }
 
 // TESTS

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -1,6 +1,8 @@
 use super::{AssemblyContext, AssemblyError, Token, TokenStream};
 pub use blocks::{combine_blocks, parse_code_blocks};
-use vm_core::{program::blocks::CodeBlock, Felt, FieldElement, Operation, StarkField};
+use vm_core::{
+    program::blocks::CodeBlock, AdviceInjector, Felt, FieldElement, Operation, StarkField,
+};
 
 mod blocks;
 mod crypto_ops;
@@ -102,6 +104,8 @@ fn parse_op_token(
         "popw" => io_ops::parse_popw(span_ops, op, num_proc_locals),
         "loadw" => io_ops::parse_loadw(span_ops, op, num_proc_locals),
         "storew" => io_ops::parse_storew(span_ops, op, num_proc_locals),
+
+        "adv" => io_ops::parse_adv_inject(span_ops, op),
 
         // ----- cryptographic operations ---------------------------------------------------------
         "rphash" => crypto_ops::parse_rphash(span_ops, op),

--- a/core/src/operations/advice.rs
+++ b/core/src/operations/advice.rs
@@ -9,12 +9,16 @@ pub enum AdviceInjector {
     /// - index of the node, 1 element
     /// - root of the tree, 4 elements
     MerkleNode,
+
+    /// TODO: add comments
+    DivResultU64,
 }
 
 impl fmt::Display for AdviceInjector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MerkleNode => write!(f, "merkle_node"),
+            Self::DivResultU64 => write!(f, "div_result_u64"),
         }
     }
 }

--- a/core/src/operations/advice.rs
+++ b/core/src/operations/advice.rs
@@ -10,7 +10,13 @@ pub enum AdviceInjector {
     /// - root of the tree, 4 elements
     MerkleNode,
 
-    /// TODO: add comments
+    /// Injects the result of u64 division (both the quotient and the remainder) at the head of
+    /// the advice tape. The stack is expected to be arranged as follows (from the top):
+    /// - divisor split into two 32-bit elements
+    /// - dividend split into two 32-bit elements
+    ///
+    /// The result is injected into the advice tape as follows: first the remainder is injected,
+    /// then the quotient is injected.
     DivResultU64,
 }
 

--- a/processor/src/tests/io_ops/adv_ops.rs
+++ b/processor/src/tests/io_ops/adv_ops.rs
@@ -1,4 +1,5 @@
 use super::{compile, execute, push_to_stack, test_execution_failure, ProgramInputs};
+use rand_utils::rand_value;
 
 // PUSHING VALUES ONTO THE STACK (PUSH)
 // ================================================================================================
@@ -53,4 +54,38 @@ fn loadw_adv() {
 fn loadw_adv_invalid() {
     // attempting to read from empty advice tape should throw an error
     test_execution_failure("loadw.adv", &[0, 0, 0, 0], "EmptyAdviceTape");
+}
+
+// ADVICE INJECTORS
+// ================================================================================================
+
+#[test]
+fn adv_inject_u64div() {
+    let script = compile("begin adv.u64div push.adv.4 end");
+
+    // get two random 64-bit integers and split them into 32-bit limbs
+    let a = rand_value::<u64>();
+    let a_hi = a >> 32;
+    let a_lo = a as u32 as u64;
+
+    let b = rand_value::<u64>();
+    let b_hi = b >> 32;
+    let b_lo = b as u32 as u64;
+
+    // compute expected quotient
+    let q = a / b;
+    let q_hi = q >> 32;
+    let q_lo = q as u32 as u64;
+
+    // compute expected remainder
+    let r = a % b;
+    let r_hi = r >> 32;
+    let r_lo = r as u32 as u64;
+
+    // inject a/b into the advice tape and then read these values from the tape
+    let inputs = ProgramInputs::new(&[a_lo, a_hi, b_lo, b_hi], &[], vec![]).unwrap();
+    let trace = execute(&script, &inputs).unwrap();
+
+    let expected = push_to_stack(&[a_lo, a_hi, b_lo, b_hi, q_lo, q_hi, r_lo, r_hi]);
+    assert_eq!(expected, trace.last_stack_state());
 }

--- a/processor/src/tests/stdlib/u64_mod.rs
+++ b/processor/src/tests/stdlib/u64_mod.rs
@@ -43,6 +43,31 @@ fn mul_unsafe() {
     test_script_execution(&script, &[a0, a1, b0, b1], &[c1, c0]);
 }
 
+#[test]
+fn div_unsafe() {
+    let a: u64 = rand_value();
+    let b: u64 = rand_value();
+    let c = a / b;
+
+    let script = compile(
+        "
+        use.std::math::u64
+        begin
+            exec.u64::div_unsafe
+        end",
+    );
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c1, c0) = split_u64(c);
+
+    test_script_execution(&script, &[a0, a1, b0, b1], &[c1, c0]);
+
+    let d = a / b0;
+    let (d1, d0) = split_u64(d);
+    test_script_execution(&script, &[a0, a1, b0, 0], &[d1, d0]);
+}
+
 // HELPER FUNCTIONS
 // ================================================================================================
 

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -29,3 +29,55 @@ export.mul_unsafe
     u32madd
     drop
 end
+
+# ===== DIVISION ================================================================================ #
+
+# Performs division of two unsigned 64 bit integers discarding the remainder. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b #
+export.div_unsafe
+    adv.u64div          # inject the quotient and the remainder into the advice tape #
+    
+    push.adv.1          # read the values from the advice tape and make sure they are u32's #
+    u32assert           # TODO: this can be optimized once we have u32assert2 instruction #
+    push.adv.1
+    u32assert
+    push.adv.1
+    u32assert
+    push.adv.1
+    u32assert
+
+    dup.5               # multiply quotient by the divisor; this also consumes the divisor #
+    dup.4
+    u32mul.unsafe
+    dup.6
+    dup.6
+    u32madd
+    eq.0
+    assert
+    movup.7
+    dup.5
+    u32madd
+    eq.0
+    assert
+    movup.6
+    dup.5
+    mul
+    eq.0
+    assert
+    swap
+
+    movup.3             # add remainder to the previous result; this also consumes the remainder #
+    u32add.unsafe
+    movup.3
+    movup.3
+    u32addc
+    eq.0
+    assert
+
+    movup.4             # make sure the result we got is equal to the dividend #
+    assert.eq
+    movup.3
+    assert.eq           # quotient remains on the stack #
+end

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -66,9 +66,9 @@ export.div_unsafe
     mul
     eq.0
     assert
-    swap
 
-    movup.3             # add remainder to the previous result; this also consumes the remainder #
+    swap                # add remainder to the previous result; this also consumes the remainder #
+    movup.3
     u32add.unsafe
     movup.3
     movup.3

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -277,9 +277,9 @@ export.div_unsafe
     mul
     eq.0
     assert
-    swap
 
-    movup.3             # add remainder to the previous result; this also consumes the remainder #
+    swap                # add remainder to the previous result; this also consumes the remainder #
+    movup.3
     u32add.unsafe
     movup.3
     movup.3

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -239,5 +239,58 @@ export.mul_unsafe
     movup.3
     u32madd
     drop
-end"),
+end
+
+# ===== DIVISION ================================================================================ #
+
+# Performs division of two unsigned 64 bit integers discarding the remainder. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b #
+export.div_unsafe
+    adv.u64div          # inject the quotient and the remainder into the advice tape #
+    
+    push.adv.1          # read the values from the advice tape and make sure they are u32's #
+    u32assert           # TODO: this can be optimized once we have u32assert2 instruction #
+    push.adv.1
+    u32assert
+    push.adv.1
+    u32assert
+    push.adv.1
+    u32assert
+
+    dup.5               # multiply quotient by the divisor; this also consumes the divisor #
+    dup.4
+    u32mul.unsafe
+    dup.6
+    dup.6
+    u32madd
+    eq.0
+    assert
+    movup.7
+    dup.5
+    u32madd
+    eq.0
+    assert
+    movup.6
+    dup.5
+    mul
+    eq.0
+    assert
+    swap
+
+    movup.3             # add remainder to the previous result; this also consumes the remainder #
+    u32add.unsafe
+    movup.3
+    movup.3
+    u32addc
+    eq.0
+    assert
+
+    movup.4             # make sure the result we got is equal to the dividend #
+    assert.eq
+    movup.3
+    assert.eq           # quotient remains on the stack #
+end
+"),
 ];


### PR DESCRIPTION
This PR implements division of 64-bit unsigned integers in the standard library. The overall methodology is to compute the actual division outside of the VM, provide the result to the VM via the advice tape, and then to verify that the result is correct within the VM. The tasks include:

- [x] Add an advice injector for computing the result of u64 division.
- [x] Add an assembly instruction to invoke the above advice injector. I named this instruction `adv.u64div`, but I'm open to other suggestions.
- [x] Implement division procedure in `std::math::u64` module.

Overall, u64 division requires about 50 VM cycles. This can be reduced to 39 cycles once we have `u32assert2` operation as described #132 (compare this with 11 cycles needed for u64 multiplication).