### PR TITLE
Add tests & fix errors in AIR constraints for Memory co-processor

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -25,3 +25,4 @@ winter-air = { package = "winter-air", version = "0.4", default-features = false
 
 [dev-dependencies]
 proptest = "1.0.0"
+rand-utils = { package = "winter-rand-utils", version = "0.4" }

--- a/air/src/aux_table/memory/mod.rs
+++ b/air/src/aux_table/memory/mod.rs
@@ -4,6 +4,9 @@ use core::ops::Range;
 use vm_core::utils::range as create_range;
 use winter_air::TransitionConstraintDegree;
 
+#[cfg(test)]
+mod tests;
+
 // CONSTANTS
 // ================================================================================================
 

--- a/air/src/aux_table/memory/mod.rs
+++ b/air/src/aux_table/memory/mod.rs
@@ -122,7 +122,7 @@ fn enforce_delta<E: FieldElement>(
         frame.n1() * frame.addr_change() + frame.not_n1() * frame.clk_change(),
     );
     // Always subtract the delta. It should offset the other changes.
-    result.agg_constraint(0, memory_flag, -frame.delta());
+    result[0] -= memory_flag * frame.delta_next();
 
     constraint_count
 }
@@ -179,8 +179,8 @@ trait EvaluationFrameExt<E: FieldElement> {
     /// The next value of the upper 16-bits of the delta value being tracked between two consecutive
     /// context IDs, addresses, or clock cycles.
     fn d1_next(&self) -> E;
-    /// The current value of the column tracking the inverse delta used for constraint evaluations.
-    fn d_inv(&self) -> E;
+    /// The next value of the column tracking the inverse delta used for constraint evaluations.
+    fn d_inv_next(&self) -> E;
 
     // --- Intermediate variables & helpers -------------------------------------------------------
 
@@ -204,7 +204,7 @@ trait EvaluationFrameExt<E: FieldElement> {
     /// The difference between the next clock value and the current one, minus 1.
     fn clk_change(&self) -> E;
     /// The delta between two consecutive context IDs, addresses, or clock cycles.
-    fn delta(&self) -> E;
+    fn delta_next(&self) -> E;
 
     // --- Flags ----------------------------------------------------------------------------------
 
@@ -245,8 +245,8 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     fn d1_next(&self) -> E {
         self.next()[D1_COL_IDX]
     }
-    fn d_inv(&self) -> E {
-        self.current()[D_INV_COL_IDX]
+    fn d_inv_next(&self) -> E {
+        self.next()[D_INV_COL_IDX]
     }
 
     // --- Intermediate variables & helpers -------------------------------------------------------
@@ -256,7 +256,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     }
 
     fn n0(&self) -> E {
-        self.change(CTX_COL_IDX) * self.d_inv()
+        self.change(CTX_COL_IDX) * self.d_inv_next()
     }
 
     fn not_n0(&self) -> E {
@@ -264,7 +264,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     }
 
     fn n1(&self) -> E {
-        self.change(ADDR_COL_IDX) * self.d_inv()
+        self.change(ADDR_COL_IDX) * self.d_inv_next()
     }
 
     fn not_n1(&self) -> E {
@@ -283,7 +283,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
         self.change(CLK_COL_IDX) - E::ONE
     }
 
-    fn delta(&self) -> E {
+    fn delta_next(&self) -> E {
         E::from(2_u32.pow(16)) * self.d1_next() + self.d0_next()
     }
 

--- a/air/src/aux_table/memory/tests.rs
+++ b/air/src/aux_table/memory/tests.rs
@@ -1,0 +1,164 @@
+use super::{
+    EvaluationFrame, ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, D0_COL_IDX, D1_COL_IDX, D_INV_COL_IDX,
+    NUM_ELEMENTS, U_COL_RANGE, V_COL_RANGE,
+};
+use crate::{aux_table::memory, Felt, FieldElement};
+use vm_core::TRACE_WIDTH;
+
+use rand_utils::rand_value;
+
+// UNIT TESTS
+// ================================================================================================
+
+#[test]
+fn test_memory_write() {
+    let old_values = vec![0, 0, 0, 0];
+    let new_values = vec![1, 0, 0, 0];
+
+    // Write to a new context.
+    test_memory(MemoryTestDeltaType::Context, &old_values, &new_values);
+
+    // Write to a new address in the same context.
+    test_memory(MemoryTestDeltaType::Address, &old_values, &new_values);
+
+    // Write to the same context and address at a new clock cycle.
+    test_memory(MemoryTestDeltaType::Clock, &old_values, &new_values);
+}
+
+#[test]
+fn test_memory_read() {
+    let old_values = vec![1, 0, 0, 0];
+    let new_values = vec![1, 0, 0, 0];
+
+    // Memory reads only happen when neither the context nor the address have changed.
+    test_memory(MemoryTestDeltaType::Clock, &old_values, &new_values);
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Specifies the column where the delta should occur in a memory test frame.
+/// - Context: when the delta is in context, the address and clock columns can also change.
+/// - Address: when the delta occurs in the address, context must stay fixed, but clock can change.
+/// - Clock: when the delta occurs in the clock column, context and address must stay fixed.
+enum MemoryTestDeltaType {
+    Context,
+    Address,
+    Clock,
+}
+
+/// Generates a frame that reads or writes memory with the specified old and new values and a change
+/// in the  specified column (context, address, or clock), then asserts that the memory constraints
+/// evaluate to zero on this frame.
+///
+/// - To test a valid write, the MemoryTestDeltaType must be Context or Address and the `old_values` and
+/// `new_values` must change.
+/// - To test a valid read, the `delta_type` must be Clock and the `old_values` and `new_values`
+/// must be equal.
+fn test_memory(delta_type: MemoryTestDeltaType, old_values: &[u32], new_values: &[u32]) {
+    let delta_row = get_test_delta_row(&delta_type);
+    let frame = get_test_frame(&delta_type, &delta_row, old_values, new_values);
+
+    let mut result = [Felt::ZERO; memory::NUM_CONSTRAINTS];
+    let expected = result;
+
+    memory::enforce_constraints(&frame, &mut result, Felt::ONE);
+
+    assert_eq!(expected, result);
+}
+
+/// Generates an EvaluationFrame with memory trace data as specified by the inputs. The frame treats
+/// the current row as the first row of a memory execution trace with context, address, clock, old
+/// values, delta (d1, d0), and delta inverse set to zero. The provided inputs determine the values
+/// in the next row and therefore the transition from current to next. The generated frame will be
+/// valid when valid inputs are provided.
+///
+/// - `delta_type`: specifies the column over which the delta value should be calculated.
+/// - `delta_row`: specifies the values of the context, address, and clock columns in the next row.
+/// - `old_values`: specifies the old values, which are placed in the "new" value columns of the
+///   current row and the "old" value columns of the next row.
+/// - `new_values`: specifies the new values, which are placed in the "new" columns of the next row.
+fn get_test_frame(
+    delta_type: &MemoryTestDeltaType,
+    delta_row: &[u64],
+    old_values: &[u32],
+    new_values: &[u32],
+) -> EvaluationFrame<Felt> {
+    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+
+    // Set the context, addr, and clock columns in the next row to the values in the delta row.
+    next[CTX_COL_IDX] = Felt::new(delta_row[0]);
+    next[ADDR_COL_IDX] = Felt::new(delta_row[1]);
+    next[CLK_COL_IDX] = Felt::new(delta_row[2]);
+
+    // Set the old and new values.
+    for idx in 0..NUM_ELEMENTS {
+        let old_value = Felt::new(old_values[idx] as u64);
+        // Add a write for the old values to the current row.
+        current[U_COL_RANGE.start + idx] = Felt::ZERO;
+        current[V_COL_RANGE.start + idx] = old_value;
+        // Change the values from old to new in the next row.
+        next[U_COL_RANGE.start + idx] = old_value;
+        next[V_COL_RANGE.start + idx] = Felt::new(new_values[idx] as u64);
+    }
+
+    // Set the delta and delta inverse values. Treat the current row as if it's the first row.
+    current[D0_COL_IDX] = Felt::ZERO;
+    current[D1_COL_IDX] = Felt::ZERO;
+    current[D_INV_COL_IDX] = Felt::ZERO;
+
+    // Set the delta in the next row according to the specified delta type.
+    let delta: u64 = match delta_type {
+        MemoryTestDeltaType::Clock => delta_row[MemoryTestDeltaType::Clock as usize] - 1,
+        MemoryTestDeltaType::Context => delta_row[MemoryTestDeltaType::Context as usize],
+        MemoryTestDeltaType::Address => delta_row[MemoryTestDeltaType::Address as usize],
+    };
+    next[D0_COL_IDX] = Felt::new(delta as u16 as u64);
+    next[D1_COL_IDX] = Felt::new(delta >> 16);
+    next[D_INV_COL_IDX] = (Felt::new(delta)).inv();
+
+    EvaluationFrame::<Felt>::from_rows(current, next)
+}
+
+/// Generates a row of valid test values for the context, address, and clock columns according to
+/// the specified delta type, which determines the column over which the delta and delta inverse
+/// values of the trace would be calculated.
+///
+/// - When the delta type is Context, the address and clock columns can be anything.
+/// - When the delta type is Address, the context must remain unchanged but the clock can change.
+/// - When the delta type is Clock, both the context and address columns must remain unchanged.
+fn get_test_delta_row(delta_type: &MemoryTestDeltaType) -> Vec<u64> {
+    let delta_value = rand_value::<u32>() as u64;
+    let mut row = vec![0; 3];
+    let ctx_idx = MemoryTestDeltaType::Context as usize;
+    let addr_idx = MemoryTestDeltaType::Address as usize;
+    let clk_idx = MemoryTestDeltaType::Clock as usize;
+
+    // Set the context, addr, and clock columns according to the specified delta type.
+    match delta_type {
+        MemoryTestDeltaType::Context => {
+            // Change the row value for the context.
+            row[ctx_idx] = delta_value;
+
+            // Set addr and clock in the row column to random values.
+            row[addr_idx] = rand_value::<u32>() as u64;
+            row[clk_idx] = rand_value::<u32>() as u64;
+        }
+        MemoryTestDeltaType::Address => {
+            // Keep the context value the same in current and row rows (leave it as ZERO).
+            // Set the row value for the address.
+            row[addr_idx] = delta_value;
+
+            // Set clock in the row column to a random value.
+            row[clk_idx] = rand_value::<u32>() as u64;
+        }
+        MemoryTestDeltaType::Clock => {
+            // Keep the context and address values the same in the current and row rows.
+            // Set the current and row values for the clock.
+            row[clk_idx] = delta_value;
+        }
+    }
+
+    row
+}

--- a/air/src/aux_table/mod.rs
+++ b/air/src/aux_table/mod.rs
@@ -148,6 +148,6 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
         self.s0() * binary_not(self.s1())
     }
     fn memory_flag(&self) -> E {
-        self.s0() * self.s1() * binary_not(self.s2())
+        self.s0() * self.s1() * self.s2()
     }
 }

--- a/docs/src/design/aux_table/memory.md
+++ b/docs/src/design/aux_table/memory.md
@@ -129,8 +129,8 @@ This new column `ctx` should behave similarly to the address column: values in i
 To simplify description of constraints, we'll define two variables $n_0$ and $n_1$ as follows:
 
 $$
-n_0 = (c' - c) \cdot t \\
-n_1 = (a' - a) \cdot t
+n_0 = (c' - c) \cdot t' \\
+n_1 = (a' - a) \cdot t'
 $$
 
 Thus, $n_0 = 1$ when the context changes, and $0$ otherwise. Also, $(1 - n_0) \cdot n_1 = 1$ when context remains the same and address changes, and $0$ otherwise.

--- a/miden/tests/integration/air/memory.rs
+++ b/miden/tests/integration/air/memory.rs
@@ -1,0 +1,70 @@
+use crate::{build_op_test, build_test};
+
+#[test]
+fn push() {
+    let asm_op = "push.mem.0";
+
+    build_op_test!(asm_op).prove_and_verify(vec![], 0, false);
+}
+
+#[test]
+fn pushw() {
+    let asm_op = "pushw.mem.0";
+
+    build_op_test!(asm_op).prove_and_verify(vec![], 0, false);
+}
+
+#[test]
+fn pop() {
+    let asm_op = "pop.mem.0";
+    let pub_inputs = vec![1];
+
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+}
+
+#[test]
+fn popw() {
+    let asm_op = "popw.mem.0";
+    let pub_inputs = vec![1, 2, 3, 4];
+
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+}
+
+#[test]
+fn load() {
+    let asm_op = "loadw.mem.0";
+
+    build_op_test!(asm_op).prove_and_verify(vec![], 0, false);
+}
+
+#[test]
+fn store() {
+    let asm_op = "storew.mem.0";
+    let pub_inputs = vec![1, 2, 3, 4];
+
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+}
+
+#[test]
+fn write_read() {
+    let source = "begin popw.mem.0 pushw.mem.0 end";
+    let pub_inputs = vec![4, 3, 2, 1];
+
+    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+}
+
+#[test]
+fn update() {
+    let source = "begin pushw.mem.0 storew.mem.0 end";
+    let pub_inputs = vec![8, 7, 6, 5, 4, 3, 2, 1];
+
+    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+}
+
+#[test]
+fn incr_write_addr() {
+    let source = "begin storew.mem.0 storew.mem.1 end";
+    let pub_inputs = vec![4, 3, 2, 1];
+
+    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+}

--- a/miden/tests/integration/air/mod.rs
+++ b/miden/tests/integration/air/mod.rs
@@ -1,1 +1,19 @@
+use crate::build_test;
+use rand_utils::rand_vector;
+
 mod bitwise;
+mod memory;
+
+#[test]
+fn aux_table() {
+    // Test a script that uses all of the co-processors in the auxiliary table.
+    let script = "begin
+        rpperm                  # hasher operation
+        push.5 push.10 u32or    # bitwise operation
+        pow2                    # power of two operation
+        push.mem                # memory operation
+    end";
+    let pub_inputs = rand_vector::<u64>(8);
+
+    build_test!(script, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+}


### PR DESCRIPTION
This PR addresses the following for the Memory co-processor's AIR constraints:
- Adds simple integration tests to prove & verify each of the primary memory operations (local reads/writes are excluded. These should be tested with a more complex script that includes context changes.)
- Adds basic unit tests for the AIR constraints to test transitions between states (context change, address change, or clock change). These tests provide correct states and look for passing constraints. Tests of failure in incorrect states or missing constraints are left for another PR.
- Fixes an error with the constraints.
- Updates the mdbook docs to reflect the constraint changes.

This PR is waiting for #194 to be merged, as there is a shared test helper in the integration tests which is first added there.