### PR TITLE
Add bookkeeping & helper columns to stack trace

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -29,6 +29,9 @@ pub type StackTopState = [Felt; MIN_STACK_DEPTH];
 /// be accessed by the VM directly.
 pub const MIN_STACK_DEPTH: usize = 16;
 
+/// Number of bookkeeping and helper columns in the stack trace.
+pub const NUM_STACK_HELPER_COLS: usize = 3;
+
 // TRACE LAYOUT
 // ------------------------------------------------------------------------------------------------
 
@@ -47,7 +50,7 @@ pub const FMP_COL_IDX: usize = SYS_TRACE_OFFSET + 1;
 
 // Stack trace
 pub const STACK_TRACE_OFFSET: usize = SYS_TRACE_OFFSET + SYS_TRACE_WIDTH;
-pub const STACK_TRACE_WIDTH: usize = MIN_STACK_DEPTH; // TODO: add helper columns
+pub const STACK_TRACE_WIDTH: usize = MIN_STACK_DEPTH + NUM_STACK_HELPER_COLS;
 pub const STACK_TRACE_RANGE: Range<usize> = range(STACK_TRACE_OFFSET, STACK_TRACE_WIDTH);
 
 // TODO: range check trace

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -6,7 +6,8 @@ use vm_core::{
         Script,
     },
     AdviceInjector, DebugOptions, Felt, FieldElement, Operation, ProgramInputs, StackTopState,
-    StarkField, Word, AUX_TRACE_WIDTH, MIN_STACK_DEPTH, SYS_TRACE_WIDTH,
+    StarkField, Word, AUX_TRACE_WIDTH, MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS, STACK_TRACE_WIDTH,
+    SYS_TRACE_WIDTH,
 };
 
 mod operations;
@@ -48,7 +49,7 @@ mod tests;
 // ================================================================================================
 
 type SysTrace = [Vec<Felt>; SYS_TRACE_WIDTH];
-type StackTrace = [Vec<Felt>; MIN_STACK_DEPTH];
+type StackTrace = [Vec<Felt>; STACK_TRACE_WIDTH];
 type AuxTableTrace = [Vec<Felt>; AUX_TRACE_WIDTH]; // TODO: potentially rename to AuxiliaryTrace
 
 // EXECUTOR

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -7,6 +7,9 @@ use core::cmp;
 mod trace;
 pub use trace::StackTrace;
 
+#[cfg(test)]
+mod tests;
+
 // CONSTANTS
 // ================================================================================================
 

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -28,7 +28,26 @@ const MAX_TOP_IDX: usize = MIN_STACK_DEPTH - 1;
 // STACK
 // ================================================================================================
 
