### PR TITLE
Add u64 comparisons and other fixes

### DIFF
--- a/processor/src/tests/stdlib/math/u64_mod.rs
+++ b/processor/src/tests/stdlib/math/u64_mod.rs
@@ -224,7 +224,7 @@ proptest! {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// Split the provided u64 value into 32 hight and low bits.
+/// Split the provided u64 value into 32 high and low bits.
 fn split_u64(value: u64) -> (u64, u64) {
     (value >> 32, value as u32 as u64)
 }

--- a/processor/src/tests/stdlib/math/u64_mod.rs
+++ b/processor/src/tests/stdlib/math/u64_mod.rs
@@ -202,6 +202,23 @@ proptest! {
         build_test!(source, &[a0, a1, b0, b1]).prop_expect_stack(&[c])?;
     }
 
+    #[test]
+    fn div_unsafe_proptest(a in any::<u64>(), b in any::<u64>()) {
+
+        let c = a / b;
+
+        let (a1, a0) = split_u64(a);
+        let (b1, b0) = split_u64(b);
+        let (c1, c0) = split_u64(c);
+
+        let source = "
+            use.std::math::u64
+            begin
+                exec.u64::div_unsafe
+            end";
+
+        build_test!(source, &[a0, a1, b0, b1]).prop_expect_stack(&[c1, c0])?;
+    }
 }
 
 // HELPER FUNCTIONS

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -1,3 +1,5 @@
+# ===== ADDITION ================================================================================ #
+
 # Performs addition of two unsigned 64 bit integers discarding the overflow. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
@@ -11,6 +13,8 @@ export.add_unsafe
     u32addc
     drop
 end
+
+# ===== MULTIPLICATION ========================================================================== #
 
 # Performs multiplication of two unsigned 64 bit integers discarding the overflow. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
@@ -28,6 +32,62 @@ export.mul_unsafe
     movup.3
     u32madd
     drop
+end
+
+# ===== COMPARISONS ============================================================================= #
+
+# Performs less-than comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a < b, and 0 otherwise. #
+export.lt_unsafe
+    movup.3
+    movup.2
+    u32sub.unsafe
+    movdn.3
+    drop
+    u32sub.unsafe
+    swap
+    eq.0
+    movup.2
+    and
+    or
+end
+
+# Performs greater-than comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a > b, and 0 otherwise. #
+export.gt_unsafe
+    movup.2
+    u32sub.unsafe
+    movup.2
+    movup.3
+    u32sub.unsafe
+    swap
+    drop
+    movup.2
+    eq.0
+    and
+    or
+end
+
+# Performs less-than-or-equal comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a <= b, and 0 otherwise. #
+export.lte_unsafe
+    exec.gt_unsafe
+    not
+end
+
+# Performs greater-than-or-equal comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a >= b, and 0 otherwise. #
+export.gte_unsafe
+    exec.lt_unsafe
+    not
 end
 
 # ===== DIVISION ================================================================================ #

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -10,7 +10,7 @@ export.add_unsafe
     u32add.unsafe
     movup.3
     movup.3
-    u32addc
+    u32addc.unsafe
     drop
 end
 
@@ -26,11 +26,11 @@ export.mul_unsafe
     u32mul.unsafe
     movup.4
     movup.4
-    u32madd
+    u32madd.unsafe
     drop
     movup.3
     movup.3
-    u32madd
+    u32madd.unsafe
     drop
 end
 
@@ -39,7 +39,7 @@ end
 # Performs less-than comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a < b, and 0 otherwise. #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise. #
 export.lt_unsafe
     movup.3
     movup.2
@@ -57,7 +57,7 @@ end
 # Performs greater-than comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a > b, and 0 otherwise. #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise. #
 export.gt_unsafe
     movup.2
     u32sub.unsafe
@@ -75,7 +75,7 @@ end
 # Performs less-than-or-equal comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a <= b, and 0 otherwise. #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise. #
 export.lte_unsafe
     exec.gt_unsafe
     not
@@ -84,7 +84,7 @@ end
 # Performs greater-than-or-equal comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a >= b, and 0 otherwise. #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise. #
 export.gte_unsafe
     exec.lt_unsafe
     not
