### PR TITLE
introduce u32assert2 opcode to VM instruction

### DIFF
--- a/assembly/src/parsers/u32_ops.rs
+++ b/assembly/src/parsers/u32_ops.rs
@@ -69,19 +69,15 @@ pub fn parse_u32testw(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), A
 
 /// Translates u32assert assembly instruction to VM operations.
 ///
-/// Implemented as: `U32SPLIT EQZ ASSERT` (3 VM cycles).
+/// u32assert, u32assert.1: Implemented as: `U32SPLIT EQZ ASSERT` (3 VM cycles).
+/// u32assert.2: Implemented as: ``U32assert2` (1 VM cycles).
 pub fn parse_u32assert(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
     match op.num_parts() {
         0 => return Err(AssemblyError::missing_param(op)),
         1 => assert_u32(span_ops),
         2 => match op.parts()[1] {
             "1" => assert_u32(span_ops),
-            "2" => {
-                assert_u32(span_ops);
-                span_ops.push(Operation::Swap);
-                assert_u32(span_ops);
-                span_ops.push(Operation::Swap);
-            }
+            "2" => span_ops.push(Operation::U32assert2),
             _ => return Err(AssemblyError::invalid_param(op, 1)),
         },
         _ => return Err(AssemblyError::extra_param(op)),

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -115,6 +115,10 @@ pub enum Operation {
     /// operation is undefined.
     U32add,
 
+    /// Pops two elements off the stack and checks if each of them represents a 32-bit value.
+    /// If both of them are, they are pushed back onto the stack, otherwise an error is returned.
+    U32assert2,
+
     /// Pops three elements off the stack, adds them together, and splits the result into upper
     /// and lower 32-bit values. Then pushes the result back onto the stack.
     ///
@@ -461,6 +465,7 @@ impl Operation {
             Self::U32and => Some(0b0011_0111),
             Self::U32or => Some(0b0011_1000),
             Self::U32xor => Some(0b0011_1001),
+            Self::U32assert2 => Some(0b0111_1001),
 
             Self::LoadW => Some(0b0011_1010),
             Self::StoreW => Some(0b0011_1011),
@@ -553,6 +558,7 @@ impl fmt::Display for Operation {
             Self::U32and => write!(f, "u32and"),
             Self::U32or => write!(f, "u32or"),
             Self::U32xor => write!(f, "u32xor"),
+            Self::U32assert2 => write!(f, "u32assert2"),
 
             // ----- stack manipulation -----------------------------------------------------------
             Self::Drop => write!(f, "drop"),

--- a/docs/src/user_docs/assembly/u32_operations.md
+++ b/docs/src/user_docs/assembly/u32_operations.md
@@ -13,7 +13,8 @@ For instructions where one or more operands can be provided as immediate paramet
 | ------------- | ----------- | ------------- | ------------------------------------------ |
 | u32test       | [a, ...]    | [b, a, ...]   | $b \leftarrow \begin{cases} 1, & \text{if}\ a < 2^{32} \\ 0, & \text{otherwise}\ \end{cases}$ |
 | u32testw      | [A, ...]    | [b, A, ...]   | $b \leftarrow \begin{cases} 1, & \text{if}\ \forall\ i \in \{0, 1, 2, 3\}\ a_i < 2^{32} \\ 0, & \text{otherwise}\ \end{cases}$ |
-| u32assert     | [a, ...]    | [a, ...]      | Fails if $a \ge 2^{32}$ |
+| u32assert <br> u32assert.1 | [a, ...]    | [a, ...]  | Fails if $a \ge 2^{32}$ |
+| u32assert.2   | [b, a,...]  | [b, a,...] | Fails if $a \ge 2^{32}$ or $b \ge 2^{32}$ |
 | u32assertw    | [A, ...]    | [A, ...]      | Fails if $\exists\ i \in \{0, 1, 2, 3\} \ni a_i \ge 2^{32}$ |
 | u32cast       | [a, ...]    | [b, ...]      | $b \leftarrow a \mod 2^{32}$ |
 | u32split      | [a, ...]    | [c, b, ...]   | $b \leftarrow a \mod 2^{32}$, $c \leftarrow \lfloor{a / 2^{32}}\rfloor$ |

--- a/miden/tests/integration/operations/u32_ops/conversion_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/conversion_ops.rs
@@ -135,7 +135,7 @@ fn u32assert2() {
 #[test]
 fn u32assert2_fail() {
     let asm_op = "u32assert.2";
-    let err = "FailedAssertion";
+    let err = "NotU32Value";
 
     // vars to test
     // -------- Case 1: a > 2^32 and b > 2^32 ---------------------------------------------------

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -65,6 +65,7 @@ impl Process {
             Operation::U32and => self.op_u32and()?,
             Operation::U32or => self.op_u32or()?,
             Operation::U32xor => self.op_u32xor()?,
+            Operation::U32assert2 => self.op_u32assert2()?,
 
             // ----- stack manipulation -----------------------------------------------------------
             Operation::Pad => self.op_pad()?,


### PR DESCRIPTION
Partly address #132 
Introduced `u32assert2` opcode to the core VM instruction set. It will reduce down the total VM cycle of checking whether top 2 values in the stack is u32 to 1 from atleast 6.   