### PR TITLE
Update Winterfell dependencies to v0.4

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/maticnetwork/miden"
 categories = ["cryptography", "no-std"]
 keywords = ["air", "arithmetization", "crypto", "miden"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -17,9 +17,8 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["vm-core/std", "winter-air/std", "winter-utils/std"]
+std = ["vm-core/std", "winter-air/std"]
 
 [dependencies]
 vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
-winter-air = { package = "winter-air", version = "0.3", default-features = false }
-winter-utils = { package = "winter-utils", version = "0.3", default-features = false }
+winter-air = { package = "winter-air", version = "0.4", default-features = false }

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -1,9 +1,12 @@
-use vm_core::{hasher::Digest, CLK_COL_IDX, FMP_COL_IDX, MIN_STACK_DEPTH, STACK_TRACE_OFFSET};
+use vm_core::{
+    hasher::Digest,
+    utils::{ByteWriter, Serializable},
+    CLK_COL_IDX, FMP_COL_IDX, MIN_STACK_DEPTH, STACK_TRACE_OFFSET,
+};
 use winter_air::{
     Air, AirContext, Assertion, EvaluationFrame, ProofOptions as WinterProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
-use winter_utils::{ByteWriter, Serializable};
 
 mod options;
 mod range;
@@ -38,8 +41,14 @@ impl Air for ProcessorAir {
         // Add the range checker's constraint degrees.
         degrees.append(&mut range::get_transition_constraint_degrees());
 
+        // TODO: determine dynamically
+        let num_assertions = 2
+            + pub_inputs.stack_inputs.len()
+            + pub_inputs.stack_outputs.len()
+            + range::NUM_ASSERTIONS;
+
         Self {
-            context: AirContext::new(trace_info, degrees, options),
+            context: AirContext::new(trace_info, degrees, num_assertions, options),
             stack_inputs: pub_inputs.stack_inputs,
             stack_outputs: pub_inputs.stack_outputs,
         }

--- a/air/src/range.rs
+++ b/air/src/range.rs
@@ -12,6 +12,8 @@ pub const S0_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 1;
 pub const S1_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 2;
 pub const V_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 3;
 
+pub const NUM_ASSERTIONS: usize = 2;
+
 // CONSTRAINT DEGREES
 // ================================================================================================
 

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/maticnetwork/miden"
 categories = ["compilers", "no-std"]
 keywords = ["assembler", "assembly", "language", "miden"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -17,9 +17,8 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["vm-core/std", "winter-utils/std"]
+std = ["vm-core/std"]
 
 [dependencies]
 vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
 vm-stdlib = { package = "miden-stdlib", path = "../stdlib", version = "0.1", default-features = false }
-winter-utils = { package = "winter-utils", version = "0.3", default-features = false }

--- a/assembly/src/context/mod.rs
+++ b/assembly/src/context/mod.rs
@@ -1,5 +1,5 @@
 use super::{CodeBlock, ProcMap, Procedure, MODULE_PATH_DELIM};
-use winter_utils::collections::BTreeMap;
+use vm_core::utils::collections::BTreeMap;
 
 // ASSEMBLY CONTEXT
 // ================================================================================================

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -1,6 +1,8 @@
-use vm_core::program::{blocks::CodeBlock, Library, Script};
+use vm_core::{
+    program::{blocks::CodeBlock, Library, Script},
+    utils::collections::BTreeMap,
+};
 use vm_stdlib::StdLibrary;
-use winter_utils::collections::BTreeMap;
 
 mod context;
 use context::AssemblyContext;

--- a/assembly/src/parsers/blocks.rs
+++ b/assembly/src/parsers/blocks.rs
@@ -1,7 +1,7 @@
 use super::{
     parse_op_token, AssemblyContext, AssemblyError, CodeBlock, Operation, Token, TokenStream,
 };
-use winter_utils::{collections::Vec, group_vector_elements};
+use vm_core::utils::{collections::Vec, group_vector_elements};
 
 // BLOCK PARSER
 // ================================================================================================

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/maticnetwork/miden"
 categories = ["emulators", "no-std"]
 keywords = ["instruction-set", "miden", "program"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -20,6 +20,6 @@ default = ["std"]
 std = ["math/std", "winter-utils/std"]
 
 [dependencies]
-crypto = { package = "winter-crypto", version = "0.3.2", default-features = false }
-math = { package = "winter-math", version = "0.3", default-features = false }
-winter-utils = { package = "winter-utils", version = "0.3", default-features = false }
+crypto = { package = "winter-crypto", version = "0.4", default-features = false }
+math = { package = "winter-math", version = "0.4", default-features = false }
+winter-utils = { package = "winter-utils", version = "0.4", default-features = false }

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -1,6 +1,14 @@
 use super::{Felt, StarkField};
 use core::ops::Range;
 
+// RE-EXPORTS
+// ================================================================================================
+
+pub use winter_utils::{
+    collections, group_vector_elements, uninit_vector, ByteReader, ByteWriter, Deserializable,
+    DeserializationError, Serializable, SliceReader,
+};
+
 // TO ELEMENTS
 // ================================================================================================
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "MIT"
 repository = "https://github.com/maticnetwork/miden"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -31,4 +31,4 @@ log = { version = "0.4", default-features = false }
 miden = { path = "../miden", version = "0.2", default-features = false }
 structopt = { version = "0.3", default-features = false }
 vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
-rand-utils = { package = "winter-rand-utils", version = "0.3", optional = true }
+rand-utils = { package = "winter-rand-utils", version = "0.4", optional = true }

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/maticnetwork/miden"
 categories = ["cryptography", "emulators", "no-std"]
 keywords = ["miden", "stark", "virtual-machine", "zkp"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 name = "miden"
@@ -26,7 +26,7 @@ std = ["air/std", "assembly/std", "hex/std", "processor/std", "prover/std", "ver
 air = { package = "miden-air", path = "../air", version = "0.2", default-features = false }
 assembly = { package = "miden-assembly", path = "../assembly", version = "0.2", default-features = false }
 processor = { package = "miden-processor", path = "../processor", version = "0.2", default-features = false }
-prover = { package = "winter-prover", version = "0.3", default-features = false }
+prover = { package = "winter-prover", version = "0.4", default-features = false }
 hex = { version = "0.4", optional = true }
 log = { version = "0.4", default-features = false }
 verifier = { package = "miden-verifier", path = "../verifier", version = "0.2", default-features = false }
@@ -36,6 +36,6 @@ vm-core = { package = "miden-core", path = "../core", version = "0.2", default-f
 blake3 = "1.3.1"
 num-bigint = "0.4"
 proptest = "1.0.0"
-rand-utils = { package = "winter-rand-utils", version = "0.3" }
+rand-utils = { package = "winter-rand-utils", version = "0.4" }
 sha2 = "0.10.2"
 sha3 = "0.10.1"

--- a/miden/src/lib.rs
+++ b/miden/src/lib.rs
@@ -50,7 +50,7 @@ pub fn execute(
     #[cfg(feature = "std")]
     debug!(
         "Generated execution trace of {} columns and {} steps in {} ms",
-        trace.width(),
+        trace.layout().main_trace_width(),
         trace.length(),
         now.elapsed().as_millis()
     );

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/maticnetwork/miden"
 categories = ["emulators", "no-std"]
 keywords = ["miden", "virtual-machine"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -17,14 +17,13 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["vm-core/std", "winterfell/std", "winter-utils/std"]
+std = ["vm-core/std", "winterfell/std"]
 
 [dependencies]
 log = "0.4.14"
 vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
-winterfell = { package = "winter-prover", version = "0.3", default-features = false }
-winter-utils = { package = "winter-utils", version = "0.3", default-features = false  }
+winterfell = { package = "winter-prover", version = "0.4", default-features = false }
 
 [dev-dependencies]
 logtest = { version = "2.0.0", default-features = false  }
-rand-utils = { package = "winter-rand-utils", version = "0.3" }
+rand-utils = { package = "winter-rand-utils", version = "0.4" }

--- a/processor/src/advice/mod.rs
+++ b/processor/src/advice/mod.rs
@@ -1,6 +1,11 @@
 use super::{ExecutionError, Felt, ProgramInputs, Word};
-use vm_core::{utils::IntoBytes, AdviceSet, StarkField};
-use winter_utils::collections::{BTreeMap, Vec};
+use vm_core::{
+    utils::{
+        collections::{BTreeMap, Vec},
+        IntoBytes,
+    },
+    AdviceSet, StarkField,
+};
 
 // ADVICE PROVIDER
 // ================================================================================================

--- a/processor/src/memory/mod.rs
+++ b/processor/src/memory/mod.rs
@@ -1,6 +1,6 @@
 use super::{Felt, FieldElement, StarkField, TraceFragment, Word};
 use core::ops::RangeInclusive;
-use winter_utils::collections::BTreeMap;
+use vm_core::utils::collections::BTreeMap;
 
 #[cfg(test)]
 mod tests;

--- a/processor/src/range/mod.rs
+++ b/processor/src/range/mod.rs
@@ -1,5 +1,5 @@
 use super::{Felt, FieldElement};
-use winter_utils::{collections::BTreeMap, uninit_vector};
+use vm_core::utils::{collections::BTreeMap, uninit_vector};
 
 #[cfg(test)]
 mod tests;

--- a/processor/src/stack/overflow.rs
+++ b/processor/src/stack/overflow.rs
@@ -1,5 +1,5 @@
 use super::{Felt, FieldElement};
-use winter_utils::collections::BTreeMap;
+use vm_core::utils::collections::BTreeMap;
 
 // OVERFLOW TABLE
 // ================================================================================================

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -3,12 +3,9 @@ use super::{
     StackTrace, SysTrace,
 };
 use core::slice;
-use vm_core::{
-    StarkField, AUX_TRACE_OFFSET, AUX_TRACE_RANGE, MIN_STACK_DEPTH, RANGE_CHECK_TRACE_OFFSET,
-    RANGE_CHECK_TRACE_RANGE, STACK_TRACE_OFFSET, STACK_TRACE_RANGE, SYS_TRACE_OFFSET,
-    SYS_TRACE_RANGE, TRACE_WIDTH,
-};
+use vm_core::{StarkField, MIN_STACK_DEPTH, STACK_TRACE_OFFSET, TRACE_WIDTH};
 use winterfell::Trace;
+use winterfell::{EvaluationFrame, Matrix, TraceLayout};
 
 // VM EXECUTION TRACE
 // ================================================================================================
@@ -17,10 +14,8 @@ use winterfell::Trace;
 /// auxiliary table trace, but will also need to include the decoder trace.
 pub struct ExecutionTrace {
     meta: Vec<u8>,
-    system: SysTrace,
-    stack: StackTrace,
-    range: RangeCheckTrace,
-    aux_table: AuxTableTrace,
+    layout: TraceLayout,
+    main_trace: Matrix<Felt>,
     // TODO: program hash should be retrieved from decoder trace, but for now we store it explicitly
     program_hash: Digest,
 }
@@ -31,14 +26,19 @@ impl ExecutionTrace {
     /// Builds an execution trace for the provided process.
     pub(super) fn new(process: Process, program_hash: Digest) -> Self {
         let (system_trace, stack_trace, range_check_trace, aux_table_trace) =
-            Self::finalize_trace(process);
+            finalize_trace(process);
+
+        let main_trace = system_trace
+            .into_iter()
+            .chain(stack_trace)
+            .chain(range_check_trace)
+            .chain(aux_table_trace)
+            .collect::<Vec<_>>();
 
         Self {
             meta: Vec::new(),
-            system: system_trace,
-            stack: stack_trace,
-            range: range_check_trace,
-            aux_table: aux_table_trace,
+            layout: TraceLayout::new(TRACE_WIDTH, [0], [0]),
+            main_trace: Matrix::new(main_trace),
             program_hash,
         }
     }
@@ -52,95 +52,33 @@ impl ExecutionTrace {
         self.program_hash
     }
 
-    pub fn aux_table(&self) -> &AuxTableTrace {
-        &self.aux_table
-    }
-
-    pub fn stack(&self) -> &StackTrace {
-        &self.stack
-    }
-
-    /// TODO: add docs
+    /// Returns the initial state of the top 16 stack registers.
     pub fn init_stack_state(&self) -> StackTopState {
         let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
-        for (result, column) in result.iter_mut().zip(self.stack.iter()) {
-            *result = column[0];
+        for (i, result) in result.iter_mut().enumerate() {
+            *result = self.main_trace.get_column(i + STACK_TRACE_OFFSET)[0];
         }
         result
     }
 
-    /// TODO: add docs
+    /// Returns the final state of the top 16 stack registers.
     pub fn last_stack_state(&self) -> StackTopState {
         let last_step = self.length() - 1;
         let mut result = [Felt::ZERO; MIN_STACK_DEPTH];
-        for (result, column) in result.iter_mut().zip(self.stack.iter()) {
-            *result = column[last_step];
+        for (i, result) in result.iter_mut().enumerate() {
+            *result = self.main_trace.get_column(i + STACK_TRACE_OFFSET)[last_step];
         }
         result
     }
 
-    // HELPER FUNCTIONS
-    // ================================================================================================
-
-    fn finalize_trace(process: Process) -> (SysTrace, StackTrace, RangeCheckTrace, AuxTableTrace) {
-        let Process {
-            system,
-            decoder: _,
-            stack,
-            range,
-            hasher,
-            bitwise,
-            memory,
-            advice: _,
-        } = process;
-
-        // Get the trace length required to hold all execution trace steps.
-        let aux_trace_len = hasher.trace_len() + bitwise.trace_len() + memory.trace_len();
-        let trace_len = vec![stack.trace_len(), range.trace_len(), aux_trace_len]
-            .iter()
-            .max()
-            .expect("failed to get max of component trace lengths")
-            .next_power_of_two();
-
-        // Finalize the system trace.
-        let step = system.clk();
-        let mut system_trace = system.into_trace();
-        finalize_clk_column(&mut system_trace[0], step, trace_len);
-        finalize_column(&mut system_trace[1], step, trace_len);
-
-        // Finalize stack trace.
-        let mut stack_trace = stack.into_trace();
-        for column in stack_trace.iter_mut() {
-            finalize_column(column, step, trace_len);
-        }
-
-        // Finalize the range check trace.
-        let range_check_trace: RangeCheckTrace = range
-            .into_trace(trace_len)
-            .try_into()
-            .expect("failed to convert vector to array");
-
-        // Finalize the auxilliary table trace.
-        let mut aux_table = AuxTable::new(trace_len);
-        aux_table.fill_columns(hasher, bitwise, memory);
-        let aux_table_trace = aux_table.into_trace();
-
-        (
-            system_trace,
-            stack_trace,
-            range_check_trace,
-            aux_table_trace,
-        )
-    }
-
-    // ACCESSORS FOR TESTING
+    // TEST HELPERS
     // --------------------------------------------------------------------------------------------
 
     #[allow(dead_code)]
     pub fn print(&self) {
         let mut row = [Felt::ZERO; TRACE_WIDTH];
         for i in 0..self.length() {
-            self.read_row_into(i, &mut row);
+            self.main_trace.read_row_into(i, &mut row);
             println!("{:?}", row.iter().map(|v| v.as_int()).collect::<Vec<_>>());
         }
     }
@@ -149,7 +87,7 @@ impl ExecutionTrace {
     pub fn test_finalize_trace(
         process: Process,
     ) -> (SysTrace, StackTrace, RangeCheckTrace, AuxTableTrace) {
-        Self::finalize_trace(process)
+        finalize_trace(process)
     }
 }
 
@@ -159,54 +97,36 @@ impl ExecutionTrace {
 impl Trace for ExecutionTrace {
     type BaseField = Felt;
 
-    fn width(&self) -> usize {
-        TRACE_WIDTH
+    fn layout(&self) -> &TraceLayout {
+        &self.layout
     }
 
     fn length(&self) -> usize {
-        self.system[0].len()
-    }
-
-    fn get(&self, col_idx: usize, row_idx: usize) -> Felt {
-        match col_idx {
-            i if SYS_TRACE_RANGE.contains(&i) => self.system[i - SYS_TRACE_OFFSET][row_idx],
-            i if STACK_TRACE_RANGE.contains(&i) => self.stack[i - STACK_TRACE_OFFSET][row_idx],
-            i if RANGE_CHECK_TRACE_RANGE.contains(&i) => {
-                self.range[i - RANGE_CHECK_TRACE_OFFSET][row_idx]
-            }
-            i if AUX_TRACE_RANGE.contains(&i) => self.aux_table[i - AUX_TRACE_OFFSET][row_idx],
-            _ => panic!("invalid column index"),
-        }
+        self.main_trace.num_rows()
     }
 
     fn meta(&self) -> &[u8] {
         &self.meta
     }
 
-    fn read_row_into(&self, step: usize, target: &mut [Felt]) {
-        for (i, column) in self.system.iter().enumerate() {
-            target[i + SYS_TRACE_OFFSET] = column[step];
-        }
-
-        for (i, column) in self.stack.iter().enumerate() {
-            target[i + STACK_TRACE_OFFSET] = column[step];
-        }
-
-        for (i, column) in self.range.iter().enumerate() {
-            target[i + RANGE_CHECK_TRACE_OFFSET] = column[step];
-        }
-
-        for (i, column) in self.aux_table.iter().enumerate() {
-            target[i + AUX_TRACE_OFFSET] = column[step];
-        }
+    fn main_segment(&self) -> &Matrix<Felt> {
+        &self.main_trace
     }
 
-    fn into_columns(self) -> Vec<Vec<Felt>> {
-        let mut result: Vec<Vec<Felt>> = self.system.into();
-        self.stack.into_iter().for_each(|v| result.push(v));
-        self.range.into_iter().for_each(|v| result.push(v));
-        self.aux_table.into_iter().for_each(|v| result.push(v));
-        result
+    fn build_aux_segment<E: FieldElement<BaseField = Felt>>(
+        &mut self,
+        _aux_segments: &[Matrix<E>],
+        _rand_elements: &[E],
+    ) -> Option<Matrix<E>> {
+        // TODO: implement
+        unimplemented!()
+    }
+
+    fn read_main_frame(&self, row_idx: usize, frame: &mut EvaluationFrame<Felt>) {
+        let next_row_idx = (row_idx + 1) % self.length();
+        self.main_trace.read_row_into(row_idx, frame.current_mut());
+        self.main_trace
+            .read_row_into(next_row_idx, frame.next_mut());
     }
 }
 
@@ -277,6 +197,57 @@ impl<'a> TraceFragment<'a> {
 
 // HELPER FUNCTIONS
 // ================================================================================================
+
+fn finalize_trace(process: Process) -> (SysTrace, StackTrace, RangeCheckTrace, AuxTableTrace) {
+    let Process {
+        system,
+        decoder: _,
+        stack,
+        range,
+        hasher,
+        bitwise,
+        memory,
+        advice: _,
+    } = process;
+
+    // Get the trace length required to hold all execution trace steps.
+    let aux_trace_len = hasher.trace_len() + bitwise.trace_len() + memory.trace_len();
+    let trace_len = vec![stack.trace_len(), range.trace_len(), aux_trace_len]
+        .iter()
+        .max()
+        .expect("failed to get max of component trace lengths")
+        .next_power_of_two();
+
+    // Finalize the system trace.
+    let step = system.clk();
+    let mut system_trace = system.into_trace();
+    finalize_clk_column(&mut system_trace[0], step, trace_len);
+    finalize_column(&mut system_trace[1], step, trace_len);
+
+    // Finalize stack trace.
+    let mut stack_trace = stack.into_trace();
+    for column in stack_trace.iter_mut() {
+        finalize_column(column, step, trace_len);
+    }
+
+    // Finalize the range check trace.
+    let range_check_trace: RangeCheckTrace = range
+        .into_trace(trace_len)
+        .try_into()
+        .expect("failed to convert vector to array");
+
+    // Finalize the auxilliary table trace.
+    let mut aux_table = AuxTable::new(trace_len);
+    aux_table.fill_columns(hasher, bitwise, memory);
+    let aux_table_trace = aux_table.into_trace();
+
+    (
+        system_trace,
+        stack_trace,
+        range_check_trace,
+        aux_table_trace,
+    )
+}
 
 /// Copies the final output value down to the end of the stack trace, then extends the column to
 /// the length of the execution trace, if it's longer than the stack trace, and copies the last

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/maticnetwork/miden"
 categories = ["cryptography", "mathematics"]
 keywords = ["miden", "program", "stdlib"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -17,4 +17,3 @@ doctest = false
 
 [dependencies]
 vm-core = { package = "miden-core", path = "../core", version = "0.2" }
-winter-utils = { package = "winter-utils", version = "0.3" }

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -1,5 +1,4 @@
-use vm_core::{errors::LibraryError, program::Library};
-use winter_utils::collections::BTreeMap;
+use vm_core::{errors::LibraryError, program::Library, utils::collections::BTreeMap};
 
 mod asm;
 use asm::MODULES;

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/maticnetwork/miden"
 categories = ["cryptography", "no-std"]
 keywords = ["miden", "stark", "verifier", "zkp"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.60"
 
 [lib]
 bench = false
@@ -23,4 +23,4 @@ std = ["air/std", "assembly/std", "winterfell/std"]
 air = { package = "miden-air", path = "../air", version = "0.2", default-features = false }
 assembly = { package = "miden-assembly", path = "../assembly", version = "0.2", default-features = false }
 vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
-winterfell = { package = "winter-verifier", version = "0.3", default-features = false }
+winterfell = { package = "winter-verifier", version = "0.4", default-features = false }


### PR DESCRIPTION
This PR updated Winterfell dependencies to v0.4. This includes refactoring of the `ExecutionTrace` struct to comply with the new `Trace` interface and bumping up min Rust version to 1.6.