### PR TITLE
Integrate the range check trace with the VM execution trace

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -53,10 +53,14 @@ pub const STACK_TRACE_OFFSET: usize = SYS_TRACE_OFFSET + SYS_TRACE_WIDTH;
 pub const STACK_TRACE_WIDTH: usize = MIN_STACK_DEPTH + NUM_STACK_HELPER_COLS;
 pub const STACK_TRACE_RANGE: Range<usize> = range(STACK_TRACE_OFFSET, STACK_TRACE_WIDTH);
 
-// TODO: range check trace
+// Range check trace
+pub const RANGE_CHECK_TRACE_OFFSET: usize = STACK_TRACE_OFFSET + STACK_TRACE_WIDTH;
+pub const RANGE_CHECK_TRACE_WIDTH: usize = 4;
+pub const RANGE_CHECK_TRACE_RANGE: Range<usize> =
+    range(RANGE_CHECK_TRACE_OFFSET, RANGE_CHECK_TRACE_WIDTH);
 
 // Auxiliary table trace
-pub const AUX_TRACE_OFFSET: usize = STACK_TRACE_OFFSET + STACK_TRACE_WIDTH;
+pub const AUX_TRACE_OFFSET: usize = RANGE_CHECK_TRACE_OFFSET + RANGE_CHECK_TRACE_WIDTH;
 pub const AUX_TRACE_WIDTH: usize = 18;
 pub const AUX_TRACE_RANGE: Range<usize> = range(AUX_TRACE_OFFSET, AUX_TRACE_WIDTH);
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,6 +25,9 @@ pub type StackTopState = [Felt; MIN_STACK_DEPTH];
 // CONSTANTS
 // ================================================================================================
 
+/// The minimum length of the execution trace. This is the minimum required to support range checks.
+pub const MIN_TRACE_LEN: usize = 1024;
+
 /// The minimum stack depth enforced by the VM. This is also the number of stack registers which can
 /// be accessed by the VM directly.
 pub const MIN_STACK_DEPTH: usize = 16;

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -6,8 +6,8 @@ use vm_core::{
         Script,
     },
     AdviceInjector, DebugOptions, Felt, FieldElement, Operation, ProgramInputs, StackTopState,
-    StarkField, Word, AUX_TRACE_WIDTH, MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS, STACK_TRACE_WIDTH,
-    SYS_TRACE_WIDTH,
+    StarkField, Word, AUX_TRACE_WIDTH, MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS,
+    RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH, SYS_TRACE_WIDTH,
 };
 
 mod operations;
@@ -51,6 +51,7 @@ mod tests;
 
 type SysTrace = [Vec<Felt>; SYS_TRACE_WIDTH];
 type StackTrace = [Vec<Felt>; STACK_TRACE_WIDTH];
+type RangeCheckTrace = [Vec<Felt>; RANGE_CHECK_TRACE_WIDTH];
 type AuxTableTrace = [Vec<Felt>; AUX_TRACE_WIDTH]; // TODO: potentially rename to AuxiliaryTrace
 
 // EXECUTOR

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -6,7 +6,7 @@ use vm_core::{
         Script,
     },
     AdviceInjector, DebugOptions, Felt, FieldElement, Operation, ProgramInputs, StackTopState,
-    StarkField, Word, AUX_TRACE_WIDTH, MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS,
+    StarkField, Word, AUX_TRACE_WIDTH, MIN_STACK_DEPTH, MIN_TRACE_LEN, NUM_STACK_HELPER_COLS,
     RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH, SYS_TRACE_WIDTH,
 };
 
@@ -83,9 +83,9 @@ struct Process {
 impl Process {
     pub fn new(inputs: ProgramInputs) -> Self {
         Self {
-            system: System::new(4),
+            system: System::new(MIN_TRACE_LEN),
             decoder: Decoder::new(),
-            stack: Stack::new(&inputs, 4),
+            stack: Stack::new(&inputs, MIN_TRACE_LEN),
             range: RangeChecker::new(),
             hasher: Hasher::new(),
             bitwise: Bitwise::new(),

--- a/processor/src/tests/aux_table_trace.rs
+++ b/processor/src/tests/aux_table_trace.rs
@@ -9,31 +9,6 @@ use super::{
 };
 
 #[test]
-fn trace_len() {
-    // --- final trace lengths are equal when stack trace is longer than aux trace ----------------
-    let test = build_op_test!("popw.mem.2", &[1, 2, 3, 4]);
-    let trace = test.execute().unwrap();
-
-    assert_eq!(trace.aux_table()[0].len(), trace.stack()[0].len());
-
-    // --- final trace lengths are equal when aux trace is longer than stack trace ----------------
-    let test = build_op_test!("u32and", &[4, 8]);
-    let trace = test.execute().unwrap();
-
-    assert_eq!(trace.aux_table()[0].len(), trace.stack()[0].len());
-
-    // --- stack and aux trace lengths are equal after multi-processor aux trace ------------------
-    let source = "begin u32and pop.mem.0 u32or end";
-    let test = build_test!(source, &[1, 2, 3, 4]);
-    let trace = test.execute().unwrap();
-
-    assert_eq!(trace.aux_table()[0].len(), trace.stack()[0].len());
-
-    // --- trace len is power of 2 after multi-processor aux trace --------------------------------
-    assert!(trace.aux_table()[0].len().is_power_of_two());
-}
-
-#[test]
 fn hasher_aux_trace() {
     // --- single hasher permutation with no stack manipulation -----------------------------------
     let test = build_op_test!("rpperm", &[2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0]);
@@ -43,9 +18,8 @@ fn hasher_aux_trace() {
     let expected_len = 8;
     validate_hasher_trace(aux_table, 0, expected_len);
 
-    // expect  no bitwise trace and no memory trace
-    // so the trace only consists of the hasher trace with length 8
-    assert_eq!(aux_table[0].len(), expected_len);
+    // expect the stack trace to be the same length
+    assert_eq!(aux_table[0].len(), trace.stack()[0].len());
 }
 
 #[test]
@@ -58,9 +32,8 @@ fn bitwise_aux_trace() {
     let expected_len = 8;
     validate_bitwise_trace(aux_table, 0, expected_len);
 
-    // expect no hasher trace and no memory trace,
-    // so the trace only consists of the bitwise trace
-    assert_eq!(aux_table[0].len(), expected_len);
+    // expect the stack trace to be the same length
+    assert_eq!(aux_table[0].len(), trace.stack()[0].len());
 }
 
 #[test]
@@ -79,9 +52,8 @@ fn memory_aux_trace() {
     // check that it was padded correctly
     validate_padding(aux_table, 1, expected_len);
 
-    // expect no bitwise trace and no hasher trace,
-    // so the trace consists of the memory trace and final section of padding
-    assert_eq!(aux_table[0].len(), expected_len);
+    // expect the stack trace to be the same length
+    assert_eq!(aux_table[0].len(), trace.stack()[0].len());
 }
 
 #[test]
@@ -104,10 +76,7 @@ fn stacked_aux_trace() {
     // expect 15 rows of padding, to pad to next power of 2
     validate_padding(aux_table, 17, 32);
 
-    // expect aux table trace length to be 32
-    assert_eq!(aux_table[0].len(), 32);
-
-    // expect the stack trace to be the same
+    // expect the stack trace to be the same length
     assert_eq!(aux_table[0].len(), trace.stack()[0].len());
 }
 


### PR DESCRIPTION
This PR closes #143 by adding the trace generated by the RangeChecker to the overall execution trace.