### PR TITLE
Decoder trace generation

### DIFF
--- a/air/src/aux_table/hasher/mod.rs
+++ b/air/src/aux_table/hasher/mod.rs
@@ -4,7 +4,7 @@ use super::{EvaluationFrame, Felt, FieldElement, HASHER_TRACE_OFFSET};
 use core::ops::Range;
 use vm_core::{
     hasher::{
-        Hasher, CAPACITY_LEN, DIGEST_LEN, DIGEST_RANGE, NUM_ROUNDS, NUM_SELECTORS, STATE_WIDTH,
+        Hasher, CAPACITY_LEN, DIGEST_LEN, DIGEST_RANGE, HASH_CYCLE_LEN, NUM_SELECTORS, STATE_WIDTH,
     },
     utils::range as create_range,
 };
@@ -16,9 +16,6 @@ mod tests;
 // CONSTANTs
 // ================================================================================================
 
-/// The number of rows in the execution trace required to compute a Rescue Prime permutation. This
-/// is equal to 8.
-pub const HASH_CYCLE_LEN: usize = NUM_ROUNDS.next_power_of_two();
 /// The number of constraints on the management of the hasher co-processor.
 pub const NUM_CONSTRAINTS: usize = 31;
 

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -4,7 +4,7 @@ use core::fmt;
 // ASSEMBLY ERROR
 // ================================================================================================
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct AssemblyError {
     message: String,
     step: usize,

--- a/core/src/decoder/mod.rs
+++ b/core/src/decoder/mod.rs
@@ -1,0 +1,34 @@
+use super::{range, Operation};
+use std::ops::Range;
+
+// CONSTANTS
+// ================================================================================================
+
+/// Index of the column holding code block IDs (which are row addresses from the hasher table).
+pub const ADDR_COL_IDX: usize = 0;
+
+/// Index at which operation bit columns start in the decoder trace.
+pub const OP_BITS_OFFSET: usize = 1;
+
+/// Location of operation bits columns in the decoder trace.
+pub const OP_BITS_RANGE: Range<usize> = range(OP_BITS_OFFSET, Operation::OP_BITS);
+
+/// Index of the in_span column in the decoder trace.
+pub const IN_SPAN_COL_IDX: usize = 8;
+
+/// Index of the operation group count column in the decoder trace.
+pub const GROUP_COUNT_COL_IDX: usize = 17;
+
+/// Index of the operation index column in the decoder trace.
+pub const OP_INDEX_COL_IDX: usize = 18;
+
+// TODO: probably rename "hasher state" to something like "shared columns".
+
+/// Index at which hasher state columns start in the decoder trace.
+pub const HASHER_STATE_OFFSET: usize = 9;
+
+/// Number of hasher columns in the decoder trace.
+pub const NUM_HASHER_COLUMNS: usize = 8;
+
+/// Location of hasher columns in the decoder trace.
+pub const HASHER_STATE_RANGE: Range<usize> = range(HASHER_STATE_OFFSET, NUM_HASHER_COLUMNS);

--- a/core/src/hasher/mod.rs
+++ b/core/src/hasher/mod.rs
@@ -1,9 +1,8 @@
 //! TODO: add docs
 
-use std::ops::Range;
-
-use super::{Felt, FieldElement};
+use super::{Felt, FieldElement, Word};
 use crypto::{ElementHasher, Hasher as HashFn};
+use std::ops::Range;
 
 pub use crypto::hashers::Rp64_256 as Hasher;
 
@@ -15,6 +14,8 @@ pub use crypto::hashers::Rp64_256 as Hasher;
 /// The digest consists of 4 field elements or 32 bytes.
 pub type Digest = <Hasher as HashFn>::Digest;
 
+/// Type for Hasher trace selector. These selectors are used to define which transition function
+/// is to be applied at a specific row of the hasher execution trace.
 pub type Selectors = [Felt; NUM_SELECTORS];
 
 // CONSTANTS
@@ -27,8 +28,11 @@ pub type Selectors = [Felt; NUM_SELECTORS];
 /// permutation.
 pub const STATE_WIDTH: usize = Hasher::STATE_WIDTH;
 
-/// The length of the capacity portion of the hash state.
-pub const CAPACITY_LEN: usize = 4;
+/// Number of field elements in the rate portion of the hasher's state.
+pub const RATE_LEN: usize = 8;
+
+/// Number of field elements in the capacity portion of the hasher's state.
+pub const CAPACITY_LEN: usize = STATE_WIDTH - RATE_LEN;
 
 // The length of the output portion of the hash state.
 pub const DIGEST_LEN: usize = 4;
@@ -43,6 +47,9 @@ pub const NUM_ROUNDS: usize = Hasher::NUM_ROUNDS;
 
 /// Number of selector columns in the trace.
 pub const NUM_SELECTORS: usize = 3;
+
+/// Number of execution trace rows needed to fully describe one permutation of the hash function.
+pub const TRACE_CYCLE_LEN: usize = NUM_ROUNDS + 1;
 
 /// Number of columns in Hasher execution trace. Additional two columns are for row address and
 /// node index columns.
@@ -102,4 +109,68 @@ pub fn apply_round(state: &mut [Felt; STATE_WIDTH], round: usize) {
 #[inline(always)]
 pub fn apply_permutation(state: &mut [Felt; STATE_WIDTH]) {
     Hasher::apply_permutation(state)
+}
+
+// HASHER STATE MUTATORS
+// ================================================================================================
+
+/// Initializes hasher state with the first 8 elements to be absorbed and the specified total
+/// number of elements to be absorbed.
+#[inline(always)]
+pub fn init_state(init_values: &[Felt; RATE_LEN], num_elements: usize) -> [Felt; STATE_WIDTH] {
+    [
+        Felt::new(num_elements as u64),
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ZERO,
+        init_values[0],
+        init_values[1],
+        init_values[2],
+        init_values[3],
+        init_values[4],
+        init_values[5],
+        init_values[6],
+        init_values[7],
+    ]
+}
+
+/// Initializes hasher state with the elements from the provided words. The number of elements
+/// to be hashes is set to 8.
+#[inline(always)]
+pub fn init_state_from_words(w1: &Word, w2: &Word) -> [Felt; STATE_WIDTH] {
+    [
+        Felt::from(8_u8),
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ZERO,
+        w1[0],
+        w1[1],
+        w1[2],
+        w1[3],
+        w2[0],
+        w2[1],
+        w2[2],
+        w2[3],
+    ]
+}
+
+/// Absorbs the specified values into the provided state by adding values to corresponding
+/// elements in the rate portion of the state.
+#[inline(always)]
+pub fn absorb_into_state(state: &mut [Felt; STATE_WIDTH], values: &[Felt; RATE_LEN]) {
+    state[4] += values[0];
+    state[5] += values[1];
+    state[6] += values[2];
+    state[7] += values[3];
+    state[8] += values[4];
+    state[9] += values[5];
+    state[10] += values[6];
+    state[11] += values[7];
+}
+
+/// Returns elements representing the digest portion of the provide hasher's state.
+pub fn get_digest(state: &[Felt; STATE_WIDTH]) -> [Felt; DIGEST_LEN] {
+    state[DIGEST_RANGE]
+        .try_into()
+        .expect("failed to get digest from hasher state")
 }

--- a/core/src/hasher/mod.rs
+++ b/core/src/hasher/mod.rs
@@ -48,8 +48,9 @@ pub const NUM_ROUNDS: usize = Hasher::NUM_ROUNDS;
 /// Number of selector columns in the trace.
 pub const NUM_SELECTORS: usize = 3;
 
-/// Number of execution trace rows needed to fully describe one permutation of the hash function.
-pub const TRACE_CYCLE_LEN: usize = NUM_ROUNDS + 1;
+/// The number of rows in the execution trace required to compute a Rescue Prime permutation. This
+/// is equal to 8.
+pub const HASH_CYCLE_LEN: usize = NUM_ROUNDS.next_power_of_two();
 
 /// Number of columns in Hasher execution trace. Additional two columns are for row address and
 /// node index columns.
@@ -135,7 +136,7 @@ pub fn init_state(init_values: &[Felt; RATE_LEN], num_elements: usize) -> [Felt;
 }
 
 /// Initializes hasher state with the elements from the provided words. The number of elements
-/// to be hashes is set to 8.
+/// to be hashed is set to 8.
 #[inline(always)]
 pub fn init_state_from_words(w1: &Word, w2: &Word) -> [Felt; STATE_WIDTH] {
     [
@@ -168,7 +169,7 @@ pub fn absorb_into_state(state: &mut [Felt; STATE_WIDTH], values: &[Felt; RATE_L
     state[11] += values[7];
 }
 
-/// Returns elements representing the digest portion of the provide hasher's state.
+/// Returns elements representing the digest portion of the provided hasher's state.
 pub fn get_digest(state: &[Felt; STATE_WIDTH]) -> [Felt; DIGEST_LEN] {
     state[DIGEST_RANGE]
         .try_into()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -40,7 +40,7 @@ pub const NUM_STACK_HELPER_COLS: usize = 3;
 // ------------------------------------------------------------------------------------------------
 
 //      system          decoder           stack      range checks    auxiliary table
-//    (2 columns)     (22 columns)    (19 columns)    (4 columns)     (18 columns)
+//    (2 columns)     (18 columns)    (19 columns)    (4 columns)     (18 columns)
 // ├───────────────┴───────────────┴───────────────┴───────────────┴─────────────────┤
 
 pub const SYS_TRACE_OFFSET: usize = 0;
@@ -50,10 +50,13 @@ pub const SYS_TRACE_RANGE: Range<usize> = range(SYS_TRACE_OFFSET, SYS_TRACE_WIDT
 pub const CLK_COL_IDX: usize = SYS_TRACE_OFFSET;
 pub const FMP_COL_IDX: usize = SYS_TRACE_OFFSET + 1;
 
-// TODO: decoder column trace
+// decoder trace
+pub const DECODER_TRACE_OFFSET: usize = SYS_TRACE_OFFSET + SYS_TRACE_WIDTH;
+pub const DECODER_TRACE_WIDTH: usize = 19;
+pub const DECODER_TRACE_RANGE: Range<usize> = range(DECODER_TRACE_OFFSET, DECODER_TRACE_WIDTH);
 
 // Stack trace
-pub const STACK_TRACE_OFFSET: usize = SYS_TRACE_OFFSET + SYS_TRACE_WIDTH;
+pub const STACK_TRACE_OFFSET: usize = DECODER_TRACE_OFFSET + DECODER_TRACE_WIDTH;
 pub const STACK_TRACE_WIDTH: usize = MIN_STACK_DEPTH + NUM_STACK_HELPER_COLS;
 pub const STACK_TRACE_RANGE: Range<usize> = range(STACK_TRACE_OFFSET, STACK_TRACE_WIDTH);
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 use core::ops::Range;
 
 pub mod bitwise;
+pub mod decoder;
 pub mod hasher;
 pub mod program;
 pub use math::{fields::f64::BaseElement as Felt, FieldElement, StarkField};
@@ -40,7 +41,7 @@ pub const NUM_STACK_HELPER_COLS: usize = 3;
 // ------------------------------------------------------------------------------------------------
 
 //      system          decoder           stack      range checks    auxiliary table
-//    (2 columns)     (18 columns)    (19 columns)    (4 columns)     (18 columns)
+//    (2 columns)     (19 columns)    (19 columns)    (4 columns)     (18 columns)
 // ├───────────────┴───────────────┴───────────────┴───────────────┴─────────────────┤
 
 pub const SYS_TRACE_OFFSET: usize = 0;

--- a/core/src/operations/advice.rs
+++ b/core/src/operations/advice.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 /// TODO: add docs
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum AdviceInjector {
     /// Injects a node of the Merkle tree specified by the values on the stack at the head of the
     /// advice tape. The stack is expected to be arranged as follows (from the top):

--- a/core/src/operations/debug.rs
+++ b/core/src/operations/debug.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 /// TODO: add docs
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum DebugOptions {
     All,
     Stack(Option<usize>),

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -12,7 +12,7 @@ mod tests;
 // ================================================================================================
 
 /// TODO: add docs
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Operation {
     // ----- system operations --------------------------------------------------------------------
     /// Advances cycle counter, but does not change the state of user stack.

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -1,5 +1,5 @@
 use super::{Felt, StarkField};
-use core::ops::Range;
+use core::{fmt::Debug, ops::Range};
 
 // RE-EXPORTS
 // ================================================================================================
@@ -73,4 +73,16 @@ pub const fn range(start: usize, len: usize) -> Range<usize> {
         start,
         end: start + len,
     }
+}
+
+// ARRAY CONSTRUCTORS
+// ================================================================================================
+
+/// Returns an array of N vectors initialized with the specified capacity.
+pub fn new_array_vec<T: Debug, const N: usize>(capacity: usize) -> [Vec<T>; N] {
+    (0..N)
+        .map(|_| Vec::with_capacity(capacity))
+        .collect::<Vec<_>>()
+        .try_into()
+        .expect("failed to convert vector to array")
 }

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use vm_core::Word;
 
 /// VmState holds a current process state information at a specific clock cycle.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VmState {
     pub clk: usize,
     pub fmp: Felt,

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -192,8 +192,12 @@ impl Decoder {
 
     pub fn end_control_block(&mut self, block_hash: Word) {
         let block_info = self.block_stack.pop();
-        self.trace
-            .append_block_end(block_hash, block_info.is_loop_body, block_info.is_loop);
+        self.trace.append_block_end(
+            block_info.addr,
+            block_hash,
+            block_info.is_loop_body,
+            block_info.is_loop,
+        );
     }
 
     // SPAN BLOCK

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -172,6 +172,10 @@ impl Process {
 // DECODER
 // ================================================================================================
 /// TODO: add docs
+///
+///  addr  b0  b1  b2  b3  b4  b5  b6 in_span  h0  h1  h2  h3  h4  h5  h6  h7 g_count op_idx
+/// ├────┴───┴───┴───┴───┴───┴───┴───┴───────┴───┴───┴───┴───┴───┴───┴───┴───┴───────┴───────┤
+///
 pub struct Decoder {
     block_stack: BlockStack,
     span_context: Option<SpanContext>,

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -13,10 +13,8 @@ mod tests;
 // ================================================================================================
 
 const NUM_OP_BITS: usize = Operation::OP_BITS;
-
-// TODO: get from core
-const HASHER_WIDTH: usize = 8;
-const HASHER_CYCLE_LEN: Felt = Felt::new(8);
+const HASHER_CYCLE_LEN: Felt = Felt::new(vm_core::hasher::TRACE_CYCLE_LEN as u64);
+const NUM_HASHER_COLUMNS: usize = 8;
 
 // DECODER PROCESS EXTENSION
 // ================================================================================================
@@ -32,7 +30,7 @@ impl Process {
         // row addr + 7.
         let child1_hash = block.first().hash().into();
         let child2_hash = block.second().hash().into();
-        let (addr, _result) = self.hasher.hash_2to1(child1_hash, child2_hash);
+        let (addr, _result) = self.hasher.merge(child1_hash, child2_hash);
 
         // make sure the result computed by the hasher is the same as the expected block hash
         debug_assert_eq!(block.hash(), _result.into());
@@ -64,7 +62,7 @@ impl Process {
         // row addr + 7.
         let child1_hash = block.on_true().hash().into();
         let child2_hash = block.on_false().hash().into();
-        let (addr, _result) = self.hasher.hash_2to1(child1_hash, child2_hash);
+        let (addr, _result) = self.hasher.merge(child1_hash, child2_hash);
 
         // make sure the result computed by the hasher is the same as the expected block hash
         debug_assert_eq!(block.hash(), _result.into());
@@ -97,7 +95,7 @@ impl Process {
         // hasher is used as the ID of the block; the result of the hash is expected to be in
         // row addr + 7.
         let body_hash = block.body().hash().into();
-        let (addr, _result) = self.hasher.hash_2to1(body_hash, [Felt::ZERO; 4]);
+        let (addr, _result) = self.hasher.merge(body_hash, [Felt::ZERO; 4]);
 
         // make sure the result computed by the hasher is the same as the expected block hash
         debug_assert_eq!(block.hash(), _result.into());

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -1,8 +1,7 @@
 use super::{
-    ExecutionError, Felt, Join, Loop, OpBatch, Operation, Process, Span, Split, StarkField,
-    MIN_TRACE_LEN,
+    ExecutionError, Felt, FieldElement, Join, Loop, OpBatch, Operation, Process, Span, Split,
+    StarkField, Word, MIN_TRACE_LEN, OP_BATCH_SIZE,
 };
-use vm_core::{FieldElement, Word};
 
 mod trace;
 use trace::DecoderTrace;
@@ -26,106 +25,147 @@ impl Process {
     // JOIN BLOCK
     // --------------------------------------------------------------------------------------------
 
+    /// Starts decoding of a JOIN block.
     pub(super) fn start_join_block(&mut self, block: &Join) -> Result<(), ExecutionError> {
-        self.execute_op(Operation::Noop)?;
+        // use the hasher to compute the hash of the JOIN block; the row address returned by the
+        // hasher is used as the ID of the block; the result of the hash is expected to be in
+        // row addr + 7.
+        let child1_hash = block.first().hash().into();
+        let child2_hash = block.second().hash().into();
+        let (addr, _result) = self.hasher.hash_2to1(child1_hash, child2_hash);
 
-        let hasher_state = [Felt::ZERO; 12];
-        let (addr, _result) = self.hasher.hash(hasher_state);
-        self.decoder.start_join(block, addr);
+        // make sure the result computed by the hasher is the same as the expected block hash
+        debug_assert_eq!(block.hash(), _result.into());
 
-        Ok(())
+        // start decoding the JOIN block; this appends a row with JOIN operation to the decoder
+        // trace. when JOIN operation is executed, the rest of the VM state does not change
+        self.decoder.start_join(child1_hash, child2_hash, addr);
+        self.execute_op(Operation::Noop)
     }
 
+    ///  Ends decoding of a JOIN block.
     pub(super) fn end_join_block(&mut self, block: &Join) -> Result<(), ExecutionError> {
-        self.execute_op(Operation::Noop)?;
+        // this appends a row with END operation to the decoder trace. when END operation is
+        // executed the rest of the VM state does not change
         self.decoder.end_control_block(block.hash().into());
-        Ok(())
+        self.execute_op(Operation::Noop)
     }
 
     // SPLIT BLOCK
     // --------------------------------------------------------------------------------------------
 
+    /// Starts decoding a SPLIT block. This also pops the value from the top of the stack and
+    /// returns it.
     pub(super) fn start_split_block(&mut self, block: &Split) -> Result<Felt, ExecutionError> {
         let condition = self.stack.peek();
+
+        // use the hasher to compute the hash of the SPLIT block; the row address returned by the
+        // hasher is used as the ID of the block; the result of the hash is expected to be in
+        // row addr + 7.
+        let child1_hash = block.on_true().hash().into();
+        let child2_hash = block.on_false().hash().into();
+        let (addr, _result) = self.hasher.hash_2to1(child1_hash, child2_hash);
+
+        // make sure the result computed by the hasher is the same as the expected block hash
+        debug_assert_eq!(block.hash(), _result.into());
+
+        // start decoding the SPLIT block. this appends a row with SPLIT operation to the decoder
+        // trace. we also pop the value off the top of the stack and return it.
+        self.decoder.start_split(child1_hash, child2_hash, addr);
         self.execute_op(Operation::Drop)?;
-
-        let hasher_state = [Felt::ZERO; 12];
-        let (addr, _result) = self.hasher.hash(hasher_state);
-        self.decoder.start_split(block, addr);
-
         Ok(condition)
     }
 
+    /// Ends decoding of a SPLIT block.
     pub(super) fn end_split_block(&mut self, block: &Split) -> Result<(), ExecutionError> {
-        self.execute_op(Operation::Noop)?;
+        // this appends a row with END operation to the decoder trace. when END operation is
+        // executed the rest of the VM state does not change
         self.decoder.end_control_block(block.hash().into());
-        Ok(())
+        self.execute_op(Operation::Noop)
     }
 
     // LOOP BLOCK
     // --------------------------------------------------------------------------------------------
 
+    /// Starts decoding a LOOP block. This also pops the value from the top of the stack and
+    /// returns it.
     pub(super) fn start_loop_block(&mut self, block: &Loop) -> Result<Felt, ExecutionError> {
         let condition = self.stack.peek();
+
+        // use the hasher to compute the hash of the LOOP block; for LOOP block there is no
+        // second child so we set the second hash to ZEROs; the row address returned by the
+        // hasher is used as the ID of the block; the result of the hash is expected to be in
+        // row addr + 7.
+        let body_hash = block.body().hash().into();
+        let (addr, _result) = self.hasher.hash_2to1(body_hash, [Felt::ZERO; 4]);
+
+        // make sure the result computed by the hasher is the same as the expected block hash
+        debug_assert_eq!(block.hash(), _result.into());
+
+        // start decoding the LOOP block; this appends a row with LOOP operation to the decoder
+        // trace, but if the value on the top of the stack is not ONE, the block is not marked
+        // as the loop block, and the hash of the body will not be added to the block hash table.
+        // basically, if the top of the stack is ZERO, a LOOP operation should be immediately
+        // followed by an END operation.
+        self.decoder.start_loop(body_hash, addr, condition);
         self.execute_op(Operation::Drop)?;
-
-        let hasher_state = [Felt::ZERO; 12];
-        let (addr, _result) = self.hasher.hash(hasher_state);
-        self.decoder.start_loop(block, addr, condition);
-
         Ok(condition)
     }
 
+    /// Ends decoding of a LOOP block. If pop_stack is set to true, this also removes the
+    /// value at the top of the stack.
     pub(super) fn end_loop_block(
         &mut self,
         block: &Loop,
         pop_stack: bool,
     ) -> Result<(), ExecutionError> {
-        if pop_stack {
-            self.execute_op(Operation::Drop)?;
-        } else {
-            self.execute_op(Operation::Noop)?;
-        }
-
+        // this appends a row with END operation to the decoder trace.
         self.decoder.end_control_block(block.hash().into());
 
-        Ok(())
+        // if we are exiting a loop, we also need to pop the top value off the stack (and this
+        // value must be ZERO - otherwise, we should have stayed in the loop). but, if we never
+        // entered the loop in the first place, the stack would have been popped when the LOOP
+        // operation was executed.
+        if pop_stack {
+            #[cfg(debug_assertions)]
+            let condition = self.stack.peek();
+            debug_assert_eq!(Felt::ZERO, condition);
+
+            self.execute_op(Operation::Drop)
+        } else {
+            self.execute_op(Operation::Noop)
+        }
     }
 
     // SPAN BLOCK
     // --------------------------------------------------------------------------------------------
 
+    /// Starts decoding a SPAN block.
     pub(super) fn start_span_block(&mut self, block: &Span) -> Result<(), ExecutionError> {
-        self.execute_op(Operation::Noop)?;
+        // use the hasher to compute the hash of the SPAN block; the row address returned by the
+        // hasher is used as the ID of the block; hash of a SPAN block is computed by sequentially
+        // hashing operation batches. Thus, the result of the hash is expected to be in row
+        // addr + (num_batches * 8) - 1.
+        let op_batches = block.op_batches();
+        let (addr, _result) = self.hasher.hash_span_block(op_batches);
 
-        let first_batch = &block.op_batches()[0].groups();
+        // make sure the result computed by the hasher is the same as the expected block hash
+        debug_assert_eq!(block.hash(), _result.into());
 
-        let hasher_state = [
-            first_batch[0],
-            first_batch[1],
-            first_batch[2],
-            first_batch[3],
-            first_batch[4],
-            first_batch[5],
-            first_batch[6],
-            first_batch[7],
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-        ];
-        let (addr, _result) = self.hasher.hash(hasher_state);
-        self.decoder.start_span(block, addr);
-
-        Ok(())
+        // start decoding the first operation batch; this also appends a row with SPAN operation
+        // to th decoder trace. we also need the total number of operation groups so that we can
+        // set the value of the group_count register at the beginning of the SPAN.
+        let num_op_groups = Felt::new((op_batches.len() * OP_BATCH_SIZE) as u64);
+        self.decoder.start_span(&op_batches[0], num_op_groups, addr);
+        self.execute_op(Operation::Noop)
     }
 
+    /// Ends decoding a SPAN block.
     pub(super) fn end_span_block(&mut self, block: &Span) -> Result<(), ExecutionError> {
-        self.execute_op(Operation::Noop)?;
-
-        self.decoder.end_span(block);
-
-        Ok(())
+        // this appends a row with END operation to the decoder trace. when END operation is
+        // executed the rest of the VM state does not change
+        self.decoder.end_span(block.hash().into());
+        self.execute_op(Operation::Noop)
     }
 }
 
@@ -139,6 +179,9 @@ pub struct Decoder {
 }
 
 impl Decoder {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns an empty instance of [Decoder].
     pub fn new() -> Self {
         Self {
             block_stack: BlockStack::new(),
@@ -150,10 +193,12 @@ impl Decoder {
     // CONTROL BLOCKS
     // --------------------------------------------------------------------------------------------
 
-    pub fn start_join(&mut self, block: &Join, addr: Felt) {
+    /// Starts decoding of a JOIN block.
+    ///
+    /// This pushes a block with ID=addr onto the block stack and appending execution of a JOIN
+    /// operation to the trace.
+    pub fn start_join(&mut self, left_child_hash: Word, right_child_hash: Word, addr: Felt) {
         let parent_addr = self.block_stack.push(addr, Felt::ZERO);
-        let left_child_hash: Word = block.first().hash().into();
-        let right_child_hash: Word = block.second().hash().into();
         self.trace.append_block_start(
             parent_addr,
             Operation::Join,
@@ -162,10 +207,12 @@ impl Decoder {
         );
     }
 
-    pub fn start_split(&mut self, block: &Split, addr: Felt) {
+    /// Starts decoding of a SPLIT block.
+    ///
+    /// This pushes a block with ID=addr onto the block stack and appending execution of a SPLIT
+    /// operation to the trace.
+    pub fn start_split(&mut self, left_child_hash: Word, right_child_hash: Word, addr: Felt) {
         let parent_addr = self.block_stack.push(addr, Felt::ZERO);
-        let left_child_hash: Word = block.on_true().hash().into();
-        let right_child_hash: Word = block.on_false().hash().into();
         self.trace.append_block_start(
             parent_addr,
             Operation::Split,
@@ -174,9 +221,12 @@ impl Decoder {
         );
     }
 
-    pub fn start_loop(&mut self, block: &Loop, addr: Felt, is_loop: Felt) {
+    /// Starts decoding of a LOOP block.
+    ///
+    /// This pushes a block with ID=addr onto the block stack and appending execution of a LOOP
+    /// operation to the trace. A block is marked as a loop block only if is_loop = ONE.
+    pub fn start_loop(&mut self, loop_body_hash: Word, addr: Felt, is_loop: Felt) {
         let parent_addr = self.block_stack.push(addr, is_loop);
-        let loop_body_hash: Word = block.body().hash().into();
         self.trace.append_block_start(
             parent_addr,
             Operation::Loop,
@@ -185,11 +235,19 @@ impl Decoder {
         );
     }
 
-    pub fn repeat(&mut self, _block: &Loop) {
-        let loop_addr = self.block_stack.peek().addr;
-        self.trace.append_loop_repeat(loop_addr);
+    /// Starts decoding another iteration of a loop.
+    ///
+    /// This appending execution of a REPEAT operation to the trace.
+    pub fn repeat(&mut self) {
+        let block_info = self.block_stack.peek();
+        debug_assert_eq!(Felt::ONE, block_info.is_loop);
+        self.trace.append_loop_repeat(block_info.addr);
     }
 
+    /// Ends decoding of a control block (i.e., a non-SPAN block).
+    ///
+    /// This appending execution of an END operation to the trace. The top block on the block
+    /// stack is also popped.
     pub fn end_control_block(&mut self, block_hash: Word) {
         let block_info = self.block_stack.pop();
         self.trace.append_block_end(
@@ -203,50 +261,65 @@ impl Decoder {
     // SPAN BLOCK
     // --------------------------------------------------------------------------------------------
 
-    pub fn start_span(&mut self, block: &Span, addr: Felt) {
+    /// Starts decoding of a SPAN block defined by the specified operation batches.
+    pub fn start_span(&mut self, first_op_batch: &OpBatch, num_op_groups: Felt, addr: Felt) {
         debug_assert!(self.span_context.is_none(), "already in span");
         let parent_addr = self.block_stack.push(addr, Felt::ZERO);
-        let first_op_batch = &block.op_batches()[0].groups();
-        let num_op_groups = get_num_op_groups_in_span(block);
+
+        // add a SPAN row to the trace
         self.trace
-            .append_span_start(parent_addr, first_op_batch, num_op_groups);
+            .append_span_start(parent_addr, first_op_batch.groups(), num_op_groups);
+
+        // after SPAN operation is executed, we decrement the number of remaining groups by the
+        // number of unused groups in the batch + 1. We add one because executing SPAN consumes
+        // the first group of the batch.
+        let num_unused_groups = get_num_unused_groups(first_op_batch);
+        let consumed_op_groups = Felt::from(num_unused_groups + 1);
 
         self.span_context = Some(SpanContext {
-            num_groups_left: num_op_groups - Felt::ONE,
-            group_ops_left: first_op_batch[0],
+            num_groups_left: num_op_groups - consumed_op_groups,
+            group_ops_left: first_op_batch.groups()[0],
         });
     }
 
+    /// Starts decoding of the next operation batch in the current SPAN.
     pub fn respan(&mut self, op_batch: &OpBatch) {
+        // add RESPAN row to the trace
         self.trace.append_respan(op_batch.groups());
 
-        let block = self.block_stack.pop();
-        self.block_stack
-            .push(block.addr + HASHER_CYCLE_LEN, block.is_loop);
+        // we also need to increment block address by 8 because hashing every additional operation
+        // batch requires 8 rows of the hasher trace.
+        let block_info = self.block_stack.peek_mut();
+        block_info.addr += HASHER_CYCLE_LEN;
+
+        // after RESPAN operation is executed, we decrement the number of remaining groups by the
+        // number of unused groups in the batch + 1. We add one because executing RESPAN consumes
+        // the first group of the batch.
+        let num_unused_groups = get_num_unused_groups(op_batch);
+        let consumed_op_groups = Felt::from(num_unused_groups + 1);
 
         let ctx = self.span_context.as_mut().expect("not in span");
-        ctx.num_groups_left -= Felt::ONE;
+        ctx.num_groups_left -= consumed_op_groups;
         ctx.group_ops_left = op_batch.groups()[0];
     }
 
-    pub fn consume_imm_value(&mut self) {
-        let ctx = self.span_context.as_mut().expect("not a span");
-        ctx.num_groups_left -= Felt::ONE
-    }
-
+    /// Starts decoding a new operation group.
     pub fn start_op_group(&mut self, op_group: Felt) {
-        let ctx = self.span_context.as_mut().expect("not a span");
+        let ctx = self.span_context.as_mut().expect("not in span");
         ctx.group_ops_left = op_group;
         ctx.num_groups_left -= Felt::ONE;
     }
 
+    /// Decodes a user operation (i.e., not a control flow operation).
     pub fn execute_user_op(&mut self, op: Operation, op_idx: usize) {
         debug_assert!(!op.is_decorator(), "op is a decorator");
         let block = self.block_stack.peek();
         let ctx = self.span_context.as_mut().expect("not in span");
 
+        // update operations left to be executed in the group
         ctx.group_ops_left = remove_opcode_from_group(ctx.group_ops_left, op);
 
+        // append the row for the operation to the trace
         self.trace.append_user_op(
             op,
             block.addr,
@@ -255,20 +328,27 @@ impl Decoder {
             ctx.group_ops_left,
             Felt::from(op_idx as u32),
         );
+
+        // if the operation carries an immediate value, decrement the number of  operation
+        // groups left to decode. this number will be inserted into the trace in the next row
+        if op.imm_value().is_some() {
+            ctx.num_groups_left -= Felt::ONE
+        }
     }
 
-    pub fn end_span(&mut self, block: &Span) {
-        let block_info = self.block_stack.pop();
-        let block_hash: Word = block.hash().into();
-        self.trace
-            .append_span_end(block_hash, block_info.is_loop_body);
+    /// Ends decoding of a SPAN block.
+    pub fn end_span(&mut self, block_hash: Word) {
+        let is_loop_body = self.block_stack.pop().is_loop_body;
+        self.trace.append_span_end(block_hash, is_loop_body);
         self.span_context = None;
     }
 
     // TRACE GENERATIONS
     // --------------------------------------------------------------------------------------------
 
-    /// TODO: add docs
+    /// Returns an columns of the execution trace for this decoder.
+    ///
+    /// The columns are extended to match the specified trace length.
     pub fn into_trace(self, trace_len: usize, num_rand_rows: usize) -> super::DecoderTrace {
         self.trace
             .into_vec(trace_len, num_rand_rows)
@@ -283,20 +363,28 @@ impl Default for Decoder {
     }
 }
 
-// BLOCK INFO
+// BLOCK STACK
 // ================================================================================================
 
-pub struct BlockStack {
+/// Keeps track of code blocks which are currently being executed by the VM.
+struct BlockStack {
     blocks: Vec<BlockInfo>,
 }
 
 impl BlockStack {
+    /// Returns an empty [BlockStack].
     pub fn new() -> Self {
         Self { blocks: Vec::new() }
     }
 
+    /// Pushes a new code block onto the block stack and returns the address of the block's parent.
+    ///
+    /// The block is identified by its address, and we also need to know whether this block is a
+    /// LOOP block. Other information (i.e., the block's parent and whether the block is a body of
+    /// a loop) is determined from the information already on the stack.
     pub fn push(&mut self, addr: Felt, is_loop: Felt) -> Felt {
         let (parent_addr, is_loop_body) = if self.blocks.is_empty() {
+            // if the stack is empty, the new block has no parent and cannot be a body of a LOOP
             (Felt::ZERO, Felt::ZERO)
         } else {
             let parent = &self.blocks[self.blocks.len() - 1];
@@ -312,17 +400,25 @@ impl BlockStack {
         parent_addr
     }
 
+    /// Removes a block from the top of the stack and returns it.
     pub fn pop(&mut self) -> BlockInfo {
         self.blocks.pop().expect("block stack is empty")
     }
 
+    /// Returns a reference to a block at the top of the stack.
     pub fn peek(&self) -> &BlockInfo {
         self.blocks.last().expect("block stack is empty")
     }
+
+    /// Returns a mutable reference to a block at the top of the stack.
+    pub fn peek_mut(&mut self) -> &mut BlockInfo {
+        self.blocks.last_mut().expect("block stack is empty")
+    }
 }
 
+/// Contains basic information about a code block.
 #[derive(Debug, Clone, Copy)]
-pub struct BlockInfo {
+struct BlockInfo {
     addr: Felt,
     parent_addr: Felt,
     is_loop_body: Felt,
@@ -332,7 +428,12 @@ pub struct BlockInfo {
 // SPAN CONTEXT
 // ================================================================================================
 
-pub struct SpanContext {
+/// Keeps track of the info needed to decode a currently executing SPAN block. The info includes:
+/// - Operations which still need to be executed in the current group. The operations are
+///   encoded as opcodes (7 bits) appended one after another into a single field element, with the
+///   next operation to be executed located at the least significant position.
+/// - Number of operation groups left to be executed in the entire SPAN block.
+struct SpanContext {
     group_ops_left: Felt,
     num_groups_left: Felt,
 }
@@ -349,14 +450,22 @@ impl Default for SpanContext {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-fn get_num_op_groups_in_span(block: &Span) -> Felt {
-    let result = block.op_batches().iter().fold(0usize, |acc, batch| {
-        acc + batch.num_groups().next_power_of_two()
-    });
-    Felt::new(result as u64)
+/// Returns the number of unused operation groups in the specified batch.
+///
+/// The number of unused groups is computed as follows:
+/// - Number of op groups in the batch is rounded to the next power of two. This is done because
+///   the processor pads these op groups with NOOPs.
+/// - Next, the number of op groups is subtracted from max batch size.
+///
+/// Thus, for example, if a batch contains 3 op groups, the number of unused op groups will be 4.
+fn get_num_unused_groups(op_batch: &OpBatch) -> u8 {
+    (OP_BATCH_SIZE - op_batch.num_groups().next_power_of_two()) as u8
 }
 
+/// Removes the specified operation from the op group and returns the resulting op group.
 fn remove_opcode_from_group(op_group: Felt, op: Operation) -> Felt {
     let opcode = op.op_code().expect("no opcode") as u64;
-    Felt::new((op_group.as_int() - opcode) >> NUM_OP_BITS)
+    let result = Felt::new((op_group.as_int() - opcode) >> NUM_OP_BITS);
+    debug_assert!(op_group.as_int() >= result.as_int(), "op group underflow");
+    result
 }

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -2,6 +2,7 @@ use super::{
     ExecutionError, Felt, FieldElement, Join, Loop, OpBatch, Operation, Process, Span, Split,
     StarkField, Word, MIN_TRACE_LEN, OP_BATCH_SIZE,
 };
+use vm_core::decoder::NUM_HASHER_COLUMNS;
 
 mod trace;
 use trace::DecoderTrace;
@@ -14,7 +15,6 @@ mod tests;
 
 const NUM_OP_BITS: usize = Operation::OP_BITS;
 const HASHER_CYCLE_LEN: Felt = Felt::new(vm_core::hasher::TRACE_CYCLE_LEN as u64);
-const NUM_HASHER_COLUMNS: usize = 8;
 
 // DECODER PROCESS EXTENSION
 // ================================================================================================

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -1,6 +1,23 @@
-use vm_core::FieldElement;
+use super::{
+    ExecutionError, Felt, Join, Loop, OpBatch, Operation, Process, Span, Split, StarkField,
+    MIN_TRACE_LEN,
+};
+use vm_core::{FieldElement, Word};
 
-use super::{ExecutionError, Felt, Join, Loop, OpBatch, Operation, Process, Span, Split};
+mod trace;
+use trace::DecoderTrace;
+
+#[cfg(test)]
+mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+const NUM_OP_BITS: usize = Operation::OP_BITS;
+
+// TODO: get from core
+const HASHER_WIDTH: usize = 8;
+const HASHER_CYCLE_LEN: Felt = Felt::new(8);
 
 // DECODER PROCESS EXTENSION
 // ================================================================================================
@@ -12,8 +29,8 @@ impl Process {
     pub(super) fn start_join_block(&mut self, block: &Join) -> Result<(), ExecutionError> {
         self.execute_op(Operation::Noop)?;
 
-        // TODO: get address from hasher
-        let addr = Felt::ZERO;
+        let hasher_state = [Felt::ZERO; 12];
+        let (addr, _result) = self.hasher.hash(hasher_state);
         self.decoder.start_join(block, addr);
 
         Ok(())
@@ -21,30 +38,56 @@ impl Process {
 
     pub(super) fn end_join_block(&mut self, block: &Join) -> Result<(), ExecutionError> {
         self.execute_op(Operation::Noop)?;
-
-        self.decoder.end_join(block);
-
+        self.decoder.end_control_block(block.hash().into());
         Ok(())
     }
 
     // SPLIT BLOCK
     // --------------------------------------------------------------------------------------------
 
-    pub(super) fn start_split_block(&mut self, block: &Split) -> Result<(), ExecutionError> {
+    pub(super) fn start_split_block(&mut self, block: &Split) -> Result<Felt, ExecutionError> {
         let condition = self.stack.peek();
         self.execute_op(Operation::Drop)?;
 
-        // TODO: get address from hasher
-        let addr = Felt::ZERO;
-        self.decoder.start_split(block, addr, condition);
+        let hasher_state = [Felt::ZERO; 12];
+        let (addr, _result) = self.hasher.hash(hasher_state);
+        self.decoder.start_split(block, addr);
 
-        Ok(())
+        Ok(condition)
     }
 
     pub(super) fn end_split_block(&mut self, block: &Split) -> Result<(), ExecutionError> {
         self.execute_op(Operation::Noop)?;
+        self.decoder.end_control_block(block.hash().into());
+        Ok(())
+    }
 
-        self.decoder.end_split(block);
+    // LOOP BLOCK
+    // --------------------------------------------------------------------------------------------
+
+    pub(super) fn start_loop_block(&mut self, block: &Loop) -> Result<Felt, ExecutionError> {
+        let condition = self.stack.peek();
+        self.execute_op(Operation::Drop)?;
+
+        let hasher_state = [Felt::ZERO; 12];
+        let (addr, _result) = self.hasher.hash(hasher_state);
+        self.decoder.start_loop(block, addr, condition);
+
+        Ok(condition)
+    }
+
+    pub(super) fn end_loop_block(
+        &mut self,
+        block: &Loop,
+        pop_stack: bool,
+    ) -> Result<(), ExecutionError> {
+        if pop_stack {
+            self.execute_op(Operation::Drop)?;
+        } else {
+            self.execute_op(Operation::Noop)?;
+        }
+
+        self.decoder.end_control_block(block.hash().into());
 
         Ok(())
     }
@@ -55,8 +98,23 @@ impl Process {
     pub(super) fn start_span_block(&mut self, block: &Span) -> Result<(), ExecutionError> {
         self.execute_op(Operation::Noop)?;
 
-        // TODO: get address from hasher
-        let addr = Felt::ZERO;
+        let first_batch = &block.op_batches()[0].groups();
+
+        let hasher_state = [
+            first_batch[0],
+            first_batch[1],
+            first_batch[2],
+            first_batch[3],
+            first_batch[4],
+            first_batch[5],
+            first_batch[6],
+            first_batch[7],
+            Felt::ZERO,
+            Felt::ZERO,
+            Felt::ZERO,
+            Felt::ZERO,
+        ];
+        let (addr, _result) = self.hasher.hash(hasher_state);
         self.decoder.start_span(block, addr);
 
         Ok(())
@@ -73,43 +131,228 @@ impl Process {
 
 // DECODER
 // ================================================================================================
-pub struct Decoder {}
+/// TODO: add docs
+pub struct Decoder {
+    block_stack: BlockStack,
+    span_context: Option<SpanContext>,
+    trace: DecoderTrace,
+}
 
 impl Decoder {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            block_stack: BlockStack::new(),
+            span_context: None,
+            trace: DecoderTrace::new(),
+        }
     }
 
-    // JOIN BLOCK
+    // CONTROL BLOCKS
     // --------------------------------------------------------------------------------------------
 
-    pub fn start_join(&mut self, _block: &Join, _addr: Felt) {}
+    pub fn start_join(&mut self, block: &Join, addr: Felt) {
+        let parent_addr = self.block_stack.push(addr, Felt::ZERO);
+        let left_child_hash: Word = block.first().hash().into();
+        let right_child_hash: Word = block.second().hash().into();
+        self.trace.append_block_start(
+            parent_addr,
+            Operation::Join,
+            left_child_hash,
+            right_child_hash,
+        );
+    }
 
-    pub fn end_join(&mut self, _block: &Join) {}
+    pub fn start_split(&mut self, block: &Split, addr: Felt) {
+        let parent_addr = self.block_stack.push(addr, Felt::ZERO);
+        let left_child_hash: Word = block.on_true().hash().into();
+        let right_child_hash: Word = block.on_false().hash().into();
+        self.trace.append_block_start(
+            parent_addr,
+            Operation::Split,
+            left_child_hash,
+            right_child_hash,
+        );
+    }
 
-    // SPLIT BLOCK
-    // --------------------------------------------------------------------------------------------
+    pub fn start_loop(&mut self, block: &Loop, addr: Felt, is_loop: Felt) {
+        let parent_addr = self.block_stack.push(addr, is_loop);
+        let loop_body_hash: Word = block.body().hash().into();
+        self.trace.append_block_start(
+            parent_addr,
+            Operation::Loop,
+            loop_body_hash,
+            [Felt::ZERO; 4],
+        );
+    }
 
-    pub fn start_split(&mut self, _block: &Split, _addr: Felt, _condition: Felt) {}
+    pub fn repeat(&mut self, _block: &Loop) {
+        let loop_addr = self.block_stack.peek().addr;
+        self.trace.append_loop_repeat(loop_addr);
+    }
 
-    pub fn end_split(&mut self, _block: &Split) {}
-
-    // LOOP BLOCK
-    // --------------------------------------------------------------------------------------------
-
-    pub fn start_loop(&mut self, _block: &Loop, _condition: Felt) {}
-
-    pub fn repeat(&mut self, _block: &Loop) {}
-
-    pub fn end_loop(&mut self, _block: &Loop) {}
+    pub fn end_control_block(&mut self, block_hash: Word) {
+        let block_info = self.block_stack.pop();
+        self.trace
+            .append_block_end(block_hash, block_info.is_loop_body, block_info.is_loop);
+    }
 
     // SPAN BLOCK
     // --------------------------------------------------------------------------------------------
-    pub fn start_span(&mut self, _block: &Span, _addr: Felt) {}
 
-    pub fn respan(&mut self, _op_batch: &OpBatch) {}
+    pub fn start_span(&mut self, block: &Span, addr: Felt) {
+        debug_assert!(self.span_context.is_none(), "already in span");
+        let parent_addr = self.block_stack.push(addr, Felt::ZERO);
+        let first_op_batch = &block.op_batches()[0].groups();
+        let num_op_groups = get_num_op_groups_in_span(block);
+        self.trace
+            .append_span_start(parent_addr, first_op_batch, num_op_groups);
 
-    pub fn execute_user_op(&mut self, _op: Operation) {}
+        self.span_context = Some(SpanContext {
+            num_groups_left: num_op_groups - Felt::ONE,
+            group_ops_left: first_op_batch[0],
+        });
+    }
 
-    pub fn end_span(&mut self, _block: &Span) {}
+    pub fn respan(&mut self, op_batch: &OpBatch) {
+        self.trace.append_respan(op_batch.groups());
+
+        let block = self.block_stack.pop();
+        self.block_stack
+            .push(block.addr + HASHER_CYCLE_LEN, block.is_loop);
+
+        let ctx = self.span_context.as_mut().expect("not in span");
+        ctx.num_groups_left -= Felt::ONE;
+        ctx.group_ops_left = op_batch.groups()[0];
+    }
+
+    pub fn consume_imm_value(&mut self) {
+        let ctx = self.span_context.as_mut().expect("not a span");
+        ctx.num_groups_left -= Felt::ONE
+    }
+
+    pub fn start_op_group(&mut self, op_group: Felt) {
+        let ctx = self.span_context.as_mut().expect("not a span");
+        ctx.group_ops_left = op_group;
+        ctx.num_groups_left -= Felt::ONE;
+    }
+
+    pub fn execute_user_op(&mut self, op: Operation, op_idx: usize) {
+        debug_assert!(!op.is_decorator(), "op is a decorator");
+        let block = self.block_stack.peek();
+        let ctx = self.span_context.as_mut().expect("not in span");
+
+        ctx.group_ops_left = remove_opcode_from_group(ctx.group_ops_left, op);
+
+        self.trace.append_user_op(
+            op,
+            block.addr,
+            block.parent_addr,
+            ctx.num_groups_left,
+            ctx.group_ops_left,
+            Felt::from(op_idx as u32),
+        );
+    }
+
+    pub fn end_span(&mut self, block: &Span) {
+        let block_info = self.block_stack.pop();
+        let block_hash: Word = block.hash().into();
+        self.trace
+            .append_span_end(block_hash, block_info.is_loop_body);
+        self.span_context = None;
+    }
+
+    // TRACE GENERATIONS
+    // --------------------------------------------------------------------------------------------
+
+    /// TODO: add docs
+    pub fn into_trace(self, trace_len: usize, num_rand_rows: usize) -> super::DecoderTrace {
+        self.trace
+            .into_vec(trace_len, num_rand_rows)
+            .try_into()
+            .expect("failed to convert vector to array")
+    }
+}
+
+impl Default for Decoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// BLOCK INFO
+// ================================================================================================
+
+pub struct BlockStack {
+    blocks: Vec<BlockInfo>,
+}
+
+impl BlockStack {
+    pub fn new() -> Self {
+        Self { blocks: Vec::new() }
+    }
+
+    pub fn push(&mut self, addr: Felt, is_loop: Felt) -> Felt {
+        let (parent_addr, is_loop_body) = if self.blocks.is_empty() {
+            (Felt::ZERO, Felt::ZERO)
+        } else {
+            let parent = &self.blocks[self.blocks.len() - 1];
+            (parent.addr, parent.is_loop)
+        };
+
+        self.blocks.push(BlockInfo {
+            addr,
+            parent_addr,
+            is_loop_body,
+            is_loop,
+        });
+        parent_addr
+    }
+
+    pub fn pop(&mut self) -> BlockInfo {
+        self.blocks.pop().expect("block stack is empty")
+    }
+
+    pub fn peek(&self) -> &BlockInfo {
+        self.blocks.last().expect("block stack is empty")
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BlockInfo {
+    addr: Felt,
+    parent_addr: Felt,
+    is_loop_body: Felt,
+    is_loop: Felt,
+}
+
+// SPAN CONTEXT
+// ================================================================================================
+
+pub struct SpanContext {
+    group_ops_left: Felt,
+    num_groups_left: Felt,
+}
+
+impl Default for SpanContext {
+    fn default() -> Self {
+        Self {
+            group_ops_left: Felt::ZERO,
+            num_groups_left: Felt::ZERO,
+        }
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn get_num_op_groups_in_span(block: &Span) -> Felt {
+    let result = block.op_batches().iter().fold(0usize, |acc, batch| {
+        acc + batch.num_groups().next_power_of_two()
+    });
+    Felt::new(result as u64)
+}
+
+fn remove_opcode_from_group(op_group: Felt, op: Operation) -> Felt {
+    let opcode = op.op_code().expect("no opcode") as u64;
+    Felt::new((op_group.as_int() - opcode) >> NUM_OP_BITS)
 }

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -26,6 +26,25 @@ const HASHER_STATE_RANGE: Range<usize> = range(HASHER_STATE_OFFSET, HASHER_WIDTH
 // ================================================================================================
 
 #[test]
+fn span_block_small() {
+    let program = CodeBlock::new_span(vec![
+        Operation::Push(Felt::new(1)),
+        Operation::Push(Felt::new(2)),
+        Operation::Add,
+    ]);
+
+    let (trace, _trace_len) = build_trace(&[], &program);
+
+    // --- test op bits columns -------------------------------------------------------------------
+    assert!(contains_op(&trace, 0, Operation::Span));
+    assert!(contains_op(&trace, 1, Operation::Push(Felt::new(1))));
+    assert!(contains_op(&trace, 2, Operation::Push(Felt::new(2))));
+    assert!(contains_op(&trace, 3, Operation::Add));
+    assert!(contains_op(&trace, 4, Operation::Noop));
+    assert!(contains_op(&trace, 5, Operation::End));
+}
+
+#[test]
 fn span_block() {
     let program = CodeBlock::new_span(vec![
         Operation::Push(Felt::new(1)),
@@ -43,10 +62,6 @@ fn span_block() {
     ]);
 
     let (trace, trace_len) = build_trace(&[], &program);
-
-    //for i in 0..20 {
-    //    print_row(&trace, i);
-    //}
 
     // --- test op bits columns -----------------------------------------------
     // two NOOPs are inserted by the processor:
@@ -80,8 +95,6 @@ fn span_block() {
     for i in 15..trace_len {
         assert_eq!(Felt::ZERO, trace[IN_SPAN_IDX][i]);
     }
-
-    //assert!(false, "all good!");
 }
 
 #[test]
@@ -106,8 +119,6 @@ fn span_block_with_respan() {
         Operation::Push(Felt::new(8)),
         Operation::Pow2,
         Operation::Push(Felt::new(9)),
-        Operation::Pow2,
-        Operation::Push(Felt::new(63)),
         Operation::Pow2,
     ]);
 

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1,0 +1,260 @@
+use super::{super::DecoderTrace, Felt, Operation, NUM_OP_BITS};
+use crate::{ExecutionTrace, Process, ProgramInputs};
+use core::ops::Range;
+use vm_core::{
+    program::blocks::CodeBlock, utils::range, FieldElement, StarkField, DECODER_TRACE_RANGE,
+};
+
+// CONSTANTS
+// ================================================================================================
+
+/// TODO: move to core?
+const OP_BITS_OFFSET: usize = 1;
+const OP_BITS_RANGE: Range<usize> = range(OP_BITS_OFFSET, NUM_OP_BITS);
+
+const IN_SPAN_IDX: usize = 8;
+
+// TESTS
+// ================================================================================================
+
+#[test]
+fn join_block() {
+    let value1 = Felt::new(3);
+    let value2 = Felt::new(5);
+    let span1 = CodeBlock::new_span(vec![Operation::Push(value1), Operation::Mul]);
+    let span2 = CodeBlock::new_span(vec![Operation::Push(value2), Operation::Add]);
+    let program = CodeBlock::new_join([span1, span2]);
+
+    let (trace, _trace_len) = build_trace(&[], &program);
+
+    // --- test op bits columns -----------------------------------------------
+
+    // opcodes should be: JOIN SPAN PUSH END SPAN DROP END END
+    assert!(contains_op(&trace, 0, Operation::Join));
+    assert!(contains_op(&trace, 1, Operation::Span));
+    assert!(contains_op(&trace, 2, Operation::Push(value1)));
+    assert!(contains_op(&trace, 3, Operation::Mul));
+    assert!(contains_op(&trace, 4, Operation::End));
+    assert!(contains_op(&trace, 5, Operation::Span));
+    assert!(contains_op(&trace, 6, Operation::Push(value2)));
+    assert!(contains_op(&trace, 7, Operation::Add));
+    assert!(contains_op(&trace, 8, Operation::End));
+    assert!(contains_op(&trace, 9, Operation::End));
+}
+
+// SPAN BLOCK TESTS
+// ================================================================================================
+
+#[test]
+fn span_block() {
+    let program = CodeBlock::new_span(vec![
+        Operation::Push(Felt::new(1)),
+        Operation::Push(Felt::new(2)),
+        Operation::Push(Felt::new(3)),
+        Operation::Pad,
+        Operation::Mul,
+        Operation::Add,
+        Operation::Drop,
+        Operation::Push(Felt::new(4)),
+        Operation::Push(Felt::new(5)),
+        Operation::Mul,
+        Operation::Add,
+        Operation::Inv,
+    ]);
+
+    let (trace, trace_len) = build_trace(&[], &program);
+
+    for i in 0..20 {
+        print_row(&trace, i);
+    }
+
+    // --- test op bits columns -----------------------------------------------
+    // two NOOPs are inserted by the processor:
+    // - after PUSH(4) to make sure the first group doesn't end with a PUSH
+    // - before the END to pad the last group with a single NOOP
+    assert!(contains_op(&trace, 0, Operation::Span));
+    assert!(contains_op(&trace, 1, Operation::Push(Felt::new(1))));
+    assert!(contains_op(&trace, 2, Operation::Push(Felt::new(2))));
+    assert!(contains_op(&trace, 3, Operation::Push(Felt::new(3))));
+    assert!(contains_op(&trace, 4, Operation::Pad));
+    assert!(contains_op(&trace, 5, Operation::Mul));
+    assert!(contains_op(&trace, 6, Operation::Add));
+    assert!(contains_op(&trace, 7, Operation::Drop));
+    assert!(contains_op(&trace, 8, Operation::Push(Felt::new(4))));
+    assert!(contains_op(&trace, 9, Operation::Noop));
+    assert!(contains_op(&trace, 10, Operation::Push(Felt::new(5))));
+    assert!(contains_op(&trace, 11, Operation::Mul));
+    assert!(contains_op(&trace, 12, Operation::Add));
+    assert!(contains_op(&trace, 13, Operation::Inv));
+    assert!(contains_op(&trace, 14, Operation::Noop));
+    assert!(contains_op(&trace, 15, Operation::End));
+    for i in 16..trace_len {
+        assert!(contains_op(&trace, i, Operation::Halt));
+    }
+
+    // --- test is_span column ------------------------------------------------
+    assert_eq!(Felt::ZERO, trace[IN_SPAN_IDX][0]);
+    for i in 1..15 {
+        assert_eq!(Felt::ONE, trace[IN_SPAN_IDX][i]);
+    }
+    for i in 15..trace_len {
+        assert_eq!(Felt::ZERO, trace[IN_SPAN_IDX][i]);
+    }
+}
+
+#[test]
+fn span_block_with_respan() {
+    let program = CodeBlock::new_span(vec![
+        Operation::Pad,
+        Operation::Pow2,
+        Operation::Push(Felt::new(1)),
+        Operation::Pow2,
+        Operation::Push(Felt::new(2)),
+        Operation::Pow2,
+        Operation::Push(Felt::new(3)),
+        Operation::Pow2,
+        Operation::Push(Felt::new(4)),
+        Operation::Pow2,
+        Operation::Push(Felt::new(5)),
+        Operation::Pow2,
+        Operation::Push(Felt::new(6)),
+        Operation::Pow2,
+        Operation::Push(Felt::new(7)),
+        Operation::Pow2,
+        Operation::Push(Felt::new(8)),
+        Operation::Pow2,
+        Operation::Push(Felt::new(9)),
+        Operation::Pow2,
+        Operation::Push(Felt::new(63)),
+        Operation::Pow2,
+    ]);
+
+    let (trace, _trace_len) = build_trace(&[], &program);
+
+    // --- test op bits columns -----------------------------------------------
+    assert!(contains_op(&trace, 0, Operation::Span));
+}
+
+// LOOP BLOCK TESTS
+// ================================================================================================
+
+#[test]
+fn loop_block() {
+    let loop_body = CodeBlock::new_span(vec![Operation::Pad, Operation::Drop]);
+    let program = CodeBlock::new_loop(loop_body);
+
+    let (trace, trace_len) = build_trace(&[0, 1], &program);
+
+    // --- test op bits columns -----------------------------------------------
+    assert!(contains_op(&trace, 0, Operation::Loop));
+    assert!(contains_op(&trace, 1, Operation::Span));
+    assert!(contains_op(&trace, 2, Operation::Pad));
+    assert!(contains_op(&trace, 3, Operation::Drop));
+    assert!(contains_op(&trace, 4, Operation::End));
+    assert!(contains_op(&trace, 5, Operation::End));
+    for i in 6..trace_len {
+        assert!(contains_op(&trace, i, Operation::Halt));
+    }
+}
+
+#[test]
+fn loop_block_skip() {
+    let loop_body = CodeBlock::new_span(vec![Operation::Pad, Operation::Drop]);
+    let program = CodeBlock::new_loop(loop_body);
+
+    let (trace, trace_len) = build_trace(&[0], &program);
+
+    // --- test op bits columns -----------------------------------------------
+    assert!(contains_op(&trace, 0, Operation::Loop));
+    assert!(contains_op(&trace, 1, Operation::End));
+    for i in 2..trace_len {
+        assert!(contains_op(&trace, i, Operation::Halt));
+    }
+}
+
+#[test]
+fn loop_block_repeat() {
+    let loop_body = CodeBlock::new_span(vec![Operation::Pad, Operation::Drop]);
+    let program = CodeBlock::new_loop(loop_body);
+
+    let (trace, trace_len) = build_trace(&[0, 1, 1], &program);
+
+    // --- test op bits columns -----------------------------------------------
+    assert!(contains_op(&trace, 0, Operation::Loop));
+    assert!(contains_op(&trace, 1, Operation::Span));
+    assert!(contains_op(&trace, 2, Operation::Pad));
+    assert!(contains_op(&trace, 3, Operation::Drop));
+    assert!(contains_op(&trace, 4, Operation::End));
+    assert!(contains_op(&trace, 5, Operation::Repeat));
+    assert!(contains_op(&trace, 6, Operation::Span));
+    assert!(contains_op(&trace, 7, Operation::Pad));
+    assert!(contains_op(&trace, 8, Operation::Drop));
+    assert!(contains_op(&trace, 9, Operation::End));
+    assert!(contains_op(&trace, 10, Operation::End));
+    for i in 11..trace_len {
+        assert!(contains_op(&trace, i, Operation::Halt));
+    }
+
+    //for i in 0..12 {
+    //    print_row(&trace, i);
+    //}
+    //assert!(false, "all good!");
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn build_trace(stack: &[u64], program: &CodeBlock) -> (DecoderTrace, usize) {
+    let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
+    let mut process = Process::new(inputs);
+    process.execute_code_block(&program).unwrap();
+
+    let trace = ExecutionTrace::test_finalize_trace(process);
+    let trace_len = trace.len() - ExecutionTrace::NUM_RAND_ROWS;
+
+    (
+        trace[DECODER_TRACE_RANGE]
+            .to_vec()
+            .try_into()
+            .expect("failed to convert vector to array"),
+        trace_len,
+    )
+}
+
+fn contains_op(trace: &DecoderTrace, row_idx: usize, op: Operation) -> bool {
+    op.op_code().unwrap() == read_opcode(trace, row_idx)
+}
+
+fn read_opcode(trace: &DecoderTrace, row_idx: usize) -> u8 {
+    let mut result = 0;
+    for (i, column) in trace
+        .iter()
+        .skip(OP_BITS_OFFSET)
+        .take(NUM_OP_BITS)
+        .enumerate()
+    {
+        let op_bit = column[row_idx].as_int();
+        assert!(op_bit <= 1, "invalid op bit");
+        result += op_bit << i;
+    }
+    result as u8
+}
+
+#[allow(dead_code)]
+fn print_row(trace: &DecoderTrace, idx: usize) {
+    let mut row = Vec::new();
+    for column in trace.iter() {
+        row.push(column[idx].as_int());
+    }
+    println!(
+        "{}\t{}\t{:?} {} {: <16x?} {: <16x?} {} {}",
+        idx,
+        row[0],
+        &row[OP_BITS_RANGE],
+        row[8],
+        &row[9..13],
+        &row[13..17],
+        row[17],
+        row[18]
+    );
+}

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -469,7 +469,7 @@ fn loop_block_skip() {
     assert_eq!([ZERO; 4], get_hasher_state2(&trace, 0));
 
     // the hash of the program is located in the last END row; is_loop is not set to ONE because
-    // we didn't entre the loop's body
+    // we didn't enter the loop's body
     let program_hash: Word = program.hash().into();
     assert_eq!(program_hash, get_hasher_state1(&trace, 1));
     assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&trace, 1));
@@ -546,7 +546,7 @@ fn loop_block_repeat() {
 fn build_trace(stack: &[u64], program: &CodeBlock) -> (DecoderTrace, usize) {
     let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
     let mut process = Process::new(inputs);
-    process.execute_code_block(&program).unwrap();
+    process.execute_code_block(program).unwrap();
 
     let trace = ExecutionTrace::test_finalize_trace(process);
     let trace_len = trace.len() - ExecutionTrace::NUM_RAND_ROWS;
@@ -573,7 +573,7 @@ fn check_op_decoding(
     in_span: u64,
 ) {
     assert_eq!(trace[ADDR_COL_IDX][row_idx], addr);
-    assert!(contains_op(&trace, row_idx, op));
+    assert!(contains_op(trace, row_idx, op));
     assert_eq!(trace[GROUP_COUNT_COL_IDX][row_idx], Felt::new(group_count));
     assert_eq!(trace[OP_INDEX_COL_IDX][row_idx], Felt::new(op_idx));
     assert_eq!(trace[IN_SPAN_COL_IDX][row_idx], Felt::new(in_span));

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1,9 +1,11 @@
-use super::{super::DecoderTrace, Felt, Operation, Word, NUM_HASHER_COLUMNS, NUM_OP_BITS};
+use super::{super::DecoderTrace, Felt, Operation, Word, NUM_OP_BITS};
 use crate::{ExecutionTrace, Process, ProgramInputs};
-use core::ops::Range;
 use vm_core::{
+    decoder::{
+        ADDR_COL_IDX, GROUP_COUNT_COL_IDX, HASHER_STATE_RANGE, IN_SPAN_COL_IDX, OP_BITS_OFFSET,
+        OP_BITS_RANGE, OP_INDEX_COL_IDX,
+    },
     program::blocks::{CodeBlock, Span},
-    utils::range,
     FieldElement, StarkField, DECODER_TRACE_RANGE,
 };
 
@@ -12,21 +14,7 @@ use vm_core::{
 
 const ONE: Felt = Felt::ONE;
 const ZERO: Felt = Felt::ZERO;
-
-const ADDR_IDX: usize = 0;
-
-/// TODO: move to core?
-const OP_BITS_OFFSET: usize = 1;
-const OP_BITS_RANGE: Range<usize> = range(OP_BITS_OFFSET, NUM_OP_BITS);
-
-const IN_SPAN_IDX: usize = 8;
-const GROUP_COUNT_IDX: usize = 17;
-const OP_INDEX_IDX: usize = 18;
-
-const HASHER_STATE_OFFSET: usize = 9;
-const HASHER_STATE_RANGE: Range<usize> = range(HASHER_STATE_OFFSET, NUM_HASHER_COLUMNS);
-
-const INIT_ADDR: Felt = Felt::ZERO;
+const INIT_ADDR: Felt = ONE;
 
 // SPAN BLOCK TESTS
 // ================================================================================================
@@ -584,11 +572,11 @@ fn check_op_decoding(
     op_idx: u64,
     in_span: u64,
 ) {
-    assert_eq!(trace[ADDR_IDX][row_idx], addr);
+    assert_eq!(trace[ADDR_COL_IDX][row_idx], addr);
     assert!(contains_op(&trace, row_idx, op));
-    assert_eq!(trace[GROUP_COUNT_IDX][row_idx], Felt::new(group_count));
-    assert_eq!(trace[OP_INDEX_IDX][row_idx], Felt::new(op_idx));
-    assert_eq!(trace[IN_SPAN_IDX][row_idx], Felt::new(in_span));
+    assert_eq!(trace[GROUP_COUNT_COL_IDX][row_idx], Felt::new(group_count));
+    assert_eq!(trace[OP_INDEX_COL_IDX][row_idx], Felt::new(op_idx));
+    assert_eq!(trace[IN_SPAN_COL_IDX][row_idx], Felt::new(in_span));
 }
 
 fn contains_op(trace: &DecoderTrace, row_idx: usize, op: Operation) -> bool {

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1,4 +1,4 @@
-use super::{super::DecoderTrace, Felt, Operation, Word, HASHER_WIDTH, NUM_OP_BITS};
+use super::{super::DecoderTrace, Felt, Operation, Word, NUM_HASHER_COLUMNS, NUM_OP_BITS};
 use crate::{ExecutionTrace, Process, ProgramInputs};
 use core::ops::Range;
 use vm_core::{
@@ -24,7 +24,7 @@ const GROUP_COUNT_IDX: usize = 17;
 const OP_INDEX_IDX: usize = 18;
 
 const HASHER_STATE_OFFSET: usize = 9;
-const HASHER_STATE_RANGE: Range<usize> = range(HASHER_STATE_OFFSET, HASHER_WIDTH);
+const HASHER_STATE_RANGE: Range<usize> = range(HASHER_STATE_OFFSET, NUM_HASHER_COLUMNS);
 
 const INIT_ADDR: Felt = Felt::ZERO;
 

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -77,18 +77,24 @@ impl DecoderTrace {
     /// Appends a trace row marking the end of a flow control block (JOIN, SPLIT, LOOP).
     ///
     /// When a control block is ending, we do the following:
-    /// - Copy over the block address from the previous row.
+    /// - Set the block address to the specified address.
     /// - Set op_bits to END opcode.
     /// - Set in_span to ZERO.
     /// - Put the provided block hash into the first 4 elements of the hasher state.
     /// - Set the remaining 4 elements of the hasher state to [is_loop_body, is_loop, 0, 0].
     /// - Copy over op group count from the previous row. This group count must be ZERO.
     /// - Set operation index register to ZERO.
-    pub fn append_block_end(&mut self, block_hash: Word, is_loop_body: Felt, is_loop: Felt) {
+    pub fn append_block_end(
+        &mut self,
+        block_addr: Felt,
+        block_hash: Word,
+        is_loop_body: Felt,
+        is_loop: Felt,
+    ) {
         debug_assert!(is_loop_body.as_int() <= 1, "invalid loop body");
         debug_assert!(is_loop.as_int() <= 1, "invalid is loop");
 
-        self.addr_trace.push(self.last_addr());
+        self.addr_trace.push(block_addr);
         self.append_opcode(Operation::End);
         self.in_span_trace.push(Felt::ZERO);
 

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -1,6 +1,12 @@
 use super::{Felt, Operation, Word, MIN_TRACE_LEN, NUM_HASHER_COLUMNS, NUM_OP_BITS};
 use vm_core::{program::blocks::OP_BATCH_SIZE, utils::new_array_vec, FieldElement, StarkField};
 
+// CONSTANTS
+// ================================================================================================
+
+const ZERO: Felt = Felt::ZERO;
+const ONE: Felt = Felt::ONE;
+
 // DECODER TRACE
 // ================================================================================================
 
@@ -58,7 +64,7 @@ impl DecoderTrace {
     pub fn append_block_start(&mut self, parent_addr: Felt, op: Operation, h1: Word, h2: Word) {
         self.addr_trace.push(parent_addr);
         self.append_opcode(op);
-        self.in_span_trace.push(Felt::ZERO);
+        self.in_span_trace.push(ZERO);
 
         self.hasher_trace[0].push(h1[0]);
         self.hasher_trace[1].push(h1[1]);
@@ -70,8 +76,8 @@ impl DecoderTrace {
         self.hasher_trace[6].push(h2[2]);
         self.hasher_trace[7].push(h2[3]);
 
-        self.group_count_trace.push(Felt::ZERO);
-        self.op_idx_trace.push(Felt::ZERO);
+        self.group_count_trace.push(ZERO);
+        self.op_idx_trace.push(ZERO);
     }
 
     /// Appends a trace row marking the end of a flow control block (JOIN, SPLIT, LOOP).
@@ -96,7 +102,7 @@ impl DecoderTrace {
 
         self.addr_trace.push(block_addr);
         self.append_opcode(Operation::End);
-        self.in_span_trace.push(Felt::ZERO);
+        self.in_span_trace.push(ZERO);
 
         self.hasher_trace[0].push(block_hash[0]);
         self.hasher_trace[1].push(block_hash[1]);
@@ -105,14 +111,14 @@ impl DecoderTrace {
 
         self.hasher_trace[4].push(is_loop_body);
         self.hasher_trace[5].push(is_loop);
-        self.hasher_trace[6].push(Felt::ZERO);
-        self.hasher_trace[7].push(Felt::ZERO);
+        self.hasher_trace[6].push(ZERO);
+        self.hasher_trace[7].push(ZERO);
 
         let last_group_count = self.last_group_count();
-        debug_assert!(last_group_count == Felt::ZERO, "group count not zero");
+        debug_assert!(last_group_count == ZERO, "group count not zero");
         self.group_count_trace.push(last_group_count);
 
-        self.op_idx_trace.push(Felt::ZERO);
+        self.op_idx_trace.push(ZERO);
     }
 
     /// Appends a trace row marking the beginning of a new loop iteration.
@@ -129,15 +135,15 @@ impl DecoderTrace {
     pub fn append_loop_repeat(&mut self, loop_addr: Felt) {
         self.addr_trace.push(loop_addr);
         self.append_opcode(Operation::Repeat);
-        self.in_span_trace.push(Felt::ZERO);
+        self.in_span_trace.push(ZERO);
 
         let last_row = self.hasher_trace[0].len() - 1;
         for column in self.hasher_trace.iter_mut() {
             column.push(column[last_row]);
         }
 
-        self.group_count_trace.push(Felt::ZERO);
-        self.op_idx_trace.push(Felt::ZERO);
+        self.group_count_trace.push(ZERO);
+        self.op_idx_trace.push(ZERO);
     }
 
     /// Appends a trace row marking the start of a SPAN block.
@@ -159,12 +165,12 @@ impl DecoderTrace {
     ) {
         self.addr_trace.push(parent_addr);
         self.append_opcode(Operation::Span);
-        self.in_span_trace.push(Felt::ZERO);
+        self.in_span_trace.push(ZERO);
         for (i, &op_group) in first_op_batch.iter().enumerate() {
             self.hasher_trace[i].push(op_group);
         }
         self.group_count_trace.push(num_op_groups);
-        self.op_idx_trace.push(Felt::ZERO);
+        self.op_idx_trace.push(ZERO);
     }
 
     /// Appends a trace row marking a RESPAN operation.
@@ -180,12 +186,12 @@ impl DecoderTrace {
     pub fn append_respan(&mut self, op_batch: &[Felt; OP_BATCH_SIZE]) {
         self.addr_trace.push(self.last_addr());
         self.append_opcode(Operation::Respan);
-        self.in_span_trace.push(Felt::ONE);
+        self.in_span_trace.push(ONE);
         for (i, &op_group) in op_batch.iter().enumerate() {
             self.hasher_trace[i].push(op_group);
         }
         self.group_count_trace.push(self.last_group_count());
-        self.op_idx_trace.push(Felt::ZERO);
+        self.op_idx_trace.push(ZERO);
     }
 
     /// Appends a trace row for a user operation.
@@ -213,16 +219,16 @@ impl DecoderTrace {
     ) {
         self.addr_trace.push(span_addr);
         self.append_opcode(op);
-        self.in_span_trace.push(Felt::ONE);
+        self.in_span_trace.push(ONE);
 
         self.hasher_trace[0].push(group_ops_left);
         self.hasher_trace[1].push(parent_addr);
-        self.hasher_trace[2].push(Felt::ZERO);
-        self.hasher_trace[3].push(Felt::ZERO);
-        self.hasher_trace[4].push(Felt::ZERO);
-        self.hasher_trace[5].push(Felt::ZERO);
-        self.hasher_trace[6].push(Felt::ZERO);
-        self.hasher_trace[7].push(Felt::ZERO);
+        self.hasher_trace[2].push(ZERO);
+        self.hasher_trace[3].push(ZERO);
+        self.hasher_trace[4].push(ZERO);
+        self.hasher_trace[5].push(ZERO);
+        self.hasher_trace[6].push(ZERO);
+        self.hasher_trace[7].push(ZERO);
 
         self.group_count_trace.push(num_groups_left);
         self.op_idx_trace.push(op_idx);
@@ -244,7 +250,7 @@ impl DecoderTrace {
 
         self.addr_trace.push(self.last_addr());
         self.append_opcode(Operation::End);
-        self.in_span_trace.push(Felt::ZERO);
+        self.in_span_trace.push(ZERO);
 
         self.hasher_trace[0].push(span_hash[0]);
         self.hasher_trace[1].push(span_hash[1]);
@@ -253,15 +259,15 @@ impl DecoderTrace {
 
         // we don't need to set is_loop here because we know we are not in a loop block
         self.hasher_trace[4].push(is_loop_body);
-        self.hasher_trace[5].push(Felt::ZERO);
-        self.hasher_trace[6].push(Felt::ZERO);
-        self.hasher_trace[7].push(Felt::ZERO);
+        self.hasher_trace[5].push(ZERO);
+        self.hasher_trace[6].push(ZERO);
+        self.hasher_trace[7].push(ZERO);
 
         let last_group_count = self.last_group_count();
-        debug_assert!(last_group_count == Felt::ZERO, "group count not zero");
+        debug_assert!(last_group_count == ZERO, "group count not zero");
         self.group_count_trace.push(last_group_count);
 
-        self.op_idx_trace.push(Felt::ZERO);
+        self.op_idx_trace.push(ZERO);
     }
 
     // TRACE GENERATION
@@ -270,8 +276,12 @@ impl DecoderTrace {
     /// Returns vector of columns of this execution trace.
     ///
     /// Each column in the trace is extended to the specified trace length. The extension is done
-    /// by inserting ZEROs into the unfilled rows of most columns. The only exceptions are the
-    /// op_bits columns where the unfilled rows are filled with the opcode of the HALT operation.
+    /// by inserting ZEROs into the unfilled rows of most columns. The only exceptions are:
+    /// - The op_bits columns, where the unfilled rows are filled with the opcode of the HALT
+    ///   operation.
+    /// - The first 4 columns of the hasher state, where the unfilled rows are filled with the
+    ///   values from the last filled row. This is done so that the hash of the program is
+    ///   propagated to the last row.
     pub fn into_vec(mut self, trace_len: usize, num_rand_rows: usize) -> Vec<Vec<Felt>> {
         let own_len = self.trace_len();
         // make sure that only the duplicate rows will be overwritten with random values
@@ -283,7 +293,7 @@ impl DecoderTrace {
         let mut trace = Vec::new();
 
         // put ZEROs into the unfilled rows of block address column
-        self.addr_trace.resize(trace_len, Felt::ZERO);
+        self.addr_trace.resize(trace_len, ZERO);
         trace.push(self.addr_trace);
 
         // insert HALT opcode into the unfilled rows of ob_bits columns
@@ -297,24 +307,33 @@ impl DecoderTrace {
 
         // put ZEROs into the unfilled rows of in_span column
         debug_assert_eq!(own_len, self.in_span_trace.len());
-        self.in_span_trace.resize(trace_len, Felt::ZERO);
+        self.in_span_trace.resize(trace_len, ZERO);
         trace.push(self.in_span_trace);
 
-        // put ZEROs into the unfilled rows of hasher state columns
-        for mut column in self.hasher_trace {
+        // for unfilled rows of hasher state columns, copy over values from the last row for the
+        // first 4 columns, and pad the other 4 columns with ZEROs
+        for (i, mut column) in self.hasher_trace.into_iter().enumerate() {
             debug_assert_eq!(own_len, column.len());
-            column.resize(trace_len, Felt::ZERO);
+            if i < 4 {
+                // TODO: ideally, we should use `expect()` instead of `unwrap_or()` but aux_table
+                // unit tests fail if we do that as they don't expect build the decoder portion of
+                // the trace. in the future we should refactor aux_table unit tests.
+                let last_value = *column.last().unwrap_or(&ZERO);
+                column.resize(trace_len, last_value);
+            } else {
+                column.resize(trace_len, ZERO);
+            }
             trace.push(column);
         }
 
         // put ZEROs into the unfilled rows of operation group count column
         debug_assert_eq!(own_len, self.group_count_trace.len());
-        self.group_count_trace.resize(trace_len, Felt::ZERO);
+        self.group_count_trace.resize(trace_len, ZERO);
         trace.push(self.group_count_trace);
 
         // put ZEROs into the unfilled rows of operation index column
         debug_assert_eq!(own_len, self.op_idx_trace.len());
-        self.op_idx_trace.resize(trace_len, Felt::ZERO);
+        self.op_idx_trace.resize(trace_len, ZERO);
         trace.push(self.op_idx_trace);
 
         trace

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -1,0 +1,338 @@
+use super::{Felt, Operation, Word, HASHER_WIDTH, MIN_TRACE_LEN, NUM_OP_BITS};
+use vm_core::{program::blocks::OP_BATCH_SIZE, utils::new_array_vec, FieldElement, StarkField};
+
+// DECODER TRACE
+// ================================================================================================
+
+/// TODO: add docs
+pub struct DecoderTrace {
+    addr_trace: Vec<Felt>,
+    op_bits_trace: [Vec<Felt>; NUM_OP_BITS],
+    in_span_trace: Vec<Felt>,
+    hasher_trace: [Vec<Felt>; HASHER_WIDTH],
+    group_count_trace: Vec<Felt>,
+    op_idx_trace: Vec<Felt>,
+}
+
+impl DecoderTrace {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Initializes a blank [DecoderTrace].
+    pub fn new() -> Self {
+        Self {
+            addr_trace: Vec::with_capacity(MIN_TRACE_LEN),
+            op_bits_trace: new_array_vec(MIN_TRACE_LEN),
+            in_span_trace: Vec::with_capacity(MIN_TRACE_LEN),
+            hasher_trace: new_array_vec(MIN_TRACE_LEN),
+            group_count_trace: Vec::with_capacity(MIN_TRACE_LEN),
+            op_idx_trace: Vec::with_capacity(MIN_TRACE_LEN),
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the current length of columns in this trace.
+    pub fn trace_len(&self) -> usize {
+        self.addr_trace.len()
+    }
+
+    // TRACE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Appends a trace row marking the start of a flow control block (JOIN, SPLIT, LOOP).
+    ///
+    /// When a control block is starting, we do the following:
+    /// - Set the address to the address of the parent block. This is not necessarily equal to the
+    ///   address from the previous row because in a SPLIT block, the second child follows the
+    ///   first child, rather than the parent.
+    /// - Set op_bits to opcode of the specified block (e.g., JOIN, SPLIT, LOOP).
+    /// - Set is_span to ZERO.
+    /// - Set the first half of the hasher state to the h1 parameter. For JOIN and SPLIT blocks
+    ///   this will contain the hash of the left child; for LOOP block this will contain hash of
+    ///   the loop's body.
+    /// - Set the second half of the hasher state to the h2 parameter. For JOIN and SPLIT blocks
+    ///   this will contain hash of the right child.
+    /// - Set op group count register to the ZERO.
+    /// - Set operation index register to ZERO.
+    pub fn append_block_start(&mut self, parent_addr: Felt, op: Operation, h1: Word, h2: Word) {
+        self.addr_trace.push(parent_addr);
+        self.append_opcode(op);
+        self.in_span_trace.push(Felt::ZERO);
+
+        self.hasher_trace[0].push(h1[0]);
+        self.hasher_trace[1].push(h1[1]);
+        self.hasher_trace[2].push(h1[2]);
+        self.hasher_trace[3].push(h1[3]);
+
+        self.hasher_trace[4].push(h2[0]);
+        self.hasher_trace[5].push(h2[1]);
+        self.hasher_trace[6].push(h2[2]);
+        self.hasher_trace[7].push(h2[3]);
+
+        self.group_count_trace.push(Felt::ZERO);
+        self.op_idx_trace.push(Felt::ZERO);
+    }
+
+    /// Appends a trace row marking the end of a flow control block (JOIN, SPLIT, LOOP).
+    ///
+    /// When a control block is ending, we do the following:
+    /// - Copy over the block address from the previous row.
+    /// - Set op_bits to END opcode.
+    /// - Set in_span to ZERO.
+    /// - Put the provided block hash into the first 4 elements of the hasher state.
+    /// - Set the remaining 4 elements of the hasher state to [is_loop_body, is_loop, 0, 0].
+    /// - Copy over op group count from the previous row. This group count must be ZERO.
+    /// - Set operation index register to ZERO.
+    pub fn append_block_end(&mut self, block_hash: Word, is_loop_body: Felt, is_loop: Felt) {
+        debug_assert!(is_loop_body.as_int() <= 1, "invalid loop body");
+        debug_assert!(is_loop.as_int() <= 1, "invalid is loop");
+
+        self.addr_trace.push(self.last_addr());
+        self.append_opcode(Operation::End);
+        self.in_span_trace.push(Felt::ZERO);
+
+        self.hasher_trace[0].push(block_hash[0]);
+        self.hasher_trace[1].push(block_hash[1]);
+        self.hasher_trace[2].push(block_hash[2]);
+        self.hasher_trace[3].push(block_hash[3]);
+
+        self.hasher_trace[4].push(is_loop_body);
+        self.hasher_trace[5].push(is_loop);
+        self.hasher_trace[6].push(Felt::ZERO);
+        self.hasher_trace[7].push(Felt::ZERO);
+
+        let last_group_count = self.last_group_count();
+        debug_assert!(last_group_count == Felt::ZERO, "group count not zero");
+        self.group_count_trace.push(last_group_count);
+
+        self.op_idx_trace.push(Felt::ZERO);
+    }
+
+    /// Appends a trace row marking the beginning of a new loop iteration.
+    ///
+    /// When we starting a new loop iteration, we do the following:
+    /// - Set the block address to the address of the loop block.
+    /// - Set op_bits to REPEAT opcode.
+    /// - Set in_span to ZERO.
+    /// - Copy over the hasher state from the previous row. Technically, we need to copy over
+    ///   only the first 5 elements of the hasher state, but it is easier to copy over the whole
+    ///   row.
+    /// - Set op group count register to the ZERO.
+    /// - Set operation index register to ZERO.
+    pub fn append_loop_repeat(&mut self, loop_addr: Felt) {
+        self.addr_trace.push(loop_addr);
+        self.append_opcode(Operation::Repeat);
+        self.in_span_trace.push(Felt::ZERO);
+
+        let last_row = self.hasher_trace[0].len() - 1;
+        for column in self.hasher_trace.iter_mut() {
+            column.push(column[last_row]);
+        }
+
+        self.group_count_trace.push(Felt::ZERO);
+        self.op_idx_trace.push(Felt::ZERO);
+    }
+
+    /// Appends a trace row marking the start of a SPAN block.
+    ///
+    /// When a SPAN block is starting, we do the following:
+    /// - Set the address to the address of the parent block. This is not necessarily equal to the
+    ///   address from the previous row because in a SPLIT block, the second child follows the
+    ///   first child, rather than the parent.
+    /// - Set op_bits to SPAN opcode.
+    /// - Set is_span to ZERO. is_span will be set to one in the following row.
+    /// - Set hasher state to op groups of the first op batch of the SPAN.
+    /// - Set op group count to the total number of op groups in the SPAN.
+    /// - Set operation index register to ZERO.
+    pub fn append_span_start(
+        &mut self,
+        parent_addr: Felt,
+        first_op_batch: &[Felt; OP_BATCH_SIZE],
+        num_op_groups: Felt,
+    ) {
+        self.addr_trace.push(parent_addr);
+        self.append_opcode(Operation::Span);
+        self.in_span_trace.push(Felt::ZERO);
+        for (i, &op_group) in first_op_batch.iter().enumerate() {
+            self.hasher_trace[i].push(op_group);
+        }
+        self.group_count_trace.push(num_op_groups);
+        self.op_idx_trace.push(Felt::ZERO);
+    }
+
+    /// Appends a trace row marking a RESPAN operation.
+    ///
+    /// When a RESPAN operation is executed, we do the following:
+    /// - Copy over the block address from the previous row. The SPAN address will be update in
+    ///   the following row.
+    /// - Set op_bits to RESPAN opcode.
+    /// - Set in_span to ONE.
+    /// - Set hasher state to op groups of the next op batch of the SPAN.
+    /// - Copy over op group count from the previous row.
+    /// - Set operation index register to ZERO.
+    pub fn append_respan(&mut self, op_batch: &[Felt; OP_BATCH_SIZE]) {
+        self.addr_trace.push(self.last_addr());
+        self.append_opcode(Operation::Respan);
+        self.in_span_trace.push(Felt::ONE);
+        for (i, &op_group) in op_batch.iter().enumerate() {
+            self.hasher_trace[i].push(op_group);
+        }
+        self.group_count_trace.push(self.last_group_count());
+        self.op_idx_trace.push(Felt::ZERO);
+    }
+
+    /// Appends a trace row for a user operation.
+    ///
+    /// When we execute a user operation in a SPAN block, we do the following:
+    /// - Set the address of the row to the address of the span block.
+    /// - Set op_bits to the opcode of the executed operation.
+    /// - Set is_span to ONE.
+    /// - Set the first hasher state register to the aggregation of remaining operations to be
+    ///   executed in the current operation group.
+    /// - Set the second hasher state register to the address of the SPAN's parent block.
+    /// - Set the remaining hasher state registers to ZEROs.
+    /// - Set the number of groups remaining to be processed. This number of groups changes if
+    ///   in the previous row an operation with an immediate value was executed or if this
+    ///   operation is a start of a new operation group.
+    /// - Set the operation's index withing the current operation group.
+    pub fn append_user_op(
+        &mut self,
+        op: Operation,
+        span_addr: Felt,
+        parent_addr: Felt,
+        num_groups_left: Felt,
+        group_ops_left: Felt,
+        op_idx: Felt,
+    ) {
+        self.addr_trace.push(span_addr);
+        self.append_opcode(op);
+        self.in_span_trace.push(Felt::ONE);
+
+        self.hasher_trace[0].push(group_ops_left);
+        self.hasher_trace[1].push(parent_addr);
+        self.hasher_trace[2].push(Felt::ZERO);
+        self.hasher_trace[3].push(Felt::ZERO);
+        self.hasher_trace[4].push(Felt::ZERO);
+        self.hasher_trace[5].push(Felt::ZERO);
+        self.hasher_trace[6].push(Felt::ZERO);
+        self.hasher_trace[7].push(Felt::ZERO);
+
+        self.group_count_trace.push(num_groups_left);
+        self.op_idx_trace.push(op_idx);
+    }
+
+    /// Appends a trace row marking the end of a SPAN block.
+    ///
+    /// When the SPAN block is ending, we do the following:
+    /// - Copy over the block address from the previous row.
+    /// - Set op_bits to END opcode.
+    /// - Set in_span to ZERO to indicate that the span block is completed.
+    /// - Put the hash of the span block into the first 4 registers of the hasher state.
+    /// - Put a flag indicating whether the SPAN block was a body of a loop into the 5th
+    ///   register of the hasher state.
+    /// - Copy over op group count from the previous row. This group count must be ZERO.
+    /// - Set operation index register to ZERO.
+    pub fn append_span_end(&mut self, span_hash: Word, is_loop_body: Felt) {
+        debug_assert!(is_loop_body.as_int() <= 1, "invalid loop body");
+
+        self.addr_trace.push(self.last_addr());
+        self.append_opcode(Operation::End);
+        self.in_span_trace.push(Felt::ZERO);
+
+        self.hasher_trace[0].push(span_hash[0]);
+        self.hasher_trace[1].push(span_hash[1]);
+        self.hasher_trace[2].push(span_hash[2]);
+        self.hasher_trace[3].push(span_hash[3]);
+
+        // we don't need to set is_loop here because we know we are not in a loop block
+        self.hasher_trace[4].push(is_loop_body);
+        self.hasher_trace[5].push(Felt::ZERO);
+        self.hasher_trace[6].push(Felt::ZERO);
+        self.hasher_trace[7].push(Felt::ZERO);
+
+        let last_group_count = self.last_group_count();
+        debug_assert!(last_group_count == Felt::ZERO, "group count not zero");
+        self.group_count_trace.push(last_group_count);
+
+        self.op_idx_trace.push(Felt::ZERO);
+    }
+
+    // TRACE GENERATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns vector of columns of this execution trace.
+    ///
+    /// Each column in the trace is extended to the specified trace length. The extension is done
+    /// by inserting ZEROs into the unfilled rows of most columns. The only exceptions are the
+    /// op_bits columns where the unfilled rows are filled with the opcode of the HALT operation.
+    pub fn into_vec(mut self, trace_len: usize, num_rand_rows: usize) -> Vec<Vec<Felt>> {
+        let own_len = self.trace_len();
+        // make sure that only the duplicate rows will be overwritten with random values
+        assert!(
+            own_len + num_rand_rows <= trace_len,
+            "target trace length too small"
+        );
+
+        let mut trace = Vec::new();
+
+        // put ZEROs into the unfilled rows of block address column
+        self.addr_trace.resize(trace_len, Felt::ZERO);
+        trace.push(self.addr_trace);
+
+        // insert HALT opcode into the unfilled rows of ob_bits columns
+        let halt_opcode = Operation::Halt.op_code().expect("missing opcode");
+        for (i, mut column) in self.op_bits_trace.into_iter().enumerate() {
+            debug_assert_eq!(own_len, column.len());
+            let value = Felt::from((halt_opcode >> i) & 1);
+            column.resize(trace_len, value);
+            trace.push(column);
+        }
+
+        // put ZEROs into the unfilled rows of in_span column
+        debug_assert_eq!(own_len, self.in_span_trace.len());
+        self.in_span_trace.resize(trace_len, Felt::ZERO);
+        trace.push(self.in_span_trace);
+
+        // put ZEROs into the unfilled rows of hasher state columns
+        for mut column in self.hasher_trace {
+            debug_assert_eq!(own_len, column.len());
+            column.resize(trace_len, Felt::ZERO);
+            trace.push(column);
+        }
+
+        // put ZEROs into the unfilled rows of operation group count column
+        debug_assert_eq!(own_len, self.group_count_trace.len());
+        self.group_count_trace.resize(trace_len, Felt::ZERO);
+        trace.push(self.group_count_trace);
+
+        // put ZEROs into the unfilled rows of operation index column
+        debug_assert_eq!(own_len, self.op_idx_trace.len());
+        self.op_idx_trace.resize(trace_len, Felt::ZERO);
+        trace.push(self.op_idx_trace);
+
+        trace
+    }
+
+    // HELPER FUNCTIONS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the last block address.
+    fn last_addr(&self) -> Felt {
+        *self.addr_trace.last().expect("no last addr")
+    }
+
+    /// Returns the last value of the operation group count.
+    fn last_group_count(&self) -> Felt {
+        *self.group_count_trace.last().expect("no group count")
+    }
+
+    /// Populates op_bits registers for the next row with the opcode of the provided operation.
+    fn append_opcode(&mut self, op: Operation) {
+        let op_code = op.op_code().expect("missing opcode");
+        for i in 0..NUM_OP_BITS {
+            let bit = Felt::from((op_code >> i) & 1);
+            self.op_bits_trace[i].push(bit);
+        }
+    }
+}

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -1,4 +1,4 @@
-use super::{Felt, Operation, Word, HASHER_WIDTH, MIN_TRACE_LEN, NUM_OP_BITS};
+use super::{Felt, Operation, Word, MIN_TRACE_LEN, NUM_HASHER_COLUMNS, NUM_OP_BITS};
 use vm_core::{program::blocks::OP_BATCH_SIZE, utils::new_array_vec, FieldElement, StarkField};
 
 // DECODER TRACE
@@ -9,7 +9,7 @@ pub struct DecoderTrace {
     addr_trace: Vec<Felt>,
     op_bits_trace: [Vec<Felt>; NUM_OP_BITS],
     in_span_trace: Vec<Felt>,
-    hasher_trace: [Vec<Felt>; HASHER_WIDTH],
+    hasher_trace: [Vec<Felt>; NUM_HASHER_COLUMNS],
     group_count_trace: Vec<Felt>,
     op_idx_trace: Vec<Felt>,
 }

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -83,6 +83,14 @@ impl Hasher {
     // HASHING METHODS
     // --------------------------------------------------------------------------------------------
 
+    /// TODO: add docs
+    pub fn hash(&mut self, mut state: HasherState) -> (Felt, HasherState) {
+        let addr = self.trace.next_row_addr();
+        self.trace
+            .append_permutation(&mut state, LINEAR_HASH, RETURN_HASH, Felt::ZERO, Felt::ZERO);
+        (addr, state)
+    }
+
     /// Applies a single permutation of the hash function to the provided state and records the
     /// execution trace of this computation.
     ///

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -118,7 +118,7 @@ impl Hasher {
         const START: Selectors = LINEAR_HASH;
         const RETURN: Selectors = RETURN_HASH;
         // absorb selectors are the same as linear hash selectors, but absorb selectors are
-        // applies on the last row of a permutation cycle, while linear hash selectors are
+        // applied on the last row of a permutation cycle, while linear hash selectors are
         // applied on the first row of a permutation cycle.
         const ABSORB: Selectors = LINEAR_HASH;
         // to continue linear hash we need retain the 2nd and 3rd selector flags and set the

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -1,8 +1,11 @@
 use super::{Felt, FieldElement, StarkField, TraceFragment, Word};
 use core::ops::Range;
-use vm_core::hasher::{
-    Selectors, LINEAR_HASH, MP_VERIFY, MR_UPDATE_NEW, MR_UPDATE_OLD, RETURN_HASH, RETURN_STATE,
-    STATE_WIDTH, TRACE_WIDTH,
+use vm_core::{
+    hasher::{
+        Selectors, LINEAR_HASH, MP_VERIFY, MR_UPDATE_NEW, MR_UPDATE_OLD, RETURN_HASH, RETURN_STATE,
+        STATE_WIDTH, TRACE_WIDTH,
+    },
+    program::blocks::{OpBatch, OP_BATCH_SIZE},
 };
 
 mod trace;
@@ -16,6 +19,8 @@ mod tests;
 
 /// Elements of the hasher state which are returned as hash result.
 const HASH_RESULT_RANGE: Range<usize> = Range { start: 4, end: 8 };
+
+const ZERO: Felt = Felt::ZERO;
 
 // TYPE ALIASES
 // ================================================================================================
@@ -83,14 +88,6 @@ impl Hasher {
     // HASHING METHODS
     // --------------------------------------------------------------------------------------------
 
-    /// TODO: add docs
-    pub fn hash(&mut self, mut state: HasherState) -> (Felt, HasherState) {
-        let addr = self.trace.next_row_addr();
-        self.trace
-            .append_permutation(&mut state, LINEAR_HASH, RETURN_HASH, Felt::ZERO, Felt::ZERO);
-        (addr, state)
-    }
-
     /// Applies a single permutation of the hash function to the provided state and records the
     /// execution trace of this computation.
     ///
@@ -98,14 +95,55 @@ impl Hasher {
     /// execution trace at which the permutation started.
     pub fn permute(&mut self, mut state: HasherState) -> (Felt, HasherState) {
         let addr = self.trace.next_row_addr();
-        self.trace.append_permutation(
-            &mut state,
-            LINEAR_HASH,
-            RETURN_STATE,
-            Felt::ZERO,
-            Felt::ZERO,
-        );
+        self.trace
+            .append_permutation(&mut state, LINEAR_HASH, RETURN_STATE);
         (addr, state)
+    }
+
+    /// TODO: add docs
+    pub fn hash_2to1(&mut self, h1: Word, h2: Word) -> (Felt, Word) {
+        let addr = self.trace.next_row_addr();
+        // TODO: use more specialized function
+        let mut state = build_merge_state(&h1, &h2, 0);
+        self.trace
+            .append_permutation(&mut state, LINEAR_HASH, RETURN_HASH);
+        let result = state[HASH_RESULT_RANGE]
+            .try_into()
+            .expect("failed to get result from hasher state");
+        (addr, result)
+    }
+
+    /// TODO: add docs
+    pub fn hash_span_block(&mut self, op_batches: &[OpBatch]) -> (Felt, Word) {
+        let addr = self.trace.next_row_addr();
+
+        let num_elements = op_batches.len() * OP_BATCH_SIZE;
+        let mut state = init_state(op_batches[0].groups(), num_elements);
+
+        // TODO: make more readable
+        let num_batches = op_batches.len();
+        if num_batches == 1 {
+            self.trace
+                .append_permutation(&mut state, LINEAR_HASH, RETURN_HASH);
+        } else {
+            self.trace
+                .append_permutation(&mut state, LINEAR_HASH, LINEAR_HASH);
+
+            for batch in op_batches.iter().take(num_batches - 1).skip(1) {
+                absorb_into_state(&mut state, batch.groups());
+                self.trace
+                    .append_permutation(&mut state, RETURN_HASH, LINEAR_HASH);
+            }
+            absorb_into_state(&mut state, op_batches[num_batches - 1].groups());
+            self.trace
+                .append_permutation(&mut state, RETURN_HASH, RETURN_HASH);
+        }
+
+        let result = state[HASH_RESULT_RANGE]
+            .try_into()
+            .expect("failed to get result from hasher state");
+
+        (addr, result)
     }
 
     /// Performs Merkle path verification computation and records its execution trace.
@@ -237,14 +275,14 @@ impl Hasher {
         // of init_selectors is not ZERO (i.e., we are processing the first leg of the Merkle
         // path), the index for the first row is different from the index for the other rows;
         // otherwise, indexes are the same.
-        let (init_index, rest_index) = if init_selectors[0] == Felt::ZERO {
+        let (init_index, rest_index) = if init_selectors[0] == ZERO {
             (Felt::new(*index >> 1), Felt::new(*index >> 1))
         } else {
             (Felt::new(*index), Felt::new(*index >> 1))
         };
 
         // apply the permutation to the state and record its trace
-        self.trace.append_permutation(
+        self.trace.append_permutation_with_index(
             &mut state,
             init_selectors,
             final_selectors,
@@ -295,7 +333,7 @@ impl MerklePathContext {
     /// from selector values by replacing the first selector with ZERO.
     pub fn part_selectors(&self) -> Selectors {
         let selectors = self.main_selectors();
-        [Felt::ZERO, selectors[1], selectors[2]]
+        [ZERO, selectors[1], selectors[2]]
     }
 }
 
@@ -311,7 +349,6 @@ impl MerklePathContext {
 /// followed by 3 zeros.
 fn build_merge_state(a: &Word, b: &Word, index_bit: u64) -> HasherState {
     const EIGHT: Felt = Felt::new(8);
-    const ZERO: Felt = Felt::ZERO;
     match index_bit {
         0 => [
             EIGHT, ZERO, ZERO, ZERO, a[0], a[1], a[2], a[3], b[0], b[1], b[2], b[3],
@@ -321,4 +358,33 @@ fn build_merge_state(a: &Word, b: &Word, index_bit: u64) -> HasherState {
         ],
         _ => panic!("index bit is not a binary value"),
     }
+}
+
+fn init_state(init_values: &[Felt; 8], num_elements: usize) -> HasherState {
+    [
+        Felt::new(num_elements as u64),
+        ZERO,
+        ZERO,
+        ZERO,
+        init_values[0],
+        init_values[1],
+        init_values[2],
+        init_values[3],
+        init_values[4],
+        init_values[5],
+        init_values[6],
+        init_values[7],
+    ]
+}
+
+/// TODO: add comments
+fn absorb_into_state(state: &mut HasherState, values: &[Felt; 8]) {
+    state[4] += values[0];
+    state[5] += values[1];
+    state[6] += values[2];
+    state[7] += values[3];
+    state[8] += values[4];
+    state[9] += values[5];
+    state[10] += values[6];
+    state[11] += values[7];
 }

--- a/processor/src/hasher/tests.rs
+++ b/processor/src/hasher/tests.rs
@@ -20,8 +20,8 @@ fn hasher_permute() {
     let init_state: HasherState = rand_array();
     let (addr, final_state) = hasher.permute(init_state);
 
-    // address of the permutation should be zero
-    assert_eq!(Felt::ZERO, addr);
+    // address of the permutation should be ONE (as hasher address starts at ONE)
+    assert_eq!(Felt::ONE, addr);
 
     // make sure the result is correct
     let expected_state = apply_permutation(init_state);
@@ -46,9 +46,9 @@ fn hasher_permute() {
     let init_state2: HasherState = rand_array();
     let (addr2, final_state2) = hasher.permute(init_state2);
 
-    // make sure the returned addresses are correct
-    assert_eq!(Felt::ZERO, addr1);
-    assert_eq!(Felt::new(8), addr2);
+    // make sure the returned addresses are correct (they must be 8 rows apart)
+    assert_eq!(Felt::ONE, addr1);
+    assert_eq!(Felt::new(9), addr2);
 
     // make sure the results are correct
     let expected_state1 = apply_permutation(init_state1);
@@ -285,11 +285,11 @@ fn check_merkle_path(
     }
 }
 
-/// Makes sure that values in the row address column (column 3) start out at 0 and are incremented
+/// Makes sure that values in the row address column (column 3) start out at 1 and are incremented
 /// by 1 with every row.
 fn check_row_addr_trace(trace: &[Vec<Felt>]) {
     for (i, &addr) in trace[3].iter().enumerate() {
-        assert_eq!(Felt::new(i as u64), addr);
+        assert_eq!(Felt::new(i as u64 + 1), addr);
     }
 }
 

--- a/processor/src/hasher/trace.rs
+++ b/processor/src/hasher/trace.rs
@@ -60,7 +60,7 @@ impl HasherTrace {
     ///
     /// Node index values are provided via `init_index` and `rest_index` parameters. The former is
     /// used for the first row, and the latter for all subsequent rows.
-    pub fn append_permutation(
+    pub fn append_permutation_with_index(
         &mut self,
         state: &mut HasherState,
         init_selectors: Selectors,
@@ -84,6 +84,26 @@ impl HasherTrace {
         // apply the last round and append the last row to the trace
         apply_round(state, NUM_ROUNDS - 1);
         self.append_row(final_selectors, state, rest_index);
+    }
+
+    /// Appends 8 rows to the execution trace describing a single permutation of the hash function.
+    ///
+    /// This function is similar to the append_permutation_with_index() function above, but it sets
+    /// init_index and rest_index parameters to ZEROs.
+    #[inline(always)]
+    pub fn append_permutation(
+        &mut self,
+        state: &mut HasherState,
+        init_selectors: Selectors,
+        final_selectors: Selectors,
+    ) {
+        self.append_permutation_with_index(
+            state,
+            init_selectors,
+            final_selectors,
+            Felt::ZERO,
+            Felt::ZERO,
+        );
     }
 
     /// Appends a new row to the execution trace based on the supplied parameters.

--- a/processor/src/hasher/trace.rs
+++ b/processor/src/hasher/trace.rs
@@ -41,9 +41,13 @@ impl HasherTrace {
         self.row_addr.len()
     }
 
-    /// Returns next row address. The address is equal to the current trace length.
+    /// Returns next row address. The address is equal to the current trace length + 1.
+    ///
+    /// The above means that row addresses start at ONE (rather than ZERO), and are incremented by
+    /// ONE at every row. Starting at ONE is needed for the decoder so that the address of the
+    /// first code block is a non-zero value.
     pub fn next_row_addr(&self) -> Felt {
-        Felt::new(self.trace_len() as u64)
+        Felt::new(self.trace_len() as u64 + 1)
     }
 
     // TRACE MUTATORS

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -6,8 +6,8 @@ use vm_core::{
         Script,
     },
     AdviceInjector, DebugOptions, Felt, FieldElement, Operation, ProgramInputs, StackTopState,
-    StarkField, Word, AUX_TRACE_WIDTH, MIN_STACK_DEPTH, MIN_TRACE_LEN, NUM_STACK_HELPER_COLS,
-    RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH, SYS_TRACE_WIDTH,
+    StarkField, Word, AUX_TRACE_WIDTH, DECODER_TRACE_WIDTH, MIN_STACK_DEPTH, MIN_TRACE_LEN,
+    NUM_STACK_HELPER_COLS, RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH, SYS_TRACE_WIDTH,
 };
 
 mod operations;
@@ -54,6 +54,7 @@ pub use debug::{VmState, VmStateIterator};
 // ================================================================================================
 
 type SysTrace = [Vec<Felt>; SYS_TRACE_WIDTH];
+type DecoderTrace = [Vec<Felt>; DECODER_TRACE_WIDTH];
 type StackTrace = [Vec<Felt>; STACK_TRACE_WIDTH];
 type RangeCheckTrace = [Vec<Felt>; RANGE_CHECK_TRACE_WIDTH];
 type AuxTableTrace = [Vec<Felt>; AUX_TRACE_WIDTH]; // TODO: potentially rename to AuxiliaryTrace
@@ -70,7 +71,7 @@ pub fn execute(script: &Script, inputs: &ProgramInputs) -> Result<ExecutionTrace
     Ok(ExecutionTrace::new(process, *script.hash()))
 }
 
-/// Returns an iterator that allows callers to step through each exceution and inspect
+/// Returns an iterator that allows callers to step through each execution and inspect
 /// vm state information along side.
 pub fn execute_iter(script: &Script, inputs: &ProgramInputs) -> VmStateIterator {
     let mut process = Process::new_debug(inputs.clone());
@@ -149,13 +150,10 @@ impl Process {
     /// Executes the specified [Split] block.
     #[inline(always)]
     fn execute_split_block(&mut self, block: &Split) -> Result<(), ExecutionError> {
-        // get the top element from the stack here because starting a SPLIT block removes it from
-        // the stack
-        let condition = self.stack.peek();
-        self.start_split_block(block)?;
+        // start the SPLIT block; this also pops the stack and returns the popped element
+        let condition = self.start_split_block(block)?;
 
         // execute either the true or the false branch of the split block based on the condition
-        // retrieved from the top of the stack
         if condition == Felt::ONE {
             self.execute_code_block(block.on_true())?;
         } else if condition == Felt::ZERO {
@@ -170,47 +168,32 @@ impl Process {
     /// Executes the specified [Loop] block.
     #[inline(always)]
     fn execute_loop_block(&mut self, block: &Loop) -> Result<(), ExecutionError> {
-        // start LOOP block; this requires examining the top of the stack to determine whether
-        // the loop's body should be executed.
-        let condition = self.stack.peek();
-        self.decoder.start_loop(block, condition);
+        // start the LOOP block; this also pops the stack and returns the popped element
+        let condition = self.start_loop_block(block)?;
 
-        // if the top of the stack is ONE, execute the loop body; otherwise skip the loop body;
-        // before we execute the loop body we drop the condition from the stack; when the loop
-        // body is not executed, we keep the condition on the stack so that it can be dropped by
-        // the END operation later.
+        // if the top of the stack is ONE, execute the loop body; otherwise skip the loop body
         if condition == Felt::ONE {
-            // drop the condition and execute the loop body at least once
-            self.execute_op(Operation::Drop)?;
+            // execute the loop body at least once
             self.execute_code_block(block.body())?;
 
             // keep executing the loop body until the condition on the top of the stack is no
             // longer ONE; each iteration of the loop is preceded by executing REPEAT operation
             // which drops the condition from the stack
             while self.stack.peek() == Felt::ONE {
-                self.execute_op(Operation::Drop)?;
                 self.decoder.repeat(block);
-
+                self.execute_op(Operation::Drop)?;
                 self.execute_code_block(block.body())?;
             }
+
+            // end the LOOP block and drop the condition from the stack
+            self.end_loop_block(block, true)
         } else if condition == Felt::ZERO {
-            self.execute_op(Operation::Noop)?
+            // end the LOOP block, but don't drop the condition from the stack because it was
+            // already dropped when we started the LOOP block
+            self.end_loop_block(block, false)
         } else {
-            return Err(ExecutionError::NotBinaryValue(condition));
+            Err(ExecutionError::NotBinaryValue(condition))
         }
-
-        // execute END operation; this can be done only if the top of the stack is ZERO, in which
-        // case the top of the stack is dropped
-        if self.stack.peek() == Felt::ZERO {
-            self.execute_op(Operation::Drop)?;
-        } else if condition == Felt::ONE {
-            unreachable!("top of the stack should not be ONE");
-        } else {
-            return Err(ExecutionError::NotBinaryValue(self.stack.peek()));
-        }
-        self.decoder.end_loop(block);
-
-        Ok(())
     }
 
     /// Executes the specified [Span] block.
@@ -246,6 +229,11 @@ impl Process {
         let mut group_idx = 0;
         let mut next_group_idx = 1;
 
+        // round up the number of groups to be processed to the next power of two; we do this
+        // because the processor requires the number of groups to be either 1, 2, 4, or 8; if
+        // the actual number of groups is smaller, we'll pad the batch with NOOPs at the end
+        let num_batch_groups = batch.num_groups().next_power_of_two();
+
         // execute operations in the batch one by one
         for &op in batch.ops() {
             if op.is_decorator() {
@@ -256,14 +244,16 @@ impl Process {
             }
 
             // decode and execute the operation
-            self.decoder.execute_user_op(op);
+            self.decoder.execute_user_op(op, op_idx);
             self.execute_op(op)?;
 
             // if the operation carries an immediate value, the value is stored at the next group
-            // pointer; so, we advance the pointer to the following group
+            // pointer; so, we advance the pointer to the following group and also update the
+            // number of remaining operation groups in the span
             let has_imm = op.imm_value().is_some();
             if has_imm {
                 next_group_idx += 1;
+                self.decoder.consume_imm_value();
             }
 
             // determine if we've executed all non-decorator operations in a group
@@ -276,7 +266,7 @@ impl Process {
                     // is enough room in the group to execute a NOOP (if there isn't, there is a
                     // bug somewhere in the assembler)
                     debug_assert!(op_idx < OP_GROUP_SIZE - 1, "invalid op index");
-                    self.decoder.execute_user_op(Operation::Noop);
+                    self.decoder.execute_user_op(Operation::Noop, op_idx + 1);
                     self.execute_op(Operation::Noop)?;
                 }
 
@@ -284,17 +274,30 @@ impl Process {
                 group_idx = next_group_idx;
                 next_group_idx += 1;
                 op_idx = 0;
+
+                // if we haven't reached the end of the batch yet, set up the decoder for
+                // decoding the next operation group
+                if group_idx < num_batch_groups {
+                    self.decoder.start_op_group(batch.groups()[group_idx]);
+                }
             } else {
                 // if we are not at the end of the group, just increment the operation index
                 op_idx += 1;
             }
         }
 
-        // for each operation batch we must execute number of groups which is a power of 2; so
-        // if the number of groups is not a power of 2, we pad each missing group with a NOOP
-        for _ in group_idx..batch.num_groups().next_power_of_two() {
-            self.decoder.execute_user_op(Operation::Noop);
+        // make sure we execute the required number of operation groups; this would happen when
+        // the actual number of operation groups was not a power of two
+        for group_idx in group_idx..num_batch_groups {
+            self.decoder.execute_user_op(Operation::Noop, 0);
             self.execute_op(Operation::Noop)?;
+
+            // if we are not at the last group yet, set up the decoder for decoding the next
+            // operation groups. the groups were are processing are just NOOPs - so, the op group
+            // value is ZERO
+            if group_idx < num_batch_groups - 1 {
+                self.decoder.start_op_group(Felt::ZERO);
+            }
         }
 
         Ok(())
@@ -306,8 +309,8 @@ impl Process {
         self.memory.get_value(addr)
     }
 
-    pub fn to_components(self) -> (System, Stack, RangeChecker, AuxTable) {
+    pub fn to_components(self) -> (System, Decoder, Stack, RangeChecker, AuxTable) {
         let aux_table = AuxTable::new(self.hasher, self.bitwise, self.memory);
-        (self.system, self.stack, self.range, aux_table)
+        (self.system, self.decoder, self.stack, self.range, aux_table)
     }
 }


### PR DESCRIPTION
This PR implements decoder trace generation and related changes. This includes:

- [x] Implement trace generation for most columns the decoder component. Trace for 5 more decoder columns is left for another PR. These columns do not affect decoder logic and will be mostly used for degree reductions.
- [x] Add `merge()` and `hash_span_block()` methods to the hasher component. (will need to create an issue for adding tests for these functions).
- [x] Update hasher trace generation so that row address always starts at 1. (will need to create an issue for adding a boundary constraint for this).
- [x] Implement tests for the decoder trace.