### PR TITLE
Add processor design documentation to mdbook

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,6 +15,7 @@
     - [Debugging](./user_docs/assembly/debugging.md)
   - [Miden Standard Library](./user_docs/stdlib/main.md)
 - [Design](./design/main.md)
+  - [Range Checker](./design/range.md)
   - [Auxiliary Table](./design/aux_table/main.md)
     - [Hash Processor](./design/aux_table/hasher.md)
     - [Bitwise Processor](./design/aux_table/bitwise.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 [Miden](./README.md)
+
 - [Introduction](./intro.md)
 - [User Documentation](./user_docs/main.md)
   - [Miden VM Overview](./user_docs/overview/main.md)
@@ -8,10 +9,15 @@
     - [Code Organization](./user_docs/assembly/code_organization.md)
     - [Flow Control](./user_docs/assembly/flow_control.md)
     - [Field Operations](./user_docs/assembly/field_operations.md)
-    - [u32 Operations](./user_docs/assembly/u32_operations.md)    
+    - [u32 Operations](./user_docs/assembly/u32_operations.md)
     - [Input / Output Operations](./user_docs/assembly/io_operations.md)
     - [Cryptographic Operations](./user_docs/assembly/cryptographic_operations.md)
-    - [Debugging](./user_docs/assembly/debugging.md)    
+    - [Debugging](./user_docs/assembly/debugging.md)
   - [Miden Standard Library](./user_docs/stdlib/main.md)
-- [Design](./design.md)
+- [Design](./design/main.md)
+  - [Auxiliary Table](./design/aux_table/main.md)
+    - [Hash Processor](./design/aux_table/hasher.md)
+    - [Bitwise Processor](./design/aux_table/bitwise.md)
+    - [Power of Two Processor](./design/aux_table/pow2.md)
+    - [Memory Processor](./design/aux_table/memory.md)
 - [Background Material](./background.md)

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -1,3 +1,0 @@
-# Design
-
-TODO

--- a/docs/src/design/aux_table/bitwise.md
+++ b/docs/src/design/aux_table/bitwise.md
@@ -1,0 +1,195 @@
+# Bitwise Processor
+
+In this note we describe how to compute bitwise AND, OR, and XOR operations on 32-bit values and the constraints required for proving correct execution. It assumes some familiarity with [permutation checks](https://hackmd.io/@arielg/ByFgSDA7D).
+
+Assume that $a$ and $b$ are field elements in a 64-bit prime field. Assume also that $a$ and $b$ are known to contain values smaller than $2^{32}$. We want to compute $a \oplus b \rightarrow z$, where $\oplus$ is either bitwise AND, OR, or XOR, and $z$ is a field element containing the result of the corresponding bitwise operation.
+
+First, observe that we can compute AND, OR, and XOR relations for **single bit values** as follows:
+
+$$
+and(a, b) = a \cdot b
+$$
+
+$$
+or(a, b) = a + b - a \cdot b
+$$
+
+$$
+xor(a, b) = a + b - 2 \cdot a \cdot b
+$$
+
+To compute bitwise operations for multi-bit values, we will decompose the values into individual bits, apply the operations to single bits, and then aggregate the bitwsie results into the final result.
+
+To perform this operation we will use a table with 11 columns, and computing a single AND, OR, or XOR operation will require 8 table rows. We will also rely on two periodic columns as shown below.
+
+![](https://i.imgur.com/1IqHtXF.png)
+
+In the above, the columns have the following meanings:
+
+- Periodic columns $k_0$ and $k_1$. These columns contain values needed to switch various constraint on or off. $k_0$ contains a repeating sequence of a single one, followed by seven zeros. $k_1$ contains a repeating sequence of seven ones, followed by a single zero.
+- Input columns $a$ and $b$. On the first row of each 8-row cycle, the prover will set values in these columns to the upper 4 bits of the values to which a bitwise operation is to be applied. For all subsequent rows, we will append the next-most-significant 4-bit limb to each value. Thus, by the final row columns $a$ and $b$ will contain the full input values for the bitwise operation.
+- Columns $a_0$, $a_1$, $a_2$, $a_3$, $b_0$, $b_1$, $b_2$, $b_3$ will contain lower 4 bits of their corresponding values.
+- Output column $z$. This column will be used to aggregate the results of bitwise operations performed over columns $a_0$, $a_1$, $a_2$, $a_3$, $b_0$, $b_1$, $b_2$, $b_3$. By the time we get to the last row in each 8-row cycle, this column will contain the final result.
+
+## Example
+
+Let's illustrate the above table on a concrete example. For simplicity, we'll use 16-bit values, and thus, we'll only need 4 rows to complete the operation (rather than 8 for 32-bit values). Let's say $a = 41851$ (`b1010_0011_0111_1011`) and $b = 40426$ (`b1001_1101_1110_1010`), then $and(a, b) = 33130$ (`b1000_0001_0110_1010`). The table for this computation looks like so:
+
+|   a   |   b   | x0  | x1  | x2  | x3  | y0  | y1  | y2  | y3  |   z   |
+| :---: | :---: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :---: |
+|  10   |   9   |  0  |  1  |  0  |  1  |  1  |  0  |  0  |  1  |   8   |
+|  163  |  157  |  1  |  1  |  0  |  0  |  1  |  0  |  1  |  1  |  129  |
+| 2615  | 2526  |  1  |  1  |  1  |  0  |  0  |  1  |  1  |  1  | 2070  |
+| 41851 | 40426 |  1  |  1  |  0  |  1  |  0  |  1  |  0  |  1  | 33130 |
+
+Here, in the first row, we set each of the $a$ and $b$ columns to the value of their most-significant 4-bit limb. The bit columns ($a_0 .. a_3$ and $b_0 .. b_3$) in the first row contain the lower 4 bits of their corresponding values (`b1010` and `b1001`). Column $z$ contains the result of bitwise AND for the upper 4 bits (`b1000`).
+
+With every subsequent row, we inject the next-most-significant 4 bits of each value into the bit columns, increase the $a$ and $b$ columns accordingly, and aggregate the result of bitwise AND into the $z$ column, adding it to $2^4$ times the value of $z$ in the previous row. By the time we get to the last row, the $z$ column contains the result of the bitwise AND, while columns $a$ and $b$ contain their original values.
+
+## Constraints
+
+AIR constraints needed to ensure the correctness of the above table are described below.
+
+### Input decomposition
+
+We need to make sure that inputs $a$ and $b$ are decomposed correctly into their individual bits. To do this, first, we need to make sure that columns $a_0$, $a_1$, $a_2$, $a_3$, $b_0$, $b_1$, $b_2$, $b_3$, can contain only binary values ($0$ or $1$). This can be accomplished with the following constraints (for $i$ ranging between $0$ and $3$):
+
+$$
+a_i^2 - a_i = 0
+$$
+
+$$
+b_i^2 - b_i = 0
+$$
+
+Then, we need to make sure that on the first row of every 8-row cycle, the values in the columns $a$ and $b$ are exactly equal to the aggregation of binary values contained in the individual bit columns $a_i$, and $b_i$. This can be enforced with the following constraints:
+
+$$
+k_0 \cdot \left(a - \sum_{i=0}^3(2^i \cdot a_i)\right) = 0
+$$
+
+$$
+k_0 \cdot \left(b - \sum_{i=0}^3(2^i \cdot b_i)\right) = 0
+$$
+
+The above constraints enforce that when $k_0 = 1$, $a = \sum_{i=0}^3(2^i \cdot a_i)$ and $b = \sum_{i=0}^3(2^i \cdot b_i)$.
+
+Lastly, we need to make sure that for all rows in an 8-row cycle except for the last one, the values in $a$ and $b$ columns are increased by the values contained in the individual bit columns $a_i$ and $b_i$. Denoting $a$ as the value of column $a$ in the current row, and $a'$ as the value of column $a$ in the next row, we can enforce these conditions as follows:
+
+$$
+k_1 \cdot \left(a' - \left(a \cdot 16 + \sum_{i=0}^3(2^i \cdot a'_i)\right)\right) = 0
+$$
+
+$$
+k_1 \cdot \left(b' - \left(b \cdot 16 + \sum_{i=0}^3(2^i \cdot b'_i)\right)\right) = 0
+$$
+
+The above constraints enforce that when $k_1 = 1$ , $a' = 16 \cdot a + \sum_{i=0}^3(2^i \cdot a'_i)$ and $b' = 16 \cdot b + \sum_{i=0}^3(2^i \cdot b'_i)$.
+
+### Output aggregation
+
+To ensure correct aggregation of operations over individual bits, first we need to ensure that in the first row of every 8-row cycle, the value in column $z$ is exactly equal to the aggregated values of a bitwise operation applied to columns $a_0$, $a_1$, $a_2$, $a_3$, $b_0$, $b_1$, $b_2$, $b_3$. For an AND operation, the constraint enforcing this would look as follows:
+
+$$
+k_0 \cdot \left(z - \sum_{i=0}^3(2^i \cdot a_i \cdot b_i)\right) = 0
+$$
+
+Lastly, we need to ensure that for all other rows, the value in the $z$ column is computed by multiplying the value from the previous row of the column by 16 and then adding it to the bitwise operation applied to the next set of bits of $a$ and $b$. This can be enforced with the following constraint:
+
+$$
+k_1 \cdot \left(z' -(z \cdot 16 + \sum_0^3(2^i \cdot a'_i \cdot b'_i))\right) = 0
+$$
+
+The above constraint enforces that when $k_1 = 1$, $z' = 16 \cdot z + \sum_{i=0}^3(2^i \cdot a'_i \cdot b'_i)$
+
+## Permutation product
+
+For the permutation product, we want to include values of $a$, $b$ and $z$ at the last row of the cycle. Denoting the random value received from the verifier as $\alpha$, this can be achieved using the following:
+
+$$
+v_i = (1-k_1) \cdot (\alpha \cdot a + \alpha^2 \cdot b + \alpha^3 \cdot z)
+$$
+
+Thus, when $k_1 = 0$, $(\alpha \cdot a + \alpha^2 \cdot b + \alpha^3 \cdot z)$ gets included into the product.
+
+Then, denoting another random value sent by the verifier as $\beta$, and setting $m = 1 - k_1$, we can compute the permutation product as follows:
+
+$$
+\prod_{i=0}^n ((\beta + v_i) \cdot m_i + 1 - m_i)
+$$
+
+The above ensures that when $1 - k_1 = 0$ (which is true for all rows in the 8-row cycle except for the last one), the product does not change. Otherwise, $(\beta + v_i)$ gets included into the product.
+
+## Table lookups
+
+To perform a lookup into this table, we need to know values of $a$, $b$, $z$ (which the prover will provide non-deterministically). The lookup can then be performed by including the following into the lookup product:
+
+$$
+\left(\beta + (\alpha \cdot a + \alpha^2 \cdot b + \alpha^3 \cdot z)\right)
+$$
+
+## Reducing the number of rows
+
+It is possible to reduce the number of rows in the table from 8 to 4 by performing bitwise operations on 2-bit values (rather than on single bits). This would require some changes to the constraints, most important of which are listed below.
+
+### Limit column values to 2 bits
+
+We'll need to make sure that $a_0 .. a_3$ and $b_0 .. b_3$ columns contain 2-bit values. This can be accomplished with the following constraints:
+
+$$
+a_i \cdot (a_i - 1) \cdot (a_i - 2) \cdot (a_i - 3) = 0
+$$
+
+$$
+b_i \cdot (b_i - 1) \cdot (b_i - 2) \cdot (b_i - 3) = 0
+$$
+
+### Bitwise operations on 2-bit limbs
+
+Instead of simple formulas for single-bit bitwise operations, we'll need to compute results of bitwsie operations over 2-bit values using a sum of degree 6 polynomials.
+
+For example, assuming $a$ and $b$ are 2-bit values, their bitwise AND can be computed as a sum of the following polynomials:
+
+$$
+\frac{1}{4} \cdot a \cdot (a - 2) \cdot (a - 3) \cdot b \cdot (b - 2) \cdot (b - 3)
+$$
+
+$$
+\frac{1}{12} \cdot a \cdot (a - 2) \cdot (a - 3) \cdot b \cdot (b - 1) \cdot (b - 2)
+$$
+
+$$
+\frac{1}{2} \cdot a \cdot (a - 1) \cdot (a - 3) \cdot b \cdot (b - 1) \cdot (b - 3)
+$$
+
+$$
+-\frac{1}{6} \cdot a \cdot (a - 1) \cdot (a - 3) \cdot b \cdot (b - 1) \cdot (b - 2)
+$$
+
+$$
+\frac{1}{12} \cdot a \cdot (a - 1) \cdot (a - 2) \cdot b \cdot (b - 2) \cdot (b - 3)
+$$
+
+$$
+-\frac{1}{6} \cdot a \cdot (a - 1) \cdot (a - 2) \cdot b \cdot (b - 1) \cdot (b - 3)
+$$
+
+$$
+\frac{1}{12} \cdot a \cdot (a - 1) \cdot (a - 2) \cdot b \cdot (b - 1) \cdot (b - 2)
+$$
+
+We can compute 2-bit results for OR and XOR operations in a similar manner. The general idea here is that we need to list polynomials which evaluate to $1$ for a given set of input values, and then multiply each polynomial by an expected result of a bitwise operation.
+
+For example, to compute a bitwise OR of $3$ and $3$, we first need to come up with a polynomial which evaluates to $1$ for $a = 3$ and $b = 3$, and to $0$ for all other inputs. This polynomial is:
+
+$$
+\frac{1}{36} \cdot a \cdot (a - 1) \cdot (a - 2) \cdot b \cdot (b - 1) \cdot (b - 2)
+$$
+
+And then, since $or(3, 3) = 3$, we need to multiply this polynomial by $3$, obtaining:
+
+$$
+\frac{1}{12} \cdot a \cdot (a - 1) \cdot (a - 2) \cdot b \cdot (b - 1) \cdot (b - 2)
+$$
+
+We then repeat this process for all $a$ and $b$ where $or(a, b) \ne 0$ to obtain all required polynomials.

--- a/docs/src/design/aux_table/hasher.md
+++ b/docs/src/design/aux_table/hasher.md
@@ -1,0 +1,3 @@
+# Hash Processor
+
+TODO

--- a/docs/src/design/aux_table/main.md
+++ b/docs/src/design/aux_table/main.md
@@ -1,0 +1,3 @@
+# Auxiliary Table
+
+TODO

--- a/docs/src/design/aux_table/memory.md
+++ b/docs/src/design/aux_table/memory.md
@@ -1,0 +1,306 @@
+# Memory Processor
+
+This note assumes some familiarity with [permutation checks](https://hackmd.io/@arielg/ByFgSDA7D).
+
+Miden VM supports linear read-write random access memory. This memory is word-addressable, meaning, four values are located at each address, and we can read and write values to/from memory in batches of four. Each value is a field element in a $64$-bit prime field with modulus $2^{64} - 2^{32} + 1$. Memory address can be any field element.
+
+In this note we describe the rational for selecting the above design and describe AIR constraints needed to support it.
+
+The design makes extensive use of $16$-bit range checks. An efficient way of implementing such range checks is described [here](https://hackmd.io/D-vjBYtHQB2BuOB-HMUG5Q).
+
+## Alternative designs
+
+The simplest (and most efficient) alternative to the above design is contiguous write-once memory. To support such memory, we need to allocate just two trace columns as illustrated below.
+
+![](https://i.imgur.com/DJsQR7q.png)
+
+In the above, `addr` column holds memory address, and `value` column holds the field element representing the value stored at this address. Notice that some rows in this table are duplicated. This is because we need one row per memory access (either read or write operation). In the example above, value $b$ was first stored at memory address $1$, and then read from this address.
+
+The AIR constraints for this design are very simple. First, we need to ensure that values in the `addr` column either remain the same or are incremented by $1$ as we move from one row to the next. This can be achieved with the following constraint:
+
+$$
+(a' - a) \cdot (a' - a - 1) = 0
+$$
+
+where $a$ is the value in `addr` column in the current row, and $a'$ is the value in this column in the next row.
+
+Second, we need to make sure that if the value in the `addr` column didn't change, the value in the `value` column also remained the same (i.e., a value stored in a given address can only be set once). This can be achieved with the following constraint:
+
+$$
+(v' - v) \cdot (a' - a - 1) = 0
+$$
+
+where $v$ is the value in `value` column at the current row, and $v'$ is the value in this column in the next row.
+
+In addition to the above constraints we would also need to impose constraints needed for permutation checks, but we omit these constraints here because they are needed for all designs described in this note.
+
+As mentioned above, this approach is very efficient: each memory access requires just $2$ trace cells.
+
+### Read-write memory
+
+Write-once memory is tricky to work with, and many developers may need to climb a steep learning curve before they become comfortable working in this model. Thus, ideally, we'd want to support read-write memory. To do this, we need to introduce additional columns as illustrated below.
+
+![](https://i.imgur.com/8t8FBF9.png)
+
+In the above, we added `clk` column, which keeps track of the clock cycle at which memory access happened. We also need to differentiate between memory reads and writes. To do this, we now use two columns to keep track of the value: `old val` contains the value stored at the address before the operation, and `new val` contains the value after the operation. Thus, if `old val` and `new val` are the same, it was a read operation. If they are different, it was a write operation.
+
+The AIR constraints needed to support the above structure are as follows.
+
+We still need to make sure memory addresses are contiguous:
+
+$$
+(a' - a) \cdot (a' - a - 1) = 0
+$$
+
+Whenever memory address changes, we want to make sure that `old val` is set to $0$ (i.e., our memory is always initialized to $0$). This can be done with the following constraint:
+
+$$
+(a' - a) \cdot v_{old}' = 0
+$$
+
+On the other hand, if memory address doesn't change, we want to make sure that `new val` in the current row is the same as `old val` in the next row. This can be done with the following constraint:
+
+$$
+(1 + a - a') \cdot (v_{new} - v_{old}') = 0
+$$
+
+Lastly, we need to make sure that for the same address values in `clk` column are always increasing. One way to do this is to perform a $16$-bit range check on the value of $(i' - i - 1)$, where $i$ is the reference to `clk` column. However, this would mean that memory operations involving the same address must happen within $65536$ VM cycles from each other. This limitation would be difficult to enforce statically. To remove this limitation, we need to add two more columns as shown below:
+
+![](https://i.imgur.com/GgEo21V.png)
+
+In the above column `d0` contains the lower $16$ bits of $(i' - i - 1)$ while `d1` contains the upper $16$ bits. The constraint needed to enforces this is as follows:
+
+$$
+(1 + a - a') \cdot ((i' - i - 1) - (2^{16} \cdot d_1' + d_0')) = 0
+$$
+
+Additionally, we need to apply $16$-bit range checks to columns `d0` and `d1`.
+
+Overall, the cost of reading or writing a single element is now $6$ trace cells and $2$ $16$-bit range-checks.
+
+### Non-contiguous memory
+
+Requiring that memory addresses are contiguous may also be a difficult limitation to impose statically. To remove this limitation, we need to introduce one more column as shown below:
+
+![](https://i.imgur.com/U0GN06r.png)
+
+In the above, the prover sets the value in the new column `t` to $0$ when the address doesn't change, and to $1 / (a' - a)$ otherwise. To simplify constraint description, we'll define variable $n$ computed as follows:
+
+$$
+n = (a' - a) \cdot t
+$$
+
+Then, to make sure the prover sets the value of $t$ correctly, we'll impose the following constraints:
+
+$$
+n^2 - n = 0 \\
+(1 - n) \cdot  (a' - a) = 0
+$$
+
+The above constraints ensure that $n=1$ whenever the address changes, and $n=0$ otherwise. We can then define the following constraints to make sure values in columns `d0` and `d1` contain either the delta between addresses or between clock cycles.
+
+| Condition | Constraint                                      | Comments                                                                                                                                   |
+| --------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| $n=1$     | $(a' - a) - (2^{16} \cdot d_1' + d_0') = 0$     | When the address changes, columns `d0` and `d1` at the next row should contain the delta between the old and the new address.              |
+| $n=0$     | $(i' - i - 1) - (2^{16} \cdot d_1' + d_0') = 0$ | When the address remains the same, columns `d0` and `d1` at the next row should contain the delta between the old and the new clock cycle. |
+
+We can combine the above constraints as follows:
+
+$$
+\left(n \cdot (a' - a) + (1 - n) \cdot (i' - i - 1)\right) - (2^{16} \cdot d_1' + d_0') = 0
+$$
+
+The above constraint, in combination with $16$-bit range checks against columns `d0` and `d1` ensure that values in `addr` and `clk` columns always increase monotonically, and also that column `addr` may contain duplicates, while values in `clk` column must be unique for a given address.
+
+### Context separation
+
+In many situations it may be desirable to assign memories to different context. For example, when making a cross-contract calls, memories of the caller and the callee should be separate. That is, caller should not be able to access the memory of the callee and vice-versa.
+
+To accommodate this feature, we need to add one more column as illustrated below.
+
+![](https://i.imgur.com/ccbFrKU.png)
+
+This new column `ctx` should behave similarly to the address column: values in it should increase monotonically, and there could be breaks between them. We also need to change how the prover populates column `t`:
+
+- If the context changes, `t` should be set to the inverse $(c' - c)$, where $c$ is a reference to column `ctx`.
+- If the context remains the same but the address changes, column `t` should be set to the inverse of $(a' - a)$.
+- Otherwise, column `t` should be set to $0$.
+
+To simplify description of constraints, we'll define two variables $n_0$ and $n_1$ as follows:
+
+$$
+n_0 = (c' - c) \cdot t \\
+n_1 = (a' - a) \cdot t
+$$
+
+Thus, $n_0 = 1$ when the context changes, and $0$ otherwise. Also, $(1 - n_0) \cdot n_1 = 1$ when context remains the same and address changes, and $0$ otherwise.
+
+To make sure the prover sets the value of column `t` correctly, we'll need to impose the following constraints:
+
+$$
+n_0^2 - n_0 = 0 \\
+(1 - n_0) \cdot  (c' - c) = 0 \\
+(1 - n_0) \cdot (n_1^2 - n_1) = 0 \\
+(1 - n_0) \cdot (1 - n_1) \cdot (a' - a) = 0
+$$
+
+We can then define the following constraints to make sure values in columns `d0` and `d1` contain the delta between contexts, between addresses, or between clock cycles.
+
+| Condition            | Constraint                                      | Comments                                                                                                                                                         |
+| -------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| $n_0=1$              | $(c' - c) - (2^{16} \cdot d_1' + d_0') = 0$     | When the context changes, columns `d0` and `d1` at the next row should contain the delta between the old and the new contexts.                                   |
+| $n_0=0$ <br> $n_1=1$ | $(a' - a) - (2^{16} \cdot d_1' + d_0') = 0$     | When the context remains the same but the address changes, columns `d0` and `d1` at the next row should contain the delta between the old and the new addresses. |
+| $n_0=0$ <br> $n_1=0$ | $(i' - i - 1) - (2^{16} \cdot d_1' + d_0') = 0$ | When both the context and the address remain the same, columns `d0` and `d1` at the next row should contain the delta between the old and the new clock cycle.   |
+
+We can combine the above constraints as follows:
+
+$$
+\left(n_0 \cdot (c' - c) + (1 - n_0) \cdot \left(n_1 \cdot (a - a') + (1 - n_1) \cdot (i' - i - 1) \right) \right) - (2^{16} \cdot d_1' + d_0') = 0
+$$
+
+The above constraint, in combination with $16$-bit range checks against columns `d0` and `d1` ensure that values in `ctx`, `addr`, and `clk` columns always increase monotonically, and also that columns `ctx` and `addr` may contain duplicates, while the values in column `clk` must be unique for a given combination of `ctx` and `addr`.
+
+Notice that the above constraint has degree $5$.
+
+## Miden approach
+
+While the approach described above works, it comes at significant cost. Reading or writing a single value requires $8$ trace cells and $2$ $16$-bit range checks. Assuming a single range check requires roughly $2$ trace cells, the total number of trace cells needed grows to $12$. This is about $6$x worse the simple contiguous write-once memory described earlier.
+
+Miden VM frequently needs to deal with batches of $4$ field elements, which we call _words_. For example, the output of Rescue Prime hash function is a single word. A single 256-bit integer value can be stored as two words (where each element contains one $32$-bit value). Thus, we can optimize for this common use case by making the memory _word-addressable_. That is $4$ field elements are located at each memory address, and we can read and write elements to/from memory in batches of four.
+
+The layout of Miden VM memory table is shown below:
+
+![](https://i.imgur.com/4uIUxXY.png)
+
+where:
+
+- `ctx` contains context ID. Values in this column must increase monotonically but there can be gaps between two consecutive values of up to $2^{32}$. Also, two consecutive values can be the same. In AIR constraint description below, we refer to this column as $c$.
+- `addr` contains memory address. Values in this column must increase monotonically for a given context but there can be gaps between two consecutive values of up to $2^{32}$. Also, two consecutive values can be the same. In AIR constraint description below, we refer to this column as $a$.
+- `clk` contains clock cycle at which the memory operation happened. Values in this column must increase monotonically for a given context and memory address but there can be gaps between two consecutive values of up to $2^{32}$. In AIR constraint description below, we refer to this column as $i$.
+- `u0, u1, u2, u3` columns contain field elements stored at a given context/address/clock cycle prior to the memory operation.
+- `v0, v1, v2, v3` columns contain field elements stored at a given context/address/clock cycle after the memory operation.
+- Columns `d0` and `d1` contain lower and upper $16$ bits of the delta between two consecutive context IDs, addresses, or clock cycles. Specifically:
+  - When the context changes, these columns contain $(c' - c)$.
+  - When the context remains the same but the address changes, these columns contain $(a' - a)$.
+  - When both the context and the address remain the same, these columns contain $(i' - i - 1)$.
+- Column `t` contains the inverse of the delta between two consecutive context IDs, addresses, or clock cycles. Specifically:
+  - When the context changes, this column contains the inverse of $(c' - c)$.
+  - When the context remains the same but the address changes, this column contains the inverse of $(a' - a)$.
+  - When both the context and the address remain the same, this column contains the inverse of $(i' - i - 1)$.
+
+For every memory access operation (i.e., read or write), a new row is added to the memory table. For read operations values in `u` columns are equal to the corresponding values in `v` columns. For write operations, the values may be different. Memory values are always initialized to $0$.
+
+The amortized cost of reading or writing a single value is between $4$ and $5$ trace cells (this accounts for the trace cells needed for $16$-bit range checks). Thus, from performance standpoint, this approach is roughly $2.5$x worse than the simple contiguous write-once memory described earlier. However, our view is that this trade-off is worth it given that this approach provides read-write memory, context separation, and eliminates the contiguous memory requirement.
+
+### AIR constraints
+
+To simplify description of constraints, we'll define two variables $n_0$ and $n_1$ as follows:
+
+$$
+n_0 = (c' - c) \cdot t \\
+n_1 = (a' - a) \cdot t
+$$
+
+To make sure the prover sets the value of column `t` correctly, we'll need to impose the following constraints:
+
+$$
+n_0^2 - n_0 = 0 \\
+(1 - n_0) \cdot  (c' - c) = 0 \\
+(1 - n_0) \cdot (n_1^2 - n_1) = 0 \\
+(1 - n_0) \cdot (1 - n_1) \cdot (a' - a) = 0
+$$
+
+The above constraints guarantee that when context changes $n_0 = 1$, when context remains the same but address changes $(1 - n_0) \cdot n_1 = 1$, and when neither the context nor the address change, $(1 - n_0) \cdot (1 - n_1) = 1$.
+
+To enforce the values of context ID, address, and clock cycle grow monotonically as described in the previous section, we define the following constraint.
+
+$$
+\left(n_0 \cdot (c' - c) + (1 - n_0) \cdot \left(n_1 \cdot (a - a') + (1 - n_1) \cdot (i' - i - 1) \right) \right) - (2^{16} \cdot d_1' + d_0') = 0
+$$
+
+In addition to this constraint, we also need to make sure that values in registers $d_0$ and $d_1$ are less than $2^{16}$, and this can be done with permutation-based range checks.
+
+Next, we need to make sure that values at a given memory address are always initialized to $0$. This can be done with the following constraint:
+
+$$
+(n_0 + (1 - n_0) \cdot n_1) \cdot u_i' = 0
+$$
+
+where $i \in \{0, 1, 2, 3\}$. Thus, when either the context changes, or the address changes, values in $u_i$ columns are guaranteed to be zeros.
+
+Lastly, we need to make sure that for the same context/address combination, the $v_i$ columns of the current row are equal to the corresponding $u_i$ columns of the next row. This can be done with the following constraints:
+
+$$
+(1 - n_0) \cdot (1 - n_1) \cdot (u_i' - v_i) = 0
+$$
+
+where $i \in \{0, 1, 2, 3\}$.
+
+Notice that the maximum degree for all constraints described above is $5$.
+
+#### Memory row value
+
+To use the above table in permutation checks, we need to reduce each row of the memory table to a single value. This can be done like so:
+
+$$
+v = \beta + \alpha \cdot c + \alpha^2 \cdot a + \alpha^3 \cdot i + \sum_{j=0}^3(\alpha^{j+4} \cdot u_j) + \sum_{j=0}^3(\alpha^{j+8} \cdot v_j)
+$$
+
+where $\alpha$ and $\beta$ are random values sent from the verifier to the prover for use in permutation checks.
+
+### Load and store operations
+
+To move elements between the stack and the memory, Miden VM provides two operations `MLOAD` and `MSTORE`. Semantic of these operations are described below.
+
+#### Reading from memory
+
+`MLOAD` operation is used to move values from memory to the top of the stack. This operation works as follows:
+
+1. Pop the top element from the stack and interpret it as memory address.
+2. Perform a lookup into the memory table at the specified address and using the current values of context and clock cycle registers. This creates a row in the lookup table corresponding to the load operation.
+3. Overwrite the top four stack items with values located at the specified memory address.
+
+Graphically, this looks like so:
+
+![](https://i.imgur.com/jg3vYqV.png)
+
+Note that as a result of this operation the stack is shifted to the left by one.
+
+Denoting stack registers as $s_j$, clock cycle register as $i$, and context register as $c$, we can compute the lookup row value as follows:
+
+$$
+v = \beta + \alpha \cdot c + \alpha^2 \cdot s_0 + \alpha^3 \cdot i + \sum_{j=0}^3(\alpha^{j+4} \cdot s_j') + \sum_{j=0}^3(\alpha^{j+8} \cdot s_j')
+$$
+
+where $\alpha$ and $\beta$ are random values sent from the verifier to the prover for use in permutation checks.
+
+Note that the values from the top of the stack are added into the row twice: once for "old" values and once for "new" values. We can do this because old and new values in the memory table row corresponding the load operation are the same.
+
+#### Writing to memory
+
+`MSTORE` operation is used to move values from the top of the stack to the memory. This operation works as follows:
+
+1. Pop the top element from the stack and interpret it as memory address.
+2. Perform a lookup into the memory table at the specified address and using the current values of context and clock cycle registers. This creates a row in the lookup table corresponding to the store operation.
+
+Graphically, this looks like so:
+
+![](https://i.imgur.com/METn4y1.png)
+
+Note that as a result of this operation the stack is shifted to the left by one, and the values saved to memory remain on the stack.
+
+Denoting stack registers as $s_j$, helper registers as $h_j$, clock cycle register as $i$, and context register as $c$, we can compute the lookup row value as follows:
+
+$$
+v = \beta + \alpha \cdot c + \alpha^2 \cdot s_0 + \alpha^3 \cdot i + \sum_{j=0}^3(\alpha^{j+4} \cdot h_j) + \sum_{j=0}^3(\alpha^{j+8} \cdot s_j)
+$$
+
+where $\alpha$ and $\beta$ are random values sent from the verifier to the prover for use in permutation checks. Values for the helper registers $h_0, ...,  h_3$ are provided by the VM non-deterministically.
+
+We also need to make sure that the saved values remained on the stack. This can be done with the following constraint:
+
+$$
+s_i' - s_{i + 1} = 0
+$$
+
+where $i \in \{0, 1, 2, 3\}$.

--- a/docs/src/design/aux_table/pow2.md
+++ b/docs/src/design/aux_table/pow2.md
@@ -1,0 +1,163 @@
+# Power of Two Processor
+
+In this note, we describe how to compute a 32-bit or 64-bit power of two, $2^a$, given an exponent $a$ in the range $[0,64)$ as input.
+
+The general approach is to decompose the exponent value $a$ into 1's, representing single powers of two, and then re-aggregate the value of $a$ while also aggregating the powers of two into the output result $z = 2^a$.
+
+To perform this operation, we'll use a table with 12 columns and two periodic columns, as shown below. Computing a power of $2^a$ for input $a$ where $0 \leq a < 64$ will require 8 table rows.
+
+![](https://i.imgur.com/LkzpCxW.png)
+
+The columns shown above have the following meanings:
+
+- **Selector columns $k_0$ and $k_1$**, used to selectively apply different sets of constraints to different rows. $k_0$ contains a repeating sequence of one 1 followed by seven 0s. $k_1$ contains a repeating sequence of seven 1s followed by a single 0.
+- **Columns $a_0$ to $a_7$** contain the decomposition of the exponent $a$. Each cell's value is set to 1 or 0, and the sum of all $a_i$ cells over the entire 8-row cycle will be the input value $a$. If $a = 0$ then all cells will contain 0s. Otherwise, the value of $a_0$ in row 0 should be 1, and each subsequent cell should contain 1 until $a$ has been fully aggregated, at which point the next cell should be 0 and all subsequent $a_i$ cells should be 0. Therefore a transition from $1 \to 0$ can happen exactly once, and a transition from $0 \to 1$ is not allowed.
+- **Helper column $h$** is used to help aggregate the powers of two into the output column and to ensure correctness of the transition of $a_i$ values from one row to the next.
+- **Input column $a$** will contain the aggregated sum of the $a_i$ values in each row plus the previous value in column $a$. By the final row of the 8-row cycle, the value in column $a$ will be the input value of the exponent $a$.
+- **Column $p$** will contain increasing powers of 256, which will be used in the aggregation of the output result in column $z$. This represents the 8 powers of two that can be accumulated in each row by the 8 $a_i$ columns.
+- **Output column $z$** will contain the aggregated output over each row plus the previous value of $z$. By the final row of the 8-row cycle, the value in column $z$ will be the result of $2^a$.
+
+In addition to these columns, the table also depends on one running product column $p_0$ which is used for permutation checks and shared across multiple co-processors. The purpose here is the same as in the [hash processor](https://hackmd.io/Rpxt26PkScKltE469_nhRA?view).
+
+As described in that note, $p_0$ is used to associate the processor table with the main stack of the VM.
+
+> That is, inputs consumed by the processor and outputs produced by the processor are added to p0, while the main VM stack removes them from p0. Thus, if the sets of inputs and outputs between the main VM stack and hash processor are the same, value of p0 should be equal to 1 at the start and the end of the execution trace.
+
+In our case, replace "hash processor" above with "power of two processor". The rest is the same.
+
+### Output aggregation with the help of "virtual rows"
+
+Powers of two will only be aggregated into the output column in the row in which the transition between $a_i$ values from $1 \to 0$ occurs (or in the first row, if $a=0$). That is, the output value $z$ will change in the row where $a_i = 1$ and $a_{i+1} = 0$ for some $i \in \{0, ..., 7\}$, indicating that our decomposition of $a$ is complete. In all subsequent rows, the value in column z will remain the same. In all prior rows, z will be 0.
+
+Because each $a_i$ value represents a single power of 2, each full row in which $a_i = 1$ for all values of $i$ represents $2^8$ or 256 to be included as a multiple in the final output value. Each subsequent full row represents an increase to the final output by another multiple of 256.
+
+By tracking powers of 256 in column $p$, we ensure that when we aggregate our output we can simply include the value of $p$ for that row in order to account for all previous full rows where $a_i = 1$ for all values of $i$.
+
+We also need to include any remaining powers of two from the transition row. For simplicity, we'll imagine a "virtual row" below each of our trace rows to help define some intermediate helper values. Each virtual row will have values $t_0$ to $t_8$ in columns $a_0$ to $h$ as follows:
+
+- Column $a_0$:
+  - In the first virtual row, the value in column $a_0$ must be set to $t_0 = 1-a_0$, where $a_0$ comes from the trace row. This ensures that the output will be 1 when $a=0$.
+  - In all other virtual rows, the value in this column is set to $t_0 = 0$.
+- All other columns $a_i$ for $i \in \{{1, ..., 7}\}$ and column $h$:
+  - Set the value in columns $a_i$ to $t_i = a_{i-1}-a_i$ and $t_8 = a_7 - h$ in column $h$, where the $a_i$ and $h$ values come from the corresponding trace row.
+
+Thus the virtual row will contain a single 1 at the point where the decomposition of $a$ ends, and the index of that cell will represent the power of two which needs to be included in the result.
+
+The resulting power of two for $z$ can then be aggregated over the values in the virtual row and the value of $p$ in the trace row by:
+
+$$z = \sum\limits_{i=0}^8 p \cdot t_i \cdot 2^i$$
+
+Finally, in order to ensure that the value of z does not change after it is aggregated, we need to include the previous value of column $z$, giving us the following:
+
+$$z = \sum\limits_{i=0}^8 p \cdot t_i \cdot 2^i + z_{prev}$$
+
+## Example
+
+Let's illustrate the entire construction with an example. For simplicity, we'll use a table with a maximum input value of 31 so that this can be shown in just 4 rows, rather than 8. (The maximum power of two that this table can compute is therefore $2^{31}$).
+
+For our example, let's set our exponent input value as $a=23$.
+
+| p       | $a_0$ | $a_1$ | $a_2$ | $a_3$ | $a_4$ | $a_5$ | $a_6$ | $a_7$ | h   | a   | z                 |
+| ------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | --- | --- | ----------------- |
+| 1       | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 1   | 8   | 0                 |
+| 256     | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 1   | 16  | 0                 |
+| $256^2$ | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 0     | 0   | 23  | $256^2 \cdot 2^7$ |
+| $256^3$ | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0   | 23  | $256^2 \cdot 2^7$ |
+
+Now we can use the same example to demonstrate the "virtual rows" we use to help aggregate the output value in $z$. The virtual rows are shaded below, and are not included in the trace.
+
+| p       | $a_0$ | $a_1$ | $a_2$ | $a_3$ | $a_4$ | $a_5$ | $a_6$ | $a_7$ | h   | a   | z                 |
+| ------- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | --- | --- | ----------------- |
+| 1       | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 1   | 8   | 0                 |
+| -       | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0   | -   | -                 |
+| 256     | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 1   | 16  | 0                 |
+| -       | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0   | -   | -                 |
+| $256^2$ | 1     | 1     | 1     | 1     | 1     | 1     | 1     | 0     | 0   | 23  | $256^2 \cdot 2^7$ |
+| -       | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 1     | 0   | -   | -                 |
+| $256^3$ | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0   | 23  | $256^2 \cdot 2^7$ |
+| -       | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0     | 0   | -   | -                 |
+
+In this example, the third virtual row has a 1 in the $a_7$ column, so the value in $z$ is the value of $p$ in the third trace row ($256^2$) multiplied by $2^7$.
+
+## Constraints
+
+The correctness of the above table is ensured by the following AIR constraints. $x'$ indicates a value in column $x$ in the next row, while $x$ indicates a value in the current row.
+
+### Input decomposition
+
+To ensure that the input value $a$ is decomposed correctly into the $a_i$ columns, we need to ensure the following:
+
+1. Values are binary (0 or 1).
+2. Adjacent cells may either remain the same or transition from $1 \to 0$.
+3. $a_i$ transitions from the end of one row to the beginning of the next within an 8-row cycle must follow the same transition rule as above. In other words, between $a_7$ and $a_0'$ the value must also either stay the same or transition from $1 \to 0$.
+
+The first two conditions can be enforced by the following constraints for each $a_i$.
+
+$a_i^2 - a_i = 0$ for $i \in \{0, 1, ..., 7\}$
+
+$(1 - a_i) \cdot a_{i+1} = 0$ for $i \in \{0, 1, ..., 6\}$
+
+This second constraint enforces that if $a_i = 0$ then $a_{i+1}$ must also be 0, but if $a_i=1$ then $a_{i+1}$ can be either 0 or 1.
+
+We can enforce the third condition with the aid of our helper column $h$. To do this, values in $h$ must be binary, must adhere to the same transition requirement as adjacent $a_i$ cells, and must be equal to the value of $a_0$ on the next row for all but the last row of each 8-row cycle. Here are the constraints for $h$:
+
+$$h^2 - h = 0$$
+
+$$(1 - a_7) \cdot h = 0$$
+
+$$ k_1 \cdot (a_0' - h) = 0$$
+
+Finally, to ensure that the input $a$ is never greater than the maximum exponent value for the table, we should also constrain the value of $a_7$ in the final row of the cycle to be 0.
+
+$$(1-k_1) \cdot a_7 = 0$$
+
+### Input aggregation
+
+In order to finish constraining the input, we must re-aggregate the decomposed input into column $a$ so that the final value in column $a$ at the end of each 8-row cycle holds the input value of the exponent for the power of two operation. The aggregation in column $a$ must also be reset at the beginning of each new 8-row cycle.
+
+We can accomplish this by aggregating the sum of $a_i$ values in the row and using the $k_1$ selector column to selectively include the previous value of $a$ for all but the first row of each 8-row cycle.
+
+$$a' - (a_0' + a_1'+a_2'+ ... + a_7' + k_1 \cdot a) = 0$$
+
+### Powers of 256
+
+Column p contains increasing powers of 256, which are used for output aggregation. We need to ensure that the value of $p$ in the first row of each 8-row cycle is initialized to 1 and that the value in each subsequent row in the cycle is multiplied by 256.
+
+$$k_0 \cdot (p-1) = 0$$
+
+$$k_1 \cdot (p' - 256 \cdot p) = 0$$
+
+### Output aggregation
+
+To aggregate the output into column $z$, we'll make use of intermediate helper variables from the "virtual rows" described above. These variables will be used for the constraints on column $z$.
+
+Let $t_i$ be a value in our virtual row computed from values $a_i$ and $h$ in the corresponding trace row, such that:
+
+- $t_0 = k_0 \cdot (1 - a_0)$
+- $t_i = a_{i-1} - a_i$ for $i \in \{1, 2, ..., 7\}$
+- $t_8 = a_7 - h$
+
+The output column $z$ must be constrained such that:
+
+1. The first row in each 8-row cycle aggregates over only the current row.
+2. Each other row in the cycle aggregates over the current row and the previous value of column $z$.
+
+We can modify our output equation from above to selectively include or exclude the previously aggregated value of z by use of the selector column $k_1$. This gives us the following constraint:
+
+$$z' - (\sum\limits_{i=0}^8 p' \cdot t_i' \cdot 2^i + k_1 \cdot z) = 0$$
+
+This ensures that in the first row of each cycle $z$ only aggregates powers from that row, while for all other rows in the cycle the previous value of $z$ is also included.
+
+## Permutation Product
+
+For the permutation check, we only need to include the final row of each 8-row cycle, since that row includes both the input and output values that need to be checked against the main execution trace.
+
+The value $v$ which we will add to our permutation product includes both the input and output values as follows, where $\alpha$ and $\beta$ are both random values provided by the verifier after the prover has committed to the execution trace.
+
+$$v = \beta + \alpha \cdot a + \alpha^2 \cdot z$$
+
+We can once again use our selector column $k_1$ to restrict our constraint on $p_0$ so that it is only modified in the final row of each cycle.
+
+$$p_0' = p_0 \cdot ((1-k_1) \cdot v + k_1)$$
+
+This ensures that when $k_1 = 0$, in the final row of the cycle, $p_0$ will be updated. In all other rows, where $k_1 = 1$, $p_0$ will remain the same.

--- a/docs/src/design/main.md
+++ b/docs/src/design/main.md
@@ -1,5 +1,6 @@
 # Design
 
+- [Range Checker](./range.md)
 - [Auxiliary Table](./aux_table/main.md)
   - [Hash Processor](./aux_table/hasher.md)
   - [Bitwise Processor](./aux_table/bitwise.md)

--- a/docs/src/design/main.md
+++ b/docs/src/design/main.md
@@ -1,0 +1,7 @@
+# Design
+
+- [Auxiliary Table](./aux_table/main.md)
+  - [Hash Processor](./aux_table/hasher.md)
+  - [Bitwise Processor](./aux_table/bitwise.md)
+  - [Power of Two Processor](./aux_table/pow2.md)
+  - [Memory Processor](./aux_table/memory.md)

--- a/docs/src/design/range.md
+++ b/docs/src/design/range.md
@@ -1,0 +1,254 @@
+# Range Checker
+
+This note assumes some familiarity with [permutation checks](https://hackmd.io/@arielg/ByFgSDA7D).
+
+Miden VM relies very heavily on 16-bit range-checks (checking if a value of a field element is between $0$ and $2^{16}$). For example, most of the [u32 operations](https://hackmd.io/NC-yRmmtRQSvToTHb96e8Q), need to perform between two and four 16-bit range-checks per operation. Similarly, operations involving memory (e.g. load and store) require two 16-bit range-check per operation.
+
+Thus, it is very important for the VM to be able to perform a large number 16-bit range checks very efficiently. In this note we describe how this can be achieved using permutation checks.
+
+## 8-bit range checks
+
+First, let's define a construction for the simplest possible 8-bit range-check. This can be done with a single column as illustrated below.
+
+![](https://i.imgur.com/qoIhcMD.png)
+
+For this to work as a range-check we need to enforce a few constraints on this column:
+
+- Value in the first row must be $0$.
+- Value in the last row must be $255$.
+- As we move from one row to the next, we can either keep the value the same, or increment it by $1$.
+
+Denoting $v$ as the value of column $v$ in the current row, and $v'$ as the value of column $v$ in the next row, we can enforce the last condition as follows:
+
+$$
+(v' - v) \cdot (v' - v - 1) = 0
+$$
+
+Together, these constraints guarantee that all values in column $v$ are between $0$ and $255$ (inclusive).
+
+We can then add another column $p_0$, which will keep a running product of values in $v$ offset by random value $\alpha$ (provided by the verifier). Transition constraints for column $p_0$ would look like so:
+
+$$
+p'_0 - p_0 \cdot (\alpha + v) = 0
+$$
+
+Using these two columns we can check if some other column in the execution trace is a permutation of values in $v$. Let's call this other column $x$. We can compute the running product of $x$ in the same way as we compute the running product for $v$. Then, we can check that the last value in $p_0$ is the same as the final value for the running product of $x$ (this is the permutation check).
+
+While this approach works, it has a couple of limitations:
+
+- First, column $v$ must contain all values between $0$ and $255$. Thus, if column $x$ does not contain one of these values, we need to artificially add this value to $x$ somehow (i.e., we need to pad $x$ with extra values).
+- Second, assuming $n$ is the length of execution trace, we can range-check at most $n$ values. Thus, if we wanted to range-check more than $n$ values, we'd need to introduce another column similar to $v$.
+
+To get rid of the padding requirement, we can add a _selector_ column, which would contain $1$ for values we want to include in the running product, and $0$ for the ones we don't. But we can address both issues with a single solution.
+
+### A better construction
+
+Let's add two selector column to our table $s_0$ and $s_1$ as illustrated below.
+
+![](https://i.imgur.com/gL3hWGE.png)
+
+The purpose of these columns is as follows:
+
+- When $s_0 = 0$ and $s_1 = 0$, we won't include the value into the running product.
+- When $s_0 = 1$ and $s_1 = 0$, we will include the value into the running product.
+- When $s_0 = 0$ and $s_1 = 1$, we will include two copies of the value into the running product.
+- When $s_0 = 1$ and $s_1 = 1$, we will include four copies of the value into the running product.
+
+Thus, for the table pictured below, the running product will include: a single $0$, a single $1$, no $2$'s, and five $3$'s etc.
+
+To keep the description of constraints simple, we'll first define the four flag values as follows:
+
+$$
+f_0 = (1 - s_0) \cdot (1 - s_1)
+$$
+
+$$
+f_1 = s_0 \cdot (1 - s_1)
+$$
+
+$$
+f_2 = (1 - s_0) \cdot s_1
+$$
+
+$$
+f_3 = s_0 \cdot s_1
+$$
+
+Thus, for example, when $s_0 = 1$ and $s_1 = 1$, $f_3 = 1$ and $f_0 = f_1 = f_2 = 0$.
+
+Then, we'll update transition constraints for $p_0$ like so:
+
+$$
+p'_0 - p_0 \cdot \left((\alpha + v)^4 \cdot f_3 + (\alpha + v)^2 \cdot f_2 + (\alpha + v) \cdot f_1 + f_0\right) = 0
+$$
+
+The above ensures that when $f_0 = 1$, $p_0$ remains the same, when $f_1 = 1$, $p_0$ is multiplied by $(\alpha + v)$, when $f_2 = 1$, $p_0$ is multiplied by $(\alpha + v)^2$, and when $f_3 = 1$, $p_0$ is multiplied by $(\alpha + v)^4$.
+
+We also need to ensure that values in columns $s_0$ and $s_1$ are binary (either $0$ or $1$). This can be done with the following constraints:
+
+$$
+s_0^2 - s_0 = 0
+$$
+
+$$
+s_1^2 - s_1 = 0
+$$
+
+And lastly, for completeness, we still need to impose a transition constraint that we had in the naive approach:
+
+$$
+(v' - v) \cdot (v' - v - 1) = 0
+$$
+
+This 3-column table addresses the limitations we had as follows:
+
+1. We no longer need to pad the column we want to range-check with extra values because we can skip the values we don't care about.
+2. We can support almost $4n$ range checks (when $n$ is relatively large). Though, for short traces (when $n < 256$), we can range-check at most $n$ unique values.
+
+The one downside of this approach is that the degree of our constraints is now $6$ (vs. $2$ in the naive approach). But in the context of Miden VM this doesn't matter as maximum constraint degree for the VM is $8$ anyway.
+
+## 16-bit range checks
+
+To support 16-bit range checks, let's try to extend the idea of the 8-bit table. Our 16-bit table would look like so (the only difference is that column $u$ now has to end with value $65535$):
+
+![](https://i.imgur.com/AhjTVSZ.png)
+
+While this works, it is rather wasteful. In the worst case, we'd need to enumerate over 65K values, most of which we may not actually need. It would be nice if we could "skip over" the values that we don't want. We can do this by relying on 8-bit range checks. Specifically, instead of enforcing constraint:
+
+$$
+(u' - u) \cdot (u' - u - 1) = 0
+$$
+
+We would enforce:
+
+$$
+p'_1 - p_1 \cdot (\alpha + u' - u) = 0
+$$
+
+Where $p_1$ is another running product column. At the end of the execution trace, we would check that $p_0 = p_1$. This would ensure that as we move from one row to another, values in column $u$ increase by at most $255$ (we are basically performing an 8-bit range check on increments of column $u$). Now, our table can look like this:
+
+![](https://i.imgur.com/LyCnLHS.png)
+
+We still may need to include some unneeded rows because we can not "jump" by more than $255$ values, but at least we are guaranteed that the number of such unneeded rows will never be greater than $256$.
+
+We also need to add another running product column $p_2$ to support permutation checks against column $u$. The constraint that we'll need to impose against this column is identical to the constraint we imposed against column $p_0$ and will look like so:
+
+$$
+p'_2 - p_2 \cdot \left((\alpha + u)^4 \cdot f_3 + (\alpha + u)^2 \cdot f_2 + (\alpha + u) \cdot f_1 + f_0\right) = 0
+$$
+
+Overall, with this construction we have the following:
+
+- We need two table of three columns each ($6$ columns total), and we need $3$ running product columns.
+- This gives us the ability to do the following:
+  - For long traces (when $n > 2^{16}$) we can support almost $4n$ arbitrary 16-bit range-checks.
+  - For short traces, we can range-check at most $n$ unique values, but if there are duplicates, we can support up to $4n$ total range-checks.
+
+But we can do better.
+
+## Optimizations
+
+First, we can just stack the tables on top of each other. We'll need to add a column to partition the table between the sections used for 8-bit range checks and sections used for 16-bit range checks. Let's call this column $t$. When $t = 0$, we'll apply constraints for the 8-bit table, and when $t = 1$, we'll apply constraints for the 16-bit table.
+
+![](https://i.imgur.com/AverKG1.png)
+
+Second, we can merge running product columns $p_0$ and $p_1$ into a single column. We'll do it like so:
+
+- When $t = 0$, we'll multiply the current value of the column by the 8-bit value (offset by random $\alpha$) that we want to add into the running product.
+- When $t = 1$, we'll divide the current value of the column by the 8-bit value (offset by random $\alpha$) which we'd like to remove from the running product.
+
+In the end, if we added and then removed all the same values, the value in this column (let's call it $p_0$) should equal to $1$, and we can check this condition via a boundary constraint.
+
+### Optimized constraints
+
+Below we list the full set of constraints needed to support the optimized construction described above.
+
+First, we'll need to make sure that all selector flags are binary. This can be done with the following constraints:
+
+$$
+t^2 - t = 0
+$$
+
+$$
+s_0^2 - s_0 = 0
+$$
+
+$$
+s_1^2 - s_1 = 0
+$$
+
+Next, we need to make sure that values in column $t$ can "flip" from $0$ to $1$ only once. The following constraint enforces this:
+
+$$
+t \cdot (1 - t') = 0
+$$
+
+Next, we need to make sure that when column $t$ "flips" from $0$ to $1$ (we are moving from the 8-bit section of the table to the 16-bit section), the current value in column $v$ is equal to $255$, and the next value is reset to $0$. This can be done with the following constraints:
+
+$$
+(1 - t) \cdot t' \cdot (v - 255) = 0
+$$
+
+$$
+(1 - t) \cdot t' \cdot v' = 0
+$$
+
+Next, we need to enforce that running products for the 8-bit section of the table and for the 16-bit sections of the table are computed correctly. To simplify the notation, we'll first define variable $z$ as:
+
+$$
+z = (\alpha + v)^4 \cdot f_3 + (\alpha + v)^2 \cdot f_2 + (\alpha + v) \cdot f_1 + f_0
+$$
+
+We'll compute the 16-bit running product in column $p_1$. Transition constraints for this column are fairly straightforward:
+
+$$
+p'_1 = p_1 \cdot (z \cdot t - t + 1)
+$$
+
+Thus, when $t = 0$, value in $p_1$ does not change, but when $t = 1$, the next value in $p_1$ is computed by multiplying the current value by $z$.
+
+For the 8-bit running product we'll use column $p_0$. Constraints against this column are a bit more complicated. The complication stems from the fact that for the 8-bit section of the table, we want to build up the product, but for the 16-bit section of the table, we want to reduce it. The constraints look as follows:
+
+$$
+p'_0 \cdot ((\alpha + v' - v) \cdot t - t + 1) = p_0 \cdot (z - z \cdot t + t)
+$$
+
+Thsu, when $t = 0$ (we are in the 8-bit section), the above expression reduces to:
+
+$$
+p'_0 = p_0 \cdot z
+$$
+
+But when $t = 1$ (we are in the 16-bit section), we get the following:
+
+$$
+p'_0 \cdot (\alpha + v' - v) = p_0
+$$
+
+The above actually enforces that $p'_0 = p_0 / (\alpha + v' - v)$. Thus, if the prover arranged the 8-bit and the 16-bit sections of the table correctly, we should end up with $p_0 = 1$ at the end of the trace.
+
+In addition to the transition constraints described above, we also need to enforce the following boundary constraints:
+
+- Value of $v$ in the first row is $0$.
+- Value of $v$ in the last row is $65535$.
+- Value of $p_0$ in the first and last rows is $1$.
+
+Overall, with this optimized construction we have the following:
+
+- We need a single table with $4$ columns, and we need $2$ running product columns.
+- The construction gives us the following capabilities:
+  - For long traces (when $n > 2^{16}$), we can do over $3n$ arbitrary 16-bit range-checks.
+  - For short traces ($2^{10} < n \le 2^{16}$), we can range-check at slightly fewer than $n$ unique values, but if there are duplicates, we may be able to range-check up to $3n$ total values.
+
+The only downside of this construction is again higher constraint degree. Specifically, some of the transition constraints described above have degree $8$. But again, in the context of Miden VM, this doesn't matter as max constraint degree of the VM is $8$ anyway.
+
+### Cost of running product columns
+
+It is important to note that depending on the field in which we operate, a running product column may actually require more than one trace columns. This is specifically true for small field.
+
+For example, if we are in a 64-bit field, each running product column would need to be represented by $2$ columns to achieve ~100-bit security, and by $3$ columns to achieve ~128-bit security.
+
+Since the native field of Miden VM is 64 bits, the total number of columns needed for the optimized construction described above is:
+
+- 8 columns for 96-bit security level.
+- 10 columns for 128-bit security level.


### PR DESCRIPTION
This PR adds documentation of the operation & constraint designs for processors where constraints have been implemented or recently updated. This includes the following processors:

- Range Checker
- Auxiliary Table (placeholder - not fully implemented yet & may require edits)
  - Hash Processor (placeholder - not implemented yet & may require edits)
  - Bitwise Processor
  - Power of Two Processor
  - Memory Processor

During this process, the Bitwise Processor documentation was updated to match the existing implementation and the Memory Processor documentation was also updated with small fixes.