### PR TITLE
Implement AIR constraints for bitwise & power of two operations

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -22,3 +22,6 @@ std = ["vm-core/std", "winter-air/std"]
 [dependencies]
 vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
 winter-air = { package = "winter-air", version = "0.4", default-features = false }
+
+[dev-dependencies]
+proptest = "1.0.0"

--- a/air/src/aux_table/bitwise.rs
+++ b/air/src/aux_table/bitwise.rs
@@ -1,0 +1,314 @@
+use super::{EvaluationFrame, FieldElement, BITWISE_TRACE_OFFSET};
+use crate::utils::{binary_not, is_binary, EvaluationResult};
+use core::ops::Range;
+use vm_core::{bitwise::NUM_SELECTORS, utils::range as create_range};
+use winter_air::TransitionConstraintDegree;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The number of transition constraints on the bitwise co-processor.
+pub const NUM_CONSTRAINTS: usize = 8;
+/// The degrees of constraints on the bitwise co-processor.
+pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
+    4, 4, // Input decomposition values should be binary.
+    4, 4, // Enforce correct initial values of a and b columns.
+    4, 4, // Enforce correct aggregation of a and b columns during transitions.
+    7, 7, // Ensure correct output aggregation
+];
+
+/// Index of CONSTRAINT_DEGREES array after which all constraints use periodic columns.
+pub const PERIODIC_CONSTRAINTS_START: usize = 2;
+/// The number of bits decomposed per row.
+const NUM_DECOMP_BITS: usize = 4;
+
+const SELECTOR_COL_RANGE: Range<usize> = create_range(BITWISE_TRACE_OFFSET, NUM_SELECTORS);
+const A_COL_IDX: usize = SELECTOR_COL_RANGE.end;
+const B_COL_IDX: usize = A_COL_IDX + 1;
+const A_COL_RANGE: Range<usize> = create_range(B_COL_IDX + 1, NUM_DECOMP_BITS);
+const B_COL_RANGE: Range<usize> = create_range(A_COL_RANGE.end, NUM_DECOMP_BITS);
+const OUTPUT_COL_IDX: usize = B_COL_RANGE.end;
+
+// BITWISE TRANSITION CONSTRAINTS
+// ================================================================================================
+
+/// Builds the transition constraint degrees for the bitwise co-processor.
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    // Add the degrees of non-periodic constraints.
+    let mut degrees: Vec<TransitionConstraintDegree> = CONSTRAINT_DEGREES
+        [..PERIODIC_CONSTRAINTS_START]
+        .iter()
+        .map(|&degree| TransitionConstraintDegree::new(degree))
+        .collect();
+
+    // Add the degrees of periodic constraints.
+    degrees.append(
+        &mut CONSTRAINT_DEGREES[PERIODIC_CONSTRAINTS_START..]
+            .iter()
+            .map(|&degree| TransitionConstraintDegree::with_cycles(degree - 1, vec![8]))
+            .collect(),
+    );
+
+    degrees
+}
+
+/// Returns the number of transition constraints for the bitwise co-processor.
+pub fn get_transition_constraint_count() -> usize {
+    NUM_CONSTRAINTS
+}
+
+/// Enforces constraints for the bitwise co-processor, which includes the constraints for bitwise
+/// operations.
+pub fn enforce_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    bitwise_flag: E,
+) {
+    // Enforce correct decomposition of the input values into the a and b columns.
+    let index = enforce_input_decomposition(frame, periodic_values, result, bitwise_flag);
+
+    // Enforce that the operation result is aggregated into the output column correctly.
+    enforce_output_aggregation(frame, periodic_values, &mut result[index..], bitwise_flag);
+}
+
+// TRANSITION CONSTRAINT HELPERS
+// ================================================================================================
+fn enforce_input_decomposition<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) -> usize {
+    let constraint_count = 6;
+    // Flag that enforces these constraints when this co-processor segment is selected in the
+    // auxiliary table and the co-processor's selectors specify a bitwise operation.
+    let bitwise_op_flag = processor_flag * frame.bitwise_op_flag();
+
+    // Values in bit decomposition columns a0..a3 and b0..b3 should be binary.
+    for idx in 0..NUM_DECOMP_BITS {
+        result.agg_constraint(0, bitwise_op_flag, is_binary(frame.a_bit(idx)));
+        result.agg_constraint(1, bitwise_op_flag, is_binary(frame.b_bit(idx)));
+    }
+
+    // The values in columns a and b in the first row should be the aggregation of the decomposed
+    // bit columns a0..a3 and b0..b3.
+    let first_row_flag = bitwise_op_flag * periodic_values[0];
+    result.agg_constraint(2, first_row_flag, frame.a() - frame.a_agg_bits());
+    result.agg_constraint(3, first_row_flag, frame.b() - frame.b_agg_bits());
+
+    // During a transition between rows, the next value in the a or b columns should be 16 times the
+    // previous value plus the aggregation of the next row's bit values.
+    let transition_flag = bitwise_op_flag * periodic_values[1];
+    result.agg_constraint(
+        4,
+        transition_flag,
+        frame.a_next() - (E::from(16_u8) * frame.a() + frame.a_agg_bits_next()),
+    );
+    result.agg_constraint(
+        5,
+        transition_flag,
+        frame.b_next() - (E::from(16_u8) * frame.b() + frame.b_agg_bits_next()),
+    );
+
+    constraint_count
+}
+
+fn enforce_output_aggregation<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) -> usize {
+    let constraint_count = 2;
+    // Periodic column flags
+    let k0_flag = periodic_values[0];
+    let k1_flag = periodic_values[1];
+    // Operator flags
+    let bitwise_and_flag = processor_flag * frame.bitwise_and_flag();
+    let bitwise_or_flag = processor_flag * frame.bitwise_or_flag();
+    let bitwise_xor_flag = processor_flag * frame.bitwise_xor_flag();
+
+    // The value in the output column in the first row must be exactly equal to the the aggregated
+    // value of the operation applied to the bitwise decomposition columns a0..a3 and b0..b3.
+    result.agg_constraint(
+        0,
+        k0_flag * bitwise_and_flag,
+        frame.output() - bitwise_and(frame.bit_decomp()),
+    );
+    result.agg_constraint(
+        0,
+        k0_flag * bitwise_or_flag,
+        frame.output() - bitwise_or(frame.bit_decomp()),
+    );
+    result.agg_constraint(
+        0,
+        k0_flag * bitwise_xor_flag,
+        frame.output() - bitwise_xor(frame.bit_decomp()),
+    );
+
+    // During a transition between rows, the next value in the output column should be 16 times the
+    // previous value plus the aggregation of the nevt row's operation output.
+    let shifted_output = frame.output() * E::from(16_u8);
+    result.agg_constraint(
+        1,
+        k1_flag * bitwise_and_flag,
+        frame.output_next() - (shifted_output + bitwise_and(frame.bit_decomp_next())),
+    );
+    result.agg_constraint(
+        1,
+        k1_flag * bitwise_or_flag,
+        frame.output_next() - (shifted_output + bitwise_or(frame.bit_decomp_next())),
+    );
+    result.agg_constraint(
+        1,
+        k1_flag * bitwise_xor_flag,
+        frame.output_next() - (shifted_output + bitwise_xor(frame.bit_decomp_next())),
+    );
+
+    constraint_count
+}
+
+fn bitwise_and<E: FieldElement>(decomposed_values: &[E]) -> E {
+    let mut result = E::ZERO;
+    // Aggregate the result of the bitwise AND over the decomposed bits in the row.
+    for idx in 0..NUM_DECOMP_BITS {
+        let a = decomposed_values[idx];
+        let b = decomposed_values[idx + NUM_DECOMP_BITS];
+        result += E::from(2_u64.pow(idx as u32)) * a * b
+    }
+    result
+}
+
+fn bitwise_or<E: FieldElement>(decomposed_values: &[E]) -> E {
+    let mut result = E::ZERO;
+    // Aggregate the result of the bitwise OR over the decomposed bits in the row.
+    for idx in 0..NUM_DECOMP_BITS {
+        let a = decomposed_values[idx];
+        let b = decomposed_values[idx + NUM_DECOMP_BITS];
+        result += E::from(2_u64.pow(idx as u32)) * (a + b - a * b)
+    }
+    result
+}
+fn bitwise_xor<E: FieldElement>(decomposed_values: &[E]) -> E {
+    let mut result = E::ZERO;
+    // Aggregate the result of the bitwise XOR over the decomposed bits in the row.
+    for idx in 0..NUM_DECOMP_BITS {
+        let a = decomposed_values[idx];
+        let b = decomposed_values[idx + NUM_DECOMP_BITS];
+        result += E::from(2_u64.pow(idx as u32)) * (a + b - E::from(2_u8) * a * b)
+    }
+    result
+}
+
+// BITWISE FRAME EXTENSION TRAIT
+// ================================================================================================
+trait EvaluationFrameExt<E: FieldElement> {
+    // --- Column accessors -----------------------------------------------------------------------
+
+    fn selector(&self, index: usize) -> E;
+    fn a(&self) -> E;
+    fn a_next(&self) -> E;
+    fn a_bit(&self, index: usize) -> E;
+    fn b(&self) -> E;
+    fn b_next(&self) -> E;
+    fn b_bit(&self, index: usize) -> E;
+    fn bit_decomp(&self) -> &[E];
+    fn bit_decomp_next(&self) -> &[E];
+    fn output(&self) -> E;
+    fn output_next(&self) -> E;
+
+    // --- Intermediate variables & helpers -------------------------------------------------------
+    fn a_agg_bits(&self) -> E;
+    fn a_agg_bits_next(&self) -> E;
+    fn b_agg_bits(&self) -> E;
+    fn b_agg_bits_next(&self) -> E;
+
+    // --- Flags ----------------------------------------------------------------------------------
+
+    fn bitwise_op_flag(&self) -> E;
+    fn bitwise_and_flag(&self) -> E;
+    fn bitwise_or_flag(&self) -> E;
+    fn bitwise_xor_flag(&self) -> E;
+}
+
+impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
+    // --- Column accessors -----------------------------------------------------------------------
+
+    fn selector(&self, index: usize) -> E {
+        self.current()[SELECTOR_COL_RANGE.start + index]
+    }
+    fn a(&self) -> E {
+        self.current()[A_COL_IDX]
+    }
+    fn a_next(&self) -> E {
+        self.next()[A_COL_IDX]
+    }
+    fn a_bit(&self, index: usize) -> E {
+        self.current()[A_COL_RANGE.start + index]
+    }
+    fn b(&self) -> E {
+        self.current()[B_COL_IDX]
+    }
+    fn b_next(&self) -> E {
+        self.next()[B_COL_IDX]
+    }
+    fn b_bit(&self, index: usize) -> E {
+        self.current()[B_COL_RANGE.start + index]
+    }
+    fn bit_decomp(&self) -> &[E] {
+        &self.current()[A_COL_RANGE.start..B_COL_RANGE.end]
+    }
+    fn bit_decomp_next(&self) -> &[E] {
+        &self.next()[A_COL_RANGE.start..B_COL_RANGE.end]
+    }
+    fn output(&self) -> E {
+        self.current()[OUTPUT_COL_IDX]
+    }
+    fn output_next(&self) -> E {
+        self.next()[OUTPUT_COL_IDX]
+    }
+
+    // --- Intermediate variables & helpers -------------------------------------------------------
+    fn a_agg_bits(&self) -> E {
+        agg_bits(self.current(), A_COL_RANGE.start)
+    }
+    fn a_agg_bits_next(&self) -> E {
+        agg_bits(self.next(), A_COL_RANGE.start)
+    }
+    fn b_agg_bits(&self) -> E {
+        agg_bits(self.current(), B_COL_RANGE.start)
+    }
+    fn b_agg_bits_next(&self) -> E {
+        agg_bits(self.next(), B_COL_RANGE.start)
+    }
+
+    // --- Flags ----------------------------------------------------------------------------------
+
+    fn bitwise_op_flag(&self) -> E {
+        binary_not(self.selector(0) * self.selector(1))
+    }
+    fn bitwise_and_flag(&self) -> E {
+        binary_not(self.selector(0)) * binary_not(self.selector(1))
+    }
+    fn bitwise_or_flag(&self) -> E {
+        binary_not(self.selector(0)) * self.selector(1)
+    }
+    fn bitwise_xor_flag(&self) -> E {
+        self.selector(0) * binary_not(self.selector(1))
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+fn agg_bits<E: FieldElement>(row: &[E], start_idx: usize) -> E {
+    let mut result = E::ZERO;
+    // TODO: this can be optimized.
+    // From Bobbin: "we are multiplying by a small power of two and then summing up the results -
+    // thus, in theory, we could just aggregate results in a 128-bit integer and perform only a
+    // single reduction in the end. This works only when we are in the base field."
+    for bit_idx in 0..NUM_DECOMP_BITS {
+        result += E::from(2_u64.pow(bit_idx as u32)) * row[start_idx + bit_idx];
+    }
+    result
+}

--- a/air/src/aux_table/bitwise.rs
+++ b/air/src/aux_table/bitwise.rs
@@ -22,11 +22,17 @@ pub const PERIODIC_CONSTRAINTS_START: usize = 2;
 /// The number of bits decomposed per row.
 const NUM_DECOMP_BITS: usize = 4;
 
+/// The range of the selector columns in the trace.
 const SELECTOR_COL_RANGE: Range<usize> = create_range(BITWISE_TRACE_OFFSET, NUM_SELECTORS);
+/// The index of the column holding the aggregated value of input `a`.
 const A_COL_IDX: usize = SELECTOR_COL_RANGE.end;
+/// The index of the column holding the aggregated value of input `b`.
 const B_COL_IDX: usize = A_COL_IDX + 1;
+/// The index range for the bit decomposition of `a`.
 const A_COL_RANGE: Range<usize> = create_range(B_COL_IDX + 1, NUM_DECOMP_BITS);
+/// The index range for the bit decomposition of `b`.
 const B_COL_RANGE: Range<usize> = create_range(A_COL_RANGE.end, NUM_DECOMP_BITS);
+/// The index of the column containing the aggregated output value.
 const OUTPUT_COL_IDX: usize = B_COL_RANGE.end;
 
 // BITWISE TRANSITION CONSTRAINTS
@@ -74,6 +80,14 @@ pub fn enforce_constraints<E: FieldElement>(
 
 // TRANSITION CONSTRAINT HELPERS
 // ================================================================================================
+
+/// Enforces correct decomposition of the input values `a` and `b` in each row. This requires the
+/// following constraints:
+/// - All values in decomposition columns must be binary.
+/// - In the first row, the values in `a` and `b` must be the aggregation of their respective bit
+///   columns.
+/// - For every row except the last, the aggregated input value in the next row must be 16 times the
+///   the value in the current row plus the aggregation of the bit decomposition in the next row.
 fn enforce_input_decomposition<E: FieldElement>(
     frame: &EvaluationFrame<E>,
     periodic_values: &[E],
@@ -114,6 +128,15 @@ fn enforce_input_decomposition<E: FieldElement>(
     constraint_count
 }
 
+/// Enforces correct output aggregation for the operation. This requires the following 2 constraints
+/// for each operation:
+/// - In the first row, the output value must equal the aggregated result of the operation applied
+///   to the row.
+/// - For every row except the last, the output value in the next row must equal the output in the
+///   current row plus the aggregated result of the specified operation applied to the next row.
+///
+/// Because the selectors for the AND, OR, and XOR operations are mutually exclusive, the
+/// constraints for different operations can be aggregated into the same result indices.
 fn enforce_output_aggregation<E: FieldElement>(
     frame: &EvaluationFrame<E>,
     periodic_values: &[E],
@@ -148,7 +171,7 @@ fn enforce_output_aggregation<E: FieldElement>(
     );
 
     // During a transition between rows, the next value in the output column should be 16 times the
-    // previous value plus the aggregation of the nevt row's operation output.
+    // previous value plus the aggregation of the next row's operation output.
     let shifted_output = frame.output() * E::from(16_u8);
     result.agg_constraint(
         1,
@@ -169,6 +192,8 @@ fn enforce_output_aggregation<E: FieldElement>(
     constraint_count
 }
 
+/// Calculates the result of bitwise AND applied to the decomposed values provided as a bit array.
+/// The result will be the AND of the first 4 bits in the provided array with the latter 4 bits.
 fn bitwise_and<E: FieldElement>(decomposed_values: &[E]) -> E {
     let mut result = E::ZERO;
     // Aggregate the result of the bitwise AND over the decomposed bits in the row.
@@ -180,6 +205,8 @@ fn bitwise_and<E: FieldElement>(decomposed_values: &[E]) -> E {
     result
 }
 
+/// Calculates the result of bitwise OR applied to the decomposed values provided as a bit array.
+/// The result will be the OR of the first 4 bits in the provided array with the latter 4 bits.
 fn bitwise_or<E: FieldElement>(decomposed_values: &[E]) -> E {
     let mut result = E::ZERO;
     // Aggregate the result of the bitwise OR over the decomposed bits in the row.
@@ -190,6 +217,9 @@ fn bitwise_or<E: FieldElement>(decomposed_values: &[E]) -> E {
     }
     result
 }
+
+/// Calculates the result of bitwise XOR applied to the decomposed values provided as a bit array.
+/// The result will be the XOR of the first 4 bits in the provided array with the latter 4 bits.
 fn bitwise_xor<E: FieldElement>(decomposed_values: &[E]) -> E {
     let mut result = E::ZERO;
     // Aggregate the result of the bitwise XOR over the decomposed bits in the row.
@@ -206,29 +236,48 @@ fn bitwise_xor<E: FieldElement>(decomposed_values: &[E]) -> E {
 trait EvaluationFrameExt<E: FieldElement> {
     // --- Column accessors -----------------------------------------------------------------------
 
+    /// Gets the current value of the specified selector column.
     fn selector(&self, index: usize) -> E;
+    /// Gets the current value of the aggregated `a` input.
     fn a(&self) -> E;
+    /// Gets the value of the aggregated `a` input in the next row.
     fn a_next(&self) -> E;
+    /// Gets the value of the decomposed bit of `a` at the specified index in the current row.
     fn a_bit(&self, index: usize) -> E;
+    /// Gets the current value of the aggregated `b` input.
     fn b(&self) -> E;
+    /// Gets the value of the aggregated `b` input in the next row.
     fn b_next(&self) -> E;
+    /// Gets the value of the decomposed bit of `b` at the specified index in the current row.
     fn b_bit(&self, index: usize) -> E;
+    /// Gets the entire range of decomposed input values for `a` and `b` in the current row.
     fn bit_decomp(&self) -> &[E];
+    /// Gets the entire range of decomposed input values for `a` and `b` in the next row.
     fn bit_decomp_next(&self) -> &[E];
+    /// Gets the value of the aggregated output in the current row.
     fn output(&self) -> E;
+    /// Gets the value of the aggregated output in the next row.
     fn output_next(&self) -> E;
 
     // --- Intermediate variables & helpers -------------------------------------------------------
+    /// The aggregated value of the decomposed bits from `a` in the current row.
     fn a_agg_bits(&self) -> E;
+    /// The aggregated value of the decomposed bits from `a` in the next row.
     fn a_agg_bits_next(&self) -> E;
+    /// The aggregated value of the decomposed bits from `b` in the current row.
     fn b_agg_bits(&self) -> E;
+    /// The aggregated value of the decomposed bits from `b` in the next row.
     fn b_agg_bits_next(&self) -> E;
 
     // --- Flags ----------------------------------------------------------------------------------
 
+    /// A selector flag that specifies the operation is any one of bitwise AND, OR or XOR.
     fn bitwise_op_flag(&self) -> E;
+    /// The selector flag for the bitwise AND operation.
     fn bitwise_and_flag(&self) -> E;
+    /// The selector flag for the bitwise OR operation.
     fn bitwise_or_flag(&self) -> E;
+    /// The selector flag for the bitwise XOR operation.
     fn bitwise_xor_flag(&self) -> E;
 }
 
@@ -301,6 +350,8 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
 
 // HELPER FUNCTIONS
 // ================================================================================================
+/// Aggregate 4 decomposed bits representing a 4-bit binary value into a decimal value, starting
+/// from `start_idx` in the provided row.
 fn agg_bits<E: FieldElement>(row: &[E], start_idx: usize) -> E {
     let mut result = E::ZERO;
     // TODO: this can be optimized.

--- a/air/src/aux_table/bitwise_pow2/bitwise.rs
+++ b/air/src/aux_table/bitwise_pow2/bitwise.rs
@@ -9,11 +9,13 @@ use winter_air::TransitionConstraintDegree;
 
 /// The number of transition constraints on the bitwise co-processor.
 pub const NUM_CONSTRAINTS: usize = 8;
-/// The degrees of constraints on the bitwise co-processor.
+/// The degrees of constraints on the bitwise co-processor. The degree of all
+/// constraints is increased by 4 due to the co-processor selector flag from the auxiliary table
+/// (degree 2) and the selector flag specifying the bitwise operation (degree 2).
 pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
-    4, 4, // Input decomposition values should be binary.
-    4, 4, // Enforce correct initial values of a and b columns.
-    4, 4, // Enforce correct aggregation of a and b columns during transitions.
+    6, 6, // Input decomposition values should be binary.
+    6, 6, // Enforce correct initial values of a and b columns.
+    6, 6, // Enforce correct aggregation of a and b columns during transitions.
     7, 7, // Ensure correct output aggregation
 ];
 

--- a/air/src/aux_table/bitwise_pow2/bitwise.rs
+++ b/air/src/aux_table/bitwise_pow2/bitwise.rs
@@ -365,3 +365,81 @@ fn agg_bits<E: FieldElement>(row: &[E], start_idx: usize) -> E {
     }
     result
 }
+
+// TEST HELPER FUNCTIONS
+// ================================================================================================
+#[cfg(test)]
+use super::PERIODIC_CYCLE_LEN;
+#[cfg(test)]
+use vm_core::{
+    bitwise::{Selectors, BITWISE_AND, BITWISE_OR, BITWISE_XOR},
+    Felt, TRACE_WIDTH,
+};
+
+/// Generates the correct current and next rows for the specified operation, inputs, and current
+/// cycle row number and returns an EvaluationFrame for testing. It only tests frames within a
+/// cycle.
+///
+/// # Errors
+/// It expects the specified `cycle_row_num` for the current row to be such that the next row will
+/// still be in the same cycle. It will fail with a row number input.
+#[cfg(test)]
+pub fn get_test_frame(
+    operation: Selectors,
+    a: u32,
+    b: u32,
+    cycle_row_num: usize,
+) -> EvaluationFrame<Felt> {
+    assert!(
+        cycle_row_num < PERIODIC_CYCLE_LEN - 1,
+        "Failed to build test EvaluationFrame for bitwise operation. The next row would be in a new cycle."
+    );
+
+    // Initialize the rows.
+    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+
+    // Define the shift amounts for the specified rows.
+    let current_shift = NUM_DECOMP_BITS * (PERIODIC_CYCLE_LEN - cycle_row_num - 1);
+    let next_shift = current_shift - NUM_DECOMP_BITS;
+
+    // Set the operation selectors.
+    for idx in 0..NUM_SELECTORS {
+        current[SELECTOR_COL_RANGE.start + idx] = operation[idx];
+        next[SELECTOR_COL_RANGE.start + idx] = operation[idx];
+    }
+
+    // Set the input aggregation values.
+    let current_a = (a >> current_shift) as u64;
+    let current_b = (b >> current_shift) as u64;
+    let next_a = (a >> next_shift) as u64;
+    let next_b = (b >> next_shift) as u64;
+
+    current[A_COL_IDX] = Felt::new(current_a);
+    next[A_COL_IDX] = Felt::new(next_a);
+    current[B_COL_IDX] = Felt::new(current_b);
+    next[B_COL_IDX] = Felt::new(next_b);
+
+    // Set the input decomposition values.
+    for idx in 0..NUM_DECOMP_BITS {
+        current[A_COL_RANGE.start + idx] = Felt::new((current_a >> idx) & 1);
+        current[B_COL_RANGE.start + idx] = Felt::new((current_b >> idx) & 1);
+        next[A_COL_RANGE.start + idx] = Felt::new((next_a >> idx) & 1);
+        next[B_COL_RANGE.start + idx] = Felt::new((next_b >> idx) & 1);
+    }
+
+    // Set the output.
+    let output = if operation == BITWISE_AND {
+        a & b
+    } else if operation == BITWISE_OR {
+        a | b
+    } else if operation == BITWISE_XOR {
+        a ^ b
+    } else {
+        panic!("Test bitwise EvaluationFrame requested for unrecognized operation.");
+    };
+    current[OUTPUT_COL_IDX] = Felt::new((output >> current_shift) as u64);
+    next[OUTPUT_COL_IDX] = Felt::new((output >> next_shift) as u64);
+
+    EvaluationFrame::<Felt>::from_rows(current, next)
+}

--- a/air/src/aux_table/bitwise_pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/mod.rs
@@ -6,6 +6,9 @@ use vm_core::{bitwise::NUM_SELECTORS, utils::range as create_range, Felt};
 mod bitwise;
 mod pow2;
 
+#[cfg(test)]
+mod tests;
+
 // CONSTANTS
 // ================================================================================================
 

--- a/air/src/aux_table/bitwise_pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/mod.rs
@@ -1,0 +1,153 @@
+use super::{EvaluationFrame, FieldElement, TransitionConstraintDegree, BITWISE_TRACE_OFFSET};
+use crate::utils::is_binary;
+use core::ops::Range;
+use vm_core::{bitwise::NUM_SELECTORS, utils::range as create_range, Felt};
+
+mod bitwise;
+mod pow2;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The length of a periodic cycle in the Bitwise & Power of Two co-processor.
+pub const PERIODIC_CYCLE_LEN: usize = 8;
+/// The number of shared constraints on the combined trace of the Bitwise and Power of Two
+/// operation execution traces.
+pub const NUM_CONSTRAINTS: usize = 2;
+/// The degrees of constraints on the combined trace of the Bitwise and Power of Two traces. The
+/// degree of all constraints is increased by 2 due to the co-processor selector flag from the
+/// Auxiliary Table.
+pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
+    4, 4, // Selector flags must be binary.
+];
+/// The range of indices for selector columns in the trace.
+const SELECTOR_COL_RANGE: Range<usize> = create_range(BITWISE_TRACE_OFFSET, NUM_SELECTORS);
+/// The starting index of the trace for the power of two operation.
+const POW2_TRACE_OFFSET: usize = SELECTOR_COL_RANGE.end;
+
+// AUXILIARY TABLE TRANSITION CONSTRAINTS
+// ================================================================================================
+
+/// Builds the transition constraint degrees for the combined bitwise and power of two trace,
+/// including the shared constraints and the constraints for each of the co-processors.
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    let mut degrees: Vec<TransitionConstraintDegree> = CONSTRAINT_DEGREES
+        .iter()
+        .map(|&degree| TransitionConstraintDegree::new(degree))
+        .collect();
+
+    degrees.append(&mut bitwise::get_transition_constraint_degrees());
+
+    degrees.append(&mut pow2::get_transition_constraint_degrees());
+
+    degrees
+}
+
+/// Returns the number of transition constraints for the combined bitwise and power of two trace,
+/// including the shared constraints and the constraints for each of the co-processors.
+pub fn get_transition_constraint_count() -> usize {
+    NUM_CONSTRAINTS
+        + bitwise::get_transition_constraint_count()
+        + pow2::get_transition_constraint_count()
+}
+
+/// Enforces constraints for the combined bitwise and power of two trace, including the shared
+/// constraints and the constraints for each of the co-processors.
+pub fn enforce_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) {
+    // Selector transition constraints applying to both bitwise and power of two operations.
+    enforce_selectors(frame, result, processor_flag);
+
+    let mut constraint_offset = NUM_CONSTRAINTS;
+    // bitwise transition constraints
+    bitwise::enforce_constraints(
+        frame,
+        periodic_values,
+        &mut result[constraint_offset..],
+        processor_flag,
+    );
+    constraint_offset += bitwise::get_transition_constraint_count();
+
+    // power of two transition constraints
+    pow2::enforce_constraints(
+        frame,
+        periodic_values,
+        &mut result[constraint_offset..],
+        processor_flag * frame.pow2_flag(),
+    );
+}
+
+// TRANSITION CONSTRAINT HELPERS
+// ================================================================================================
+
+/// Constraint evaluation function to enforce that the Bitwise and Power of Two selector columns
+/// must be binary.
+fn enforce_selectors<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    processor_flag: E,
+) {
+    // All selectors must be binary for the entire table.
+    for (idx, result) in result.iter_mut().enumerate().take(NUM_SELECTORS) {
+        *result = processor_flag * is_binary(frame.selector(idx));
+    }
+}
+
+// BITWISE & POWER OF TWO FRAME EXTENSION TRAIT
+// ================================================================================================
+
+/// Trait to allow easy access to column values and intermediate variables used in constraint
+/// calculations for the shared contraints and the Power of Two co-processor.
+trait EvaluationFrameExt<E: FieldElement> {
+    // --- Column accessors -----------------------------------------------------------------------
+
+    /// Accessor for the selector column of the current row at the specified index.
+    fn selector(&self, index: usize) -> E;
+
+    // --- Co-processor selector flags ------------------------------------------------------------
+
+    /// Flag to indicate if the frame is executing a power of two operation.
+    fn pow2_flag(&self) -> E;
+}
+
+impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
+    // --- Column accessors -----------------------------------------------------------------------
+
+    fn selector(&self, index: usize) -> E {
+        self.current()[SELECTOR_COL_RANGE.start + index]
+    }
+
+    // --- Co-processor selector flags ------------------------------------------------------------
+
+    fn pow2_flag(&self) -> E {
+        self.selector(0) * self.selector(1)
+    }
+}
+
+// CYCLE MASKS
+// ================================================================================================
+pub const BITWISE_POW2_K0_MASK: [Felt; PERIODIC_CYCLE_LEN] = [
+    Felt::ONE,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+];
+
+pub const BITWISE_POW2_K1_MASK: [Felt; PERIODIC_CYCLE_LEN] = [
+    Felt::ONE,
+    Felt::ONE,
+    Felt::ONE,
+    Felt::ONE,
+    Felt::ONE,
+    Felt::ONE,
+    Felt::ONE,
+    Felt::ZERO,
+];

--- a/air/src/aux_table/bitwise_pow2/pow2.rs
+++ b/air/src/aux_table/bitwise_pow2/pow2.rs
@@ -1,0 +1,267 @@
+use crate::utils::{binary_not, is_binary};
+
+use super::{EvaluationFrame, FieldElement, POW2_TRACE_OFFSET};
+use core::ops::Range;
+use vm_core::{bitwise::POW2_POWERS_PER_ROW, utils::range as create_range};
+use winter_air::TransitionConstraintDegree;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The number of constraints on the management of the power of two co-processor.
+pub const NUM_CONSTRAINTS: usize = 24;
+/// The degrees of constraints on the management of the power of two co-processor. The degree of all
+/// constraints is increased by 4 due to the co-processor selector flag from the auxiliary table
+/// (degree 2) and the power of two operation selector flag (degree 2).
+pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
+    // --- INPUT DECOMPOSITION --------------------------------------------------------------------
+    6, 6, 6, 6, 6, 6, 6, 6, // All power decomposition columns are binary.
+    6, 6, 6, 6, 6, 6,
+    6, // Adjacent power decomposition cells can only transition from 1 -> 1 or 1 -> 0.
+    6, // The helper column must be binary.
+    6, // The transition between a7 and helper column can only be 1 -> 1 or 1 -> 0.
+    6, // The value of the helper column must equal the next value of a0, except in the last row.
+    6, // Ensure the input value a never exceeds the maximum allowed exponent value for the table.
+    6, // Constrain the input aggregation.
+    6, 6, // Enforce that the powers of 256 start at 1 and increase by 256 with each row.
+    6, 7, // Ensure that the output is aggregated correctly.
+];
+/// Index of CONSTRAINT_DEGREES array after which all constraints use periodic columns.
+const PERIODIC_CONSTRAINTS_START: usize = 17;
+
+const A_POWERS_COL_RANGE: Range<usize> = create_range(POW2_TRACE_OFFSET, POW2_POWERS_PER_ROW);
+const H_COL_IDX: usize = A_POWERS_COL_RANGE.end;
+const A_AGG_COL_IDX: usize = H_COL_IDX + 1;
+const P_COL_IDX: usize = A_AGG_COL_IDX + 1;
+const Z_AGG_COL_IDX: usize = P_COL_IDX + 1;
+
+// POWER OF TWO TRANSITION CONSTRAINTS
+// ================================================================================================
+
+/// Builds the transition constraint degrees for the power of two co-processor.
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    // Add the degrees of non-periodic constraints.
+    let mut degrees: Vec<TransitionConstraintDegree> = CONSTRAINT_DEGREES
+        [..PERIODIC_CONSTRAINTS_START]
+        .iter()
+        .map(|&degree| TransitionConstraintDegree::new(degree))
+        .collect();
+
+    // Add the degrees of periodic constraints.
+    degrees.append(
+        &mut CONSTRAINT_DEGREES[PERIODIC_CONSTRAINTS_START..]
+            .iter()
+            .map(|&degree| TransitionConstraintDegree::with_cycles(degree - 1, vec![8]))
+            .collect(),
+    );
+
+    degrees
+}
+
+/// Returns the number of transition constraints for the power of two co-processor.
+pub fn get_transition_constraint_count() -> usize {
+    NUM_CONSTRAINTS
+}
+
+/// Enforces constraints for the power of two co-processor.
+pub fn enforce_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) {
+    let mut index = enforce_input_decomposition(frame, periodic_values, result, processor_flag);
+
+    index +=
+        enforce_input_aggregation(frame, periodic_values, &mut result[index..], processor_flag);
+
+    index += enforce_powers_of_256(frame, periodic_values, &mut result[index..], processor_flag);
+
+    enforce_output_aggregation(frame, periodic_values, &mut result[index..], processor_flag);
+}
+
+// TRANSITION CONSTRAINT HELPERS
+// ================================================================================================
+
+fn enforce_input_decomposition<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) -> usize {
+    let num_constraints = 19;
+    let k1 = periodic_values[1];
+
+    // Values in power decomposition columns are all binary.
+    for (idx, result) in result.iter_mut().enumerate().take(POW2_POWERS_PER_ROW) {
+        *result = processor_flag * is_binary(frame.a_power(idx));
+    }
+    let mut constraint_index = POW2_POWERS_PER_ROW;
+
+    // Adjacent cells in decomposition columns can stay the same or transition from 1 -> 0.
+    for (idx, result) in result[constraint_index..]
+        .iter_mut()
+        .enumerate()
+        .take(POW2_POWERS_PER_ROW - 1)
+    {
+        *result = processor_flag * binary_not(frame.a_power(idx)) * frame.a_power(idx + 1);
+    }
+    constraint_index += POW2_POWERS_PER_ROW - 1;
+
+    // The helper column is binary.
+    result[constraint_index] = processor_flag * is_binary(frame.h());
+    constraint_index += 1;
+
+    // The transition from a7 to the helper column can stay the same or change from 1 -> 0.
+    result[constraint_index] = processor_flag * binary_not(frame.a_power(7)) * frame.h();
+    constraint_index += 1;
+
+    // The helper column value equals the value of a0 in the next row for all rows except the last.
+    result[constraint_index] = processor_flag * k1 * (frame.a_power_next(0) - frame.h());
+    constraint_index += 1;
+
+    // Ensure input is never greater than the maximum exponent of the table by enforcing that the
+    // last power decomposition cell is always zero.
+    result[constraint_index] = processor_flag * binary_not(k1) * frame.a_power(7);
+
+    num_constraints
+}
+
+fn enforce_input_aggregation<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) -> usize {
+    let num_constraints = 1;
+    let k1 = periodic_values[1];
+
+    // Aggregate the next row's decomposed powers.
+    let agg_row_powers: E =
+        (0..POW2_POWERS_PER_ROW).fold(E::ZERO, |r, idx| r + frame.a_power_next(idx));
+
+    // Ensure the decomposed input is aggregated into column a.
+    result[0] = processor_flag * (frame.a_next() - (agg_row_powers + k1 * frame.a()));
+
+    num_constraints
+}
+
+fn enforce_powers_of_256<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) -> usize {
+    let num_constraints = 2;
+    let k0 = periodic_values[0];
+    let k1 = periodic_values[1];
+
+    result[0] = processor_flag * k0 * (frame.p() - E::ONE);
+    result[1] = processor_flag * k1 * (frame.p_next() - E::from(256_u16) * frame.p());
+
+    num_constraints
+}
+
+fn enforce_output_aggregation<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) -> usize {
+    let num_constraints = 2;
+    let k0 = periodic_values[0];
+    let k1 = periodic_values[1];
+
+    // Enforce correct output aggregation in the first row.
+    let agg_row_output = (0..=POW2_POWERS_PER_ROW).fold(E::ZERO, |r, idx| r + frame.a_output(idx));
+    result[0] = processor_flag * k0 * (frame.z() - agg_row_output);
+
+    // For all rows except the last, enforce the next row's output is the aggregation of the
+    // decomposed powers in the next row and the output value in the current row.
+    let agg_next_row_output =
+        (0..=POW2_POWERS_PER_ROW).fold(E::ZERO, |r, idx| r + frame.a_output_next(idx));
+    result[1] =
+        processor_flag * k1 * (frame.z_next() - (frame.p_next() * agg_next_row_output + frame.z()));
+
+    num_constraints
+}
+
+// BITWISE FRAME EXTENSION TRAIT
+// ================================================================================================
+trait EvaluationFrameExt<E: FieldElement> {
+    // --- Column accessors -----------------------------------------------------------------------
+
+    fn a_power(&self, index: usize) -> E;
+    fn a_power_next(&self, index: usize) -> E;
+    fn h(&self) -> E;
+    fn h_next(&self) -> E;
+    fn a(&self) -> E;
+    fn a_next(&self) -> E;
+    fn p(&self) -> E;
+    fn p_next(&self) -> E;
+    fn z(&self) -> E;
+    fn z_next(&self) -> E;
+
+    // --- Intermediate variables & helpers -------------------------------------------------------
+    fn a_output(&self, index: usize) -> E;
+    fn a_output_next(&self, index: usize) -> E;
+
+    // --- Flags ----------------------------------------------------------------------------------
+}
+
+impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
+    // --- Column accessors -----------------------------------------------------------------------
+
+    fn a_power(&self, index: usize) -> E {
+        self.current()[A_POWERS_COL_RANGE.start + index]
+    }
+    fn a_power_next(&self, index: usize) -> E {
+        self.next()[A_POWERS_COL_RANGE.start + index]
+    }
+    fn h(&self) -> E {
+        self.current()[H_COL_IDX]
+    }
+    fn h_next(&self) -> E {
+        self.next()[H_COL_IDX]
+    }
+    fn a(&self) -> E {
+        self.current()[A_AGG_COL_IDX]
+    }
+    fn a_next(&self) -> E {
+        self.next()[A_AGG_COL_IDX]
+    }
+    fn p(&self) -> E {
+        self.current()[P_COL_IDX]
+    }
+    fn p_next(&self) -> E {
+        self.next()[P_COL_IDX]
+    }
+    fn z(&self) -> E {
+        self.current()[Z_AGG_COL_IDX]
+    }
+    fn z_next(&self) -> E {
+        self.next()[Z_AGG_COL_IDX]
+    }
+
+    // --- Intermediate variables & helpers -------------------------------------------------------
+
+    fn a_output(&self, index: usize) -> E {
+        match index {
+            0 => binary_not(self.a_power(0)),
+            8 => (self.a_power(index - 1) - self.h()) * E::from(2_u64.pow(index as u32)),
+            _ => (self.a_power(index - 1) - self.a_power(index)) * E::from(2_u64.pow(index as u32)),
+        }
+    }
+    fn a_output_next(&self, index: usize) -> E {
+        match index {
+            0 => E::ZERO,
+            8 => (self.a_power_next(7) - self.h_next()) * E::from(2_u64.pow(index as u32)),
+            _ => {
+                (self.a_power_next(index - 1) - self.a_power_next(index))
+                    * E::from(2_u64.pow(index as u32))
+            }
+        }
+    }
+
+    // --- Flags ----------------------------------------------------------------------------------
+}

