### PR TITLE
feat: add range checker constraints (excluding permutation checks)

### DIFF
--- a/air/src/range.rs
+++ b/air/src/range.rs
@@ -1,0 +1,75 @@
+use vm_core::RANGE_CHECK_TRACE_OFFSET;
+
+use super::{
+    utils::is_binary, Assertion, EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree,
+};
+
+// CONSTANTS
+// ================================================================================================
+
+pub const T_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET;
+pub const S0_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 1;
+pub const S1_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 2;
+pub const V_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 3;
+
+// CONSTRAINT DEGREES
+// ================================================================================================
+
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    vec![
+        // Selector flags must be binary: t, s0, s1
+        TransitionConstraintDegree::new(2),
+        TransitionConstraintDegree::new(2),
+        TransitionConstraintDegree::new(2),
+        // Constrain the row transitions in the 8-bit section of the table.
+        TransitionConstraintDegree::new(3),
+        // Transition from 8-bit to 16-bit section of range check table occurs at most once.
+        TransitionConstraintDegree::new(2),
+        // Enforce values of column v before and after 8-bit to 16-bit transition.
+        TransitionConstraintDegree::new(3),
+        TransitionConstraintDegree::new(3),
+    ]
+}
+
+// BOUNDARY CONSTRAINTS
+// ================================================================================================
+
+pub fn get_assertions_first_step(result: &mut Vec<Assertion<Felt>>) {
+    result.push(Assertion::single(V_COL_IDX, 0, Felt::ZERO));
+}
+
+pub fn get_assertions_last_step(result: &mut Vec<Assertion<Felt>>, step: usize) {
+    result.push(Assertion::single(V_COL_IDX, step, Felt::new(65535)));
+}
+
+// TRANSITION CONSTRAINTS
+// ================================================================================================
+
+pub fn enforce_constraints<E: FieldElement<BaseField = Felt>>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+) {
+    let current = frame.current();
+    let next = frame.next();
+
+    // --- Constrain the selector flags. ----------------------------------------------------------
+    result[0] = is_binary(current[T_COL_IDX]);
+    result[1] = is_binary(current[S0_COL_IDX]);
+    result[2] = is_binary(current[S1_COL_IDX]);
+
+    // --- Constrain the row transitions in the 8-bit section of the table. -----------------------
+    let row_diff = next[V_COL_IDX] - current[V_COL_IDX];
+    result[3] = (E::ONE - next[T_COL_IDX]) * (row_diff) * (row_diff - E::ONE);
+
+    // --- Constrain the transition from 8-bit to 16-bit section of the table. --------------------
+    let flip = (E::ONE - current[T_COL_IDX]) * next[T_COL_IDX];
+
+    // Values in column t can "flip" from 0 to 1 only once.
+    result[4] = current[T_COL_IDX] * (E::ONE - next[T_COL_IDX]);
+
+    // When column t "flips", column v must equal 255.
+    result[5] = flip * (current[V_COL_IDX] - E::from(255_u8));
+
+    // When column t "flips", the next value column v must be reset to 0.
+    result[6] = flip * next[V_COL_IDX];
+}

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -1,0 +1,9 @@
+use super::FieldElement;
+
+// BASIC CONSTRAINT OPERATORS
+// ================================================================================================
+
+#[inline(always)]
+pub fn is_binary<E: FieldElement>(v: E) -> E {
+    v.square() - v
+}

--- a/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -287,7 +287,7 @@ fn u32shl_unsafe() {
     let a = rand_value::<u64>() as u32;
     let b = (rand_value::<u64>() % 32) as u32;
     let c = a.wrapping_shl(b);
-    let d = a.wrapping_shr(32 - b);
+    let d = if b == 0 { 0 } else { a.wrapping_shr(32 - b) };
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[d as u64, c as u64]);
@@ -416,7 +416,7 @@ fn u32shr_unsafe() {
     let a = rand_value::<u64>() as u32;
     let b = (rand_value::<u64>() % 32) as u32;
     let c = a.wrapping_shr(b);
-    let d = a.wrapping_shl(32 - b);
+    let d = if b == 0 { 0 } else { a.wrapping_shl(32 - b) };
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[d as u64, c as u64]);


### PR DESCRIPTION
This is a simple initial implementation of the range checker constraints, excluding the constraints for the running product columns used for permutation checks.

There are no tests yet, since I expect that we'll design a system for testing constraints in a separate issue. Additionally, we will likely need to include the number of range checker transition constraints in the ProcessorAir for use when enforcing constraints of other components, but I left this to be done alongside future constraints, since the overall handling of constraints will likely change.