### PR TITLE
refactor: air crate for consistency and to reduce chance of errors

### DIFF
--- a/air/src/aux_table/bitwise_pow2/bitwise/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/bitwise/mod.rs
@@ -309,65 +309,84 @@ trait EvaluationFrameExt<E: FieldElement> {
 impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     // --- Column accessors -----------------------------------------------------------------------
 
+    #[inline(always)]
     fn selector(&self, index: usize) -> E {
         self.current()[SELECTOR_COL_RANGE.start + index]
     }
+    #[inline(always)]
     fn a(&self) -> E {
         self.current()[A_COL_IDX]
     }
+    #[inline(always)]
     fn a_next(&self) -> E {
         self.next()[A_COL_IDX]
     }
+    #[inline(always)]
     fn a_bit(&self, index: usize) -> E {
         self.current()[A_COL_RANGE.start + index]
     }
+    #[inline(always)]
     fn b(&self) -> E {
         self.current()[B_COL_IDX]
     }
+    #[inline(always)]
     fn b_next(&self) -> E {
         self.next()[B_COL_IDX]
     }
+    #[inline(always)]
     fn b_bit(&self, index: usize) -> E {
         self.current()[B_COL_RANGE.start + index]
     }
+    #[inline(always)]
     fn bit_decomp(&self) -> &[E] {
         &self.current()[A_COL_RANGE.start..B_COL_RANGE.end]
     }
+    #[inline(always)]
     fn bit_decomp_next(&self) -> &[E] {
         &self.next()[A_COL_RANGE.start..B_COL_RANGE.end]
     }
+    #[inline(always)]
     fn output(&self) -> E {
         self.current()[OUTPUT_COL_IDX]
     }
+    #[inline(always)]
     fn output_next(&self) -> E {
         self.next()[OUTPUT_COL_IDX]
     }
 
     // --- Intermediate variables & helpers -------------------------------------------------------
+    #[inline(always)]
     fn a_agg_bits(&self) -> E {
         agg_bits(self.current(), A_COL_RANGE.start)
     }
+    #[inline(always)]
     fn a_agg_bits_next(&self) -> E {
         agg_bits(self.next(), A_COL_RANGE.start)
     }
+    #[inline(always)]
     fn b_agg_bits(&self) -> E {
         agg_bits(self.current(), B_COL_RANGE.start)
     }
+    #[inline(always)]
     fn b_agg_bits_next(&self) -> E {
         agg_bits(self.next(), B_COL_RANGE.start)
     }
 
     // --- Flags ----------------------------------------------------------------------------------
 
+    #[inline(always)]
     fn bitwise_op_flag(&self) -> E {
         binary_not(self.selector(0) * self.selector(1))
     }
+    #[inline(always)]
     fn bitwise_and_flag(&self) -> E {
         binary_not(self.selector(0)) * binary_not(self.selector(1))
     }
+    #[inline(always)]
     fn bitwise_or_flag(&self) -> E {
         binary_not(self.selector(0)) * self.selector(1)
     }
+    #[inline(always)]
     fn bitwise_xor_flag(&self) -> E {
         self.selector(0) * binary_not(self.selector(1))
     }

--- a/air/src/aux_table/bitwise_pow2/bitwise/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/bitwise/mod.rs
@@ -1,4 +1,4 @@
-use super::{EvaluationFrame, FieldElement, BITWISE_TRACE_OFFSET};
+use super::{EvaluationFrame, FieldElement, BITWISE_TRACE_OFFSET, OP_CYCLE_LEN};
 use crate::utils::{binary_not, is_binary, EvaluationResult};
 use core::ops::Range;
 use vm_core::{
@@ -60,7 +60,7 @@ pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
     degrees.append(
         &mut CONSTRAINT_DEGREES[PERIODIC_CONSTRAINTS_START..]
             .iter()
-            .map(|&degree| TransitionConstraintDegree::with_cycles(degree - 1, vec![8]))
+            .map(|&degree| TransitionConstraintDegree::with_cycles(degree - 1, vec![OP_CYCLE_LEN]))
             .collect(),
     );
 

--- a/air/src/aux_table/bitwise_pow2/bitwise/tests.rs
+++ b/air/src/aux_table/bitwise_pow2/bitwise/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{get_periodic_values, PERIODIC_CYCLE_LEN},
+    super::{get_periodic_values, OP_CYCLE_LEN},
     agg_bits, bitwise_and, bitwise_or, bitwise_xor, enforce_constraints, EvaluationFrame,
     A_COL_IDX, A_COL_RANGE, BITWISE_TRACE_OFFSET, B_COL_IDX, B_COL_RANGE, NUM_CONSTRAINTS,
     NUM_DECOMP_BITS, OUTPUT_COL_IDX, SELECTOR_COL_RANGE,
@@ -77,17 +77,17 @@ fn test_bitwise_selectors_fail() {
 
 proptest! {
     #[test]
-    fn test_bitwise_and(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(PERIODIC_CYCLE_LEN - 1)) {
+    fn test_bitwise_and(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(OP_CYCLE_LEN - 1)) {
         test_bitwise_frame(BITWISE_AND, a, b, cycle_row);
     }
 
     #[test]
-    fn test_bitwise_or(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(PERIODIC_CYCLE_LEN - 1)) {
+    fn test_bitwise_or(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(OP_CYCLE_LEN - 1)) {
         test_bitwise_frame(BITWISE_OR, a, b, cycle_row);
     }
 
     #[test]
-    fn test_bitwise_xor(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(PERIODIC_CYCLE_LEN - 1)) {
+    fn test_bitwise_xor(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(OP_CYCLE_LEN - 1)) {
         test_bitwise_frame(BITWISE_XOR, a, b, cycle_row);
     }
 }
@@ -132,7 +132,7 @@ pub fn get_test_frame(
     cycle_row_num: usize,
 ) -> EvaluationFrame<Felt> {
     assert!(
-        cycle_row_num < PERIODIC_CYCLE_LEN - 1,
+        cycle_row_num < OP_CYCLE_LEN - 1,
         "Failed to build test EvaluationFrame for bitwise operation. The next row would be in a new cycle."
     );
 
@@ -141,7 +141,7 @@ pub fn get_test_frame(
     let mut next = vec![Felt::ZERO; TRACE_WIDTH];
 
     // Define the shift amounts for the specified rows.
-    let current_shift = NUM_DECOMP_BITS * (PERIODIC_CYCLE_LEN - cycle_row_num - 1);
+    let current_shift = NUM_DECOMP_BITS * (OP_CYCLE_LEN - cycle_row_num - 1);
     let next_shift = current_shift - NUM_DECOMP_BITS;
 
     // Set the operation selectors.

--- a/air/src/aux_table/bitwise_pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/mod.rs
@@ -6,9 +6,6 @@ use vm_core::{bitwise::NUM_SELECTORS, utils::range as create_range, Felt};
 mod bitwise;
 mod pow2;
 
-#[cfg(test)]
-mod tests;
-
 // CONSTANTS
 // ================================================================================================
 
@@ -154,3 +151,17 @@ pub const BITWISE_POW2_K1_MASK: [Felt; PERIODIC_CYCLE_LEN] = [
     Felt::ONE,
     Felt::ZERO,
 ];
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Returns the values from the shared bitwise & power of two processor's periodic columns for the
+/// specified cycle row.
+#[cfg(test)]
+fn get_periodic_values(cycle_row: usize) -> [Felt; 2] {
+    match cycle_row {
+        0 => [Felt::ONE, Felt::ONE],
+        8 => [Felt::ZERO, Felt::ZERO],
+        _ => [Felt::ZERO, Felt::ONE],
+    }
+}

--- a/air/src/aux_table/bitwise_pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/mod.rs
@@ -9,8 +9,8 @@ mod pow2;
 // CONSTANTS
 // ================================================================================================
 
-/// The length of a periodic cycle in the Bitwise & Power of Two co-processor.
-pub const PERIODIC_CYCLE_LEN: usize = 8;
+/// The number of rows required to compute an operation in the Bitwise & Power of Two co-processor.
+pub const OP_CYCLE_LEN: usize = 8;
 /// The number of shared constraints on the combined trace of the Bitwise and Power of Two
 /// operation execution traces.
 pub const NUM_CONSTRAINTS: usize = 2;
@@ -130,7 +130,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
 
 // CYCLE MASKS
 // ================================================================================================
-pub const BITWISE_POW2_K0_MASK: [Felt; PERIODIC_CYCLE_LEN] = [
+pub const BITWISE_POW2_K0_MASK: [Felt; OP_CYCLE_LEN] = [
     Felt::ONE,
     Felt::ZERO,
     Felt::ZERO,
@@ -141,7 +141,7 @@ pub const BITWISE_POW2_K0_MASK: [Felt; PERIODIC_CYCLE_LEN] = [
     Felt::ZERO,
 ];
 
-pub const BITWISE_POW2_K1_MASK: [Felt; PERIODIC_CYCLE_LEN] = [
+pub const BITWISE_POW2_K1_MASK: [Felt; OP_CYCLE_LEN] = [
     Felt::ONE,
     Felt::ONE,
     Felt::ONE,

--- a/air/src/aux_table/bitwise_pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/mod.rs
@@ -117,12 +117,14 @@ trait EvaluationFrameExt<E: FieldElement> {
 impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     // --- Column accessors -----------------------------------------------------------------------
 
+    #[inline(always)]
     fn selector(&self, index: usize) -> E {
         self.current()[SELECTOR_COL_RANGE.start + index]
     }
 
     // --- Co-processor selector flags ------------------------------------------------------------
 
+    #[inline(always)]
     fn pow2_flag(&self) -> E {
         self.selector(0) * self.selector(1)
     }

--- a/air/src/aux_table/bitwise_pow2/pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/pow2/mod.rs
@@ -260,39 +260,50 @@ trait EvaluationFrameExt<E: FieldElement> {
 impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     // --- Column accessors -----------------------------------------------------------------------
 
+    #[inline(always)]
     fn a_power(&self, index: usize) -> E {
         self.current()[A_POWERS_COL_RANGE.start + index]
     }
+    #[inline(always)]
     fn a_power_next(&self, index: usize) -> E {
         self.next()[A_POWERS_COL_RANGE.start + index]
     }
+    #[inline(always)]
     fn h(&self) -> E {
         self.current()[H_COL_IDX]
     }
+    #[inline(always)]
     fn h_next(&self) -> E {
         self.next()[H_COL_IDX]
     }
+    #[inline(always)]
     fn a(&self) -> E {
         self.current()[A_AGG_COL_IDX]
     }
+    #[inline(always)]
     fn a_next(&self) -> E {
         self.next()[A_AGG_COL_IDX]
     }
+    #[inline(always)]
     fn p(&self) -> E {
         self.current()[P_COL_IDX]
     }
+    #[inline(always)]
     fn p_next(&self) -> E {
         self.next()[P_COL_IDX]
     }
+    #[inline(always)]
     fn z(&self) -> E {
         self.current()[Z_AGG_COL_IDX]
     }
+    #[inline(always)]
     fn z_next(&self) -> E {
         self.next()[Z_AGG_COL_IDX]
     }
 
     // --- Intermediate variables & helpers -------------------------------------------------------
 
+    #[inline(always)]
     fn a_output(&self, index: usize) -> E {
         match index {
             0 => binary_not(self.a_power(0)),
@@ -300,6 +311,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
             _ => (self.a_power(index - 1) - self.a_power(index)) * E::from(2_u64.pow(index as u32)),
         }
     }
+    #[inline(always)]
     fn a_output_next(&self, index: usize) -> E {
         match index {
             0 => E::ZERO,

--- a/air/src/aux_table/bitwise_pow2/pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/pow2/mod.rs
@@ -1,6 +1,6 @@
 use crate::utils::{binary_not, is_binary};
 
-use super::{EvaluationFrame, FieldElement, POW2_TRACE_OFFSET};
+use super::{EvaluationFrame, FieldElement, OP_CYCLE_LEN, POW2_TRACE_OFFSET};
 use core::ops::Range;
 use vm_core::{bitwise::POW2_POWERS_PER_ROW, utils::range as create_range};
 use winter_air::TransitionConstraintDegree;
@@ -62,7 +62,7 @@ pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
     degrees.append(
         &mut CONSTRAINT_DEGREES[PERIODIC_CONSTRAINTS_START..]
             .iter()
-            .map(|&degree| TransitionConstraintDegree::with_cycles(degree - 1, vec![8]))
+            .map(|&degree| TransitionConstraintDegree::with_cycles(degree - 1, vec![OP_CYCLE_LEN]))
             .collect(),
     );
 

--- a/air/src/aux_table/bitwise_pow2/pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/pow2/mod.rs
@@ -5,6 +5,9 @@ use core::ops::Range;
 use vm_core::{bitwise::POW2_POWERS_PER_ROW, utils::range as create_range};
 use winter_air::TransitionConstraintDegree;
 
+#[cfg(test)]
+mod tests;
+
 // CONSTANTS
 // ================================================================================================
 
@@ -298,121 +301,4 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
             }
         }
     }
-}
-
-// TEST HELPER FUNCTIONS
-// ================================================================================================
-#[cfg(test)]
-use super::{NUM_SELECTORS, PERIODIC_CYCLE_LEN, SELECTOR_COL_RANGE};
-#[cfg(test)]
-use vm_core::{bitwise::POWER_OF_TWO, Felt, TRACE_WIDTH};
-
-/// Generates the correct current and next rows for the power of two operation with the specified
-/// input exponent at the specified cycle row number, then returns an EvaluationFrame for testing.
-/// It only tests frames within a cycle.
-///
-/// # Errors
-/// It expects the specified `cycle_row_num` for the current row to be such that the next row will
-/// still be in the same cycle. It will fail with a row number input.
-#[cfg(test)]
-pub fn get_test_frame(exponent: u32, cycle_row_num: usize) -> EvaluationFrame<Felt> {
-    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
-    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
-
-    // Set the operation selectors.
-    for idx in 0..NUM_SELECTORS {
-        current[SELECTOR_COL_RANGE.start + idx] = POWER_OF_TWO[idx];
-        next[SELECTOR_COL_RANGE.start + idx] = POWER_OF_TWO[idx];
-    }
-
-    // The index of the final decomposition row.
-    let mut final_decomp_row = exponent as usize / POW2_POWERS_PER_ROW;
-    if exponent != 0 && exponent % POW2_POWERS_PER_ROW as u32 == 0 {
-        // Multiples of 8 are aggregated in the previous row, except for 0.
-        // Both 0 and 8 are aggregated in the first row.
-        final_decomp_row -= 1;
-    }
-
-    if (cycle_row_num + 1) < final_decomp_row {
-        // Both rows in this frame come before the decomposition finishes.
-        set_pre_output_agg_row(cycle_row_num, &mut current);
-        set_pre_output_agg_row(cycle_row_num + 1, &mut next);
-    } else if cycle_row_num > final_decomp_row {
-        // Both rows in this frame come after the decomposition & aggregation have finished.
-        set_post_output_agg_row(exponent, cycle_row_num, &mut current);
-        set_post_output_agg_row(exponent, cycle_row_num + 1, &mut next);
-    } else if cycle_row_num == final_decomp_row {
-        // The current row is the output aggregation row.
-        set_output_agg_row(exponent, cycle_row_num, &mut current);
-        set_post_output_agg_row(exponent, cycle_row_num + 1, &mut next);
-    } else {
-        // The next row is the output aggregation row.
-        set_pre_output_agg_row(cycle_row_num, &mut current);
-        set_output_agg_row(exponent, cycle_row_num + 1, &mut next);
-    }
-
-    EvaluationFrame::<Felt>::from_rows(current, next)
-}
-
-/// Fill a frame row with the expected values for a power of two operation row before the input
-/// decomposition finishes. In this case, all input decomposition columns in the row will be set
-/// to ONE. This function expects that the values in the frame_row have been initialized to
-/// ZERO.
-#[cfg(test)]
-fn set_pre_output_agg_row(row_num: usize, frame_row: &mut [Felt]) {
-    // Set the power decomposition and helper columns to one while decomposition is continuing.
-    for cell in frame_row
-        .iter_mut()
-        .take(H_COL_IDX + 1)
-        .skip(A_POWERS_COL_RANGE.start)
-    {
-        *cell = Felt::ONE;
-    }
-
-    // set the input aggregation column
-    frame_row[A_AGG_COL_IDX] = Felt::new((POW2_POWERS_PER_ROW * (row_num + 1)) as u64);
-
-    // Set the power of 256 column value.
-    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
-
-    // The output is zero before it is aggregated.
-}
-
-/// Fill a frame row with the expected values for a power of two operation row where the input
-/// decomposition finishes and the output is aggregated. This function expects that the values
-/// in the frame_row have been initialized to ZERO.
-#[cfg(test)]
-fn set_output_agg_row(exponent: u32, row_num: usize, frame_row: &mut [Felt]) {
-    let final_decomp_row_power = exponent as usize - row_num * POW2_POWERS_PER_ROW;
-
-    for idx in 0..final_decomp_row_power {
-        frame_row[A_POWERS_COL_RANGE.start + idx] = Felt::ONE;
-    }
-    // The rest of the helper and power decomposition columns should be left as zero.
-
-    // After decomposition is finished, the value of a is the input exponent.
-    frame_row[A_AGG_COL_IDX] = Felt::new(exponent as u64);
-
-    // Set the power of 256 column value.
-    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
-
-    // After aggregation, the output is the result.
-    frame_row[Z_AGG_COL_IDX] = Felt::new(2_u64.pow(exponent));
-}
-
-/// Fill a frame row with the expected values for a power of two operation row after the output
-/// aggregation has been done. This function expects that the values in the frame_row have been
-/// initialized to ZERO.
-#[cfg(test)]
-fn set_post_output_agg_row(exponent: u32, row_num: usize, frame_row: &mut [Felt]) {
-    // The power decomposition and helper columns are zero after decomposition is finished.
-
-    // After decomposition is finished, the value of a is the input exponent.
-    frame_row[A_AGG_COL_IDX] = Felt::new(exponent as u64);
-
-    // Set the power of 256 column value.
-    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
-
-    // After aggregation, the output is the result.
-    frame_row[Z_AGG_COL_IDX] = Felt::new(2_u64.pow(exponent));
 }

--- a/air/src/aux_table/bitwise_pow2/pow2/tests.rs
+++ b/air/src/aux_table/bitwise_pow2/pow2/tests.rs
@@ -1,0 +1,140 @@
+use super::{
+    super::{
+        get_periodic_values, EvaluationFrame, NUM_SELECTORS, PERIODIC_CYCLE_LEN, SELECTOR_COL_RANGE,
+    },
+    enforce_constraints, A_AGG_COL_IDX, A_POWERS_COL_RANGE, H_COL_IDX, NUM_CONSTRAINTS,
+    POW2_POWERS_PER_ROW, P_COL_IDX, Z_AGG_COL_IDX,
+};
+use vm_core::{bitwise::POWER_OF_TWO, Felt, FieldElement, TRACE_WIDTH};
+
+use proptest::prelude::*;
+
+proptest! {
+
+    #[test]
+    fn test_pow2(exponent in 0_u32..64, cycle_row in 0..(PERIODIC_CYCLE_LEN - 1)) {
+        test_pow2_frame(exponent, cycle_row);
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Generates the specified trace frame for the specified power of two operation, then asserts
+/// that applying the constraints to this frame yields valid results (all zeros).
+fn test_pow2_frame(exponent: u32, cycle_row: usize) {
+    let frame = get_test_frame(exponent, cycle_row);
+    let periodic_values = get_periodic_values(cycle_row);
+    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = result;
+
+    enforce_constraints(&frame, &periodic_values, &mut result, Felt::ONE);
+
+    assert_eq!(expected, result);
+}
+
+/// Generates the correct current and next rows for the power of two operation with the specified
+/// input exponent at the specified cycle row number, then returns an EvaluationFrame for testing.
+/// It only tests frames within a cycle.
+///
+/// # Errors
+/// It expects the specified `cycle_row_num` for the current row to be such that the next row will
+/// still be in the same cycle. It will fail with a row number input.
+pub fn get_test_frame(exponent: u32, cycle_row_num: usize) -> EvaluationFrame<Felt> {
+    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+
+    // Set the operation selectors.
+    for idx in 0..NUM_SELECTORS {
+        current[SELECTOR_COL_RANGE.start + idx] = POWER_OF_TWO[idx];
+        next[SELECTOR_COL_RANGE.start + idx] = POWER_OF_TWO[idx];
+    }
+
+    // The index of the final decomposition row.
+    let mut final_decomp_row = exponent as usize / POW2_POWERS_PER_ROW;
+    if exponent != 0 && exponent % POW2_POWERS_PER_ROW as u32 == 0 {
+        // Multiples of 8 are aggregated in the previous row, except for 0.
+        // Both 0 and 8 are aggregated in the first row.
+        final_decomp_row -= 1;
+    }
+
+    if (cycle_row_num + 1) < final_decomp_row {
+        // Both rows in this frame come before the decomposition finishes.
+        set_pre_output_agg_row(cycle_row_num, &mut current);
+        set_pre_output_agg_row(cycle_row_num + 1, &mut next);
+    } else if cycle_row_num > final_decomp_row {
+        // Both rows in this frame come after the decomposition & aggregation have finished.
+        set_post_output_agg_row(exponent, cycle_row_num, &mut current);
+        set_post_output_agg_row(exponent, cycle_row_num + 1, &mut next);
+    } else if cycle_row_num == final_decomp_row {
+        // The current row is the output aggregation row.
+        set_output_agg_row(exponent, cycle_row_num, &mut current);
+        set_post_output_agg_row(exponent, cycle_row_num + 1, &mut next);
+    } else {
+        // The next row is the output aggregation row.
+        set_pre_output_agg_row(cycle_row_num, &mut current);
+        set_output_agg_row(exponent, cycle_row_num + 1, &mut next);
+    }
+
+    EvaluationFrame::<Felt>::from_rows(current, next)
+}
+
+/// Fill a frame row with the expected values for a power of two operation row before the input
+/// decomposition finishes. In this case, all input decomposition columns in the row will be set
+/// to ONE. This function expects that the values in the frame_row have been initialized to
+/// ZERO.
+fn set_pre_output_agg_row(row_num: usize, frame_row: &mut [Felt]) {
+    // Set the power decomposition and helper columns to one while decomposition is continuing.
+    for cell in frame_row
+        .iter_mut()
+        .take(H_COL_IDX + 1)
+        .skip(A_POWERS_COL_RANGE.start)
+    {
+        *cell = Felt::ONE;
+    }
+
+    // set the input aggregation column
+    frame_row[A_AGG_COL_IDX] = Felt::new((POW2_POWERS_PER_ROW * (row_num + 1)) as u64);
+
+    // Set the power of 256 column value.
+    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
+
+    // The output is zero before it is aggregated.
+}
+
+/// Fill a frame row with the expected values for a power of two operation row where the input
+/// decomposition finishes and the output is aggregated. This function expects that the values
+/// in the frame_row have been initialized to ZERO.
+fn set_output_agg_row(exponent: u32, row_num: usize, frame_row: &mut [Felt]) {
+    let final_decomp_row_power = exponent as usize - row_num * POW2_POWERS_PER_ROW;
+
+    for idx in 0..final_decomp_row_power {
+        frame_row[A_POWERS_COL_RANGE.start + idx] = Felt::ONE;
+    }
+    // The rest of the helper and power decomposition columns should be left as zero.
+
+    // After decomposition is finished, the value of a is the input exponent.
+    frame_row[A_AGG_COL_IDX] = Felt::new(exponent as u64);
+
+    // Set the power of 256 column value.
+    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
+
+    // After aggregation, the output is the result.
+    frame_row[Z_AGG_COL_IDX] = Felt::new(2_u64.pow(exponent));
+}
+
+/// Fill a frame row with the expected values for a power of two operation row after the output
+/// aggregation has been done. This function expects that the values in the frame_row have been
+/// initialized to ZERO.
+fn set_post_output_agg_row(exponent: u32, row_num: usize, frame_row: &mut [Felt]) {
+    // The power decomposition and helper columns are zero after decomposition is finished.
+
+    // After decomposition is finished, the value of a is the input exponent.
+    frame_row[A_AGG_COL_IDX] = Felt::new(exponent as u64);
+
+    // Set the power of 256 column value.
+    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
+
+    // After aggregation, the output is the result.
+    frame_row[Z_AGG_COL_IDX] = Felt::new(2_u64.pow(exponent));
+}

--- a/air/src/aux_table/bitwise_pow2/pow2/tests.rs
+++ b/air/src/aux_table/bitwise_pow2/pow2/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     super::{
-        get_periodic_values, EvaluationFrame, NUM_SELECTORS, PERIODIC_CYCLE_LEN, SELECTOR_COL_RANGE,
+        get_periodic_values, EvaluationFrame, NUM_SELECTORS, OP_CYCLE_LEN, SELECTOR_COL_RANGE,
     },
     enforce_constraints, A_AGG_COL_IDX, A_POWERS_COL_RANGE, H_COL_IDX, NUM_CONSTRAINTS,
     POW2_POWERS_PER_ROW, P_COL_IDX, Z_AGG_COL_IDX,
@@ -12,7 +12,7 @@ use proptest::prelude::*;
 proptest! {
 
     #[test]
-    fn test_pow2(exponent in 0_u32..64, cycle_row in 0..(PERIODIC_CYCLE_LEN - 1)) {
+    fn test_pow2(exponent in 0_u32..64, cycle_row in 0..(OP_CYCLE_LEN - 1)) {
         test_pow2_frame(exponent, cycle_row);
     }
 }
@@ -97,7 +97,7 @@ fn set_pre_output_agg_row(row_num: usize, frame_row: &mut [Felt]) {
     frame_row[A_AGG_COL_IDX] = Felt::new((POW2_POWERS_PER_ROW * (row_num + 1)) as u64);
 
     // Set the power of 256 column value.
-    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
+    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % OP_CYCLE_LEN) as u32));
 
     // The output is zero before it is aggregated.
 }
@@ -117,7 +117,7 @@ fn set_output_agg_row(exponent: u32, row_num: usize, frame_row: &mut [Felt]) {
     frame_row[A_AGG_COL_IDX] = Felt::new(exponent as u64);
 
     // Set the power of 256 column value.
-    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
+    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % OP_CYCLE_LEN) as u32));
 
     // After aggregation, the output is the result.
     frame_row[Z_AGG_COL_IDX] = Felt::new(2_u64.pow(exponent));
@@ -133,7 +133,7 @@ fn set_post_output_agg_row(exponent: u32, row_num: usize, frame_row: &mut [Felt]
     frame_row[A_AGG_COL_IDX] = Felt::new(exponent as u64);
 
     // Set the power of 256 column value.
-    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % PERIODIC_CYCLE_LEN) as u32));
+    frame_row[P_COL_IDX] = Felt::new(256_u64.pow((row_num % OP_CYCLE_LEN) as u32));
 
     // After aggregation, the output is the result.
     frame_row[Z_AGG_COL_IDX] = Felt::new(2_u64.pow(exponent));

--- a/air/src/aux_table/memory/mod.rs
+++ b/air/src/aux_table/memory/mod.rs
@@ -218,81 +218,102 @@ trait EvaluationFrameExt<E: FieldElement> {
 impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     // --- Column accessors -----------------------------------------------------------------------
 
+    #[inline(always)]
     fn ctx(&self) -> E {
         self.current()[CTX_COL_IDX]
     }
+    #[inline(always)]
     fn addr(&self) -> E {
         self.next()[ADDR_COL_IDX]
     }
+    #[inline(always)]
     fn clk(&self) -> E {
         self.current()[CLK_COL_IDX]
     }
+    #[inline(always)]
     fn clk_next(&self) -> E {
         self.next()[CLK_COL_IDX]
     }
+    #[inline(always)]
     fn u(&self, index: usize) -> E {
         self.current()[U_COL_RANGE.start + index]
     }
+    #[inline(always)]
     fn u_next(&self, index: usize) -> E {
         self.next()[U_COL_RANGE.start + index]
     }
+    #[inline(always)]
     fn v(&self, index: usize) -> E {
         self.current()[V_COL_RANGE.start + index]
     }
+    #[inline(always)]
     fn d0_next(&self) -> E {
         self.next()[D0_COL_IDX]
     }
+    #[inline(always)]
     fn d1_next(&self) -> E {
         self.next()[D1_COL_IDX]
     }
+    #[inline(always)]
     fn d_inv_next(&self) -> E {
         self.next()[D_INV_COL_IDX]
     }
 
     // --- Intermediate variables & helpers -------------------------------------------------------
 
+    #[inline(always)]
     fn change(&self, column: usize) -> E {
         self.next()[column] - self.current()[column]
     }
 
+    #[inline(always)]
     fn n0(&self) -> E {
         self.change(CTX_COL_IDX) * self.d_inv_next()
     }
 
+    #[inline(always)]
     fn not_n0(&self) -> E {
         binary_not(self.n0())
     }
 
+    #[inline(always)]
     fn n1(&self) -> E {
         self.change(ADDR_COL_IDX) * self.d_inv_next()
     }
 
+    #[inline(always)]
     fn not_n1(&self) -> E {
         binary_not(self.n1())
     }
 
+    #[inline(always)]
     fn ctx_change(&self) -> E {
         self.change(CTX_COL_IDX)
     }
 
+    #[inline(always)]
     fn addr_change(&self) -> E {
         self.change(ADDR_COL_IDX)
     }
 
+    #[inline(always)]
     fn clk_change(&self) -> E {
         self.change(CLK_COL_IDX) - E::ONE
     }
 
+    #[inline(always)]
     fn delta_next(&self) -> E {
         E::from(2_u32.pow(16)) * self.d1_next() + self.d0_next()
     }
 
     // --- Flags ----------------------------------------------------------------------------------
 
+    #[inline(always)]
     fn init_memory_flag(&self) -> E {
         self.n0() + self.not_n0() * self.n1()
     }
 
+    #[inline(always)]
     fn copy_memory_flag(&self) -> E {
         self.not_n0() * self.not_n1()
     }

--- a/air/src/aux_table/mod.rs
+++ b/air/src/aux_table/mod.rs
@@ -130,23 +130,31 @@ trait EvaluationFrameExt<E: FieldElement> {
 
 impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     // --- Column accessors -----------------------------------------------------------------------
+
+    #[inline(always)]
     fn s0(&self) -> E {
         self.current()[S0_COL_IDX]
     }
+    #[inline(always)]
     fn s1(&self) -> E {
         self.current()[S1_COL_IDX]
     }
+    #[inline(always)]
     fn s2(&self) -> E {
         self.current()[S2_COL_IDX]
     }
 
     // --- Co-processor selector flags ------------------------------------------------------------
+
+    #[inline(always)]
     fn hasher_flag(&self) -> E {
         binary_not(self.s0())
     }
+    #[inline(always)]
     fn bitwise_flag(&self) -> E {
         self.s0() * binary_not(self.s1())
     }
+    #[inline(always)]
     fn memory_flag(&self) -> E {
         self.s0() * self.s1() * self.s2()
     }

--- a/air/src/range.rs
+++ b/air/src/range.rs
@@ -149,38 +149,46 @@ trait EvaluationFrameExt<E: FieldElement> {
 impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     // --- Column accessors -----------------------------------------------------------------------
 
+    #[inline(always)]
     fn t(&self) -> E {
         self.current()[T_COL_IDX]
     }
 
+    #[inline(always)]
     fn t_next(&self) -> E {
         self.next()[T_COL_IDX]
     }
 
+    #[inline(always)]
     fn s0(&self) -> E {
         self.current()[S0_COL_IDX]
     }
 
+    #[inline(always)]
     fn s1(&self) -> E {
         self.current()[S1_COL_IDX]
     }
 
+    #[inline(always)]
     fn v(&self) -> E {
         self.current()[V_COL_IDX]
     }
 
+    #[inline(always)]
     fn v_next(&self) -> E {
         self.next()[V_COL_IDX]
     }
 
     // --- Intermediate variables & helpers -------------------------------------------------------
 
+    #[inline(always)]
     fn change(&self, column: usize) -> E {
         self.next()[column] - self.current()[column]
     }
 
     // --- Flags -------------------------------------------------------------------------
 
+    #[inline(always)]
     fn flip_to_16bit_flag(&self) -> E {
         binary_not(self.t()) * self.t_next()
     }

--- a/core/src/bitwise/mod.rs
+++ b/core/src/bitwise/mod.rs
@@ -9,6 +9,8 @@ pub const NUM_SELECTORS: usize = 2;
 /// Number of columns needed to record an execution trace of the bitwise and power of two helper.
 pub const TRACE_WIDTH: usize = NUM_SELECTORS + 12;
 
+// --- OPERATION SELECTORS ------------------------------------------------------------------------
+
 /// Specifies a bitwise AND operation.
 pub const BITWISE_AND: Selectors = [Felt::ZERO, Felt::ZERO];
 
@@ -21,8 +23,27 @@ pub const BITWISE_XOR: Selectors = [Felt::ONE, Felt::ZERO];
 /// Specifies a power of two operation.
 pub const POWER_OF_TWO: Selectors = [Felt::ONE, Felt::ONE];
 
+// --- INPUT DECOMPOSITION ------------------------------------------------------------------------
+
+/// The number of bits decomposed per row per input parameter `a` or `b`.
+pub const BITWISE_NUM_DECOMP_BITS: usize = 4;
+
 /// The maximum power of two that can be added to the trace per row.
 pub const POW2_POWERS_PER_ROW: usize = 8;
+
+// --- COLUMN ACCESSORS ---------------------------------------------------------------------------
+
+/// The index of the column holding the aggregated value of input `a` within the bitwise execution
+/// trace.
+pub const BITWISE_A_COL_IDX: usize = NUM_SELECTORS;
+
+/// The index of the column holding the aggregated value of input `b` within the bitwise execution
+/// trace.
+pub const BITWISE_B_COL_IDX: usize = BITWISE_A_COL_IDX + 1;
+
+/// The index of the column containing the aggregated output value within the bitwise execution
+/// trace.
+pub const BITWISE_OUTPUT_COL_IDX: usize = BITWISE_B_COL_IDX + 1 + 2 * BITWISE_NUM_DECOMP_BITS;
 
 // TYPE ALIASES
 // ================================================================================================


### PR DESCRIPTION
This PR introduces several minor refactors within the air crate, especially the auxiliary table module and tests. The changes address the following:

- make the testing approach consistent in the different co-processors
- makes the constraints more explicit, to make it clearer to understand and minimize the likelihood of errors (reducing agg_constraint usage unless a single constraint is being aggregated)
- fixes an incorrect set of constraints in the bitwise processor
- inlines the methods in the extension frames to improve performance