### PR TITLE
Add range checks for u32 operations

### DIFF
--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -22,6 +22,7 @@ mod stack;
 use stack::Stack;
 
 mod range;
+use range::RangeChecker;
 
 mod hasher;
 use hasher::Hasher;
@@ -71,6 +72,7 @@ struct Process {
     system: System,
     decoder: Decoder,
     stack: Stack,
+    range: RangeChecker,
     hasher: Hasher,
     bitwise: Bitwise,
     memory: Memory,
@@ -83,6 +85,7 @@ impl Process {
             system: System::new(4),
             decoder: Decoder::new(),
             stack: Stack::new(&inputs, 4),
+            range: RangeChecker::new(),
             hasher: Hasher::new(),
             bitwise: Bitwise::new(),
             memory: Memory::new(),

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -32,6 +32,7 @@ impl ExecutionTrace {
             system,
             decoder: _,
             stack,
+            range: _,
             hasher,
             bitwise,
             memory,


### PR DESCRIPTION
This PR addresses the first half of #143 by adding the values that require range checks during u32 operations to the RangeChecker, according to the [specs for u32 operations](https://hackmd.io/NC-yRmmtRQSvToTHb96e8Q#Bitwise-AND)