-/// TODO: add comments
+/// Stack for the VM.
+///
+/// This component is responsible for managing the state of the VM's stack, as well
+/// as building an execution trace for all stack transitions.
+///
+/// ## Execution trace
+/// The stack execution trace consists of 19 columns as illustrated below:
+///
+///   s0   s1   s2        s13   s14   s15   b0   b1   h0
+/// ├────┴────┴────┴ ... ┴────┴─────┴─────┴────┴────┴────┤
+///
+/// The meaning of the above columns is as follows:
+/// * - s0...s15 are the columns representing the top 16 slots of the stack.
+/// * - Bookkeeping column b0 contains the number of items on the stack (i.e., the stack depth).
+/// * - Bookkeeping column b1 contains an address of a row in the “overflow table” in which we’ll
+/// store the data that doesn’t fit into the top 16 slots. When b1=0, it means that all stack data
+/// fits into the top 16 slots of the stack.
+/// * - Helper column h0 is used to ensure that stack depth does not drop below 16. Values in this
+/// column are set by the prover non-deterministically to 1 / (b0−16) when b0 != 16, and to any
+/// other value otherwise.
 pub struct Stack {
     step: usize,
     trace: StackTrace,
@@ -39,7 +58,7 @@ pub struct Stack {
 impl Stack {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-    /// TODO: add comments
+    /// Returns a [Stack] initialized with the specified program inputs.
     pub fn new(inputs: &ProgramInputs, init_trace_length: usize) -> Self {
         let trace = StackTrace::new(inputs, init_trace_length);
 

--- a/processor/src/stack/tests.rs
+++ b/processor/src/stack/tests.rs
@@ -1,0 +1,175 @@
+use vm_core::{FieldElement, NUM_STACK_HELPER_COLS};
+
+use super::{Felt, ProgramInputs, Stack, StackTopState, MIN_STACK_DEPTH};
+
+#[test]
+fn initialize() {
+    // initialize a new stack with some initial values
+    let mut stack_inputs = [1, 2, 3, 4];
+    let inputs = ProgramInputs::new(&stack_inputs, &[], vec![]).unwrap();
+    let stack = Stack::new(&inputs, 4);
+
+    // Prepare the expected results.
+    stack_inputs.reverse();
+    let expected_stack = build_stack(&[4, 3, 2, 1]);
+    let expected_helpers = [Felt::new(MIN_STACK_DEPTH as u64), Felt::ZERO, Felt::ZERO];
+
+    // Check the stack state.
+    assert_eq!(stack.trace_state(), expected_stack);
+
+    // Check the helper columns.
+    assert_eq!(
+        stack.trace.get_helpers_state_at(stack.current_step()),
+        expected_helpers
+    );
+}
+
+#[test]
+fn shift_left() {
+    let inputs = ProgramInputs::new(&[1, 2, 3, 4], &[], vec![]).unwrap();
+    let mut stack = Stack::new(&inputs, 4);
+
+    // ---- left shift an entire stack of minimum depth -------------------------------------------
+    // Prepare the expected results.
+    let expected_stack = build_stack(&[3, 2, 1]);
+    let expected_helpers = build_helpers_left(0, 0);
+
+    // Perform the left shift.
+    stack.shift_left(1);
+    stack.advance_clock();
+
+    // Check the stack state.
+    assert_eq!(stack.trace_state(), expected_stack);
+
+    // Check the helper columns.
+    assert_eq!(
+        stack.trace.get_helpers_state_at(stack.current_step()),
+        expected_helpers
+    );
+
+    // ---- left shift an entire stack with multiple overflow items -------------------------------
+    let mut stack = Stack::new(&inputs, 4);
+    // Shift right twice to add 2 items to the overflow table.
+    stack.shift_right(0);
+    let prev_overflow_addr = stack.current_step();
+    stack.advance_clock();
+    stack.shift_right(0);
+    stack.advance_clock();
+
+    // Prepare the expected results.
+    let expected_stack = build_stack(&[0, 4, 3, 2, 1]);
+    let expected_helpers = build_helpers_left(1, prev_overflow_addr);
+
+    // Perform the left shift.
+    stack.shift_left(1);
+    stack.advance_clock();
+
+    // Check the stack state.
+    assert_eq!(stack.trace_state(), expected_stack);
+
+    // Check the helper columns.
+    assert_eq!(
+        stack.trace.get_helpers_state_at(stack.current_step()),
+        expected_helpers
+    );
+
+    // ---- left shift an entire stack with one overflow item -------------------------------------
+    // Prepare the expected results.
+    let expected_stack = build_stack(&[4, 3, 2, 1]);
+    let expected_helpers = build_helpers_left(0, 0);
+
+    // Perform the left shift.
+    stack.ensure_trace_capacity();
+    stack.shift_left(1);
+    stack.advance_clock();
+
+    // Check the stack state.
+    assert_eq!(stack.trace_state(), expected_stack);
+
+    // Check the helper columns.
+    assert_eq!(
+        stack.trace.get_helpers_state_at(stack.current_step()),
+        expected_helpers
+    );
+}
+
+#[test]
+fn shift_right() {
+    let inputs = ProgramInputs::new(&[1, 2, 3, 4], &[], vec![]).unwrap();
+    let mut stack = Stack::new(&inputs, 4);
+
+    // ---- right shift an entire stack of minimum depth ------------------------------------------
+    let expected_stack = build_stack(&[0, 4, 3, 2, 1]);
+    let expected_helpers = build_helpers_right(1, stack.current_step());
+
+    stack.shift_right(0);
+    stack.advance_clock();
+
+    // Check the stack state.
+    assert_eq!(stack.trace_state(), expected_stack);
+
+    // Check the helper columns.
+    assert_eq!(
+        stack.trace.get_helpers_state_at(stack.current_step()),
+        expected_helpers
+    );
+
+    // ---- right shift when the overflow table is non-empty --------------------------------------
+    let expected_stack = build_stack(&[0, 0, 4, 3, 2, 1]);
+    let expected_helpers = build_helpers_right(2, stack.current_step());
+
+    stack.shift_right(0);
+    stack.advance_clock();
+
+    // Check the stack state.
+    assert_eq!(stack.trace_state(), expected_stack);
+
+    // Check the helper columns.
+    assert_eq!(
+        stack.trace.get_helpers_state_at(stack.current_step()),
+        expected_helpers
+    );
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Builds the trace row of stack helpers expected as the result of a right shift at clock cycle
+/// `step` when there are `num_overflow` items in the overflow table.
+fn build_helpers_right(num_overflow: usize, step: usize) -> [Felt; NUM_STACK_HELPER_COLS] {
+    let b0 = Felt::new((MIN_STACK_DEPTH + num_overflow) as u64);
+    let b1 = Felt::new(step as u64);
+    let h0 = Felt::ONE / (b0 - Felt::new(MIN_STACK_DEPTH as u64));
+
+    [b0, b1, h0]
+}
+
+/// Builds the trace row of stack helpers expected as the result of a left shift when there are
+/// `num_overflow` items in the overflow table and the top row in the table has address
+/// `next_overflow_addr`.
+fn build_helpers_left(
+    num_overflow: usize,
+    next_overflow_addr: usize,
+) -> [Felt; NUM_STACK_HELPER_COLS] {
+    let depth = MIN_STACK_DEPTH + num_overflow;
+    let b0 = Felt::new(depth as u64);
+    let b1 = Felt::new(next_overflow_addr as u64);
+    let h0 = if depth > MIN_STACK_DEPTH {
+        Felt::ONE / (b0 - Felt::new(MIN_STACK_DEPTH as u64))
+    } else {
+        Felt::ZERO
+    };
+
+    [b0, b1, h0]
+}
+
+/// Builds a [StackTopState] that starts with the provided stack inputs and is padded with zeros
+/// until the minimum stack depth.
+fn build_stack(stack_inputs: &[u64]) -> StackTopState {
+    let mut expected_stack = [Felt::ZERO; MIN_STACK_DEPTH];
+    for (idx, &input) in stack_inputs.iter().enumerate() {
+        expected_stack[idx] = Felt::new(input);
+    }
+
+    expected_stack
+}

--- a/processor/src/stack/trace.rs
+++ b/processor/src/stack/trace.rs
@@ -1,0 +1,200 @@
+use vm_core::StarkField;
+
+use super::{
+    Felt, FieldElement, ProgramInputs, StackTopState, MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS,
+    STACK_TRACE_WIDTH,
+};
+
+// CONSTANTS
+// ================================================================================================
+
+// The largest stack index accessible by the VM.
+const MAX_TOP_IDX: usize = MIN_STACK_DEPTH - 1;
+
+// STACK TRACE
+// ================================================================================================
+
+pub struct StackTrace {
+    stack: [Vec<Felt>; MIN_STACK_DEPTH],
+    helpers: [Vec<Felt>; NUM_STACK_HELPER_COLS],
+}
+
+impl StackTrace {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a [StackTrace] instantiated with empty vectors for all columns.
+    pub fn new(inputs: &ProgramInputs, init_trace_length: usize) -> Self {
+        // Initialize the stack.
+        let init_values = inputs.stack_init();
+        let mut stack: Vec<Vec<Felt>> = Vec::with_capacity(MIN_STACK_DEPTH);
+        for i in 0..MIN_STACK_DEPTH {
+            let mut column = Felt::zeroed_vector(init_trace_length);
+            if i < init_values.len() {
+                column[0] = init_values[i];
+            }
+            stack.push(column)
+        }
+
+        // Initialize the bookkeeping & helper columns.
+        let mut b0 = Felt::zeroed_vector(init_trace_length);
+        b0[0] = Felt::new(MIN_STACK_DEPTH as u64);
+        let helpers: [Vec<Felt>; 3] = [
+            b0,
+            Felt::zeroed_vector(init_trace_length),
+            Felt::zeroed_vector(init_trace_length),
+        ];
+
+        StackTrace {
+            stack: stack
+                .try_into()
+                .expect("Failed to convert vector to an array"),
+            helpers,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the length of the execution trace for this stack.
+    pub fn trace_len(&self) -> usize {
+        self.stack[0].len()
+    }
+
+    pub fn into_array(self) -> [Vec<Felt>; STACK_TRACE_WIDTH] {
+        let mut trace = Vec::with_capacity(STACK_TRACE_WIDTH);
+        trace.extend_from_slice(&self.stack);
+        trace.extend_from_slice(&self.helpers);
+
+        trace
+            .try_into()
+            .expect("Failed to convert vector to an array")
+    }
+
+    // STACK ACCESSORS AND MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a copy of the item at the top of the stack at the specified step
+    pub fn peek_at(&self, step: usize) -> Felt {
+        self.stack[0][step]
+    }
+
+    /// Returns the value located at the specified position on the stack at the specified clock
+    /// cycle.
+    pub fn get_stack_value_at(&self, step: usize, pos: usize) -> Felt {
+        self.stack[pos][step]
+    }
+
+    /// Sets the value at the specified position on the stack at the specified cycle.
+    pub fn set_stack_value_at(&mut self, step: usize, pos: usize, value: Felt) {
+        self.stack[pos][step] = value;
+    }
+
+    /// Return the specified number of states from the top of the stack at the specified step.
+    pub fn get_stack_values_at(&self, step: usize, num_items: usize) -> Vec<Felt> {
+        self.get_stack_state_at(step)[..num_items].to_vec()
+    }
+
+    /// Returns the stack trace state at the specified step.
+    ///
+    /// Trace state is always 16 elements long and contains the top 16 values of the stack.
+    pub fn get_stack_state_at(&self, step: usize) -> StackTopState {
+        let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
+        for (result, column) in result.iter_mut().zip(self.stack.iter()) {
+            *result = column[step];
+        }
+        result
+    }
+
+    /// Copies the stack values starting at the specified position at the specified clock cycle to
+    /// the same position at the next clock cycle.
+    pub fn copy_stack_state_at(&mut self, step: usize, start_pos: usize) {
+        debug_assert!(
+            start_pos < MIN_STACK_DEPTH,
+            "start cannot exceed stack top size"
+        );
+        for i in start_pos..MIN_STACK_DEPTH {
+            self.stack[i][step + 1] = self.stack[i][step];
+        }
+    }
+
+    /// Copies the stack values starting at the specified position at the specified clock cycle to
+    /// position - 1 at the next clock cycle.
+    ///
+    /// The final register is filled with the provided value in `last_value`.
+    pub fn stack_shift_left_at(&mut self, step: usize, start_pos: usize, last_value: Felt) {
+        for i in start_pos..=MAX_TOP_IDX {
+            self.stack[i - 1][step + 1] = self.stack[i][step];
+        }
+        self.stack[MIN_STACK_DEPTH - 1][step + 1] = last_value;
+    }
+
+    /// Copies stack values starting at the specified position at the specified clock cycle to
+    /// position + 1 at the next clock cycle.
+    pub fn stack_shift_right_at(&mut self, step: usize, start_pos: usize) {
+        for i in start_pos..MAX_TOP_IDX {
+            self.stack[i + 1][step + 1] = self.stack[i][step];
+        }
+    }
+
+    // BOOKKEEPING & HELPER COLUMN ACCESSORS AND MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the trace state of the stack helper columns at the specified step.
+    #[allow(dead_code)]
+    pub fn get_helpers_state_at(&self, step: usize) -> [Felt; NUM_STACK_HELPER_COLS] {
+        let mut result = [Felt::ZERO; NUM_STACK_HELPER_COLS];
+        for (result, column) in result.iter_mut().zip(self.helpers.iter()) {
+            *result = column[step];
+        }
+        result
+    }
+
+    /// Copies the helper values at the specified clock cycle to the next clock cycle.
+    pub fn copy_helpers_at(&mut self, step: usize) {
+        for i in 0..NUM_STACK_HELPER_COLS {
+            self.helpers[i][step + 1] = self.helpers[i][step];
+        }
+    }
+
+    pub fn helpers_shift_right_at(&mut self, step: usize) {
+        // Increment b0 by one.
+        let b0 = self.helpers[0][step] + Felt::ONE;
+        self.helpers[0][step + 1] = b0;
+        // Set b1 to the curren tclock cycle.
+        self.helpers[1][step + 1] = Felt::new(step as u64);
+        // Update the helper column to 1 / (b0 - 16).
+        self.helpers[2][step + 1] = Felt::ONE / (b0 - Felt::new(MIN_STACK_DEPTH as u64));
+    }
+
+    pub fn helpers_shift_left_at(&mut self, step: usize, next_overflow_addr: Felt) {
+        // Decrement b0 by one.
+        let b0 = self.helpers[0][step] - Felt::ONE;
+        self.helpers[0][step + 1] = b0;
+
+        // Set b1 to the overflow table address of the item at the top of the updated table.
+        self.helpers[1][step + 1] = next_overflow_addr;
+
+        // Update the helper column to 1 / (b0 - 16) if depth > MIN_STACK_DEPTH or 0 otherwise.
+        let h0 = if b0.as_int() > MIN_STACK_DEPTH as u64 {
+            Felt::ONE / (b0 - Felt::new(MIN_STACK_DEPTH as u64))
+        } else {
+            Felt::ZERO
+        };
+        self.helpers[2][step + 1] = h0;
+    }
+
+    // UTILITY METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Makes sure there is enough memory allocated for the trace to accommodate a new row.
+    ///
+    /// Trace length is doubled every time it needs to be increased.
+    pub fn ensure_trace_capacity(&mut self, step: usize) {
+        if step + 1 >= self.trace_len() {
+            let new_length = self.trace_len() * 2;
+            for register in self.stack.iter_mut().chain(self.helpers.iter_mut()) {
+                register.resize(new_length, Felt::ZERO);
+            }
+        }
+    }
+}

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -4,8 +4,8 @@ use super::{
 };
 use core::slice;
 use vm_core::{
-    StarkField, AUX_TRACE_OFFSET, AUX_TRACE_RANGE, AUX_TRACE_WIDTH, STACK_TRACE_OFFSET,
-    STACK_TRACE_RANGE, STACK_TRACE_WIDTH, SYS_TRACE_OFFSET, SYS_TRACE_RANGE, TRACE_WIDTH,
+    StarkField, AUX_TRACE_OFFSET, AUX_TRACE_RANGE, AUX_TRACE_WIDTH, MIN_STACK_DEPTH,
+    STACK_TRACE_OFFSET, STACK_TRACE_RANGE, SYS_TRACE_OFFSET, SYS_TRACE_RANGE, TRACE_WIDTH,
 };
 use winterfell::Trace;
 
@@ -42,9 +42,7 @@ impl ExecutionTrace {
         let aux_trace_len = hasher.trace_len() + bitwise.trace_len() + memory.trace_len();
         let mut trace_len = usize::max(stack.trace_len(), aux_trace_len);
         // pad the trace length to the next power of 2
-        if !trace_len.is_power_of_two() {
-            trace_len = trace_len.next_power_of_two();
-        }
+        trace_len = trace_len.next_power_of_two();
 
         // allocate columns for the trace of the auxiliary table
         // note: it may be possible to optimize this by initializing with Felt::zeroed_vector,
@@ -91,7 +89,7 @@ impl ExecutionTrace {
 
     /// TODO: add docs
     pub fn init_stack_state(&self) -> StackTopState {
-        let mut result = [Felt::ZERO; STACK_TRACE_WIDTH];
+        let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
         for (result, column) in result.iter_mut().zip(self.stack.iter()) {
             *result = column[0];
         }
@@ -101,7 +99,7 @@ impl ExecutionTrace {
     /// TODO: add docs
     pub fn last_stack_state(&self) -> StackTopState {
         let last_step = self.length() - 1;
-        let mut result = [Felt::ZERO; STACK_TRACE_WIDTH];
+        let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
         for (result, column) in result.iter_mut().zip(self.stack.iter()) {
             *result = column[last_step];
         }


### PR DESCRIPTION
This PR addresses #65 and updates the stack trace to match the constraint requirement [specs](https://hackmd.io/WhJ7fWXAQRasmS7ebqAKzg) for the minimum stack depth.

- refactors the overflow handling into a table to match the spec
- adds the bookkeeping and helper columns to the stack trace
- updates the documentation in the stack module
- adds simple tests for the stack and helper states after initialization, left shift, and right shift