### PR TITLE
air bitwise operation bug poc test

### DIFF
--- a/air/src/aux_table/bitwise_pow2/bitwise.rs
+++ b/air/src/aux_table/bitwise_pow2/bitwise.rs
@@ -22,7 +22,7 @@ pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
 /// Index of CONSTRAINT_DEGREES array after which all constraints use periodic columns.
 pub const PERIODIC_CONSTRAINTS_START: usize = 2;
 /// The number of bits decomposed per row.
-const NUM_DECOMP_BITS: usize = 4;
+pub const NUM_DECOMP_BITS: usize = 4;
 
 /// The range of the selector columns in the trace.
 const SELECTOR_COL_RANGE: Range<usize> = create_range(BITWISE_TRACE_OFFSET, NUM_SELECTORS);
@@ -196,7 +196,7 @@ fn enforce_output_aggregation<E: FieldElement>(
 
 /// Calculates the result of bitwise AND applied to the decomposed values provided as a bit array.
 /// The result will be the AND of the first 4 bits in the provided array with the latter 4 bits.
-fn bitwise_and<E: FieldElement>(decomposed_values: &[E]) -> E {
+pub fn bitwise_and<E: FieldElement>(decomposed_values: &[E]) -> E {
     let mut result = E::ZERO;
     // Aggregate the result of the bitwise AND over the decomposed bits in the row.
     for idx in 0..NUM_DECOMP_BITS {
@@ -209,7 +209,7 @@ fn bitwise_and<E: FieldElement>(decomposed_values: &[E]) -> E {
 
 /// Calculates the result of bitwise OR applied to the decomposed values provided as a bit array.
 /// The result will be the OR of the first 4 bits in the provided array with the latter 4 bits.
-fn bitwise_or<E: FieldElement>(decomposed_values: &[E]) -> E {
+pub fn bitwise_or<E: FieldElement>(decomposed_values: &[E]) -> E {
     let mut result = E::ZERO;
     // Aggregate the result of the bitwise OR over the decomposed bits in the row.
     for idx in 0..NUM_DECOMP_BITS {
@@ -222,7 +222,7 @@ fn bitwise_or<E: FieldElement>(decomposed_values: &[E]) -> E {
 
 /// Calculates the result of bitwise XOR applied to the decomposed values provided as a bit array.
 /// The result will be the XOR of the first 4 bits in the provided array with the latter 4 bits.
-fn bitwise_xor<E: FieldElement>(decomposed_values: &[E]) -> E {
+pub fn bitwise_xor<E: FieldElement>(decomposed_values: &[E]) -> E {
     let mut result = E::ZERO;
     // Aggregate the result of the bitwise XOR over the decomposed bits in the row.
     for idx in 0..NUM_DECOMP_BITS {
@@ -354,7 +354,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
 // ================================================================================================
 /// Aggregate 4 decomposed bits representing a 4-bit binary value into a decimal value, starting
 /// from `start_idx` in the provided row.
-fn agg_bits<E: FieldElement>(row: &[E], start_idx: usize) -> E {
+pub fn agg_bits<E: FieldElement>(row: &[E], start_idx: usize) -> E {
     let mut result = E::ZERO;
     // TODO: this can be optimized.
     // From Bobbin: "we are multiplying by a small power of two and then summing up the results -

--- a/air/src/aux_table/bitwise_pow2/tests.rs
+++ b/air/src/aux_table/bitwise_pow2/tests.rs
@@ -1,11 +1,82 @@
-use super::{bitwise, pow2, PERIODIC_CYCLE_LEN};
+use super::bitwise::{NUM_CONSTRAINTS, NUM_DECOMP_BITS};
+use super::{bitwise, pow2, EvaluationFrame, BITWISE_TRACE_OFFSET, PERIODIC_CYCLE_LEN};
 use crate::{Felt, FieldElement};
-use vm_core::bitwise::{Selectors, BITWISE_AND, BITWISE_OR, BITWISE_XOR};
+use vm_core::{
+    bitwise::{
+        Selectors, BITWISE_AND, BITWISE_OR, BITWISE_XOR, NUM_SELECTORS,
+        TRACE_WIDTH as BITWISE_TRACE_WIDTH,
+    },
+    TRACE_WIDTH,
+};
 
 use proptest::prelude::*;
 
+// CONSTANTS
+// ================================================================================================
+
+/// The index of the column holding the aggregated value of input `a`.
+const A_COL_IDX: usize = 2;
+/// The index of the column holding the aggregated value of input `b`.
+const B_COL_IDX: usize = 3;
+/// The index of the column containing the aggregated output value.
+const OUTPUT_COL_IDX: usize = 12;
+/// The index of the column from where the input decomposition starts in a cycle row.
+const BITWISE_DECOMPOSITION_OFFSET: usize = 4;
+/// Number of columns needed for input decomposition of `a` & `b` in a cycle row.
+const BITWISE_DECOMPOSITION_SIZE: usize = 8;
+
 // UNIT TESTS
 // ================================================================================================
+
+/// Takes two custom consecutive row cycle state of bitwise decompostion with two distinct selectors. Outputs failure
+/// as all constraint are not zero (not satisfied)
+#[test]
+fn test_bitwise_selectors_fail() {
+    let current_bitwise = vec![
+        // decomposed a
+        Felt::ONE,
+        Felt::ONE,
+        Felt::ZERO,
+        Felt::ZERO,
+        // decomposed b
+        Felt::ONE,
+        Felt::ZERO,
+        Felt::ONE,
+        Felt::ONE,
+    ];
+
+    let next_bitwise = vec![
+        Felt::ONE,
+        Felt::ONE,
+        Felt::ONE,
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ONE,
+        Felt::ONE,
+        Felt::ONE,
+    ];
+    let cycle = 1;
+    let expected = [Felt::ZERO; bitwise::NUM_CONSTRAINTS];
+
+    let frame =
+        get_test_frame_with_two_selectors(&current_bitwise, &next_bitwise, BITWISE_AND, BITWISE_OR);
+    let result = get_bitwise_frame_result(frame, cycle);
+    assert_ne!(result, expected);
+
+    let frame = get_test_frame_with_two_selectors(
+        &current_bitwise,
+        &next_bitwise,
+        BITWISE_XOR,
+        BITWISE_AND,
+    );
+    let result = get_bitwise_frame_result(frame, cycle);
+    assert_ne!(result, expected);
+
+    let frame =
+        get_test_frame_with_two_selectors(&current_bitwise, &next_bitwise, BITWISE_OR, BITWISE_XOR);
+    let result = get_bitwise_frame_result(frame, cycle);
+    assert_ne!(result, expected);
+}
 
 proptest! {
     #[test]
@@ -53,6 +124,100 @@ fn test_bitwise_frame(operation: Selectors, a: u32, b: u32, cycle_row: usize) {
     bitwise::enforce_constraints(&frame, &periodic_values, &mut result, Felt::ONE);
 
     assert_eq!(expected, result);
+}
+
+/// Generates the trace frame of an customised two consecutive cycle row. Accepts decomposed input
+/// containing bits wise component of both a and b for the consecutive cycle row and two selectors.
+/// Returns the frame with these two consecutive cycle row.  
+fn get_test_frame_with_two_selectors(
+    curr: &[Felt],
+    next: &[Felt],
+    operation1: Selectors,
+    operation2: Selectors,
+) -> EvaluationFrame<Felt> {
+    // Hardcoded values of `a`,`b` and `output` values of previous cycle row.
+    let prev_input_a = Felt::new(10);
+    let prev_input_b = Felt::new(9);
+    let prev_output = Felt::new(8);
+
+    let mut current_cycle_row = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut next_cycle_row = vec![Felt::ZERO; TRACE_WIDTH];
+
+    let mut current_bitstate = vec![Felt::ZERO; BITWISE_TRACE_WIDTH];
+    let mut next_bitstate = vec![Felt::ZERO; BITWISE_TRACE_WIDTH];
+
+    // calculating the input values of current and next cycle row.
+    let input_curr_a = aggregate_input_bits(&curr[0..NUM_DECOMP_BITS], prev_input_a);
+    let input_curr_b =
+        aggregate_input_bits(&curr[NUM_DECOMP_BITS..NUM_DECOMP_BITS * 2], prev_input_b);
+    let input_next_a = aggregate_input_bits(&next[0..NUM_DECOMP_BITS], input_curr_a);
+    let input_next_b =
+        aggregate_input_bits(&next[NUM_DECOMP_BITS..NUM_DECOMP_BITS * 2], input_curr_b);
+
+    // calculating the ouptut values of current and next cycle row.
+    let output_agg_curr_op1 = aggregate_row_output(&curr, operation1, prev_output);
+    let output_agg_next_op1 = aggregate_row_output(&next, operation1, output_agg_curr_op1);
+
+    // First two columns would be selector.
+    // Assign operation2 and operation1 to the current and next cycle row respectively.
+    for idx in 0..NUM_SELECTORS {
+        current_bitstate[idx] = operation2[idx];
+        next_bitstate[idx] = operation1[idx];
+    }
+
+    current_bitstate[A_COL_IDX] = input_curr_a;
+    current_bitstate[B_COL_IDX] = input_curr_b;
+    next_bitstate[A_COL_IDX] = input_next_a;
+    next_bitstate[B_COL_IDX] = input_next_b;
+
+    current_bitstate
+        [BITWISE_DECOMPOSITION_OFFSET..BITWISE_DECOMPOSITION_OFFSET + BITWISE_DECOMPOSITION_SIZE]
+        .copy_from_slice(&curr);
+    next_bitstate
+        [BITWISE_DECOMPOSITION_OFFSET..BITWISE_DECOMPOSITION_OFFSET + BITWISE_DECOMPOSITION_SIZE]
+        .copy_from_slice(&next);
+
+    current_bitstate[OUTPUT_COL_IDX] = output_agg_curr_op1;
+    next_bitstate[OUTPUT_COL_IDX] = output_agg_next_op1;
+
+    current_cycle_row[BITWISE_TRACE_OFFSET..BITWISE_TRACE_OFFSET + BITWISE_TRACE_WIDTH]
+        .copy_from_slice(&current_bitstate);
+    next_cycle_row[BITWISE_TRACE_OFFSET..BITWISE_TRACE_OFFSET + BITWISE_TRACE_WIDTH]
+        .copy_from_slice(&next_bitstate);
+
+    let frame = EvaluationFrame::<Felt>::from_rows(current_cycle_row, next_cycle_row);
+
+    frame
+}
+
+/// Generates the expected and calculated constraint result on an input frame.
+fn get_bitwise_frame_result(frame: EvaluationFrame<Felt>, row: usize) -> [Felt; NUM_CONSTRAINTS] {
+    let cycle_row = get_test_periodic_values(row);
+    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    bitwise::enforce_constraints(&frame, &cycle_row, &mut result, Felt::ONE);
+
+    result
+}
+
+/// Aggregates the decomposed value of input bits.
+fn aggregate_input_bits(bits_array: &[Felt], prev_input: Felt) -> Felt {
+    bitwise::agg_bits(bits_array, 0) + prev_input * Felt::new(2_u64.pow(4))
+}
+
+/// Generates the output value from decomposed input using a specified input operation (AND, OR, XOR)
+fn aggregate_row_output(bits_array: &[Felt], operation: Selectors, prev_output: Felt) -> Felt {
+    let output = if operation == BITWISE_AND {
+        bitwise::bitwise_and(bits_array) + prev_output * Felt::new(2_u64.pow(4))
+    } else if operation == BITWISE_OR {
+        bitwise::bitwise_or(bits_array) + prev_output * Felt::new(2_u64.pow(4))
+    } else if operation == BITWISE_XOR {
+        bitwise::bitwise_xor(bits_array) + prev_output * Felt::new(2_u64.pow(4))
+    } else {
+        panic!("unrecognized operation.");
+    };
+
+    output
 }
 
 /// Generates the specified trace frame for the specified power of two operation, then asserts


### PR DESCRIPTION
Addressing part 1 of #206. 

- [x] Add a failing test to the [bitwise_pow2 unit tests](https://github.com/maticnetwork/miden/blob/next/air/src/aux_table/bitwise_pow2/tests.rs) to demonstrate the issue. This can be done by manually creating a test frame with different selectors, testing against a row that is not the first row in the cycle, and asserting that enforce constraints should result in an array that is not all zeros. This can be done first as one PR.
- [ ] Define new constraints on the selectors so that they can only change at the first row of a new periodic cycle, then update the mdbook docs for the Auxiliary Table.
- [ ] Implement the new constraints in the [Bitwise & Power of Two co-processor](https://github.com/maticnetwork/miden/blob/next/air/src/aux_table/bitwise_pow2/mod.rs)