### PR TITLE
Random element injection into last trace row

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -54,8 +54,13 @@ impl Air for ProcessorAir {
             + pub_inputs.stack_outputs.len()
             + range::NUM_ASSERTIONS;
 
+        // create the context and set the number of transition constraint exemptions to two; this
+        // allows us to inject random values into the last row of the execution trace
+        let context = AirContext::new(trace_info, degrees, num_assertions, options)
+            .set_num_transition_exemptions(2);
+
         Self {
-            context: AirContext::new(trace_info, degrees, num_assertions, options),
+            context,
             stack_inputs: pub_inputs.stack_inputs,
             stack_outputs: pub_inputs.stack_outputs,
         }

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -29,6 +29,13 @@ pub struct ProcessorAir {
     stack_outputs: Vec<Felt>,
 }
 
+impl ProcessorAir {
+    /// Returns last step of the execution trace.
+    pub fn last_step(&self) -> usize {
+        self.trace_length() - self.context().num_transition_exemptions()
+    }
+}
+
 impl Air for ProcessorAir {
     type BaseField = Felt;
     type PublicInputs = PublicInputs;
@@ -75,7 +82,7 @@ impl Air for ProcessorAir {
         range::get_assertions_first_step(&mut result);
 
         // --- set assertions for the last step ---------------------------------------------------
-        let last_step = self.trace_length() - 1;
+        let last_step = self.last_step();
 
         // stack columns at the last step should be set to stack outputs
         for (i, &value) in self.stack_outputs.iter().enumerate() {

--- a/core/src/hasher/mod.rs
+++ b/core/src/hasher/mod.rs
@@ -1,7 +1,9 @@
 //! TODO: add docs
 
 use super::Felt;
-use crypto::{hashers::Rp64_256, ElementHasher, Hasher};
+use crypto::{ElementHasher, Hasher as HashFn};
+
+pub use crypto::hashers::Rp64_256 as Hasher;
 
 // TYPES ALIASES
 // ================================================================================================
@@ -9,7 +11,7 @@ use crypto::{hashers::Rp64_256, ElementHasher, Hasher};
 /// Output type of Rescue Prime hash function.
 ///
 /// The digest consists of 4 field elements or 32 bytes.
-pub type Digest = <Rp64_256 as Hasher>::Digest;
+pub type Digest = <Hasher as HashFn>::Digest;
 
 // CONSTANTS
 // ================================================================================================
@@ -19,12 +21,12 @@ pub type Digest = <Rp64_256 as Hasher>::Digest;
 /// This value is set to 12: 8 elements are reserved for rate and the remaining 4 elements are
 /// reserved for capacity. This configuration enables computation of 2-to-1 hash in a single
 /// permutation.
-pub const STATE_WIDTH: usize = Rp64_256::STATE_WIDTH;
+pub const STATE_WIDTH: usize = Hasher::STATE_WIDTH;
 
 /// Number of needed to complete a single permutation.
 ///
 /// This value is set to 7 to target 128-bit security level with 40% security margin.
-pub const NUM_ROUNDS: usize = Rp64_256::NUM_ROUNDS;
+pub const NUM_ROUNDS: usize = Hasher::NUM_ROUNDS;
 
 // PASS-THROUGH FUNCTIONS
 // ================================================================================================
@@ -32,13 +34,13 @@ pub const NUM_ROUNDS: usize = Rp64_256::NUM_ROUNDS;
 /// Returns a hash of two digests. This method is intended for use in construction of Merkle trees.
 #[inline(always)]
 pub fn merge(values: &[Digest; 2]) -> Digest {
-    Rp64_256::merge(values)
+    Hasher::merge(values)
 }
 
 /// Returns a hash of the provided list of field elements.
 #[inline(always)]
 pub fn hash_elements(elements: &[Felt]) -> Digest {
-    Rp64_256::hash_elements(elements)
+    Hasher::hash_elements(elements)
 }
 
 /// Applies Rescue-XLIX round function to the provided state.
@@ -48,11 +50,11 @@ pub fn hash_elements(elements: &[Felt]) -> Digest {
 /// inclusive).
 #[inline(always)]
 pub fn apply_round(state: &mut [Felt; STATE_WIDTH], round: usize) {
-    Rp64_256::apply_round(state, round)
+    Hasher::apply_round(state, round)
 }
 
 /// Applies Rescue-XLIX permutation (7 rounds) to the provided state.
 #[inline(always)]
 pub fn apply_permutation(state: &mut [Felt; STATE_WIDTH]) {
-    Rp64_256::apply_permutation(state)
+    Hasher::apply_permutation(state)
 }

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -9,6 +9,8 @@ pub use winter_utils::{
     DeserializationError, Serializable, SliceReader,
 };
 
+pub use crypto::{RandomCoin, RandomCoinError};
+
 // TO ELEMENTS
 // ================================================================================================
 

--- a/processor/src/aux_table/mod.rs
+++ b/processor/src/aux_table/mod.rs
@@ -42,46 +42,55 @@ mod tests;
 /// - columns 3-17: unused columns padded with ZERO
 ///
 pub struct AuxTable {
-    trace: AuxTableTrace,
+    hasher: Hasher,
+    bitwise: Bitwise,
+    memory: Memory,
 }
 
 impl AuxTable {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
-
-    /// Returns an [AuxTable] initialized with its co-processor components and an empty trace.
-    pub fn new(target_length: usize) -> Self {
-        // Allocate columns for the trace of the auxiliary table.
-        // note: it may be possible to optimize this by initializing with Felt::zeroed_vector,
-        // depending on how the compiler reduces Felt(0) and whether initializing here + iterating
-        // to update selector values is faster than using resize to initialize all values
-        let trace = (0..AUX_TRACE_WIDTH)
-            .map(|_| Vec::<Felt>::with_capacity(target_length))
-            .collect::<Vec<_>>()
-            .try_into()
-            .expect("failed to convert vector to array");
-
-        Self { trace }
+    /// Returns an [AuxTable] initialized with its co-processor components.
+    pub fn new(hasher: Hasher, bitwise: Bitwise, memory: Memory) -> Self {
+        Self {
+            hasher,
+            bitwise,
+            memory,
+        }
     }
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns an execution trace of the auxiliary table containing the stacked traces of the
-    /// Hasher, Bitwise, and Memory coprocessors.
-    pub fn into_trace(self) -> AuxTableTrace {
-        self.trace
+    pub fn trace_len(&self) -> usize {
+        self.hasher.trace_len() + self.bitwise.trace_len() + self.memory.trace_len()
     }
 
-    // TRACE MUTATORS
+    /// Returns an execution trace of the auxiliary table containing the stacked traces of the
+    /// Hasher, Bitwise, and Memory coprocessors.
+    pub fn into_trace(self, trace_len: usize) -> AuxTableTrace {
+        // Allocate columns for the trace of the auxiliary table.
+        // note: it may be possible to optimize this by initializing with Felt::zeroed_vector,
+        // depending on how the compiler reduces Felt(0) and whether initializing here + iterating
+        // to update selector values is faster than using resize to initialize all values
+        let mut trace: AuxTableTrace = (0..AUX_TRACE_WIDTH)
+            .map(|_| Vec::<Felt>::with_capacity(trace_len))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("failed to convert vector to array");
+
+        self.fill_trace(&mut trace, trace_len);
+
+        trace
+    }
+
+    // HELPER METHODS
     // --------------------------------------------------------------------------------------------
 
     /// Fills the provided auxiliary table trace with the stacked execution traces of the Hasher,
     /// Bitwise, and Memory coprocessors, along with selector columns to identify each coprocessor
     /// trace and padding to fill the rest of the table.
-    pub fn fill_columns(&mut self, hasher: Hasher, bitwise: Bitwise, memory: Memory) {
-        let trace_len = self.trace[0].capacity();
-
+    fn fill_trace(self, trace: &mut AuxTableTrace, trace_len: usize) {
         // allocate fragments to be filled with the respective execution traces of each coprocessor
         let mut hasher_fragment = TraceFragment::new(AUX_TRACE_WIDTH);
         let mut bitwise_fragment = TraceFragment::new(AUX_TRACE_WIDTH);
@@ -90,72 +99,77 @@ impl AuxTable {
         // set the selectors and padding as required by each column and segment
         // and add the hasher, bitwise, and memory segments to their respective fragments
         // so they can be filled with the coprocessor traces
-        for (column_num, column) in self.trace.iter_mut().enumerate() {
+        for (column_num, column) in trace.iter_mut().enumerate() {
             match column_num {
                 0 => {
                     // set the selector value for the hasher segment to ZERO
-                    column.resize(hasher.trace_len(), Felt::ZERO);
+                    column.resize(self.hasher.trace_len(), Felt::ZERO);
                     // set the selector value for all other segments ONE
                     column.resize(trace_len, Felt::ONE);
                 }
                 1 => {
                     // initialize hasher segment and set bitwise segment selector value to ZERO
-                    column.resize(hasher.trace_len() + bitwise.trace_len(), Felt::ZERO);
+                    column.resize(
+                        self.hasher.trace_len() + self.bitwise.trace_len(),
+                        Felt::ZERO,
+                    );
                     // set selector value for all other segments to ONE
                     column.resize(trace_len, Felt::ONE);
                     // add hasher segment to the hasher fragment to be filled from the hasher trace
-                    hasher_fragment.push_column_slice(column, hasher.trace_len());
+                    hasher_fragment.push_column_slice(column, self.hasher.trace_len());
                 }
                 2 => {
                     // initialize hasher and bitwise segments and set memory segment selector to ZERO
                     column.resize(
-                        hasher.trace_len() + bitwise.trace_len() + memory.trace_len(),
+                        self.hasher.trace_len()
+                            + self.bitwise.trace_len()
+                            + self.memory.trace_len(),
                         Felt::ZERO,
                     );
                     // set selector value for the final segment to ONE
                     column.resize(trace_len, Felt::ONE);
                     // add hasher segment to the hasher fragment to be filled from the hasher trace
                     let rest_of_column =
-                        hasher_fragment.push_column_slice(column, hasher.trace_len());
+                        hasher_fragment.push_column_slice(column, self.hasher.trace_len());
                     // add bitwise segment to the bitwise fragment to be filled from the bitwise trace
-                    bitwise_fragment.push_column_slice(rest_of_column, bitwise.trace_len());
+                    bitwise_fragment.push_column_slice(rest_of_column, self.bitwise.trace_len());
                 }
                 16 => {
                     // initialize hasher & memory segments and pad bitwise & final segments with ZERO
                     column.resize(trace_len, Felt::ZERO);
                     // add hasher segment to the hasher fragment to be filled from the hasher trace
                     let rest_of_column =
-                        hasher_fragment.push_column_slice(column, hasher.trace_len());
+                        hasher_fragment.push_column_slice(column, self.hasher.trace_len());
                     // split the column again to skip the bitwise segment, which has already been padded
-                    let (_, rest_of_column) = rest_of_column.split_at_mut(bitwise.trace_len());
+                    let (_, rest_of_column) = rest_of_column.split_at_mut(self.bitwise.trace_len());
                     // add memory segment to the memory fragment to be filled from the memory trace
-                    memory_fragment.push_column_slice(rest_of_column, memory.trace_len());
+                    memory_fragment.push_column_slice(rest_of_column, self.memory.trace_len());
                 }
                 17 => {
                     // initialize hasher segment and pad bitwise, memory, and final segments with ZERO
                     column.resize(trace_len, Felt::ZERO);
                     // add hasher segment to the hasher fragment to be filled from the hasher trace
-                    hasher_fragment.push_column_slice(column, hasher.trace_len());
+                    hasher_fragment.push_column_slice(column, self.hasher.trace_len());
                 }
                 _ => {
                     // initialize hasher, bitwise, memory segments and pad the final segment with ZERO
                     column.resize(trace_len, Felt::ZERO);
                     // add hasher segment to the hasher fragment to be filled from the hasher trace
                     let rest_of_column =
-                        hasher_fragment.push_column_slice(column, hasher.trace_len());
+                        hasher_fragment.push_column_slice(column, self.hasher.trace_len());
                     // add bitwise segment to the bitwise fragment to be filled from the bitwise trace
-                    let rest_of_column =
-                        bitwise_fragment.push_column_slice(rest_of_column, bitwise.trace_len());
+                    let rest_of_column = bitwise_fragment
+                        .push_column_slice(rest_of_column, self.bitwise.trace_len());
                     // add memory segment to the memory fragment to be filled from the memory trace
-                    memory_fragment.push_column_slice(rest_of_column, memory.trace_len());
+                    memory_fragment.push_column_slice(rest_of_column, self.memory.trace_len());
                 }
             }
         }
 
         // fill the fragments with the execution trace from each coprocessor
         // TODO: this can be parallelized to fill the traces in multiple threads
-        hasher.fill_trace(&mut hasher_fragment);
-        bitwise.fill_trace(&mut bitwise_fragment);
-        memory.fill_trace(&mut memory_fragment);
+        self.hasher.fill_trace(&mut hasher_fragment);
+        self.bitwise.fill_trace(&mut bitwise_fragment);
+        self.memory.fill_trace(&mut memory_fragment);
     }
 }

--- a/processor/src/aux_table/mod.rs
+++ b/processor/src/aux_table/mod.rs
@@ -68,7 +68,17 @@ impl AuxTable {
 
     /// Returns an execution trace of the auxiliary table containing the stacked traces of the
     /// Hasher, Bitwise, and Memory coprocessors.
-    pub fn into_trace(self, trace_len: usize) -> AuxTableTrace {
+    ///
+    /// `num_rand_rows` indicates the number of rows at the end of the trace which will be
+    /// overwritten with random values. This parameter is unused because last rows should be
+    /// padding rows which can be safely overwritten.
+    pub fn into_trace(self, trace_len: usize, num_rand_rows: usize) -> AuxTableTrace {
+        // make sure that only padding rows will be overwritten by random values
+        assert!(
+            self.trace_len() + num_rand_rows <= trace_len,
+            "target trace length too small"
+        );
+
         // Allocate columns for the trace of the auxiliary table.
         // note: it may be possible to optimize this by initializing with Felt::zeroed_vector,
         // depending on how the compiler reduces Felt(0) and whether initializing here + iterating

--- a/processor/src/aux_table/mod.rs
+++ b/processor/src/aux_table/mod.rs
@@ -62,6 +62,8 @@ impl AuxTable {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
+    /// Returns the length of the trace required to accommodate co-processor components (excluding
+    /// the padding component).
     pub fn trace_len(&self) -> usize {
         self.hasher.trace_len() + self.bitwise.trace_len() + self.memory.trace_len()
     }

--- a/processor/src/aux_table/tests.rs
+++ b/processor/src/aux_table/tests.rs
@@ -6,7 +6,7 @@ use super::{
     },
     AuxTableTrace,
 };
-use vm_core::{Felt, FieldElement, ProgramInputs, MIN_TRACE_LEN};
+use vm_core::{Felt, FieldElement, ProgramInputs};
 
 #[test]
 fn hasher_aux_trace() {
@@ -14,9 +14,13 @@ fn hasher_aux_trace() {
     let stack = [2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0];
     let operations = vec![Operation::RpPerm];
     let aux_table_trace = build_trace(&stack, operations);
+    let trace_len = aux_table_trace[0].len();
 
     let expected_len = 8;
     validate_hasher_trace(&aux_table_trace, 0, expected_len);
+
+    // validate that the table was padded correctly
+    validate_padding(&aux_table_trace, 8, trace_len);
 }
 
 #[test]
@@ -25,9 +29,13 @@ fn bitwise_aux_trace() {
     let stack = [4, 8];
     let operations = vec![Operation::U32or];
     let aux_table_trace = build_trace(&stack, operations);
+    let trace_len = aux_table_trace[0].len();
 
     let expected_len = 8;
     validate_bitwise_trace(&aux_table_trace, 0, expected_len);
+
+    // validate that the table was padded correctly
+    validate_padding(&aux_table_trace, 8, trace_len);
 }
 
 #[test]
@@ -36,12 +44,13 @@ fn memory_aux_trace() {
     let stack = [1, 2, 3, 4];
     let operations = vec![Operation::Push(Felt::new(2)), Operation::StoreW];
     let aux_table_trace = build_trace(&stack, operations);
+    let trace_len = aux_table_trace[0].len();
 
     // check the memory trace
     validate_memory_trace(&aux_table_trace, 0, 1, 2);
 
-    // check that it was padded correctly
-    validate_padding(&aux_table_trace, 1, MIN_TRACE_LEN);
+    // validate that the table was padded correctly
+    validate_padding(&aux_table_trace, 1, trace_len);
 }
 
 #[test]
@@ -55,6 +64,7 @@ fn stacked_aux_trace() {
         Operation::RpPerm,
     ];
     let aux_table_trace = build_trace(&stack, operations);
+    let trace_len = aux_table_trace[0].len();
 
     // expect 8 rows of hasher trace
     validate_hasher_trace(&aux_table_trace, 0, 8);
@@ -66,7 +76,7 @@ fn stacked_aux_trace() {
     validate_memory_trace(&aux_table_trace, 16, 17, 0);
 
     // expect 15 rows of padding, to pad to next power of 2
-    validate_padding(&aux_table_trace, 17, 32);
+    validate_padding(&aux_table_trace, 17, trace_len);
 }
 
 // HELPER FUNCTIONS

--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -384,6 +384,12 @@ impl Bitwise {
     }
 }
 
+impl Default for Bitwise {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // HELPER FUNCTIONS
 // --------------------------------------------------------------------------------------------
 

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -282,6 +282,12 @@ impl Hasher {
     }
 }
 
+impl Default for Hasher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // MERKLE PATH CONTEXT
 // ================================================================================================
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -263,4 +263,9 @@ impl Process {
     pub fn get_memory_value(&self, addr: u64) -> Option<Word> {
         self.memory.get_value(addr)
     }
+
+    pub fn to_components(self) -> (System, Stack, RangeChecker, AuxTable) {
+        let aux_table = AuxTable::new(self.hasher, self.bitwise, self.memory);
+        (self.system, self.stack, self.range, aux_table)
+    }
 }

--- a/processor/src/memory/mod.rs
+++ b/processor/src/memory/mod.rs
@@ -268,6 +268,12 @@ impl Memory {
     }
 }
 
+impl Default for Memory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // HELPER FUNCTIONS
 // ================================================================================================
 

--- a/processor/src/range/mod.rs
+++ b/processor/src/range/mod.rs
@@ -206,6 +206,12 @@ impl RangeChecker {
     }
 }
 
+impl Default for RangeChecker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // HELPER FUNCTIONS
 // ================================================================================================
 

--- a/processor/src/range/mod.rs
+++ b/processor/src/range/mod.rs
@@ -103,25 +103,32 @@ impl RangeChecker {
     /// If the number of rows need to represent execution trace of this range checker is smaller
     /// than `target_len` parameter, the trace is padded with extra rows.
     ///
+    /// `num_rand_rows` indicates the number of rows at the end of the trace which will be
+    /// overwritten with random values. Values in these rows are not initialized.
+    ///
     /// # Panics
     /// Panics if `target_len` is not a power of two or is smaller than the trace length needed
     /// to represent all lookups in this range checker.
-    pub fn into_trace(self, target_len: usize) -> RangeCheckTrace {
+    pub fn into_trace(self, target_len: usize, num_rand_rows: usize) -> RangeCheckTrace {
         assert!(
             target_len.is_power_of_two(),
             "target trace length is not a power of two"
         );
 
         // determine the length of the trace required to support all the lookups in this range
-        // checker, and make sure this length is smaller than or equal to the target trace length.
+        // checker, and make sure this length is smaller than or equal to the target trace length,
+        // accounting for rows with random values.
         //
         // we do the trace length computation here instead of using Self::trace_len() because we
         // need to use lookups_8bit table later in this function, and we don't want to create it
         // twice.
         let (lookups_8bit, num_16_bit_rows) = self.build_8bit_lookup();
         let num_8bit_rows = get_num_8bit_rows(&lookups_8bit);
-        let trace_length = num_8bit_rows + num_16_bit_rows;
-        assert!(trace_length <= target_len, "target trace too small");
+        let trace_len = num_8bit_rows + num_16_bit_rows;
+        assert!(
+            trace_len + num_rand_rows <= target_len,
+            "target trace length too small"
+        );
 
         // allocated memory for the trace; this memory is un-initialized but this is not a problem
         // because we'll overwrite all values in it anyway.
@@ -136,7 +143,7 @@ impl RangeChecker {
 
         // determine the number of padding rows needed to get to target trace length and pad the
         // table with the required number of rows.
-        let num_padding_rows = target_len - trace_length;
+        let num_padding_rows = target_len - trace_len - num_rand_rows;
         trace[1][..num_padding_rows].fill(Felt::ZERO);
         trace[2][..num_padding_rows].fill(Felt::ZERO);
         trace[3][..num_padding_rows].fill(Felt::ZERO);

--- a/processor/src/range/tests.rs
+++ b/processor/src/range/tests.rs
@@ -12,7 +12,7 @@ fn range_checks() {
         checker.add_value(value.as_int() as u16)
     }
 
-    let trace = checker.into_trace(1024);
+    let trace = checker.into_trace(1024, 0);
     validate_trace(&trace, &values);
 
     // skip the 8-bit portion of the trace
@@ -48,7 +48,7 @@ fn range_checks_rand() {
     }
 
     let trace_len = checker.trace_len().next_power_of_two();
-    let trace = checker.into_trace(trace_len);
+    let trace = checker.into_trace(trace_len, 0);
     validate_trace(&trace, &values);
 }
 

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -119,12 +119,21 @@ impl Stack {
     ///
     /// If the stack trace is smaller than the specified `trace_len`, last value in each column is
     /// duplicated until the length of the columns reaches `trace_len`.
-    pub fn into_trace(self, trace_len: usize) -> [Vec<Felt>; STACK_TRACE_WIDTH] {
+    ///
+    /// `num_rand_rows` indicates the number of rows at the end of the trace which will be
+    /// overwritten with random values. This parameter is unused because last rows are just
+    /// duplicates of the prior rows and thus can be safely overwritten.
+    pub fn into_trace(self, trace_len: usize, num_rand_rows: usize) -> super::StackTrace {
         let clk = self.current_clk();
-        let mut trace = self.trace.into_array();
+        // make sure that only the duplicate rows will be overwritten with random values
+        assert!(
+            clk + num_rand_rows <= trace_len,
+            "target trace length too small"
+        );
 
         // fill in all trace columns after the last clock cycle with the value at the last clock
         // cycle
+        let mut trace = self.trace.into_array();
         for column in trace.iter_mut() {
             let last_value = column[clk];
             column[clk..].fill(last_value);

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -61,12 +61,12 @@ impl Stack {
     /// Returns a [Stack] initialized with the specified program inputs.
     pub fn new(
         inputs: &ProgramInputs,
-        init_trace_length: usize,
+        init_trace_capacity: usize,
         keep_overflow_trace: bool,
     ) -> Self {
         Self {
             clk: 0,
-            trace: StackTrace::new(inputs, init_trace_length),
+            trace: StackTrace::new(inputs, init_trace_capacity),
             overflow: OverflowTable::new(keep_overflow_trace),
             depth: MIN_STACK_DEPTH,
         }
@@ -87,8 +87,10 @@ impl Stack {
     }
 
     /// Returns execution trace length for this stack.
+    ///
+    /// Trace length of the stack is equal to the number of cycles executed by the VM.
     pub fn trace_len(&self) -> usize {
-        self.trace.trace_len()
+        self.clk
     }
 
     /// Returns a copy of the item currently at the top of the stack.

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -81,7 +81,6 @@ impl Stack {
     }
 
     /// Returns the current clock cycle of the execution trace.
-    #[allow(dead_code)]
     pub fn current_clk(&self) -> usize {
         self.clk
     }
@@ -117,8 +116,21 @@ impl Stack {
     }
 
     /// Returns an execution trace of the top 16 stack slots and helper columns as a single array.
-    pub fn into_trace(self) -> [Vec<Felt>; STACK_TRACE_WIDTH] {
-        self.trace.into_array()
+    ///
+    /// If the stack trace is smaller than the specified `trace_len`, last value in each column is
+    /// duplicated until the length of the columns reaches `trace_len`.
+    pub fn into_trace(self, trace_len: usize) -> [Vec<Felt>; STACK_TRACE_WIDTH] {
+        let clk = self.current_clk();
+        let mut trace = self.trace.into_array();
+
+        // fill in all trace columns after the last clock cycle with the value at the last clock
+        // cycle
+        for column in trace.iter_mut() {
+            let last_value = column[clk];
+            column[clk..].fill(last_value);
+            column.resize(trace_len, last_value);
+        }
+        trace
     }
 
     /// Returns stack state at the specified clock cycle.

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -69,8 +69,17 @@ impl System {
     /// extended to match the specified length as follows:
     /// - the remainder of the `clk` column is filled in with increasing values of `clk`.
     /// - the remainder of the `fmp` column is filled in with the last value in the column.
-    pub fn into_trace(mut self, trace_len: usize) -> SysTrace {
+    ///
+    /// `num_rand_rows` indicates the number of rows at the end of the trace which will be
+    /// overwritten with random values. This parameter is unused because last rows are just
+    /// duplicates of the prior rows and thus can be safely overwritten.
+    pub fn into_trace(mut self, trace_len: usize, num_rand_rows: usize) -> SysTrace {
         let clk = self.clk();
+        // make sure that only the duplicate rows will be overwritten with random values
+        assert!(
+            clk + num_rand_rows <= trace_len,
+            "target trace length too small"
+        );
 
         // complete the clk column by filling in all values after the last clock cycle. The values
         // in the clk column are equal to the index of the row in the trace table.

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -26,15 +26,15 @@ impl System {
     // --------------------------------------------------------------------------------------------
     /// Returns a new [System] struct with execution traces instantiated with the specified length.
     /// Initializes the free memory pointer `fmp` used for local memory offsets to 2^30.
-    pub fn new(init_trace_length: usize) -> Self {
+    pub fn new(init_trace_capacity: usize) -> Self {
         // set the first value of the fmp trace to 2^30.
         let fmp = Felt::new(FMP_MIN);
-        let mut fmp_trace = Felt::zeroed_vector(init_trace_length);
+        let mut fmp_trace = Felt::zeroed_vector(init_trace_capacity);
         fmp_trace[0] = fmp;
 
         Self {
             clk: 0,
-            clk_trace: Felt::zeroed_vector(init_trace_length),
+            clk_trace: Felt::zeroed_vector(init_trace_capacity),
             fmp,
             fmp_trace,
         }
@@ -55,10 +55,12 @@ impl System {
         self.fmp
     }
 
-    /// Returns execution trace length for a process.
+    /// Returns execution trace length for the systems columns of the process.
+    ///
+    /// Trace length of the system columns is equal to the number of cycles executed by the VM.
     #[inline(always)]
     pub fn trace_len(&self) -> usize {
-        self.clk_trace.len()
+        self.clk
     }
 
     /// Returns an execution trace of this system info container.
@@ -97,8 +99,9 @@ impl System {
     ///
     /// Trace length is doubled every time it needs to be increased.
     pub fn ensure_trace_capacity(&mut self) {
-        if self.clk + 1 >= self.trace_len() {
-            let new_length = self.trace_len() * 2;
+        let current_capacity = self.clk_trace.len();
+        if self.clk + 1 >= current_capacity {
+            let new_length = current_capacity * 2;
             self.clk_trace.resize(new_length, Felt::ZERO);
             self.fmp_trace.resize(new_length, Felt::ZERO);
         }

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -208,7 +208,7 @@ impl<'a> TraceFragment<'a> {
 /// - Padding the columns to make sure all columns are of the same length.
 /// - Inserting random values in the last row of all columns. This helps ensure that there
 ///   are no repeating patterns in each column and each column contains a least two distinct
-///   values. Thus, in turn, ensures that polynomial degrees of all columns are stable.
+///   values. This, in turn, ensures that polynomial degrees of all columns are stable.
 fn finalize_trace(process: Process, mut rng: RandomCoin) -> Vec<Vec<Felt>> {
     let (system, stack, range, aux_table) = process.to_components();
 

--- a/processor/src/trace.rs
+++ b/processor/src/trace.rs
@@ -1,11 +1,10 @@
 use super::{
-    AuxTable, AuxTableTrace, Digest, Felt, FieldElement, Process, RangeCheckTrace, StackTopState,
-    StackTrace, SysTrace,
+    AuxTableTrace, Digest, Felt, FieldElement, Process, RangeCheckTrace, StackTopState, StackTrace,
+    SysTrace,
 };
 use core::slice;
-use vm_core::{StarkField, MIN_STACK_DEPTH, STACK_TRACE_OFFSET, TRACE_WIDTH};
-use winterfell::Trace;
-use winterfell::{EvaluationFrame, Matrix, TraceLayout};
+use vm_core::{StarkField, MIN_STACK_DEPTH, MIN_TRACE_LEN, STACK_TRACE_OFFSET, TRACE_WIDTH};
+use winterfell::{EvaluationFrame, Matrix, Trace, TraceLayout};
 
 // VM EXECUTION TRACE
 // ================================================================================================
@@ -198,36 +197,46 @@ impl<'a> TraceFragment<'a> {
 // HELPER FUNCTIONS
 // ================================================================================================
 
+/// Converts a process into a set of execution trace columns for each component of the trace.
+///
+/// The process includes:
+/// - Determining the length of the trace required to accommodate the longest trace column.
+/// - Padding the columns to make sure all columns are of the same length.
+/// - Inserting random values in the last row of all columns. This helps ensure that there
+///   are no repeating patterns in each column and each column contains a least two distinct
+///   values. Thus, in turn, ensures that polynomial degrees of all columns are stable.
 fn finalize_trace(process: Process) -> (SysTrace, StackTrace, RangeCheckTrace, AuxTableTrace) {
-    let Process {
-        system,
-        decoder: _,
-        stack,
-        range,
-        hasher,
-        bitwise,
-        memory,
-        advice: _,
-    } = process;
+    let (system, stack, range, aux_table) = process.to_components();
+
+    let clk = system.clk();
+
+    // trace lengths of system and stack components must be equal to the number of executed cycles
+    assert_eq!(clk, system.trace_len(), "inconsistent system trace lengths");
+    assert_eq!(clk, stack.trace_len(), "inconsistent stack trace lengths");
 
     // Get the trace length required to hold all execution trace steps.
-    let aux_trace_len = hasher.trace_len() + bitwise.trace_len() + memory.trace_len();
-    let trace_len = vec![stack.trace_len(), range.trace_len(), aux_trace_len]
-        .iter()
+    let trace_len = [clk, range.trace_len(), aux_table.trace_len()]
+        .into_iter()
         .max()
         .expect("failed to get max of component trace lengths")
         .next_power_of_two();
 
+    assert!(
+        trace_len >= MIN_TRACE_LEN,
+        "trace length must be at least {}, but was {}",
+        MIN_TRACE_LEN,
+        trace_len
+    );
+
     // Finalize the system trace.
-    let step = system.clk();
     let mut system_trace = system.into_trace();
-    finalize_clk_column(&mut system_trace[0], step, trace_len);
-    finalize_column(&mut system_trace[1], step, trace_len);
+    finalize_clk_column(&mut system_trace[0], clk, trace_len);
+    finalize_column(&mut system_trace[1], clk, trace_len);
 
     // Finalize stack trace.
     let mut stack_trace = stack.into_trace();
     for column in stack_trace.iter_mut() {
-        finalize_column(column, step, trace_len);
+        finalize_column(column, clk, trace_len);
     }
 
     // Finalize the range check trace.
@@ -236,10 +245,8 @@ fn finalize_trace(process: Process) -> (SysTrace, StackTrace, RangeCheckTrace, A
         .try_into()
         .expect("failed to convert vector to array");
 
-    // Finalize the auxilliary table trace.
-    let mut aux_table = AuxTable::new(trace_len);
-    aux_table.fill_columns(hasher, bitwise, memory);
-    let aux_table_trace = aux_table.into_trace();
+    // Finalize the auxiliary table trace.
+    let aux_table_trace = aux_table.into_trace(trace_len);
 
     (
         system_trace,
@@ -252,17 +259,17 @@ fn finalize_trace(process: Process) -> (SysTrace, StackTrace, RangeCheckTrace, A
 /// Copies the final output value down to the end of the stack trace, then extends the column to
 /// the length of the execution trace, if it's longer than the stack trace, and copies the last
 /// value to the end of that as well.
-fn finalize_column(column: &mut Vec<Felt>, step: usize, trace_len: usize) {
-    let last_value = column[step];
-    column[step..].fill(last_value);
+fn finalize_column(column: &mut Vec<Felt>, clk: usize, trace_len: usize) {
+    let last_value = column[clk];
+    column[clk..].fill(last_value);
     column.resize(trace_len, last_value);
 }
 
-/// Completes the clk column by filling in all values after the specified step. The values
+/// Completes the clk column by filling in all values after the specified clock cycle. The values
 /// in the clk column are equal to the index of the row in the trace table.
-fn finalize_clk_column(column: &mut Vec<Felt>, step: usize, trace_len: usize) {
+fn finalize_clk_column(column: &mut Vec<Felt>, clk: usize, trace_len: usize) {
     column.resize(trace_len, Felt::ZERO);
-    for (i, clk) in column.iter_mut().enumerate().take(trace_len).skip(step) {
+    for (i, clk) in column.iter_mut().enumerate().take(trace_len).skip(clk) {
         // converting from u32 is OK here because max trace length is 2^32
         *clk = Felt::from(i as u32);
     }


### PR DESCRIPTION
This PR implements injection of random values into the last row of execution trace. This ensures that constraint degrees are always stable (regardless of the executed program). The PR also refactors how trace components are merged together into a single execution trace matrix.

One unfortunate consequence of this change is that using random values in tests slows them down quite a bit. In my benchmarking tests are now taking roughly twice as long to run (this is almost exclusively due to integration tests).

In release mode, there is no observable slowdown.