@@ -109,12 +109,12 @@ export.div_unsafe
     u32mul.unsafe
     dup.4
     dup.4
-    u32madd
+    u32madd.unsafe
     eq.0
     assert
     dup.5
     dup.3
-    u32madd
+    u32madd.unsafe
     eq.0
     assert
     dup.4
@@ -140,7 +140,7 @@ export.div_unsafe
     u32add.unsafe
     movup.3
     movup.3
-    u32addc
+    u32addc.unsafe
     eq.0
     assert
 

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -99,32 +99,40 @@ end
 export.div_unsafe
     adv.u64div          # inject the quotient and the remainder into the advice tape #
     
-    push.adv.1          # read the values from the advice tape and make sure they are u32's #
-    u32assert           # TODO: this can be optimized once we have u32assert2 instruction #
-    push.adv.1
+    push.adv.1          # read the quotient from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
+    push.adv.1          # TODO: this can be optimized once we have u32assert2 instruction #
     u32assert
-    push.adv.1
-    u32assert
+
+    dup.3               # multiply quotient by the divisor and make sure the resulting value #
+    dup.2               # fits into 2 32-bit limbs #
+    u32mul.unsafe
+    dup.4
+    dup.4
+    u32madd
+    eq.0
+    assert
+    dup.5
+    dup.3
+    u32madd
+    eq.0
+    assert
+    dup.4
+    dup.3
+    mul
+    eq.0
+    assert
+
+    push.adv.1          # read the remainder from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
     push.adv.1
     u32assert
 
-    dup.5               # multiply quotient by the divisor; this also consumes the divisor #
-    dup.4
-    u32mul.unsafe
-    dup.6
-    dup.6
-    u32madd
-    eq.0
-    assert
-    movup.7
-    dup.5
-    u32madd
-    eq.0
-    assert
-    movup.6
-    dup.5
-    mul
-    eq.0
+    movup.7             # make sure the divisor is greater than the remainder. this also consumes #
+    movup.7             # the divisor #
+    dup.3
+    dup.3
+    exec.gt_unsafe
     assert
 
     swap                # add remainder to the previous result; this also consumes the remainder #

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -1522,7 +1522,7 @@ export.add_unsafe
     u32add.unsafe
     movup.3
     movup.3
-    u32addc
+    u32addc.unsafe
     drop
 end
 
@@ -1538,11 +1538,11 @@ export.mul_unsafe
     u32mul.unsafe
     movup.4
     movup.4
-    u32madd
+    u32madd.unsafe
     drop
     movup.3
     movup.3
-    u32madd
+    u32madd.unsafe
     drop
 end
 
@@ -1551,7 +1551,7 @@ end
 # Performs less-than comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a < b, and 0 otherwise. #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise. #
 export.lt_unsafe
     movup.3
     movup.2
@@ -1569,7 +1569,7 @@ end
 # Performs greater-than comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a > b, and 0 otherwise. #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise. #
 export.gt_unsafe
     movup.2
     u32sub.unsafe
@@ -1587,7 +1587,7 @@ end
 # Performs less-than-or-equal comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a <= b, and 0 otherwise. #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise. #
 export.lte_unsafe
     exec.gt_unsafe
     not
@@ -1596,7 +1596,7 @@ end
 # Performs greater-than-or-equal comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a >= b, and 0 otherwise. #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise. #
 export.gte_unsafe
     exec.lt_unsafe
     not
@@ -1621,12 +1621,12 @@ export.div_unsafe
     u32mul.unsafe
     dup.4
     dup.4
-    u32madd
+    u32madd.unsafe
     eq.0
     assert
     dup.5
     dup.3
-    u32madd
+    u32madd.unsafe
     eq.0
     assert
     dup.4
@@ -1652,7 +1652,7 @@ export.div_unsafe
     u32add.unsafe
     movup.3
     movup.3
-    u32addc
+    u32addc.unsafe
     eq.0
     assert
 

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -1542,6 +1542,62 @@ export.mul_unsafe
     drop
 end
 
