### PR TITLE
Add mdbook github action

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,32 @@
+name: miden book
+
+on:
+  push:
+    branches:
+      - main
+      - next
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: 'latest'
+
+      - name: Build miden book
+        run: mdbook build docs/
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book


### PR DESCRIPTION
Add github action that automatically pushes doc changes into github page on both pushes to next and master branch

Example running
https://github.com/tnachen/miden/runs/5749281007?check_suite_focus=true