--- a/air/src/aux_table/bitwise_pow2/pow2.rs
+++ b/air/src/aux_table/bitwise_pow2/pow2.rs
@@ -299,3 +299,120 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
         }
     }
 }
+
+// TEST HELPER FUNCTIONS
+// ================================================================================================
+#[cfg(test)]
+use super::{NUM_SELECTORS, PERIODIC_CYCLE_LEN, SELECTOR_COL_RANGE};
+#[cfg(test)]
+use vm_core::{bitwise::POWER_OF_TWO, Felt, TRACE_WIDTH};
+
+/// Generates the correct current and next rows for the power of two operation with the specified
+/// input exponent at the specified cycle row number, then returns an EvaluationFrame for testing.
+/// It only tests frames within a cycle.
+///
+/// # Errors
+/// It expects the specified `cycle_row_num` for the current row to be such that the next row will
+/// still be in the same cycle. It will fail with a row number input.
+#[cfg(test)]
+pub fn get_test_frame(exponent: u32, cycle_row_num: usize) -> EvaluationFrame<Felt> {
+    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+
+    // Set the operation selectors.
+    for idx in 0..NUM_SELECTORS {
+        current[SELECTOR_COL_RANGE.start + idx] = POWER_OF_TWO[idx];
+        next[SELECTOR_COL_RANGE.start + idx] = POWER_OF_TWO[idx];
+    }
+
+    // The index of the final decomposition row.
+    let mut final_decomp_row = exponent as usize / POW2_POWERS_PER_ROW;
+    if exponent != 0 && exponent % POW2_POWERS_PER_ROW as u32 == 0 {
+        // Multiples of 8 are aggregated in the previous row, except for 0.
+        // Both 0 and 8 are aggregated in the first row.
+        final_decomp_row -= 1;
+    }
+
+    if (cycle_row_num + 1) < final_decomp_row {
+        // Both rows in this frame come before the decomposition finishes.
+        set_pre_output_agg_row(cycle_row_num, &mut current);
+        set_pre_output_agg_row(cycle_row_num + 1, &mut next);
+    } else if cycle_row_num > final_decomp_row {
+        // Both rows in this frame come after the decomposition & aggregation have finished.
+        set_post_output_agg_row(exponent, cycle_row_num, &mut current);
+        set_post_output_agg_row(exponent, cycle_row_num + 1, &mut next);
+    } else if cycle_row_num == final_decomp_row {
+        // The current row is the output aggregation row.
+        set_output_agg_row(exponent, cycle_row_num, &mut current);
+        set_post_output_agg_row(exponent, cycle_row_num + 1, &mut next);
+    } else {
+        // The next row is the output aggregation row.
+        set_pre_output_agg_row(cycle_row_num, &mut current);
+        set_output_agg_row(exponent, cycle_row_num + 1, &mut next);
+    }
+
+    EvaluationFrame::<Felt>::from_rows(current, next)
+}
+
+/// Fill a frame row with the expected values for a power of two operation row before the input
+/// decomposition finishes. In this case, all input decomposition columns in the row will be set
+/// to ONE. This function expects that the values in the frame_row have been initialized to
+/// ZERO.
+#[cfg(test)]
+fn set_pre_output_agg_row(row_num: usize, frame_row: &mut [Felt]) {
+    // Set the power decomposition and helper columns to one while decomposition is continuing.
+    for cell in frame_row
+        .iter_mut()
+        .take(H_COL_IDX + 1)
+        .skip(A_POWERS_COL_RANGE.start)
+    {
+        *cell = Felt::ONE;
+    }
+
+    // set the input aggregation column
+    frame_row[A_AGG_COL_IDX] = Felt::new((POW2_POWERS_PER_ROW * (row_num + 1)) as u64);
+
+    // Set the power of 256 column value.
+    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
+
+    // The output is zero before it is aggregated.
+}
+
+/// Fill a frame row with the expected values for a power of two operation row where the input
+/// decomposition finishes and the output is aggregated. This function expects that the values
+/// in the frame_row have been initialized to ZERO.
+#[cfg(test)]
+fn set_output_agg_row(exponent: u32, row_num: usize, frame_row: &mut [Felt]) {
+    let final_decomp_row_power = exponent as usize - row_num * POW2_POWERS_PER_ROW;
+
+    for idx in 0..final_decomp_row_power {
+        frame_row[A_POWERS_COL_RANGE.start + idx] = Felt::ONE;
+    }
+    // The rest of the helper and power decomposition columns should be left as zero.
+
+    // After decomposition is finished, the value of a is the input exponent.
+    frame_row[A_AGG_COL_IDX] = Felt::new(exponent as u64);
+
+    // Set the power of 256 column value.
+    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
+
+    // After aggregation, the output is the result.
+    frame_row[Z_AGG_COL_IDX] = Felt::new(2_u64.pow(exponent));
+}
+
+/// Fill a frame row with the expected values for a power of two operation row after the output
+/// aggregation has been done. This function expects that the values in the frame_row have been
+/// initialized to ZERO.
+#[cfg(test)]
+fn set_post_output_agg_row(exponent: u32, row_num: usize, frame_row: &mut [Felt]) {
+    // The power decomposition and helper columns are zero after decomposition is finished.
+
+    // After decomposition is finished, the value of a is the input exponent.
+    frame_row[A_AGG_COL_IDX] = Felt::new(exponent as u64);
+
+    // Set the power of 256 column value.
+    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
+
+    // After aggregation, the output is the result.
+    frame_row[Z_AGG_COL_IDX] = Felt::new(2_u64.pow(exponent));
+}