+# ===== COMPARISONS ============================================================================= #
+
+# Performs less-than comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a < b, and 0 otherwise. #
+export.lt_unsafe
+    movup.3
+    movup.2
+    u32sub.unsafe
+    movdn.3
+    drop
+    u32sub.unsafe
+    swap
+    eq.0
+    movup.2
+    and
+    or
+end
+
+# Performs greater-than comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a > b, and 0 otherwise. #
+export.gt_unsafe
+    movup.2
+    u32sub.unsafe
+    movup.2
+    movup.3
+    u32sub.unsafe
+    swap
+    drop
+    movup.2
+    eq.0
+    and
+    or
+end
+
+# Performs less-than-or-equal comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a <= b, and 0 otherwise. #
+export.lte_unsafe
+    exec.gt_unsafe
+    not
+end
+
+# Performs greater-than-or-equal comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> c, ...], where c = 1 when a >= b, and 0 otherwise. #
+export.gte_unsafe
+    exec.lt_unsafe
+    not
+end
+
 # ===== DIVISION ================================================================================ #
 
 # Performs division of two unsigned 64 bit integers discarding the remainder. #

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -1510,7 +1510,9 @@ export.mul_unsafe.6
     swapw
 end"),
 // ----- std::math::u64 ---------------------------------------------------------------------------
-("std::math::u64", "# Performs addition of two unsigned 64 bit integers discarding the overflow. #
+("std::math::u64", "# ===== ADDITION ================================================================================ #
+
+# Performs addition of two unsigned 64 bit integers discarding the overflow. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64 #
@@ -1523,6 +1525,8 @@ export.add_unsafe
     u32addc
     drop
 end
+
+# ===== MULTIPLICATION ========================================================================== #
 
 # Performs multiplication of two unsigned 64 bit integers discarding the overflow. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
@@ -1607,32 +1611,40 @@ end
 export.div_unsafe
     adv.u64div          # inject the quotient and the remainder into the advice tape #
     
-    push.adv.1          # read the values from the advice tape and make sure they are u32's #
-    u32assert           # TODO: this can be optimized once we have u32assert2 instruction #
-    push.adv.1
+    push.adv.1          # read the quotient from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
+    push.adv.1          # TODO: this can be optimized once we have u32assert2 instruction #
     u32assert
-    push.adv.1
-    u32assert
+
+    dup.3               # multiply quotient by the divisor and make sure the resulting value #
+    dup.2               # fits into 2 32-bit limbs #
+    u32mul.unsafe
+    dup.4
+    dup.4
+    u32madd
+    eq.0
+    assert
+    dup.5
+    dup.3
+    u32madd
+    eq.0
+    assert
+    dup.4
+    dup.3
+    mul
+    eq.0
+    assert
+
+    push.adv.1          # read the remainder from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
     push.adv.1
     u32assert
 
-    dup.5               # multiply quotient by the divisor; this also consumes the divisor #
-    dup.4
-    u32mul.unsafe
-    dup.6
-    dup.6
-    u32madd
-    eq.0
-    assert
-    movup.7
-    dup.5
-    u32madd
-    eq.0
-    assert
-    movup.6
-    dup.5
-    mul
-    eq.0
+    movup.7             # make sure the divisor is greater than the remainder. this also consumes #
+    movup.7             # the divisor #
+    dup.3
+    dup.3
+    exec.gt_unsafe
     assert
 
     swap                # add remainder to the previous result; this also consumes the remainder #


### PR DESCRIPTION
This PR implements u64 comparison operations in the standard library. These include: `lt`, `lte`, `gt`, `gte`. Other comparison procedures are left for future PRs.

This PR also fixes a couple of issues:
- Changes `u32madd` to `u32madd.unsafe` and `u32addc` to `u32addc.unsafe` in `u64` module. This is OK because so far we have only unsafe versions of operations implemented.
- Adds a check to `u64::div_unsafe` to make sure that the remainder provided by the prover is less than the divisor. Without this check, the prover could have cheated. For example, the result of 9/2 could have been set to: quotient = 3, remainder = 3, and the check 2 * 3 + 3 = 9 would have been satisfied.

Overall, the cost of u64 division is now 67 cycles (vs. 11 cycles for multiplication). So, it might be worth checking in the future if another approach to division could work better.