### PR TITLE
u32assert2 assembly instruction

### DIFF
--- a/assembly/src/parsers/u32_ops.rs
+++ b/assembly/src/parsers/u32_ops.rs
@@ -74,6 +74,16 @@ pub fn parse_u32assert(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), 
     match op.num_parts() {
         0 => return Err(AssemblyError::missing_param(op)),
         1 => assert_u32(span_ops),
+        2 => match op.parts()[1] {
+            "1" => assert_u32(span_ops),
+            "2" => {
+                assert_u32(span_ops);
+                span_ops.push(Operation::Swap);
+                assert_u32(span_ops);
+                span_ops.push(Operation::Swap);
+            }
+            _ => return Err(AssemblyError::invalid_param(op, 1)),
+        },
         _ => return Err(AssemblyError::extra_param(op)),
     }
 
@@ -804,8 +814,6 @@ fn assert_u32(span_ops: &mut Vec<Operation>) {
     span_ops.push(Operation::Assert);
 }
 
-/// Asserts that both values at the top of the stack are u32 values.
-///
 /// When `preserve_order` is set to true, the stack state is preserved; otherwise the two
 /// stack items are swapped.
 ///

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -458,7 +458,6 @@ impl Operation {
             Self::U32mul => Some(0b0011_0100),
             Self::U32madd => Some(0b0011_0101),
             Self::U32div => Some(0b0011_0110),
-
             Self::U32and => Some(0b0011_0111),
             Self::U32or => Some(0b0011_1000),
             Self::U32xor => Some(0b0011_1001),


### PR DESCRIPTION
This PR partly addresses #132. In the first phase u32assert2 has been added to the assembly instruction. 