--- a/air/src/aux_table/bitwise_pow2/tests.rs
+++ b/air/src/aux_table/bitwise_pow2/tests.rs
@@ -1,0 +1,69 @@
+use super::{bitwise, pow2, PERIODIC_CYCLE_LEN};
+use crate::{Felt, FieldElement};
+use vm_core::bitwise::{Selectors, BITWISE_AND, BITWISE_OR, BITWISE_XOR};
+
+use proptest::prelude::*;
+
+// UNIT TESTS
+// ================================================================================================
+
+proptest! {
+    #[test]
+    fn test_bitwise_and(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(PERIODIC_CYCLE_LEN - 1)) {
+        test_bitwise_frame(BITWISE_AND, a, b, cycle_row);
+    }
+
+    #[test]
+    fn test_bitwise_or(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(PERIODIC_CYCLE_LEN - 1)) {
+        test_bitwise_frame(BITWISE_OR, a, b, cycle_row);
+    }
+
+    #[test]
+    fn test_bitwise_xor(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(PERIODIC_CYCLE_LEN - 1)) {
+        test_bitwise_frame(BITWISE_XOR, a, b, cycle_row);
+    }
+
+    #[test]
+    fn test_pow2(exponent in 0_u32..64, cycle_row in 0..(PERIODIC_CYCLE_LEN - 1)) {
+        test_pow2_frame(exponent, cycle_row);
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Returns the values from the shared bitwise & power of two processor's periodic columns for the
+/// specified cycle row.
+fn get_test_periodic_values(cycle_row: usize) -> [Felt; 2] {
+    match cycle_row {
+        0 => [Felt::ONE, Felt::ONE],
+        8 => [Felt::ZERO, Felt::ZERO],
+        _ => [Felt::ZERO, Felt::ONE],
+    }
+}
+
+/// Generates the specified trace frame for the specified bitwise operation and inputs, then asserts
+/// that applying the constraints to this frame yields valid results (all zeros).
+fn test_bitwise_frame(operation: Selectors, a: u32, b: u32, cycle_row: usize) {
+    let frame = bitwise::get_test_frame(operation, a, b, cycle_row);
+    let periodic_values = get_test_periodic_values(cycle_row);
+    let mut result = [Felt::ZERO; bitwise::NUM_CONSTRAINTS];
+    let expected = result;
+
+    bitwise::enforce_constraints(&frame, &periodic_values, &mut result, Felt::ONE);
+
+    assert_eq!(expected, result);
+}
+
+/// Generates the specified trace frame for the specified power of two operation, then asserts
+/// that applying the constraints to this frame yields valid results (all zeros).
+fn test_pow2_frame(exponent: u32, cycle_row: usize) {
+    let frame = pow2::get_test_frame(exponent, cycle_row);
+    let periodic_values = get_test_periodic_values(cycle_row);
+    let mut result = [Felt::ZERO; pow2::NUM_CONSTRAINTS];
+    let expected = result;
+
+    pow2::enforce_constraints(&frame, &periodic_values, &mut result, Felt::ONE);
+
+    assert_eq!(expected, result);
+}

--- a/air/src/aux_table/mod.rs
+++ b/air/src/aux_table/mod.rs
@@ -128,7 +128,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
         self.current()[S0_COL_IDX]
     }
     fn s1(&self) -> E {
-        self.next()[S1_COL_IDX]
+        self.current()[S1_COL_IDX]
     }
     fn s2(&self) -> E {
         self.current()[S2_COL_IDX]

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -21,12 +21,6 @@ pub use options::ProofOptions;
 pub use vm_core::{utils::ToElements, Felt, FieldElement, StarkField};
 pub use winter_air::{FieldExtension, HashFunction};
 
-// CONSTANTS
-// ================================================================================================
-
-/// The length of a cycle in the periodic columns.
-pub const PERIODIC_CYCLE_LEN: usize = 8;
-
 // PROCESSOR AIR
 // ================================================================================================
 
@@ -98,7 +92,10 @@ impl Air for ProcessorAir {
     /// - k0 column, which has a repeating pattern of a single one followed by 7 zeros.
     /// - k1 column, which has a repeating pattern of a 7 ones followed by a single zero.
     fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {
-        vec![K0_MASK.to_vec(), K1_MASK.to_vec()]
+        vec![
+            aux_table::BITWISE_POW2_K0_MASK.to_vec(),
+            aux_table::BITWISE_POW2_K1_MASK.to_vec(),
+        ]
     }
 
     // ASSERTIONS
@@ -208,27 +205,3 @@ impl Serializable for PublicInputs {
         target.write(self.stack_outputs.as_slice());
     }
 }
-
-// CYCLE MASKS
-// ================================================================================================
-pub const K0_MASK: [Felt; PERIODIC_CYCLE_LEN] = [
-    Felt::ONE,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-];
-
-pub const K1_MASK: [Felt; PERIODIC_CYCLE_LEN] = [
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ZERO,
-];

--- a/core/src/bitwise/mod.rs
+++ b/core/src/bitwise/mod.rs
@@ -1,0 +1,30 @@
+use super::{Felt, FieldElement};
+
+// CONSTANTS
+// ================================================================================================
+
+/// Number of selector columns in the trace.
+pub const NUM_SELECTORS: usize = 2;
+
+/// Number of columns needed to record an execution trace of the bitwise and power of two helper.
+pub const TRACE_WIDTH: usize = NUM_SELECTORS + 12;
+
+/// Specifies a bitwise AND operation.
+pub const BITWISE_AND: Selectors = [Felt::ZERO, Felt::ZERO];
+
+/// Specifies a bitwise OR operation.
+pub const BITWISE_OR: Selectors = [Felt::ZERO, Felt::ONE];
+
+/// Specifies a bitwise XOR operation.
+pub const BITWISE_XOR: Selectors = [Felt::ONE, Felt::ZERO];
+
+/// Specifies a power of two operation.
+pub const POWER_OF_TWO: Selectors = [Felt::ONE, Felt::ONE];
+
+/// The maximum power of two that can be added to the trace per row.
+pub const POW2_POWERS_PER_ROW: usize = 8;
+
+// TYPE ALIASES
+// ================================================================================================
+
+pub type Selectors = [Felt; NUM_SELECTORS];

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,6 @@
 use core::ops::Range;
 
+pub mod bitwise;
 pub mod hasher;
 pub mod program;
 pub use math::{fields::f64::BaseElement as Felt, FieldElement, StarkField};

--- a/docs/src/design/aux_table/pow2.md
+++ b/docs/src/design/aux_table/pow2.md
@@ -129,24 +129,27 @@ $$k_1 \cdot (p' - 256 \cdot p) = 0$$
 
 ### Output aggregation
 
-To aggregate the output into column $z$, we'll make use of intermediate helper variables from the "virtual rows" described above. These variables will be used for the constraints on column $z$.
+To aggregate the output into column $z$, we'll enforce the following conditions using a validity constraint for the first row and a transition constraint for the rest of the rows in the cycle.
+
+1. In the first row of each 8-row cycle, the value in $z$ aggregates over the current row.
+2. For all rows in the cycle except the last, the value of $z$ in the next row must equal the aggregation of the output in the next row plus the value of $z$ in the current row.
+
+To enforce these constraints on column $z$, we can make use of intermediate helper variables from the "virtual rows" described above.
 
 Let $t_i$ be a value in our virtual row computed from values $a_i$ and $h$ in the corresponding trace row, such that:
 
-- $t_0 = k_0 \cdot (1 - a_0)$
+- $t_0 = (1 - a_0)$ in the first row, to ensure correct output aggregation when the input value is 0.
+- $t_0 = 0$ for all other rows in the cycle.
 - $t_i = a_{i-1} - a_i$ for $i \in \{1, 2, ..., 7\}$
 - $t_8 = a_7 - h$
 
-The output column $z$ must be constrained such that:
+We can use selector $k_0$ to turn on the validity constraint for the first row and selector $k_1$ to apply the transition constraint to all but the last row in the cycle. This gives us the following constraints.
 
-1. The first row in each 8-row cycle aggregates over only the current row.
-2. Each other row in the cycle aggregates over the current row and the previous value of column $z$.
+$$k_0 \cdot \left(z - (\sum\limits_{i=0}^8 t_i \cdot 2^i)\right) = 0$$
 
-We can modify our output equation from above to selectively include or exclude the previously aggregated value of z by use of the selector column $k_1$. This gives us the following constraint:
+$$k_1 \cdot \left(z' - (p' \cdot \sum\limits_{i=0}^8 t_i' \cdot 2^i + z)\right) = 0$$
 
-$$z' - (\sum\limits_{i=0}^8 p' \cdot t_i' \cdot 2^i + k_1 \cdot z) = 0$$
-
-This ensures that in the first row of each cycle $z$ only aggregates powers from that row, while for all other rows in the cycle the previous value of $z$ is also included.
+The first constraint ensures that in the first row of each cycle $z$ only aggregates powers from that row, while the second one ensures that for all other rows in the cycle the previous value of $z$ is also included.
 
 ## Permutation Product
 

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -62,17 +62,8 @@ pub fn test_example(example: Example, fail: bool) {
         expected_result,
     } = example;
 
-    let options = ProofOptions::new(
-        32,
-        16,
-        0,
-        miden::HashFunction::Blake3_256,
-        miden::FieldExtension::None,
-        8,
-        256,
-    );
-
-    let (mut outputs, proof) = miden::execute(&program, &inputs, num_outputs, &options).unwrap();
+    let (mut outputs, proof) =
+        miden::execute(&program, &inputs, num_outputs, &ProofOptions::default()).unwrap();
 
     assert_eq!(
         expected_result, outputs,
@@ -80,7 +71,7 @@ pub fn test_example(example: Example, fail: bool) {
     );
 
     if fail {
-        outputs[0] = outputs[0] + 1;
+        outputs[0] += 1;
         assert!(miden::verify(*program.hash(), &pub_inputs, &outputs, proof).is_err())
     } else {
         assert!(miden::verify(*program.hash(), &pub_inputs, &outputs, proof).is_ok());

--- a/miden/tests/integration/air/bitwise.rs
+++ b/miden/tests/integration/air/bitwise.rs
@@ -1,0 +1,58 @@
+use crate::{build_op_test, build_test};
+
+#[test]
+fn bitwise_and() {
+    // Test all bit input combinations: (1, 1), (1, 0), (0, 0). Then test larger numbers.
+    let asm_op = "u32and push.0 u32and push.0 u32and push.65535 push.137 u32and";
+    let pub_inputs = vec![1, 1];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+}
+
+#[test]
+fn bitwise_or() {
+    // Test all bit input combinations: (1, 1), (1, 0), (0, 0). Then test larger numbers.
+    let asm_op = "u32or push.0 u32or not push.0 u32or push.65535 push.137 u32or";
+    let pub_inputs = vec![1, 1];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+}
+
+#[test]
+fn bitwise_xor() {
+    // Test all bit input combinations: (1, 1), (0, 0), (1, 0). Then test larger numbers
+    let asm_op = "u32xor push.0 u32xor push.1 u32xor push.65535 push.137 u32xor";
+    let pub_inputs = vec![1, 1];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+}
+
+#[test]
+fn pow2() {
+    // Test powers of two significant to the construction: each power decomposed in the first row
+    // of the pow2 trace; the first element of a  middle row; and the maximum exponent value.
+    let script = "begin
+        push.0 pow2 
+        push.1 pow2 
+        push.2 pow2
+        push.3 pow2
+        push.4 pow2
+        push.5 pow2
+        push.6 pow2
+        push.7 pow2
+        push.8 pow2
+        push.9 pow2
+        push.63 pow2
+    end";
+    let pub_inputs = vec![];
+
+    build_test!(script, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+}
+
+#[test]
+fn all_operations() {
+    let source = "begin u32and push.0 u32or push.0 u32xor push.9 pow2 end";
+    let pub_inputs = vec![1, 1];
+
+    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+}

--- a/miden/tests/integration/air/mod.rs
+++ b/miden/tests/integration/air/mod.rs
@@ -1,0 +1,1 @@
+mod bitwise;

--- a/miden/tests/integration/main.rs
+++ b/miden/tests/integration/main.rs
@@ -1,5 +1,6 @@
 mod helpers;
 
+mod air;
 mod exec_iters;
 mod flow_control;
 mod operations;

--- a/processor/src/aux_table/tests.rs
+++ b/processor/src/aux_table/tests.rs
@@ -1,12 +1,11 @@
 use super::{
     super::{
-        bitwise::BITWISE_OR,
         hasher::{LINEAR_HASH, RETURN_STATE},
         ExecutionTrace, Operation, Process,
     },
     AuxTableTrace,
 };
-use vm_core::{Felt, FieldElement, ProgramInputs, AUX_TRACE_RANGE};
+use vm_core::{bitwise::BITWISE_OR, Felt, FieldElement, ProgramInputs, AUX_TRACE_RANGE};
 
 #[test]
 fn hasher_aux_trace() {

--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -1,4 +1,8 @@
 use super::{ExecutionError, Felt, FieldElement, StarkField, TraceFragment};
+use vm_core::bitwise::{
+    BITWISE_AND, BITWISE_OR, BITWISE_XOR, NUM_SELECTORS, POW2_POWERS_PER_ROW, POWER_OF_TWO,
+    TRACE_WIDTH,
+};
 
 #[cfg(test)]
 mod tests;
@@ -6,29 +10,9 @@ mod tests;
 // CONSTANTS
 // ================================================================================================
 
-/// Number of selector columns in the trace.
-const NUM_SELECTORS: usize = 2;
-
-/// Number of columns needed to record an execution trace of the bitwise and power of two helper.
-const TRACE_WIDTH: usize = NUM_SELECTORS + 12;
-
 /// Initial capacity of each column.
 const INIT_TRACE_CAPACITY: usize = 128;
 
-/// Specifies a bitwise AND operation.
-pub const BITWISE_AND: Selectors = [Felt::ZERO, Felt::ZERO];
-
-/// Specifies a bitwise OR operation.
-pub const BITWISE_OR: Selectors = [Felt::ZERO, Felt::ONE];
-
-/// Specifies a bitwise XOR operation.
-pub const BITWISE_XOR: Selectors = [Felt::ONE, Felt::ZERO];
-
-/// Specifies a power of two operation.
-pub const POWER_OF_TWO: Selectors = [Felt::ONE, Felt::ONE];
-
-/// The maximum power of two that can be added to the trace per row.
-const POW2_POWERS_PER_ROW: usize = 8;
 /// Column index of the helper column `h`, which indicates if the power decomposition continues onto
 /// the next row or not.
 const POW2_HELPER_COL: usize = NUM_SELECTORS + POW2_POWERS_PER_ROW;


### PR DESCRIPTION
This PR partially addresses #179, implementing AIR constraints for the bitwise and power of two operations in a shared co-processor inside the auxiliary table.

It also adds:
- a new test helper for generating & verifying a proof of a test's execution
- some simple integration tests for the auxiliary table's AIR constraints for the bitwise and pow2 operations.
- randomized unit tests for bitwise and pow2 air constraints validating that constraints evaluate to 0 for correct traces

It does not add failure tests for air constraints to test for bad trace inputs which should cause constraints to fail or to verify that all constraints are present and correctly applied. These should be addressed in a separate PR, but can use the same approach presented here of testing by frame