### PR TITLE
Add procedure to clean up stack overflow table

### DIFF
--- a/miden/tests/integration/stdlib/mod.rs
+++ b/miden/tests/integration/stdlib/mod.rs
@@ -2,3 +2,4 @@ use crate::build_test;
 
 mod crypto;
 mod math;
+mod sys;

--- a/miden/tests/integration/stdlib/sys.rs
+++ b/miden/tests/integration/stdlib/sys.rs
@@ -1,0 +1,34 @@
+use super::build_test;
+use proptest::prelude::*;
+use rand_utils::rand_vector;
+use vm_core::MIN_STACK_DEPTH;
+
+#[test]
+fn finalize_stack() {
+    let source = "use.std::sys begin repeat.12 push.0 end exec.sys::finalize_stack end";
+    let test = build_test!(
+        source,
+        &[16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    );
+    test.expect_stack(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4]);
+}
+
+proptest! {
+    #[test]
+    fn finalize_stack_proptest(test_values in prop::collection::vec(any::<u64>(), MIN_STACK_DEPTH), n in 1_usize..100) {
+        let mut push_values = rand_vector::<u64>(n);
+        let mut source_vec = vec!["use.std::sys".to_string(), "begin".to_string()];
+        for value in push_values.iter() {
+            let token = format!("push.{value}");
+            source_vec.push(token);
+        }
+        source_vec.push("exec.sys::finalize_stack".to_string());
+        source_vec.push("end".to_string());
+        let source = source_vec.join(" ");
+        let mut expected_values = test_values.clone();
+        expected_values.append(&mut push_values);
+        expected_values.reverse();
+        expected_values.truncate(MIN_STACK_DEPTH);
+        build_test!(source, &test_values).prop_expect_stack(&expected_values)?;
+    }
+}

--- a/stdlib/asm/sys.masm
+++ b/stdlib/asm/sys.masm
@@ -1,0 +1,23 @@
+# Clears the stack overflow table and ensures the stack top remains unchanged
+# Input: Stack top with 16 elements + overflow table with greater than or equal to 0 number of elements.
+# Output: Stack top with original 16 elements
+export.finalize_stack.16
+    popw.local.0
+    popw.local.1
+    popw.local.2
+    popw.local.3
+    push.env.sdepth
+    neq.16
+    while.true
+        dropw
+        push.env.sdepth
+        neq.16
+    end
+    loadw.local.3
+    swapw.3
+    loadw.local.2
+    swapw.2
+    loadw.local.1
+    swapw.1
+    loadw.local.0
+end

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -4,7 +4,7 @@
 ///
 /// Entries in the array are tuples containing module namespace and module source code.
 #[rustfmt::skip]
-pub const MODULES: [(&str, &str); 5] = [
+pub const MODULES: [(&str, &str); 6] = [
 // ----- std::crypto::hashes::blake3 --------------------------------------------------------------
 ("std::crypto::hashes::blake3", "proc.from_mem_to_stack.1
     storew.local.0
@@ -10651,6 +10651,31 @@ export.unchecked_rotr
     movup.2
     not
     cswap
+end
+"),
+// ----- std::sys ---------------------------------------------------------------------------------
+("std::sys", "# Clears the stack overflow table and ensures the stack top remains unchanged
+# Input: Stack top with 16 elements + overflow table with greater than or equal to 0 number of elements.
+# Output: Stack top with original 16 elements
+export.finalize_stack.16
+    popw.local.0
+    popw.local.1
+    popw.local.2
+    popw.local.3
+    push.env.sdepth
+    neq.16
+    while.true
+        dropw
+        push.env.sdepth
+        neq.16
+    end
+    loadw.local.3
+    swapw.3
+    loadw.local.2
+    swapw.2
+    loadw.local.1
+    swapw.1
+    loadw.local.0
 end
 "),
 ];


### PR DESCRIPTION
Partly addresses #134. 
Add a procedure to stdlib to remove elements in the stack overflow table to clean up at the end of program completion.
It's kept separate for now and not added to the assembler to include to all programs as suggested by @bobbinth.