### PR TITLE
u64 stdlib module improvements and refactoring

### DIFF
--- a/miden/tests/integration/stdlib/math/u64_mod.rs
+++ b/miden/tests/integration/stdlib/math/u64_mod.rs
@@ -6,7 +6,7 @@ use rand_utils::rand_value;
 // ------------------------------------------------------------------------------------------------
 
 #[test]
-fn add_unsafe() {
+fn wrapping_add() {
     let a: u64 = rand_value();
     let b: u64 = rand_value();
     let c = a.wrapping_add(b);
@@ -14,7 +14,7 @@ fn add_unsafe() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::add_unsafe
+            exec.u64::wrapping_add
         end";
 
     let (a1, a0) = split_u64(a);
@@ -26,11 +26,11 @@ fn add_unsafe() {
 }
 
 #[test]
-fn add() {
+fn checked_add() {
     let source = "
     use.std::math::u64
     begin
-        exec.u64::add
+        exec.u64::checked_add
     end";
 
     // --- simple case ----------------------------------------------------------------------------
@@ -51,11 +51,11 @@ fn add() {
 }
 
 #[test]
-fn add_fail() {
+fn checked_add_fail() {
     let source = "
     use.std::math::u64
     begin
-        exec.u64::add
+        exec.u64::checked_add
     end";
 
     // result overflow
@@ -77,11 +77,42 @@ fn add_fail() {
     test.expect_error(TestError::ExecutionError("FailedAssertion"));
 }
 
+#[test]
+fn overflowing_add() {
+    let source = "
+        use.std::math::u64
+        begin
+            exec.u64::overflowing_add
+        end";
+
+    let a = rand_value::<u64>() as u32 as u64;
+    let b = rand_value::<u64>() as u32 as u64;
+    let (c, _) = a.overflowing_add(b);
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c1, c0) = split_u64(c);
+
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[0, c1, c0]);
+
+    let a = u64::MAX;
+    let b = rand_value::<u64>();
+    let (c, _) = a.overflowing_add(b);
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c1, c0) = split_u64(c);
+
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[1, c1, c0]);
+}
+
 // SUBTRACTION
 // ------------------------------------------------------------------------------------------------
 
 #[test]
-fn sub_unsafe() {
+fn wrapping_sub() {
     let a: u64 = rand_value();
     let b: u64 = rand_value();
     let c = a.wrapping_sub(b);
@@ -89,7 +120,7 @@ fn sub_unsafe() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::sub_unsafe
+            exec.u64::wrapping_sub
         end";
 
     let (a1, a0) = split_u64(a);
@@ -101,11 +132,11 @@ fn sub_unsafe() {
 }
 
 #[test]
-fn sub() {
+fn checked_sub() {
     let source = "
     use.std::math::u64
     begin
-        exec.u64::sub
+        exec.u64::checked_sub
     end";
 
     // --- simple case ----------------------------------------------------------------------------
@@ -129,11 +160,11 @@ fn sub() {
 }
 
 #[test]
-fn sub_fail() {
+fn checked_sub_fail() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::sub
+            exec.u64::checked_sub
         end";
 
     // result underflow
@@ -155,11 +186,59 @@ fn sub_fail() {
     test.expect_error(TestError::ExecutionError("FailedAssertion"));
 }
 
+#[test]
+fn overflowing_sub() {
+    let a: u64 = rand_value();
+    let b: u64 = rand_value();
+    let (c, flag) = a.overflowing_sub(b);
+
+    let source = "
+        use.std::math::u64
+        begin
+            exec.u64::overflowing_sub
+        end";
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c1, c0) = split_u64(c);
+
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[flag as u64, c1, c0]);
+
+    let base = rand_value::<u64>() as u32 as u64;
+    let diff = rand_value::<u64>() as u32 as u64;
+
+    let a = base;
+    let b = base + diff;
+    let (c, _) = a.overflowing_sub(b);
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c1, c0) = split_u64(c);
+
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[1, c1, c0]);
+
+    let base = rand_value::<u64>() as u32 as u64;
+    let diff = rand_value::<u64>() as u32 as u64;
+
+    let a = base + diff;
+    let b = base;
+    let (c, _) = a.overflowing_sub(b);
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c1, c0) = split_u64(c);
+
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[0, c1, c0]);
+}
+
 // MULTIPLICATION
 // ------------------------------------------------------------------------------------------------
 
 #[test]
-fn mul_unsafe() {
+fn wrapping_mul() {
     let a: u64 = rand_value();
     let b: u64 = rand_value();
     let c = a.wrapping_mul(b);
@@ -167,7 +246,7 @@ fn mul_unsafe() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::mul_unsafe
+            exec.u64::wrapping_mul
         end";
 
     let (a1, a0) = split_u64(a);
@@ -179,11 +258,11 @@ fn mul_unsafe() {
 }
 
 #[test]
-fn mul() {
+fn checked_mul() {
     let source = "
     use.std::math::u64
     begin
-        exec.u64::mul
+        exec.u64::checked_mul
     end";
 
     // --- simple cases ---------------------------------------------------------------------------
@@ -212,11 +291,11 @@ fn mul() {
 }
 
 #[test]
-fn mul_fail() {
+fn checked_mul_fail() {
     let source = "
     use.std::math::u64
     begin
-        exec.u64::mul
+        exec.u64::checked_mul
     end";
 
     //u32 limb assertion failure
@@ -248,16 +327,53 @@ fn mul_fail() {
     test.expect_error(TestError::ExecutionError("FailedAssertion"));
 }
 
+#[test]
+fn overflowing_mul() {
+    let source = "
+    use.std::math::u64
+    begin
+        exec.u64::overflowing_mul
+    end";
+
+    let a = u64::MAX as u128;
+    let b = u64::MAX as u128;
+    let c = a.wrapping_mul(b);
+
+    let a = u64::MAX;
+    let b = u64::MAX;
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c3, c2, c1, c0) = split_u128(c);
+
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[c3, c2, c1, c0]);
+
+    let a = rand_value::<u64>() as u128;
+    let b = rand_value::<u64>() as u128;
+    let c = a.wrapping_mul(b);
+
+    let a = a as u64;
+    let b = b as u64;
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (c3, c2, c1, c0) = split_u128(c);
+
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[c3, c2, c1, c0]);
+}
+
 // COMPARISONS
 // ------------------------------------------------------------------------------------------------
 
 #[test]
-fn lt_unsafe() {
+fn unchecked_lt() {
     // test a few manual cases; randomized tests are done using proptest
     let source = "
         use.std::math::u64
         begin
-            exec.u64::lt_unsafe
+            exec.u64::unchecked_lt
         end";
 
     // a = 0, b = 0
@@ -271,11 +387,11 @@ fn lt_unsafe() {
 }
 
 #[test]
-fn lte_unsafe() {
+fn unchecked_lte() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::lte_unsafe
+            exec.u64::unchecked_lte
         end";
 
     // a = 0, b = 0
@@ -298,12 +414,12 @@ fn lte_unsafe() {
 }
 
 #[test]
-fn gt_unsafe() {
+fn unchecked_gt() {
     // test a few manual cases; randomized tests are done using proptest
     let source = "
         use.std::math::u64
         begin
-            exec.u64::gt_unsafe
+            exec.u64::unchecked_gt
         end";
 
     // a = 0, b = 0
@@ -317,11 +433,11 @@ fn gt_unsafe() {
 }
 
 #[test]
-fn gte_unsafe() {
+fn unchecked_gte() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::gte_unsafe
+            exec.u64::unchecked_gte
         end";
 
     // a = 0, b = 0
@@ -344,11 +460,11 @@ fn gte_unsafe() {
 }
 
 #[test]
-fn eq_unsafe() {
+fn unchecked_eq() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::eq_unsafe
+            exec.u64::unchecked_eq
         end";
 
     // a = 0, b = 0
@@ -371,11 +487,38 @@ fn eq_unsafe() {
 }
 
 #[test]
-fn eqz_unsafe() {
+fn unchecked_neq() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::eqz_unsafe
+            exec.u64::unchecked_neq
+        end";
+
+    // a = 0, b = 0
+    build_test!(source, &[0, 0, 0, 0]).expect_stack(&[0]);
+
+    // a = 0, b = 1
+    build_test!(source, &[0, 0, 1, 0]).expect_stack(&[1]);
+
+    // a = 1, b = 0
+    build_test!(source, &[1, 0, 0, 0]).expect_stack(&[1]);
+
+    // randomized test
+    let a: u64 = rand_value();
+    let b: u64 = rand_value();
+    let c = (a != b) as u64;
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    build_test!(source, &[a0, a1, b0, b1]).expect_stack(&[c]);
+}
+
+#[test]
+fn unchecked_eqz() {
+    let source = "
+        use.std::math::u64
+        begin
+            exec.u64::unchecked_eqz
         end";
 
     // a = 0
@@ -396,7 +539,7 @@ fn eqz_unsafe() {
 // ------------------------------------------------------------------------------------------------
 
 #[test]
-fn div_unsafe() {
+fn unchecked_div() {
     let a: u64 = rand_value();
     let b: u64 = rand_value();
     let c = a / b;
@@ -404,7 +547,7 @@ fn div_unsafe() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::div_unsafe
+            exec.u64::unchecked_div
         end";
 
     let (a1, a0) = split_u64(a);
@@ -425,7 +568,7 @@ fn div_unsafe() {
 // ------------------------------------------------------------------------------------------------
 
 #[test]
-fn mod_unsafe() {
+fn unchecked_mod() {
     let a: u64 = rand_value();
     let b: u64 = rand_value();
     let c = a % b;
@@ -433,7 +576,7 @@ fn mod_unsafe() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::mod_unsafe
+            exec.u64::unchecked_mod
         end";
 
     let (a1, a0) = split_u64(a);
@@ -450,11 +593,36 @@ fn mod_unsafe() {
     test.expect_stack(&[d1, d0]);
 }
 
+// DIVMOD OPERATION
+// ------------------------------------------------------------------------------------------------
+
+#[test]
+fn unchecked_divmod() {
+    let a: u64 = rand_value();
+    let b: u64 = rand_value();
+    let q = a / b;
+    let r = a % b;
+
+    let source = "
+        use.std::math::u64
+        begin
+            exec.u64::unchecked_divmod
+        end";
+
+    let (a1, a0) = split_u64(a);
+    let (b1, b0) = split_u64(b);
+    let (q1, q0) = split_u64(q);
+    let (r1, r0) = split_u64(r);
+
+    let test = build_test!(source, &[a0, a1, b0, b1]);
+    test.expect_stack(&[r1, r0, q1, q0]);
+}
+
 // BITWISE OPERATIONS
 // ------------------------------------------------------------------------------------------------
 
 #[test]
-fn and() {
+fn checked_and() {
     let a: u64 = rand_value();
     let b: u64 = rand_value();
     let c = a & b;
@@ -462,7 +630,7 @@ fn and() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::and
+            exec.u64::checked_and
         end";
 
     let (a1, a0) = split_u64(a);
@@ -474,7 +642,7 @@ fn and() {
 }
 
 #[test]
-fn and_fail() {
+fn checked_and_fail() {
     let a0: u64 = rand_value();
     let b0: u64 = rand_value();
 
@@ -484,7 +652,7 @@ fn and_fail() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::and
+            exec.u64::checked_and
         end";
 
     let test = build_test!(source, &[a0, a1, b0, b1]);
@@ -492,7 +660,7 @@ fn and_fail() {
 }
 
 #[test]
-fn or() {
+fn checked_or() {
     let a: u64 = rand_value();
     let b: u64 = rand_value();
     let c = a | b;
@@ -500,7 +668,7 @@ fn or() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::or
+            exec.u64::checked_or
         end";
 
     let (a1, a0) = split_u64(a);
@@ -512,7 +680,7 @@ fn or() {
 }
 
 #[test]
-fn or_fail() {
+fn checked_or_fail() {
     let a0: u64 = rand_value();
     let b0: u64 = rand_value();
 
@@ -522,7 +690,7 @@ fn or_fail() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::or
+            exec.u64::checked_or
         end";
 
     let test = build_test!(source, &[a0, a1, b0, b1]);
@@ -530,7 +698,7 @@ fn or_fail() {
 }
 
 #[test]
-fn xor() {
+fn checked_xor() {
     let a: u64 = rand_value();
     let b: u64 = rand_value();
     let c = a ^ b;
@@ -538,7 +706,7 @@ fn xor() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::xor
+            exec.u64::checked_xor
         end";
 
     let (a1, a0) = split_u64(a);
@@ -550,7 +718,7 @@ fn xor() {
 }
 
 #[test]
-fn xor_fail() {
+fn checked_xor_fail() {
     let a0: u64 = rand_value();
     let b0: u64 = rand_value();
 
@@ -560,7 +728,7 @@ fn xor_fail() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::xor
+            exec.u64::checked_xor
         end";
 
     let test = build_test!(source, &[a0, a1, b0, b1]);
@@ -568,11 +736,11 @@ fn xor_fail() {
 }
 
 #[test]
-fn shl() {
+fn unchecked_shl() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::shl
+            exec.u64::unchecked_shl
         end";
 
     // shift by 0
@@ -618,11 +786,11 @@ fn shl() {
 }
 
 #[test]
-fn shr() {
+fn unchecked_shr() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::shr
+            exec.u64::unchecked_shr
         end";
 
     // shift by 0
@@ -674,11 +842,11 @@ fn shr() {
 }
 
 #[test]
-fn rotl() {
+fn unchecked_rotl() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::rotl
+            exec.u64::unchecked_rotl
         end";
 
     // shift by 0
@@ -724,11 +892,11 @@ fn rotl() {
 }
 
 #[test]
-fn rotr() {
+fn unchecked_rotr() {
     let source = "
         use.std::math::u64
         begin
-            exec.u64::rotr
+            exec.u64::unchecked_rotr
         end";
 
     // shift by 0
@@ -778,7 +946,7 @@ fn rotr() {
 
 proptest! {
     #[test]
-    fn lt_unsafe_proptest(a in any::<u64>(), b in any::<u64>()) {
+    fn unchecked_lt_proptest(a in any::<u64>(), b in any::<u64>()) {
 
         let (a1, a0) = split_u64(a);
         let (b1, b0) = split_u64(b);
@@ -787,14 +955,14 @@ proptest! {
         let source = "
             use.std::math::u64
             begin
-                exec.u64::lt_unsafe
+                exec.u64::unchecked_lt
             end";
 
         build_test!(source, &[a0, a1, b0, b1]).prop_expect_stack(&[c])?;
     }
 
     #[test]
-    fn gt_unsafe_proptest(a in any::<u64>(), b in any::<u64>()) {
+    fn unchecked_gt_proptest(a in any::<u64>(), b in any::<u64>()) {
 
         let (a1, a0) = split_u64(a);
         let (b1, b0) = split_u64(b);
@@ -803,14 +971,14 @@ proptest! {
         let source = "
             use.std::math::u64
             begin
-                exec.u64::gt_unsafe
+                exec.u64::unchecked_gt
             end";
 
         build_test!(source, &[a0, a1, b0, b1]).prop_expect_stack(&[c])?;
     }
 
     #[test]
-    fn div_unsafe_proptest(a in any::<u64>(), b in any::<u64>()) {
+    fn unchecked_div_proptest(a in any::<u64>(), b in any::<u64>()) {
 
         let c = a / b;
 
@@ -821,14 +989,14 @@ proptest! {
         let source = "
             use.std::math::u64
             begin
-                exec.u64::div_unsafe
+                exec.u64::unchecked_div
             end";
 
         build_test!(source, &[a0, a1, b0, b1]).prop_expect_stack(&[c1, c0])?;
     }
 
     #[test]
-    fn mod_unsafe_proptest(a in any::<u64>(), b in any::<u64>()) {
+    fn unchecked_mod_proptest(a in any::<u64>(), b in any::<u64>()) {
 
         let c = a % b;
 
@@ -839,7 +1007,7 @@ proptest! {
         let source = "
             use.std::math::u64
             begin
-                exec.u64::mod_unsafe
+                exec.u64::unchecked_mod
             end";
 
         build_test!(source, &[a0, a1, b0, b1]).prop_expect_stack(&[c1, c0])?;
@@ -855,7 +1023,7 @@ proptest! {
         let source = "
         use.std::math::u64
         begin
-            exec.u64::shl
+            exec.u64::unchecked_shl
         end";
 
         build_test!(source, &[5, a0, a1, b as u64]).prop_expect_stack(&[c1, c0, 5])?;
@@ -872,7 +1040,7 @@ proptest! {
         let source = "
         use.std::math::u64
         begin
-            exec.u64::shr
+            exec.u64::unchecked_shr
         end";
 
         build_test!(source, &[5, a0, a1, b as u64]).prop_expect_stack(&[c1, c0, 5])?;
@@ -889,7 +1057,7 @@ proptest! {
         let source = "
         use.std::math::u64
         begin
-            exec.u64::rotl
+            exec.u64::unchecked_rotl
         end";
 
         build_test!(source, &[5, a0, a1, b as u64]).prop_expect_stack(&[c1, c0, 5])?;
@@ -906,7 +1074,7 @@ proptest! {
         let source = "
         use.std::math::u64
         begin
-            exec.u64::rotr
+            exec.u64::unchecked_rotr
         end";
 
         build_test!(source, &[5, a0, a1, b as u64]).prop_expect_stack(&[c1, c0, 5])?;
@@ -919,4 +1087,13 @@ proptest! {
 /// Split the provided u64 value into 32 high and low bits.
 fn split_u64(value: u64) -> (u64, u64) {
     (value >> 32, value as u32 as u64)
+}
+
+fn split_u128(value: u128) -> (u64, u64, u64, u64) {
+    (
+        (value >> 96) as u64,
+        (value >> 64) as u32 as u64,
+        (value >> 32) as u32 as u64,
+        value as u32 as u64,
+    )
 }

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -15,17 +15,25 @@ end
 
 # ===== ADDITION ================================================================================ #
 
-# Performs addition of two unsigned 64 bit integers discarding the overflow. #
+# Performs addition of two unsigned 64 bit integers preserving the overflow. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64 #
-export.add_unsafe
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [overflowing_flag, c_hi, c_lo, ...], where c = (a + b) % 2^64 #
+export.overflowing_add
     swap
     movup.3
     u32add.unsafe
     movup.3
     movup.3
     u32addc.unsafe
+end
+
+# Performs addition of two unsigned 64 bit integers discarding the overflow. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64 #
+export.wrapping_add
+    exec.overflowing_add
     drop
 end
 
@@ -33,14 +41,9 @@ end
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64 #
-export.add
+export.checked_add
     exec.u32assert4
-    swap
-    movup.3
-    u32add.unsafe
-    movup.3
-    movup.3
-    u32addc.unsafe
+    exec.overflowing_add
     eq.0
     assert
 end
@@ -51,7 +54,7 @@ end
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a - b) % 2^64 #
-export.sub_unsafe
+export.wrapping_sub
     movup.3
     movup.2
     u32sub.unsafe
@@ -68,7 +71,7 @@ end
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a - b) % 2^64 #
-export.sub
+export.checked_sub
     exec.u32assert4
     movup.3
     movup.2
@@ -84,13 +87,31 @@ export.sub
     assert
 end
 
+# Performs subtraction of two unsigned 64 bit integers preserving the overflow. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [underflowing_flag, c_hi, c_lo, ...], where c = (a - b) % 2^64 #
+export.overflowing_sub
+    movup.3
+    movup.2
+    u32sub.unsafe
+    movup.3
+    movup.3
+    u32sub.unsafe
+    swap
+    movup.2
+    u32sub.unsafe
+    movup.2
+    or
+end
+
 # ===== MULTIPLICATION ========================================================================== #
 
 # Performs multiplication of two unsigned 64 bit integers discarding the overflow. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64 #
-export.mul_unsafe
+export.wrapping_mul
     dup.3
     dup.2
     u32mul.unsafe
@@ -126,15 +147,14 @@ export.overflowing_mul
     movup.2
     u32add.unsafe
     movup.2
-    u32add.unsafe
-    drop
+    add
 end
 
 # Performs multiplication of two unsigned 64 bit integers, fails when overflowing. #
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64 #
-export.mul
+export.checked_mul
     exec.u32assert4
     exec.overflowing_mul
     u32or
@@ -148,7 +168,7 @@ end
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise. #
-export.lt_unsafe
+export.unchecked_lt
     movup.3
     movup.2
     u32sub.unsafe
@@ -166,16 +186,16 @@ end
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise. #
-export.lt
+export.checked_lt
     exec.u32assert4
-    exec.lt_unsafe
+    exec.unchecked_lt
 end
 
 # Performs greater-than comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise. #
-export.gt_unsafe
+export.unchecked_gt
     movup.2
     u32sub.unsafe
     movup.2
@@ -193,17 +213,17 @@ end
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise. #
-export.gt
+export.checked_gt
     exec.u32assert4
-    exec.gt_unsafe
+    exec.unchecked_gt
 end
 
 # Performs less-than-or-equal comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise. #
-export.lte_unsafe
-    exec.gt_unsafe
+export.unchecked_lte
+    exec.unchecked_gt
     not
 end
 
@@ -211,9 +231,9 @@ end
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise. #
-export.lte
+export.checked_lte
     exec.u32assert4
-    exec.gt_unsafe
+    exec.unchecked_gt
     not
 end
 
@@ -221,8 +241,8 @@ end
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise. #
-export.gte_unsafe
-    exec.lt_unsafe
+export.unchecked_gte
+    exec.unchecked_lt
     not
 end
 
@@ -230,9 +250,9 @@ end
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise. #
-export.gte
+export.checked_gte
     exec.u32assert4
-    exec.lt_unsafe
+    exec.unchecked_lt
     not
 end
 
@@ -240,7 +260,7 @@ end
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise. #
-export.eq_unsafe
+export.unchecked_eq
     movup.2
     u32eq
     swap
@@ -253,19 +273,41 @@ end
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise. #
-export.eq
+export.checked_eq
     exec.u32assert4
-    exec.eq_unsafe
+    exec.unchecked_eq
+end
+
+# Performs inequality comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a != b, and 0 otherwise. #
+export.unchecked_neq
+    movup.2
+    u32neq
+    swap
+    movup.2
+    u32neq
+    or
+end
+
+# Performs inequality comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise. #
+export.checked_neq
+    exec.u32assert4
+    exec.unchecked_eq
 end
 
 # Performs comparison to zero of an unsigned 64 bit integer. #
 # The input value is assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise. #
-export.eqz_unsafe
-    u32eq.0
+export.unchecked_eqz
+    eq.0
     swap
-    u32eq.0
+    eq.0
     and
 end
 
@@ -273,14 +315,14 @@ end
 # The input value is assumed to be represented using 32 bit limbs, fails if it is not. #
 # Stack transition looks as follows: #
 # [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise. #
-export.eqz
+export.checked_eqz
     u32assert
     swap
     u32assert
     swap
-    u32eq.0
+    eq.0
     swap
-    u32eq.0
+    eq.0
     and
 end
 
@@ -290,7 +332,7 @@ end
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b #
-export.div_unsafe
+export.unchecked_div
     adv.u64div          # inject the quotient and the remainder into the advice tape #
     
     push.adv.1          # read the quotient from the advice tape and make sure it consists of #
@@ -326,7 +368,7 @@ export.div_unsafe
     movup.7             # the divisor #
     dup.3
     dup.3
-    exec.gt_unsafe
+    exec.unchecked_gt
     assert
 
     swap                # add remainder to the previous result; this also consumes the remainder #
@@ -345,21 +387,21 @@ export.div_unsafe
 end
 
 # Performs division of two unsigned 64 bit integers discarding the remainder. #
-# The input values are assumed to be represented using 32 bit limbs, fails if it is not. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b #
-export.div
+export.checked_div
     exec.u32assert4
-    exec.div_unsafe
+    exec.unchecked_div
 end
 
-# ===== MODULO OPERATION ================================================================================ #
+# ===== MODULO OPERATION ======================================================================== #
 
 # Performs modulo operation of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b #
-export.mod_unsafe
+export.unchecked_mod
     adv.u64div          # inject the quotient and the remainder into the advice tape #
     
     push.adv.1          # read the quotient from the advice tape and make sure it consists of #
@@ -395,7 +437,7 @@ export.mod_unsafe
     movup.5             # the divisor #
     dup.3
     dup.3
-    exec.gt_unsafe
+    exec.unchecked_gt
     assert
 
     dup.1               # add remainder to the previous result #
@@ -414,21 +456,90 @@ export.mod_unsafe
 end
 
 # Performs modulo operation of two unsigned 64 bit integers. #
-# The input values are assumed to be represented using 32 bit limbs, fails if it is not. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b #
-export.mod
+export.checked_mod
     exec.u32assert4
-    exec.mod_unsafe
+    exec.unchecked_mod
+end
+
+# ===== DIVMOD OPERATION ======================================================================== #
+
+# Performs divmod operation of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [r_hi, r_lo, q_hi, q_lo ...], where r = a % b, q = a / b #
+export.unchecked_divmod
+    adv.u64div          # inject the quotient and the remainder into the advice tape #
+    
+    push.adv.1          # read the quotient from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
+    push.adv.1          # TODO: this can be optimized once we have u32assert2 instruction #
+    u32assert
+
+    dup.3               # multiply quotient by the divisor and make sure the resulting value #
+    dup.2               # fits into 2 32-bit limbs #
+    u32mul.unsafe
+    dup.4
+    dup.4
+    u32madd.unsafe
+    eq.0
+    assert
+    dup.5
+    dup.3
+    u32madd.unsafe
+    eq.0
+    assert
+    dup.4
+    dup.3
+    mul
+    eq.0
+    assert
+
+    push.adv.1          # read the remainder from the advice tape and make sure it consists of #
+    u32assert           # 32-bit limbs #
+    push.adv.1
+    u32assert
+
+    movup.7             # make sure the divisor is greater than the remainder. this also consumes #
+    movup.7             # the divisor #
+    dup.3
+    dup.3
+    exec.unchecked_gt
+    assert
+
+    dup.1               # add remainder to the previous result #
+    movup.4
+    u32add.unsafe
+    movup.4
+    dup.3
+    u32addc.unsafe
+    eq.0
+    assert
+
+    movup.6             # make sure the result we got is equal to the dividend #
+    assert.eq
+    movup.5
+    assert.eq           # remainder remains on the stack #
+end
+
+# Performs divmod operation of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [r_hi, r_lo, q_hi, q_lo ...], where r = a % b, q = a / b #
+export.checked_divmod
+    exec.u32assert4
+    exec.unchecked_divmod
 end
 
 # ===== BITWISE OPERATIONS ====================================================================== #
 
-# Performs bitwise AND of two unsigned 64 bit integers. #
-# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Performs divmod operation of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
-# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a AND b. #
-export.and
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [r_hi, r_lo, q_hi, q_lo ...], where r = a % b, q = a / b #
+export.checked_and
     swap
     movup.3
     u32and
@@ -441,7 +552,7 @@ end
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a OR b. #
-export.or
+export.checked_or
     swap
     movup.3
     u32or
@@ -454,7 +565,7 @@ end
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a XOR b. #
-export.xor
+export.checked_xor
     swap
     movup.3
     u32xor
@@ -469,10 +580,10 @@ end
 # Stack transition looks as follows: #
 # [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64. #
 # This takes 13 cycles. #
-export.shl
+export.unchecked_shl
     pow2
     u32split
-    exec.mul_unsafe
+    exec.wrapping_mul
 end
 
 # Performs right shift of one unsigned 64-bit integer using the pow2 operation. #
@@ -481,7 +592,7 @@ end
 # Stack transition looks as follows: #
 # [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a >> b. #
 # This takes 29 cycles. #
-export.shr
+export.unchecked_shr
     pow2
     u32split
     
@@ -519,7 +630,7 @@ end
 # Stack transition looks as follows: #
 # [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64. #
 # This takes 20 cycles. #
-export.rotl
+export.unchecked_rotl
     push.31
     dup.1
     u32sub.unsafe
@@ -556,7 +667,7 @@ end
 # Stack transition looks as follows: #
 # [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64. #
 # This takes 25 cycles. #
-export.rotr
+export.unchecked_rotr
     push.31
     dup.1
     u32sub.unsafe
@@ -591,4 +702,3 @@ export.rotr
     not
     cswap
 end
-

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -2,7 +2,7 @@
 
 # Asserts that both values at the top of the stack are u64 values. #
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
-proc.u64assert4
+proc.u32assert4
     u32assert
     movup.3
     u32assert
@@ -29,6 +29,22 @@ export.add_unsafe
     drop
 end
 
+# Performs addition of two unsigned 64 bit integers, fails when overflowing. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64 #
+export.add
+    exec.u32assert4
+    swap
+    movup.3
+    u32add.unsafe
+    movup.3
+    movup.3
+    u32addc.unsafe
+    eq.0
+    assert
+end
+
 # ===== SUBTRACTION ============================================================================= #
 
 # Performs subtraction of two unsigned 64 bit integers discarding the overflow. #
@@ -46,6 +62,26 @@ export.sub_unsafe
     swap
     u32sub.unsafe
     drop
+end
+
+# Performs subtraction of two unsigned 64 bit integers, fails when underflowing. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a - b) % 2^64 #
+export.sub
+    exec.u32assert4
+    movup.3
+    movup.2
+    u32sub.unsafe
+    movup.3
+    movup.3
+    u32sub.unsafe
+    eq.0
+    assert
+    swap
+    u32sub.unsafe
+    eq.0
+    assert
 end
 
 # ===== MULTIPLICATION ========================================================================== #
@@ -68,6 +104,44 @@ export.mul_unsafe
     drop
 end
 
+# Performs multiplication of two unsigned 64 bit integers preserving the overflow. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_mid_hi, c_mid_lo, c_lo, ...], where c = (a * b) % 2^64 #
+export.overflowing_mul
+    dup.3
+    dup.2
+    u32mul.unsafe
+    dup.4
+    movup.4
+    u32madd.unsafe
+    swap
+    movup.5
+    dup.4
+    u32madd.unsafe
+    movup.5
+    movup.5
+    u32madd.unsafe
+    movup.3
+    movup.2
+    u32add.unsafe
+    movup.2
+    u32add.unsafe
+    drop
+end
+
+# Performs multiplication of two unsigned 64 bit integers, fails when overflowing. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64 #
+export.mul
+    exec.u32assert4
+    exec.overflowing_mul
+    u32or
+    eq.0
+    assert
+end
+
 # ===== COMPARISONS ============================================================================= #
 
 # Performs less-than comparison of two unsigned 64 bit integers. #
@@ -88,6 +162,15 @@ export.lt_unsafe
     or
 end
 
+# Performs less-than comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise. #
+export.lt
+    exec.u32assert4
+    exec.lt_unsafe
+end
+
 # Performs greater-than comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
@@ -106,6 +189,15 @@ export.gt_unsafe
     or
 end
 
+# Performs greater-than comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise. #
+export.gt
+    exec.u32assert4
+    exec.gt_unsafe
+end
+
 # Performs less-than-or-equal comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
@@ -115,11 +207,31 @@ export.lte_unsafe
     not
 end
 
+# Performs less-than-or-equal comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise. #
+export.lte
+    exec.u32assert4
+    exec.gt_unsafe
+    not
+end
+
 # Performs greater-than-or-equal comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise. #
 export.gte_unsafe
+    exec.lt_unsafe
+    not
+end
+
+# Performs greater-than-or-equal comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise. #
+export.gte
+    exec.u32assert4
     exec.lt_unsafe
     not
 end
@@ -137,11 +249,35 @@ export.eq_unsafe
     and
 end
 
+# Performs equality comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise. #
+export.eq
+    exec.u32assert4
+    exec.eq_unsafe
+end
+
 # Performs comparison to zero of an unsigned 64 bit integer. #
 # The input value is assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise. #
 export.eqz_unsafe
+    u32eq.0
+    swap
+    u32eq.0
+    and
+end
+
+# Performs comparison to zero of an unsigned 64 bit integer. #
+# The input value is assumed to be represented using 32 bit limbs, fails if it is not. #
+# Stack transition looks as follows: #
+# [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise. #
+export.eqz
+    u32assert
+    swap
+    u32assert
+    swap
     u32eq.0
     swap
     u32eq.0
@@ -208,6 +344,15 @@ export.div_unsafe
     assert.eq           # quotient remains on the stack #
 end
 
+# Performs division of two unsigned 64 bit integers discarding the remainder. #
+# The input values are assumed to be represented using 32 bit limbs, fails if it is not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b #
+export.div
+    exec.u32assert4
+    exec.div_unsafe
+end
+
 # ===== MODULO OPERATION ================================================================================ #
 
 # Performs modulo operation of two unsigned 64 bit integers. #
@@ -266,6 +411,15 @@ export.mod_unsafe
     assert.eq
     movup.3
     assert.eq           # remainder remains on the stack #
+end
+
+# Performs modulo operation of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if it is not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b #
+export.mod
+    exec.u32assert4
+    exec.mod_unsafe
 end
 
 # ===== BITWISE OPERATIONS ====================================================================== #
@@ -437,3 +591,4 @@ export.rotr
     not
     cswap
 end
+

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -9904,7 +9904,7 @@ end"),
 
 # Asserts that both values at the top of the stack are u64 values. #
 # The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
-proc.u64assert4
+proc.u32assert4
     u32assert
     movup.3
     u32assert
@@ -9931,6 +9931,22 @@ export.add_unsafe
     drop
 end
 
+# Performs addition of two unsigned 64 bit integers, fails when overflowing. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64 #
+export.add
+    exec.u32assert4
+    swap
+    movup.3
+    u32add.unsafe
+    movup.3
+    movup.3
+    u32addc.unsafe
+    eq.0
+    assert
+end
+
 # ===== SUBTRACTION ============================================================================= #
 
 # Performs subtraction of two unsigned 64 bit integers discarding the overflow. #
@@ -9948,6 +9964,26 @@ export.sub_unsafe
     swap
     u32sub.unsafe
     drop
+end
+
+# Performs subtraction of two unsigned 64 bit integers, fails when underflowing. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a - b) % 2^64 #
+export.sub
+    exec.u32assert4
+    movup.3
+    movup.2
+    u32sub.unsafe
+    movup.3
+    movup.3
+    u32sub.unsafe
+    eq.0
+    assert
+    swap
+    u32sub.unsafe
+    eq.0
+    assert
 end
 
 # ===== MULTIPLICATION ========================================================================== #
@@ -9970,6 +10006,44 @@ export.mul_unsafe
     drop
 end
 
+# Performs multiplication of two unsigned 64 bit integers preserving the overflow. #
+# The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_mid_hi, c_mid_lo, c_lo, ...], where c = (a * b) % 2^64 #
+export.overflowing_mul
+    dup.3
+    dup.2
+    u32mul.unsafe
+    dup.4
+    movup.4
+    u32madd.unsafe
+    swap
+    movup.5
+    dup.4
+    u32madd.unsafe
+    movup.5
+    movup.5
+    u32madd.unsafe
+    movup.3
+    movup.2
+    u32add.unsafe
+    movup.2
+    u32add.unsafe
+    drop
+end
+
+# Performs multiplication of two unsigned 64 bit integers, fails when overflowing. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64 #
+export.mul
+    exec.u32assert4
+    exec.overflowing_mul
+    u32or
+    eq.0
+    assert
+end
+
 # ===== COMPARISONS ============================================================================= #
 
 # Performs less-than comparison of two unsigned 64 bit integers. #
@@ -9990,6 +10064,15 @@ export.lt_unsafe
     or
 end
 
+# Performs less-than comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise. #
+export.lt
+    exec.u32assert4
+    exec.lt_unsafe
+end
+
 # Performs greater-than comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
@@ -10008,6 +10091,15 @@ export.gt_unsafe
     or
 end
 
+# Performs greater-than comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise. #
+export.gt
+    exec.u32assert4
+    exec.gt_unsafe
+end
+
 # Performs less-than-or-equal comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
@@ -10017,11 +10109,31 @@ export.lte_unsafe
     not
 end
 
+# Performs less-than-or-equal comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise. #
+export.lte
+    exec.u32assert4
+    exec.gt_unsafe
+    not
+end
+
 # Performs greater-than-or-equal comparison of two unsigned 64 bit integers. #
 # The input values are assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise. #
 export.gte_unsafe
+    exec.lt_unsafe
+    not
+end
+
+# Performs greater-than-or-equal comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise. #
+export.gte
+    exec.u32assert4
     exec.lt_unsafe
     not
 end
@@ -10039,11 +10151,35 @@ export.eq_unsafe
     and
 end
 
+# Performs equality comparison of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if they are not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise. #
+export.eq
+    exec.u32assert4
+    exec.eq_unsafe
+end
+
 # Performs comparison to zero of an unsigned 64 bit integer. #
 # The input value is assumed to be represented using 32 bit limbs, but this is not checked. #
 # Stack transition looks as follows: #
 # [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise. #
 export.eqz_unsafe
+    u32eq.0
+    swap
+    u32eq.0
+    and
+end
+
+# Performs comparison to zero of an unsigned 64 bit integer. #
+# The input value is assumed to be represented using 32 bit limbs, fails if it is not. #
+# Stack transition looks as follows: #
+# [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise. #
+export.eqz
+    u32assert
+    swap
+    u32assert
+    swap
     u32eq.0
     swap
     u32eq.0
@@ -10110,6 +10246,15 @@ export.div_unsafe
     assert.eq           # quotient remains on the stack #
 end
 
+# Performs division of two unsigned 64 bit integers discarding the remainder. #
+# The input values are assumed to be represented using 32 bit limbs, fails if it is not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b #
+export.div
+    exec.u32assert4
+    exec.div_unsafe
+end
+
 # ===== MODULO OPERATION ================================================================================ #
 
 # Performs modulo operation of two unsigned 64 bit integers. #
@@ -10168,6 +10313,15 @@ export.mod_unsafe
     assert.eq
     movup.3
     assert.eq           # remainder remains on the stack #
+end
+
+# Performs modulo operation of two unsigned 64 bit integers. #
+# The input values are assumed to be represented using 32 bit limbs, fails if it is not. #
+# Stack transition looks as follows: #
+# [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b #
+export.mod
+    exec.u32assert4
+    exec.mod_unsafe
 end
 
 # ===== BITWISE OPERATIONS ====================================================================== #
@@ -10339,5 +10493,6 @@ export.rotr
     not
     cswap
 end
+
 "),
 ];


### PR DESCRIPTION
1. Implementation of safe versions of u64 `add`, `sub`, `mul`, `div`, `mod`, `eq`, `eqz`, `lt`, `lte`, `gt`, `gte`. 
2. Renaming of arithmetic operations according to the Rust convention:
unsafe -> wrapping
safe -> checked
3. Adding an overflowing version for `add`, `sub` and `mul` procedures.
4. implementation of `divmod` procedure.
