### PR TITLE
Add u64 unsafe modulo operation

### DIFF
--- a/miden/tests/integration/stdlib/math/u64_mod.rs
+++ b/miden/tests/integration/stdlib/math/u64_mod.rs
@@ -235,6 +235,35 @@ fn div_unsafe() {
     test.expect_stack(&[d1, d0]);
 }
 
+// MODULO OPERATION
+// ------------------------------------------------------------------------------------------------
+
+#[test]
+fn mod_unsafe() {
+    let a: u64 = rand_value();
+    let b: u64 = rand_value();
+    let c = a % b;
+
+    let source = "
+        use.std::math::u64
+        begin
+            exec.u64::mod_unsafe
+        end";
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c1, c0) = split_u64(c);
+
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[c1, c0]);
+
+    let d = a % b0;
+    let (d1, d0) = split_u64(d);
+
+    let test = build_test!(source, &[a0, a1, b0, 0]);
+    test.expect_stack(&[d1, d0]);
+}
+
 // BITWISE OPERATIONS
 // ------------------------------------------------------------------------------------------------
 
@@ -401,6 +430,24 @@ proptest! {
             use.std::math::u64
             begin
                 exec.u64::div_unsafe
+            end";
+
+        build_test!(source, &[a0, a1, b0, b1]).prop_expect_stack(&[c1, c0])?;
+    }
+
+    #[test]
+    fn mod_unsafe_proptest(a in any::<u64>(), b in any::<u64>()) {
+
+        let c = a % b;
+
+        let (a1, a0) = split_u64(a);
+        let (b1, b0) = split_u64(b);
+        let (c1, c0) = split_u64(c);
+
+        let source = "
+            use.std::math::u64
+            begin
+                exec.u64::mod_unsafe
             end";
 
         build_test!(source, &[a0, a1, b0, b1]).prop_expect_stack(&[c1, c0])?;

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -248,3 +248,70 @@ export.div_unsafe
     movup.3
     assert.eq           # quotient remains on the stack #
 end
+
+# ===== MODULO OPERATION ================================================================================ #
+
+# Performs modulo operation of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b #
+export.mod_unsafe
+    adv.u64div          # inject the quotient and the remainder into the advice tape #
+    
+    push.adv.1          # read the quotient from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
+    push.adv.1          # TODO: this can be optimized once we have u32assert2 instruction #
+    u32assert
+
+    dup.3               # multiply quotient by the divisor and make sure the resulting value #
+    dup.2               # fits into 2 32-bit limbs #
+    u32mul.unsafe
+    dup.4
+    dup.4
+    u32madd.unsafe
+    eq.0
+    assert
+    dup.5
+    dup.3
+    u32madd.unsafe
+    eq.0
+    assert
+    dup.4
+    dup.3
+    mul
+    eq.0
+    assert
+
+    push.adv.1          # read the remainder from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
+    push.adv.1
+    u32assert
+
+    movup.7             # make sure the divisor is greater than the remainder. this also consumes #
+    movup.7             # the divisor #
+    dup.3
+    dup.3
+    exec.gt_unsafe
+    assert
+
+    dup.1               # change remaining on stack value from quotient to remainder #
+    dup.1
+    swap.6
+    drop
+    swap.6
+    drop
+
+    swap                # add remainder to the previous result; this also consumes the remainder #
+    movup.3
+    u32add.unsafe
+    movup.3
+    movup.3
+    u32addc.unsafe
+    eq.0
+    assert
+
+    movup.4             # make sure the result we got is equal to the dividend #
+    assert.eq
+    movup.3
+    assert.eq           # remainder remains on the stack #
+end

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -267,17 +267,17 @@ export.mod_unsafe
     dup.2               # fits into 2 32-bit limbs #
     u32mul.unsafe
     dup.4
-    dup.4
-    u32madd.unsafe
-    eq.0
-    assert
-    dup.5
-    dup.3
+    movup.4
     u32madd.unsafe
     eq.0
     assert
     dup.4
     dup.3
+    u32madd.unsafe
+    eq.0
+    assert
+    dup.3
+    movup.3
     mul
     eq.0
     assert
@@ -287,25 +287,18 @@ export.mod_unsafe
     push.adv.1
     u32assert
 
-    movup.7             # make sure the divisor is greater than the remainder. this also consumes #
-    movup.7             # the divisor #
+    movup.5             # make sure the divisor is greater than the remainder. this also consumes #
+    movup.5             # the divisor #
     dup.3
     dup.3
     exec.gt_unsafe
     assert
 
-    dup.1               # change remaining on stack value from quotient to remainder #
-    dup.1
-    swap.6
-    drop
-    swap.6
-    drop
-
-    swap                # add remainder to the previous result; this also consumes the remainder #
-    movup.3
+    dup.1               # add remainder to the previous result #
+    movup.4
     u32add.unsafe
-    movup.3
-    movup.3
+    movup.4
+    dup.3
     u32addc.unsafe
     eq.0
     assert

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -4858,5 +4858,72 @@ export.div_unsafe
     movup.3
     assert.eq           # quotient remains on the stack #
 end
+
+# ===== MODULO OPERATION ================================================================================ #
+
+# Performs modulo operation of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b #
+export.mod_unsafe
+    adv.u64div          # inject the quotient and the remainder into the advice tape #
+    
+    push.adv.1          # read the quotient from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
+    push.adv.1          # TODO: this can be optimized once we have u32assert2 instruction #
+    u32assert
+
+    dup.3               # multiply quotient by the divisor and make sure the resulting value #
+    dup.2               # fits into 2 32-bit limbs #
+    u32mul.unsafe
+    dup.4
+    dup.4
+    u32madd.unsafe
+    eq.0
+    assert
+    dup.5
+    dup.3
+    u32madd.unsafe
+    eq.0
+    assert
+    dup.4
+    dup.3
+    mul
+    eq.0
+    assert
+
+    push.adv.1          # read the remainder from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
+    push.adv.1
+    u32assert
+
+    movup.7             # make sure the divisor is greater than the remainder. this also consumes #
+    movup.7             # the divisor #
+    dup.3
+    dup.3
+    exec.gt_unsafe
+    assert
+
+    dup.1               # change remaining on stack value from quotient to remainder #
+    dup.1
+    swap.6
+    drop
+    swap.6
+    drop
+
+    swap                # add remainder to the previous result; this also consumes the remainder #
+    movup.3
+    u32add.unsafe
+    movup.3
+    movup.3
+    u32addc.unsafe
+    eq.0
+    assert
+
+    movup.4             # make sure the result we got is equal to the dividend #
+    assert.eq
+    movup.3
+    assert.eq           # remainder remains on the stack #
+end
 "),
 ];

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -4877,17 +4877,17 @@ export.mod_unsafe
     dup.2               # fits into 2 32-bit limbs #
     u32mul.unsafe
     dup.4
