### PR TITLE
Stack refactoring in the processor

### DIFF
--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -189,7 +189,7 @@ mod tests {
         let expected = build_expected(&[a + b, c]);
 
         assert_eq!(MIN_STACK_DEPTH + 2, process.stack.depth());
-        assert_eq!(4, process.stack.current_step());
+        assert_eq!(4, process.stack.current_clk());
         assert_eq!(expected, process.stack.trace_state());
 
         // calling add with a stack of minimum depth is ok
@@ -209,7 +209,7 @@ mod tests {
 
         assert_eq!(expected, process.stack.trace_state());
         assert_eq!(MIN_STACK_DEPTH + 3, process.stack.depth());
-        assert_eq!(4, process.stack.current_step());
+        assert_eq!(4, process.stack.current_clk());
     }
 
     #[test]
@@ -223,7 +223,7 @@ mod tests {
         let expected = build_expected(&[a * b, c]);
 
         assert_eq!(MIN_STACK_DEPTH + 2, process.stack.depth());
-        assert_eq!(4, process.stack.current_step());
+        assert_eq!(4, process.stack.current_clk());
         assert_eq!(expected, process.stack.trace_state());
 
         // calling mul with a stack of minimum depth is ok
@@ -243,7 +243,7 @@ mod tests {
             let expected = build_expected(&[a.inv(), b, c]);
 
             assert_eq!(MIN_STACK_DEPTH + 3, process.stack.depth());
-            assert_eq!(4, process.stack.current_step());
+            assert_eq!(4, process.stack.current_clk());
             assert_eq!(expected, process.stack.trace_state());
         }
 
@@ -263,7 +263,7 @@ mod tests {
         let expected = build_expected(&[a + Felt::ONE, b, c]);
 
         assert_eq!(MIN_STACK_DEPTH + 3, process.stack.depth());
-        assert_eq!(4, process.stack.current_step());
+        assert_eq!(4, process.stack.current_clk());
         assert_eq!(expected, process.stack.trace_state());
     }
 

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -135,7 +135,7 @@ mod tests {
     fn op_push() {
         let mut process = Process::new_dummy();
         assert_eq!(MIN_STACK_DEPTH, process.stack.depth());
-        assert_eq!(0, process.stack.current_step());
+        assert_eq!(0, process.stack.current_clk());
         assert_eq!([Felt::ZERO; 16], process.stack.trace_state());
 
         // push one item onto the stack
@@ -145,7 +145,7 @@ mod tests {
         expected[0] = Felt::ONE;
 
         assert_eq!(MIN_STACK_DEPTH + 1, process.stack.depth());
-        assert_eq!(1, process.stack.current_step());
+        assert_eq!(1, process.stack.current_clk());
         assert_eq!(expected, process.stack.trace_state());
 
         // push another item onto the stack
@@ -156,7 +156,7 @@ mod tests {
         expected[1] = Felt::ONE;
 
         assert_eq!(MIN_STACK_DEPTH + 2, process.stack.depth());
-        assert_eq!(2, process.stack.current_step());
+        assert_eq!(2, process.stack.current_clk());
         assert_eq!(expected, process.stack.trace_state());
     }
 

--- a/processor/src/operations/stack_ops.rs
+++ b/processor/src/operations/stack_ops.rs
@@ -271,7 +271,7 @@ mod tests {
         let expected = build_expected(&[0, 1]);
 
         assert_eq!(MIN_STACK_DEPTH + 2, process.stack.depth());
-        assert_eq!(2, process.stack.current_step());
+        assert_eq!(2, process.stack.current_clk());
         assert_eq!(expected, process.stack.trace_state());
 
         // pad the stack again
@@ -279,7 +279,7 @@ mod tests {
         let expected = build_expected(&[0, 0, 1]);
 
         assert_eq!(MIN_STACK_DEPTH + 3, process.stack.depth());
-        assert_eq!(3, process.stack.current_step());
+        assert_eq!(3, process.stack.current_clk());
         assert_eq!(expected, process.stack.trace_state());
     }
 

--- a/processor/src/stack/overflow.rs
+++ b/processor/src/stack/overflow.rs
@@ -1,0 +1,90 @@
+use super::{Felt, FieldElement};
+use winter_utils::collections::BTreeMap;
+
+// OVERFLOW TABLE
+// ================================================================================================
+
+/// Stores the values which beyond the top 16 elements of the stack.
+///
+/// For each overflow item we also track the clock cycle at which it was inserted into the overflow
+/// table.
+///
+/// When `trace_enabled` is set to true, we also record all changes to the table so that we can
+/// reconstruct the overflow table at any clock cycle. This can be used for debugging purposes.
+pub struct OverflowTable {
+    rows: Vec<OverflowRow>,
+    trace: BTreeMap<usize, Vec<Felt>>,
+    trace_enabled: bool,
+}
+
+impl OverflowTable {
+    /// Returns a new [OverflowTable]. The returned table is empty.
+    pub fn new(enable_trace: bool) -> Self {
+        Self {
+            rows: Vec::new(),
+            trace: BTreeMap::new(),
+            trace_enabled: enable_trace,
+        }
+    }
+
+    /// Pushes the specified value into the overflow table.
+    pub fn push(&mut self, value: Felt, clk: usize) {
+        self.rows.push(OverflowRow::new(clk, value));
+        if self.trace_enabled {
+            // insert a copy of the current table state into the trace
+            self.trace.insert(clk, self.get_values());
+        }
+    }
+
+    /// Removes the last value from the overflow table and returns it together with the clock
+    /// cycle of the next value in the table.
+    ///
+    /// If after the top value is removed the table is empty, the returned clock cycle is ZERO.
+    pub fn pop(&mut self, clk: usize) -> (Felt, Felt) {
+        let row = self.rows.pop().expect("overflow table is empty");
+
+        if self.trace_enabled {
+            // insert a copy of the current table state into the trace
+            self.trace.insert(clk, self.get_values());
+        }
+
+        // determine the clock cycle of the next row and return
+        if self.rows.is_empty() {
+            (row.val, Felt::ZERO)
+        } else {
+            let prev_row = self.rows.last().expect("no previous row");
+            (row.val, prev_row.clk)
+        }
+    }
+
+    /// Appends the top n values from the overflow table to the end of the provided vector.
+    pub fn append_into(&self, target: &mut Vec<Felt>, n: usize) {
+        for row in self.rows.iter().rev().take(n) {
+            target.push(row.val);
+        }
+    }
+
+    /// Returns a vector consisting of just the value portion of each table row.
+    fn get_values(&self) -> Vec<Felt> {
+        self.rows.iter().map(|r| r.val).collect()
+    }
+}
+
+// OVERFLOW ROW
+// ================================================================================================
+
+/// A single row in the stack overflow table. Each row stores the value of the stack item as well
+/// as the clock cycle at which the stack item was pushed into the overflow table.
+struct OverflowRow {
+    clk: Felt,
+    val: Felt,
+}
+
+impl OverflowRow {
+    pub fn new(clk: usize, val: Felt) -> Self {
+        Self {
+            clk: Felt::new(clk as u64),
+            val,
+        }
+    }
+}

--- a/processor/src/stack/tests.rs
+++ b/processor/src/stack/tests.rs
@@ -19,7 +19,7 @@ fn initialize() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_step()),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 }
@@ -43,7 +43,7 @@ fn shift_left() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_step()),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 
@@ -51,7 +51,7 @@ fn shift_left() {
     let mut stack = Stack::new(&inputs, 4);
     // Shift right twice to add 2 items to the overflow table.
     stack.shift_right(0);
-    let prev_overflow_addr = stack.current_step();
+    let prev_overflow_addr = stack.current_clk();
     stack.advance_clock();
     stack.shift_right(0);
     stack.advance_clock();
@@ -69,7 +69,7 @@ fn shift_left() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_step()),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 
@@ -88,7 +88,7 @@ fn shift_left() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_step()),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 }
@@ -100,7 +100,7 @@ fn shift_right() {
 
     // ---- right shift an entire stack of minimum depth ------------------------------------------
     let expected_stack = build_stack(&[0, 4, 3, 2, 1]);
-    let expected_helpers = build_helpers_right(1, stack.current_step());
+    let expected_helpers = build_helpers_right(1, stack.current_clk());
 
     stack.shift_right(0);
     stack.advance_clock();
@@ -110,13 +110,13 @@ fn shift_right() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_step()),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 
     // ---- right shift when the overflow table is non-empty --------------------------------------
     let expected_stack = build_stack(&[0, 0, 4, 3, 2, 1]);
-    let expected_helpers = build_helpers_right(2, stack.current_step());
+    let expected_helpers = build_helpers_right(2, stack.current_clk());
 
     stack.shift_right(0);
     stack.advance_clock();
@@ -126,7 +126,7 @@ fn shift_right() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_step()),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 }
@@ -135,10 +135,10 @@ fn shift_right() {
 // ================================================================================================
 
 /// Builds the trace row of stack helpers expected as the result of a right shift at clock cycle
-/// `step` when there are `num_overflow` items in the overflow table.
-fn build_helpers_right(num_overflow: usize, step: usize) -> [Felt; NUM_STACK_HELPER_COLS] {
+/// `clk` when there are `num_overflow` items in the overflow table.
+fn build_helpers_right(num_overflow: usize, clk: usize) -> [Felt; NUM_STACK_HELPER_COLS] {
     let b0 = Felt::new((MIN_STACK_DEPTH + num_overflow) as u64);
-    let b1 = Felt::new(step as u64);
+    let b1 = Felt::new(clk as u64);
     let h0 = Felt::ONE / (b0 - Felt::new(MIN_STACK_DEPTH as u64));
 
     [b0, b1, h0]

--- a/processor/src/stack/trace.rs
+++ b/processor/src/stack/trace.rs
@@ -73,50 +73,51 @@ impl StackTrace {
     // STACK ACCESSORS AND MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a copy of the item at the top of the stack at the specified step
+    /// Returns a copy of the item at the top of the stack at the specified clock cycle.
     #[inline(always)]
-    pub fn peek_at(&self, step: usize) -> Felt {
-        self.stack[0][step]
+    pub fn peek_at(&self, clk: usize) -> Felt {
+        self.stack[0][clk]
     }
 
     /// Returns the value located at the specified position on the stack at the specified clock
     /// cycle.
     #[inline(always)]
-    pub fn get_stack_value_at(&self, step: usize, pos: usize) -> Felt {
-        self.stack[pos][step]
+    pub fn get_stack_value_at(&self, clk: usize, pos: usize) -> Felt {
+        self.stack[pos][clk]
     }
 
     /// Sets the value at the specified position on the stack at the specified cycle.
     #[inline(always)]
-    pub fn set_stack_value_at(&mut self, step: usize, pos: usize, value: Felt) {
-        self.stack[pos][step] = value;
+    pub fn set_stack_value_at(&mut self, clk: usize, pos: usize, value: Felt) {
+        self.stack[pos][clk] = value;
     }
 
-    /// Return the specified number of states from the top of the stack at the specified step.
-    pub fn get_stack_values_at(&self, step: usize, num_items: usize) -> Vec<Felt> {
-        self.get_stack_state_at(step)[..num_items].to_vec()
+    /// Return the specified number of states from the top of the stack at the specified clock
+    /// cycle.
+    pub fn get_stack_values_at(&self, clk: usize, num_items: usize) -> Vec<Felt> {
+        self.get_stack_state_at(clk)[..num_items].to_vec()
     }
 
-    /// Returns the stack trace state at the specified step.
+    /// Returns the stack trace state at the specified clock cycle.
     ///
     /// Trace state is always 16 elements long and contains the top 16 values of the stack.
-    pub fn get_stack_state_at(&self, step: usize) -> StackTopState {
+    pub fn get_stack_state_at(&self, clk: usize) -> StackTopState {
         let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
         for (result, column) in result.iter_mut().zip(self.stack.iter()) {
-            *result = column[step];
+            *result = column[clk];
         }
         result
     }
 
     /// Copies the stack values starting at the specified position at the specified clock cycle to
     /// the same position at the next clock cycle.
-    pub fn copy_stack_state_at(&mut self, step: usize, start_pos: usize) {
+    pub fn copy_stack_state_at(&mut self, clk: usize, start_pos: usize) {
         debug_assert!(
             start_pos < MIN_STACK_DEPTH,
             "start cannot exceed stack top size"
         );
         for i in start_pos..MIN_STACK_DEPTH {
-            self.stack[i][step + 1] = self.stack[i][step];
+            self.stack[i][clk + 1] = self.stack[i][clk];
         }
     }
 
@@ -124,38 +125,38 @@ impl StackTrace {
     /// position - 1 at the next clock cycle.
     ///
     /// The final register is filled with the provided value in `last_value`.
-    pub fn stack_shift_left_at(&mut self, step: usize, start_pos: usize, last_value: Felt) {
+    pub fn stack_shift_left_at(&mut self, clk: usize, start_pos: usize, last_value: Felt) {
         for i in start_pos..=MAX_TOP_IDX {
-            self.stack[i - 1][step + 1] = self.stack[i][step];
+            self.stack[i - 1][clk + 1] = self.stack[i][clk];
         }
-        self.stack[MAX_TOP_IDX][step + 1] = last_value;
+        self.stack[MAX_TOP_IDX][clk + 1] = last_value;
     }
 
     /// Copies stack values starting at the specified position at the specified clock cycle to
     /// position + 1 at the next clock cycle.
-    pub fn stack_shift_right_at(&mut self, step: usize, start_pos: usize) {
+    pub fn stack_shift_right_at(&mut self, clk: usize, start_pos: usize) {
         for i in start_pos..MAX_TOP_IDX {
-            self.stack[i + 1][step + 1] = self.stack[i][step];
+            self.stack[i + 1][clk + 1] = self.stack[i][clk];
         }
     }
 
     // BOOKKEEPING & HELPER COLUMN ACCESSORS AND MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the trace state of the stack helper columns at the specified step.
+    /// Returns the trace state of the stack helper columns at the specified clock cycle.
     #[allow(dead_code)]
-    pub fn get_helpers_state_at(&self, step: usize) -> [Felt; NUM_STACK_HELPER_COLS] {
+    pub fn get_helpers_state_at(&self, clk: usize) -> [Felt; NUM_STACK_HELPER_COLS] {
         let mut result = [Felt::ZERO; NUM_STACK_HELPER_COLS];
         for (result, column) in result.iter_mut().zip(self.helpers.iter()) {
-            *result = column[step];
+            *result = column[clk];
         }
         result
     }
 
     /// Copies the helper values at the specified clock cycle to the next clock cycle.
-    pub fn copy_helpers_at(&mut self, step: usize) {
+    pub fn copy_helpers_at(&mut self, clk: usize) {
         for i in 0..NUM_STACK_HELPER_COLS {
-            self.helpers[i][step + 1] = self.helpers[i][step];
+            self.helpers[i][clk + 1] = self.helpers[i][clk];
         }
     }
 
@@ -168,14 +169,14 @@ impl StackTrace {
     /// b0: Increment the stack depth by one.
     /// b1: Save the address of the new top row in overflow table, which is the current clock cycle.
     /// h0: Set the value to 1 / (depth - 16).
-    pub fn helpers_shift_right_at(&mut self, step: usize) {
+    pub fn helpers_shift_right_at(&mut self, clk: usize) {
         // Increment b0 by one.
-        let b0 = self.helpers[0][step] + Felt::ONE;
-        self.helpers[0][step + 1] = b0;
+        let b0 = self.helpers[0][clk] + Felt::ONE;
+        self.helpers[0][clk + 1] = b0;
         // Set b1 to the curren tclock cycle.
-        self.helpers[1][step + 1] = Felt::new(step as u64);
+        self.helpers[1][clk + 1] = Felt::new(clk as u64);
         // Update the helper column to 1 / (b0 - 16).
-        self.helpers[2][step + 1] = Felt::ONE / (b0 - Felt::new(MIN_STACK_DEPTH as u64));
+        self.helpers[2][clk + 1] = Felt::ONE / (b0 - Felt::new(MIN_STACK_DEPTH as u64));
     }
 
     /// Updates the bookkeeping and helper columns to manage a left shift at the specified clock
@@ -189,13 +190,13 @@ impl StackTrace {
     /// `next_overflow_addr`.
     /// h0: Set the value to 1 / (depth - 16) if the depth is still greater than the minimum stack
     /// depth, or to zero otherwise.
-    pub fn helpers_shift_left_at(&mut self, step: usize, next_overflow_addr: Felt) {
+    pub fn helpers_shift_left_at(&mut self, clk: usize, next_overflow_addr: Felt) {
         // Decrement b0 by one.
-        let b0 = self.helpers[0][step] - Felt::ONE;
-        self.helpers[0][step + 1] = b0;
+        let b0 = self.helpers[0][clk] - Felt::ONE;
+        self.helpers[0][clk + 1] = b0;
 
         // Set b1 to the overflow table address of the item at the top of the updated table.
-        self.helpers[1][step + 1] = next_overflow_addr;
+        self.helpers[1][clk + 1] = next_overflow_addr;
 
         // Update the helper column to 1 / (b0 - 16) if depth > MIN_STACK_DEPTH or 0 otherwise.
         let h0 = if b0.as_int() > MIN_STACK_DEPTH as u64 {
@@ -203,7 +204,7 @@ impl StackTrace {
         } else {
             Felt::ZERO
         };
-        self.helpers[2][step + 1] = h0;
+        self.helpers[2][clk + 1] = h0;
     }
 
     // UTILITY METHODS
@@ -212,8 +213,8 @@ impl StackTrace {
     /// Makes sure there is enough memory allocated for the trace to accommodate a new row.
     ///
     /// Trace length is doubled every time it needs to be increased.
-    pub fn ensure_trace_capacity(&mut self, step: usize) {
-        if step + 1 >= self.trace_len() {
+    pub fn ensure_trace_capacity(&mut self, clk: usize) {
+        if clk + 1 >= self.trace_len() {
             let new_length = self.trace_len() * 2;
             for register in self.stack.iter_mut().chain(self.helpers.iter_mut()) {
                 register.resize(new_length, Felt::ZERO);

--- a/processor/src/stack/trace.rs
+++ b/processor/src/stack/trace.rs
@@ -1,15 +1,9 @@
 use vm_core::StarkField;
 
 use super::{
-    Felt, FieldElement, ProgramInputs, StackTopState, MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS,
-    STACK_TRACE_WIDTH,
+    Felt, FieldElement, ProgramInputs, StackTopState, MAX_TOP_IDX, MIN_STACK_DEPTH,
+    NUM_STACK_HELPER_COLS, STACK_TRACE_WIDTH,
 };
-
-// CONSTANTS
-// ================================================================================================
-
-// The largest stack index accessible by the VM.
-const MAX_TOP_IDX: usize = MIN_STACK_DEPTH - 1;
 
 // STACK TRACE
 // ================================================================================================
@@ -61,6 +55,7 @@ impl StackTrace {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the length of the execution trace for this stack.
+    #[inline(always)]
     pub fn trace_len(&self) -> usize {
         self.stack[0].len()
     }
@@ -79,17 +74,20 @@ impl StackTrace {
     // --------------------------------------------------------------------------------------------
 
     /// Returns a copy of the item at the top of the stack at the specified step
+    #[inline(always)]
     pub fn peek_at(&self, step: usize) -> Felt {
         self.stack[0][step]
     }
 
     /// Returns the value located at the specified position on the stack at the specified clock
     /// cycle.
+    #[inline(always)]
     pub fn get_stack_value_at(&self, step: usize, pos: usize) -> Felt {
         self.stack[pos][step]
     }
 
     /// Sets the value at the specified position on the stack at the specified cycle.
+    #[inline(always)]
     pub fn set_stack_value_at(&mut self, step: usize, pos: usize, value: Felt) {
         self.stack[pos][step] = value;
     }
@@ -130,7 +128,7 @@ impl StackTrace {
         for i in start_pos..=MAX_TOP_IDX {
             self.stack[i - 1][step + 1] = self.stack[i][step];
         }
-        self.stack[MIN_STACK_DEPTH - 1][step + 1] = last_value;
+        self.stack[MAX_TOP_IDX][step + 1] = last_value;
     }
 
     /// Copies stack values starting at the specified position at the specified clock cycle to


### PR DESCRIPTION
This PR refactors processor stack modules to break out overflow table into a separate stack. This approach aligns better with the work being done in #128 

Also, I've used this opportunity to change `step` to `clk` in all stack-related modules. I think having two different names for this is a bit confusing, and between the two, I prefer `clk`. But I'm open to other suggestions.