-    dup.4
-    u32madd.unsafe
-    eq.0
-    assert
-    dup.5
-    dup.3
+    movup.4
     u32madd.unsafe
     eq.0
     assert
     dup.4
     dup.3
+    u32madd.unsafe
+    eq.0
+    assert
+    dup.3
+    movup.3
     mul
     eq.0
     assert
@@ -4897,25 +4897,18 @@ export.mod_unsafe
     push.adv.1
     u32assert
 
-    movup.7             # make sure the divisor is greater than the remainder. this also consumes #
-    movup.7             # the divisor #
+    movup.5             # make sure the divisor is greater than the remainder. this also consumes #
+    movup.5             # the divisor #
     dup.3
     dup.3
     exec.gt_unsafe
     assert
 
-    dup.1               # change remaining on stack value from quotient to remainder #
-    dup.1
-    swap.6
-    drop
-    swap.6
-    drop
-
-    swap                # add remainder to the previous result; this also consumes the remainder #
-    movup.3
+    dup.1               # add remainder to the previous result #
+    movup.4
     u32add.unsafe
-    movup.3
-    movup.3
+    movup.4
+    dup.3
     u32addc.unsafe
     eq.0
     assert


### PR DESCRIPTION
Due to the great similarity of the division operation and the modulo operation, the division operation code was taken as the basis, in which the value remaining on the stack was replaced. Now there remains not a quotient, but the remainder of the division.