### PR TITLE
Implement hash processor AIR constraints

### DIFF
--- a/air/src/aux_table/bitwise_pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/mod.rs
@@ -25,6 +25,18 @@ const SELECTOR_COL_RANGE: Range<usize> = create_range(BITWISE_TRACE_OFFSET, NUM_
 /// The starting index of the trace for the power of two operation.
 const POW2_TRACE_OFFSET: usize = SELECTOR_COL_RANGE.end;
 
+// PERIODIC COLUMNS
+// ================================================================================================
+
+/// Returns the set of periodic columns required by the Bitwise & Power of Two co-processor.
+///
+/// The columns consist of:
+/// - k0 column, which has a repeating pattern of a single one followed by 7 zeros.
+/// - k1 column, which has a repeating pattern of a 7 ones followed by a single zero.
+pub fn get_periodic_column_values() -> Vec<Vec<Felt>> {
+    vec![BITWISE_POW2_K0_MASK.to_vec(), BITWISE_POW2_K1_MASK.to_vec()]
+}
+
 // AUXILIARY TABLE TRANSITION CONSTRAINTS
 // ================================================================================================
 

--- a/air/src/aux_table/hasher/mod.rs
+++ b/air/src/aux_table/hasher/mod.rs
@@ -1,0 +1,613 @@
+use crate::utils::{are_equal, binary_not, is_binary, EvaluationResult};
+
+use super::{EvaluationFrame, Felt, FieldElement, HASHER_TRACE_OFFSET};
+use core::ops::Range;
+use vm_core::{
+    hasher::{
+        Hasher, CAPACITY_LEN, DIGEST_LEN, DIGEST_RANGE, NUM_ROUNDS, NUM_SELECTORS, STATE_WIDTH,
+    },
+    utils::range as create_range,
+};
+use winter_air::TransitionConstraintDegree;
+
+// CONSTANTs
+// ================================================================================================
+
+/// The number of rows in the execution trace required to compute a Rescue Prime permutation. This
+/// is equal to 8.
+pub const HASH_CYCLE_LEN: usize = NUM_ROUNDS.next_power_of_two();
+/// The number of constraints on the management of the hasher co-processor.
+pub const NUM_CONSTRAINTS: usize = 31;
+
+/// The number of periodic columns which are used as selectors to specify a particular row or rows
+/// within the hash cycle.
+pub const NUM_PERIODIC_SELECTOR_COLUMNS: usize = 3;
+/// The total number of periodic columns used by the hash processor, which is the sum of the number
+/// of periodic selector columns plus the columns of round constants for the Rescue Hash permutation.
+pub const NUM_PERIODIC_COLUMNS: usize = STATE_WIDTH * 2 + NUM_PERIODIC_SELECTOR_COLUMNS;
+
+/// The column index range in the execution trace containing the selector columns in the hasher.
+const SELECTOR_COL_RANGE: Range<usize> = create_range(HASHER_TRACE_OFFSET, NUM_SELECTORS);
+/// The index of the hasher's row column in the execution trace.
+const ROW_COL_IDX: usize = SELECTOR_COL_RANGE.end;
+/// The range of columns in the execution trace that contain the hasher's state.
+const HASHER_STATE_COL_RANGE: Range<usize> = create_range(ROW_COL_IDX + 1, STATE_WIDTH);
+/// The index of the hasher's node index column in the execution trace.
+const NODE_INDEX_COL_IDX: usize = HASHER_STATE_COL_RANGE.end;
+
+// PERIODIC COLUMNS
+// ================================================================================================
+
+/// Returns the set of periodic columns required by the Hash processor.
+///
+/// The columns consist of:
+/// - k0 column, which has a repeating pattern of 7 zeros followed by a single one.
+/// - k1 column, which has a repeating pattern of 6 zeros, a single 1, and a final zero.
+/// - k2 column, which has a repeating pattern of a single one followed by 7 zeros.
+/// - the round constants for the Rescue Prime permutation.
+pub fn get_periodic_column_values() -> Vec<Vec<Felt>> {
+    let mut result = vec![
+        HASH_K0_MASK.to_vec(),
+        HASH_K1_MASK.to_vec(),
+        HASH_K2_MASK.to_vec(),
+    ];
+    result.append(&mut get_round_constants());
+    result
+}
+
+// HASHER TRANSITION CONSTRAINTS
+// ================================================================================================
+
+/// Builds the transition constraint degrees for the hash co-processor.
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    let degrees: [TransitionConstraintDegree; NUM_CONSTRAINTS] = [
+        // Enforce that the row address increases by 1 at each step except the last.
+        TransitionConstraintDegree::new(3),
+        // Ensure selector columns are binary.
+        TransitionConstraintDegree::new(3),
+        TransitionConstraintDegree::new(3),
+        TransitionConstraintDegree::new(3),
+        // Enforce the selector values depending on the value of f_out.
+        TransitionConstraintDegree::with_cycles(6, vec![HASH_CYCLE_LEN; 2]),
+        TransitionConstraintDegree::with_cycles(6, vec![HASH_CYCLE_LEN; 2]),
+        TransitionConstraintDegree::with_cycles(3, vec![HASH_CYCLE_LEN]),
+        // Enforce all flag combinations are valid.
+        TransitionConstraintDegree::with_cycles(3, vec![HASH_CYCLE_LEN]),
+        // Enforce the node index is set properly at the start and end of computations and when
+        // absorbing a new node.
+        TransitionConstraintDegree::with_cycles(4, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(6, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(5, vec![HASH_CYCLE_LEN]),
+        // Apply rescue rounds.
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(8, vec![HASH_CYCLE_LEN]),
+        // When the absorption flag is set, copy the capacity portion to the next row.
+        TransitionConstraintDegree::with_cycles(5, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(5, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(5, vec![HASH_CYCLE_LEN]),
+        TransitionConstraintDegree::with_cycles(5, vec![HASH_CYCLE_LEN]),
+        // Enforce correct node absorption during Merkle path computation.
+        TransitionConstraintDegree::with_cycles(6, vec![HASH_CYCLE_LEN; 2]),
+        TransitionConstraintDegree::with_cycles(6, vec![HASH_CYCLE_LEN; 2]),
+        TransitionConstraintDegree::with_cycles(6, vec![HASH_CYCLE_LEN; 2]),
+        TransitionConstraintDegree::with_cycles(6, vec![HASH_CYCLE_LEN; 2]),
+    ];
+
+    degrees.into()
+}
+
+/// Returns the number of transition constraints for the hash co-processor.
+pub fn get_transition_constraint_count() -> usize {
+    NUM_CONSTRAINTS
+}
+
+/// Enforces constraints for the hash co-processor.
+///
+/// - The `processor_flag` indicates whether the current row is in the section of the auxiliary
+///   table that contains this processor's trace.
+/// - The `transition_flag` indicates whether or not the constraints should be enforced for this
+///   transition. It is expected to be false when the next row will be the last row of this
+///   processor's execution trace.
+pub fn enforce_constraints<E: FieldElement<BaseField = Felt>>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+    transition_flag: E,
+) {
+    // Enforce that the row address increases by 1 at each step when the transition flag is set.
+    result.agg_constraint(
+        0,
+        processor_flag * transition_flag,
+        frame.row_next() - frame.row() - E::ONE,
+    );
+    let mut index = 1;
+
+    index += enforce_selectors(frame, periodic_values, &mut result[index..], processor_flag);
+
+    index += enforce_node_index(frame, periodic_values, &mut result[index..], processor_flag);
+
+    enforce_hasher_state(frame, periodic_values, &mut result[index..], processor_flag);
+}
+
+// TRANSITION CONSTRAINT HELPERS
+// ================================================================================================
+
+/// Enforces that all selectors and selector transitions are valid.
+///
+/// - All selectors must contain binary values.
+/// - s1 and s2 must be copied to the next row unless f_out is set in the current or next row.
+/// - When a cycle ends by absorbing more elements or a Merkle path node, ensure the next value of
+///   s0 is always zero. Otherwise, s0 should be unconstrained.
+/// - Prevent an invalid combination of flags where s_0 = 0 and s_1 = 1.
+fn enforce_selectors<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) -> usize {
+    // Ensure the selectors are all binary values.
+    for (idx, result) in result.iter_mut().take(NUM_SELECTORS).enumerate() {
+        *result = processor_flag * is_binary(frame.s(idx));
+    }
+    let mut constraint_offset = NUM_SELECTORS;
+
+    // Ensure the values in s1 and s2 in the current row are copied to the next row when f_out != 1
+    // and f_out' != 1.
+    let copy_selectors_flag = processor_flag
+        * binary_not(frame.f_out(periodic_values))
+        * binary_not(frame.f_out_next(periodic_values));
+    result[constraint_offset] = copy_selectors_flag * (frame.s_next(1) - frame.s(1));
+    constraint_offset += 1;
+
+    result[constraint_offset] = copy_selectors_flag * (frame.s_next(2) - frame.s(2));
+    constraint_offset += 1;
+
+    // s0 should be unconstrained except in the last row of the cycle if any of f_abp, f_mpa, f_mva,
+    // or f_mua are 1, in which case the next value of s0 must be zero.
+    result[constraint_offset] = processor_flag
+        * periodic_values[0]
+        * frame.s_next(0)
+        * (frame.f_abp() + frame.f_mpa() + frame.f_mva() + frame.f_mua());
+    constraint_offset += 1;
+
+    // Prevent an invalid combinations of flags.
+    result[constraint_offset] =
+        processor_flag * periodic_values[0] * binary_not(frame.s(0)) * frame.s(1);
+    constraint_offset += 1;
+
+    constraint_offset
+}
+
+/// Enforces that the node index value is always set correctly. It is only needed during Merkle path
+/// verification and root update computations, but constraints are enforced in all cases for
+/// simplicity.
+///
+/// The constraints enforce the following:
+/// - Ensure `i` is zero at the end of the computation.
+/// - Ensure `i` is shifted one bit to the right when a new node is absorbed into the hasher state.
+/// - Otherwise, ensure the value of `i` is copied to the next row.
+fn enforce_node_index<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) -> usize {
+    let mut constraint_offset = 0;
+
+    // Enforce that the node index is 0 when a computation is finished.
+    result[constraint_offset] = processor_flag * frame.f_out(periodic_values) * frame.i();
+    constraint_offset += 1;
+
+    // When a new node is being absorbed into the hasher state, ensure that the shift to the right
+    // was performed correctly by enforcing that the discarded bit is a binary value.
+    result[constraint_offset] = processor_flag * frame.f_an(periodic_values) * is_binary(frame.b());
+    constraint_offset += 1;
+
+    // When we are not absorbing a new row and the computation is not finished, make sure the value
+    // of i is copied to the next row.
+    result[constraint_offset] = processor_flag
+        * (E::ONE - frame.f_an(periodic_values) - frame.f_out(periodic_values))
+        * (frame.i_next() - frame.i());
+    constraint_offset += 1;
+
+    constraint_offset
+}
+
+/// Enforces constraints on the correct update of the hasher state. For all rounds in the cycle
+/// except the last, the constraints for the Rescue-XLIX round computation are applied.
+///
+/// For the last row in the cycle, the hash state update depends on the selector flags as follows.
+/// - When absorbing a new set of elements during linear hash computation, the capacity portion is
+///   copied to the next row.
+/// - When absorbing a new node during Merkle path computation, the result of the previous hash (the
+///   digest) is copied to the next row in the position specified by the bit shifted out of the node
+///   index.
+fn enforce_hasher_state<E: FieldElement + From<Felt>>(
+    frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
+    result: &mut [E],
+    processor_flag: E,
+) -> usize {
+    let mut constraint_offset = 0;
+
+    // Get the constraint flags and the Rescue round constants from the periodic values.
+    let hash_flag = processor_flag * binary_not(periodic_values[0]);
+    let last_row = processor_flag * periodic_values[0];
+    let ark = &periodic_values[NUM_PERIODIC_SELECTOR_COLUMNS..];
+
+    // Enforce the Rescue-XLIX round constraints.
+    enforce_rescue_round(frame, result, ark, hash_flag);
+    constraint_offset += STATE_WIDTH;
+
+    // When absorbing the next set of elements into the state during linear hash computation,
+    // the first 4 elements (the capacity portion) is carried over to the next row.
+    let hash_abp_flag = last_row * frame.f_abp();
+    for (idx, result) in result[constraint_offset..]
+        .iter_mut()
+        .take(CAPACITY_LEN)
+        .enumerate()
+    {
+        *result = hash_abp_flag * (frame.h_next(idx) - frame.h(idx))
+    }
+    constraint_offset += CAPACITY_LEN;
+
+    // When absorbing the next node during Merkle path computation, the result of the previous
+    // hash (h4,...,h7) is copied over either to (h′4,...,h′7) or to (h′8,...,h′11) depending
+    // on the value of b.
+    let mp_abp_flag = last_row
+        * (frame.f_mp(periodic_values) + frame.f_mv(periodic_values) + frame.f_mu(periodic_values));
+    for (idx, result) in result[constraint_offset..]
+        .iter_mut()
+        .take(DIGEST_LEN)
+        .enumerate()
+    {
+        let digest_idx = DIGEST_RANGE.start + idx;
+        let h_copy_down = frame.h_next(digest_idx) - frame.h(digest_idx);
+        let h_copy_over = frame.h_next(DIGEST_LEN + digest_idx) - frame.h(digest_idx);
+
+        *result = mp_abp_flag * (binary_not(frame.b()) * h_copy_down + frame.b() * h_copy_over);
+    }
+    constraint_offset += DIGEST_LEN;
+
+    constraint_offset
+}
+
+/// Enforces constraints for a single round of Rescue hash functions when flag = 1 using the
+/// provided round constants.
+pub fn enforce_rescue_round<E: FieldElement + From<Felt>>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    ark: &[E],
+    flag: E,
+) {
+    // Compute the state that should result from applying the first half of Rescue round
+    // to the current state of the computation.
+    let mut step1 = [E::ZERO; STATE_WIDTH];
+    step1.copy_from_slice(frame.hash_state());
+    apply_sbox(&mut step1);
+    apply_mds(&mut step1);
+    for i in 0..STATE_WIDTH {
+        step1[i] += ark[i];
+    }
+
+    // Compute the state that should result from applying the inverse for the second
+    // half for Rescue round to the next step of the computation.
+    let mut step2 = [E::ZERO; STATE_WIDTH];
+    step2.copy_from_slice(frame.hash_state_next());
+    for i in 0..STATE_WIDTH {
+        step2[i] -= ark[STATE_WIDTH + i];
+    }
+    apply_inv_mds(&mut step2);
+    apply_sbox(&mut step2);
+
+    // Make sure that the results are equal.
+    for i in 0..STATE_WIDTH {
+        result.agg_constraint(i, flag, are_equal(step2[i], step1[i]));
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+#[inline(always)]
+fn apply_sbox<E: FieldElement + From<Felt>>(state: &mut [E; STATE_WIDTH]) {
+    state.iter_mut().for_each(|v| {
+        let t2 = v.square();
+        let t4 = t2.square();
+        *v *= t2 * t4;
+    });
+}
+
+#[inline(always)]
+fn apply_mds<E: FieldElement + From<Felt>>(state: &mut [E; STATE_WIDTH]) {
+    let mut result = [E::ZERO; STATE_WIDTH];
+    result.iter_mut().zip(Hasher::MDS).for_each(|(r, mds_row)| {
+        state.iter().zip(mds_row).for_each(|(&s, m)| {
+            *r += E::from(m) * s;
+        });
+    });
+    *state = result
+}
+
+#[inline(always)]
+fn apply_inv_mds<E: FieldElement + From<Felt>>(state: &mut [E; STATE_WIDTH]) {
+    let mut result = [E::ZERO; STATE_WIDTH];
+    result
+        .iter_mut()
+        .zip(Hasher::INV_MDS)
+        .for_each(|(r, mds_row)| {
+            state.iter().zip(mds_row).for_each(|(&s, m)| {
+                *r += E::from(m) * s;
+            });
+        });
+    *state = result
+}
+
+// HASHER FRAME EXTENSION TRAIT
+// ================================================================================================
+
+/// Trait to allow easy access to column values and intermediate variables used in constraint
+/// calculations for the Hasher co-processor.
+trait EvaluationFrameExt<E: FieldElement> {
+    // --- Column accessors -----------------------------------------------------------------------
+
+    /// Gets the value of the selector column at the specified index in the current row.
+    fn s(&self, idx: usize) -> E;
+    /// Gets the value of the selector column at the specified index in the next row.
+    fn s_next(&self, idx: usize) -> E;
+    /// Gets the row address in the current row.
+    fn row(&self) -> E;
+    /// Gets the row address in the next row.
+    fn row_next(&self) -> E;
+    /// Gets the full hasher state in the current row.
+    fn hash_state(&self) -> &[E];
+    /// Gets the full hasher state in the next row.
+    fn hash_state_next(&self) -> &[E];
+    /// Gets the value of the specified index of the hasher state in the current row.
+    fn h(&self, idx: usize) -> E;
+    /// Gets the value of the specified index of the hasher state in the next row.
+    fn h_next(&self, idx: usize) -> E;
+    /// Gets the value of the node index in the current row.
+    fn i(&self) -> E;
+    /// Gets the value of the node index in the next row.
+    fn i_next(&self) -> E;
+
+    // --- Intermediate variables & helpers -------------------------------------------------------
+
+    /// The value of the bit which is discarded when the node index is shifted by one bit to the
+    /// right.
+    fn b(&self) -> E;
+
+    // --- Flags ----------------------------------------------------------------------------------
+
+    /// Set to 1 on the first 7 steps of every 8-step cycle. This flag is degree 1.
+    fn f_rpr(&self, k: &[E]) -> E;
+    /// Set to 1 when selector flags are (1,0,0) on rows which are multiples of 8. This flag is
+    /// degree 4.
+    fn f_bp(&self, k: &[E]) -> E;
+    /// Set to 1 when selector flags are (1,0,1) on rows which are multiples of 8. This flag is
+    /// degree 4.
+    fn f_mp(&self, k: &[E]) -> E;
+    /// Set to 1 when selector flags are (1,1,0) on rows which are multiples of 8. This flag is
+    /// degree 4.
+    fn f_mv(&self, k: &[E]) -> E;
+    /// Set to 1 when selector flags are (1,1,1) on rows which are multiples of 8. This flag is
+    /// degree 4.
+    fn f_mu(&self, k: &[E]) -> E;
+    /// Set to 1 when selector flags are (0,0,0) on rows which are 1 less than a multiple of 8. This
+    /// flag is degree 4.
+    fn f_hout(&self, k: &[E]) -> E;
+    /// Set to 1 when selector flags are (0,0,1) on rows which are 1 less than a multiple of 8. This
+    /// flag is degree 4.
+    fn f_sout(&self, k: &[E]) -> E;
+    /// This flag will be set to 1 when either f_hout=1 or f_sout=1 in the current row. This flag is
+    /// degree 3.
+    fn f_out(&self, k: &[E]) -> E;
+    /// This flag will be set to 1 when either f_hout=1 or f_sout=1 in the next row. This flag is
+    /// degree 3.
+    fn f_out_next(&self, k: &[E]) -> E;
+    /// Set to 1 when selector flags are (1,0,0). It should only be used on rows which are 1 less
+    /// than a multiple of 8 (where k0 = 1). `k0` has been excluded from the flag computation for
+    /// optimization purposes. This flag is degree 4 when combined with k0.
+    fn f_abp(&self) -> E;
+    /// Set to 1 when selector flags are (1,0,1). It should only be used on rows which are 1 less
+    /// than a multiple of 8 (where k0 = 1). `k0` has been excluded from the flag computation for
+    /// optimization purposes. This flag is degree 4 when combined with k0.
+    fn f_mpa(&self) -> E;
+    /// Set to 1 when selector flags are (1,1,0). It should only be used on rows which are 1 less
+    /// than a multiple of 8 (where k0 = 1). `k0` has been excluded from the flag computation for
+    /// optimization purposes. This flag is degree 4 when combined with k0.
+    fn f_mva(&self) -> E;
+    /// Set to 1 when selector flags are (1,1,1). It should only be used on rows which are 1 less
+    /// than a multiple of 8 (where k0 = 1). `k0` has been excluded from the flag computation for
+    /// optimization purposes. This flag is degree 4 when combined with k0.
+    fn f_mua(&self) -> E;
+    /// Gets a flag indicating that a new node is absorbed into the hasher state. This flag is
+    /// degree 4.
+    fn f_an(&self, k: &[E]) -> E;
+}
+
+impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
+    // --- Column accessors -----------------------------------------------------------------------
+
+    #[inline(always)]
+    fn s(&self, idx: usize) -> E {
+        self.current()[SELECTOR_COL_RANGE.start + idx]
+    }
+    #[inline(always)]
+    fn s_next(&self, idx: usize) -> E {
+        self.next()[SELECTOR_COL_RANGE.start + idx]
+    }
+    #[inline(always)]
+    fn row(&self) -> E {
+        self.current()[ROW_COL_IDX]
+    }
+    #[inline(always)]
+    fn row_next(&self) -> E {
+        self.next()[ROW_COL_IDX]
+    }
+    #[inline(always)]
+    fn hash_state(&self) -> &[E] {
+        &self.current()[HASHER_STATE_COL_RANGE]
+    }
+    #[inline(always)]
+    fn hash_state_next(&self) -> &[E] {
+        &self.next()[HASHER_STATE_COL_RANGE]
+    }
+    #[inline(always)]
+    fn h(&self, idx: usize) -> E {
+        self.current()[HASHER_STATE_COL_RANGE.start + idx]
+    }
+    #[inline(always)]
+    fn h_next(&self, idx: usize) -> E {
+        self.next()[HASHER_STATE_COL_RANGE.start + idx]
+    }
+    #[inline(always)]
+    fn i(&self) -> E {
+        self.current()[NODE_INDEX_COL_IDX]
+    }
+    #[inline(always)]
+    fn i_next(&self) -> E {
+        self.next()[NODE_INDEX_COL_IDX]
+    }
+
+    // --- Intermediate variables & helpers -------------------------------------------------------
+
+    #[inline(always)]
+    fn b(&self) -> E {
+        self.i() - E::from(2_u8) * self.i_next()
+    }
+
+    // --- Flags ----------------------------------------------------------------------------------
+
+    #[inline(always)]
+    fn f_rpr(&self, k: &[E]) -> E {
+        binary_not(k[0])
+    }
+    #[inline(always)]
+    fn f_bp(&self, k: &[E]) -> E {
+        k[2] * self.s(0) * binary_not(self.s(1)) * binary_not(self.s(2))
+    }
+    #[inline(always)]
+    fn f_mp(&self, k: &[E]) -> E {
+        k[2] * self.s(0) * binary_not(self.s(1)) * self.s(2)
+    }
+    #[inline(always)]
+    fn f_mv(&self, k: &[E]) -> E {
+        k[2] * self.s(0) * self.s(1) * binary_not(self.s(2))
+    }
+    #[inline(always)]
+    fn f_mu(&self, k: &[E]) -> E {
+        k[2] * self.s(0) * self.s(1) * self.s(2)
+    }
+    #[inline(always)]
+    fn f_hout(&self, k: &[E]) -> E {
+        k[0] * binary_not(self.s(0)) * binary_not(self.s(1)) * binary_not(self.s(2))
+    }
+    #[inline(always)]
+    fn f_sout(&self, k: &[E]) -> E {
+        k[0] * binary_not(self.s(0)) * binary_not(self.s(1)) * self.s(2)
+    }
+    #[inline(always)]
+    fn f_out(&self, k: &[E]) -> E {
+        k[0] * binary_not(self.s(0)) * binary_not(self.s(1))
+    }
+    #[inline(always)]
+    fn f_out_next(&self, k: &[E]) -> E {
+        k[1] * binary_not(self.s_next(0)) * binary_not(self.s_next(1))
+    }
+    #[inline(always)]
+    fn f_abp(&self) -> E {
+        self.s(0) * binary_not(self.s(1)) * binary_not(self.s(2))
+    }
+    #[inline(always)]
+    fn f_mpa(&self) -> E {
+        self.s(0) * binary_not(self.s(1)) * self.s(2)
+    }
+    #[inline(always)]
+    fn f_mva(&self) -> E {
+        self.s(0) * self.s(1) * binary_not(self.s(2))
+    }
+    #[inline(always)]
+    fn f_mua(&self) -> E {
+        self.s(0) * self.s(1) * self.s(2)
+    }
+    #[inline(always)]
+    fn f_an(&self, k: &[E]) -> E {
+        self.f_mp(k)
+            + self.f_mv(k)
+            + self.f_mu(k)
+            + k[0] * (self.f_mpa() + self.f_mva() + self.f_mua())
+    }
+}
+
+// CYCLE MASKS
+// ================================================================================================
+
+/// Periodic column mask used to indicate the last row of a cycle.
+pub const HASH_K0_MASK: [Felt; HASH_CYCLE_LEN] = [
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ONE,
+];
+
+/// Periodic column mask used to indicate when the next row will be the last row of a cycle.
+pub const HASH_K1_MASK: [Felt; HASH_CYCLE_LEN] = [
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ONE,
+    Felt::ZERO,
+];
+
+/// Periodic column mask used to identify the first row of a cycle.
+pub const HASH_K2_MASK: [Felt; HASH_CYCLE_LEN] = [
+    Felt::ONE,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+    Felt::ZERO,
+];
+
+// ROUND CONSTANTS
+// ================================================================================================
+
+/// Returns Rescue round constants arranged in column-major form.
+pub fn get_round_constants() -> Vec<Vec<Felt>> {
+    let mut constants = Vec::new();
+    for _ in 0..(STATE_WIDTH * 2) {
+        constants.push(vec![Felt::ZERO; HASH_CYCLE_LEN]);
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..HASH_CYCLE_LEN - 1 {
+        for j in 0..STATE_WIDTH {
+            constants[j][i] = Hasher::ARK1[i][j];
+            constants[j + STATE_WIDTH][i] = Hasher::ARK2[i][j];
+        }
+    }
+
+    constants
+}

--- a/air/src/aux_table/hasher/mod.rs
+++ b/air/src/aux_table/hasher/mod.rs
@@ -10,6 +10,9 @@ use vm_core::{
 };
 use winter_air::TransitionConstraintDegree;
 
+#[cfg(test)]
+mod tests;
+
 // CONSTANTs
 // ================================================================================================
 

--- a/air/src/aux_table/hasher/tests.rs
+++ b/air/src/aux_table/hasher/tests.rs
@@ -1,0 +1,97 @@
+use super::{
+    enforce_constraints, Hasher, HASHER_STATE_COL_RANGE, NODE_INDEX_COL_IDX, NUM_CONSTRAINTS,
+    ROW_COL_IDX, SELECTOR_COL_RANGE,
+};
+use rand_utils::rand_array;
+use vm_core::{
+    hasher::{apply_round, Selectors, LINEAR_HASH, STATE_WIDTH},
+    Felt, FieldElement, TRACE_WIDTH,
+};
+use winter_air::EvaluationFrame;
+
+// UNIT TESTS
+// ================================================================================================
+
+/// Tests instruction RPR, which is executed on all cycles that are not one less than a multiple of
+/// eight, and applies a round of Rescue-XLIX.
+#[test]
+fn rescue_round() {
+    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    let cycle_row_num: usize = 3;
+    let current_selectors = [Felt::ZERO, LINEAR_HASH[1], LINEAR_HASH[2]];
+    let next_selectors = current_selectors;
+
+    let frame = get_test_hashing_frame(current_selectors, next_selectors, cycle_row_num);
+    let result = get_constraint_evaluation(frame, cycle_row_num);
+    assert_eq!(expected, result);
+}
+
+// TEST HELPER FUNCTIONS
+// ================================================================================================
+
+/// Returns the result of Hash processor's constraint evaluations on the provided frame starting at
+/// the specified row.
+fn get_constraint_evaluation(
+    frame: EvaluationFrame<Felt>,
+    cycle_row_num: usize,
+) -> [Felt; NUM_CONSTRAINTS] {
+    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let periodic_values = get_test_periodic_values(cycle_row_num);
+
+    enforce_constraints(&frame, &periodic_values, &mut result, Felt::ONE, Felt::ONE);
+
+    result
+}
+
+/// Returns the values from the periodic columns for the specified cycle row.
+fn get_test_periodic_values(cycle_row: usize) -> Vec<Felt> {
+    // Set the periodic column values.
+    let mut periodic_values = match cycle_row {
+        0 => vec![Felt::ZERO, Felt::ZERO, Felt::ONE],
+        7 => vec![Felt::ZERO, Felt::ONE, Felt::ZERO],
+        8 => vec![Felt::ONE, Felt::ZERO, Felt::ZERO],
+        _ => vec![Felt::ZERO, Felt::ZERO, Felt::ZERO],
+    };
+
+    // Add the Rescue Prime round constants for the first 7 rows of the cycle, or pad with zeros.
+    if cycle_row == 7 {
+        periodic_values.resize(periodic_values.len() + STATE_WIDTH * 2, Felt::ZERO);
+    } else {
+        periodic_values.extend_from_slice(&Hasher::ARK1[cycle_row]);
+        periodic_values.extend_from_slice(&Hasher::ARK2[cycle_row]);
+    }
+    periodic_values
+}
+
+/// Returns a valid test frame for a transition where one round of Rescue-XLIX is computed.
+fn get_test_hashing_frame(
+    current_selectors: Selectors,
+    next_selectors: Selectors,
+    cycle_row_num: usize,
+) -> EvaluationFrame<Felt> {
+    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+
+    // Set the selectors for the hash operation.
+    current[SELECTOR_COL_RANGE].copy_from_slice(&current_selectors);
+    next[SELECTOR_COL_RANGE].copy_from_slice(&next_selectors);
+
+    // add the row values
+    current[ROW_COL_IDX] = Felt::new(cycle_row_num as u64);
+    next[ROW_COL_IDX] = Felt::new(cycle_row_num as u64 + 1);
+
+    // Set the starting hasher state.
+    let mut state = rand_array();
+    current[HASHER_STATE_COL_RANGE].copy_from_slice(&state);
+
+    // Set the hasher state after a single permutation.
+    apply_round(&mut state, cycle_row_num);
+    next[HASHER_STATE_COL_RANGE].copy_from_slice(&state);
+
+    // Set the node index values to zero for hash computations.
+    current[NODE_INDEX_COL_IDX] = Felt::ZERO;
+    next[NODE_INDEX_COL_IDX] = Felt::ZERO;
+
+    EvaluationFrame::from_rows(current, next)
+}

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -87,15 +87,8 @@ impl Air for ProcessorAir {
     // --------------------------------------------------------------------------------------------
 
     /// Returns a set of periodic columns for the ProcessorAir.
-    ///
-    /// The columns consist of:
-    /// - k0 column, which has a repeating pattern of a single one followed by 7 zeros.
-    /// - k1 column, which has a repeating pattern of a 7 ones followed by a single zero.
     fn get_periodic_column_values(&self) -> Vec<Vec<Felt>> {
-        vec![
-            aux_table::BITWISE_POW2_K0_MASK.to_vec(),
-            aux_table::BITWISE_POW2_K1_MASK.to_vec(),
-        ]
+        aux_table::get_periodic_column_values()
     }
 
     // ASSERTIONS

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -5,6 +5,11 @@ use vm_core::utils::range as create_range;
 // BASIC CONSTRAINT OPERATORS
 // ================================================================================================
 
+/// Returns zero only when a == b.
+pub fn are_equal<E: FieldElement>(a: E, b: E) -> E {
+    a - b
+}
+
 #[inline(always)]
 pub fn is_binary<E: FieldElement>(v: E) -> E {
     v.square() - v

--- a/core/src/hasher/mod.rs
+++ b/core/src/hasher/mod.rs
@@ -1,6 +1,8 @@
 //! TODO: add docs
 
-use super::Felt;
+use std::ops::Range;
+
+use super::{Felt, FieldElement};
 use crypto::{ElementHasher, Hasher as HashFn};
 
 pub use crypto::hashers::Rp64_256 as Hasher;
@@ -13,6 +15,8 @@ pub use crypto::hashers::Rp64_256 as Hasher;
 /// The digest consists of 4 field elements or 32 bytes.
 pub type Digest = <Hasher as HashFn>::Digest;
 
+pub type Selectors = [Felt; NUM_SELECTORS];
+
 // CONSTANTS
 // ================================================================================================
 
@@ -23,10 +27,51 @@ pub type Digest = <Hasher as HashFn>::Digest;
 /// permutation.
 pub const STATE_WIDTH: usize = Hasher::STATE_WIDTH;
 
+/// The length of the capacity portion of the hash state.
+pub const CAPACITY_LEN: usize = 4;
+
+// The length of the output portion of the hash state.
+pub const DIGEST_LEN: usize = 4;
+
+/// The output portion of the hash state, located in state elements 4, 5, 6, and 7.
+pub const DIGEST_RANGE: Range<usize> = Hasher::DIGEST_RANGE;
+
 /// Number of needed to complete a single permutation.
 ///
 /// This value is set to 7 to target 128-bit security level with 40% security margin.
 pub const NUM_ROUNDS: usize = Hasher::NUM_ROUNDS;
+
+/// Number of selector columns in the trace.
+pub const NUM_SELECTORS: usize = 3;
+
+/// Number of columns in Hasher execution trace. Additional two columns are for row address and
+/// node index columns.
+pub const TRACE_WIDTH: usize = NUM_SELECTORS + STATE_WIDTH + 2;
+
+/// Specifies a start of a new linear hash computation or absorption of new elements into an
+/// executing linear hash computation. These selectors can also be used for a simple 2-to-1 hash
+/// computation.
+pub const LINEAR_HASH: Selectors = [Felt::ONE, Felt::ZERO, Felt::ZERO];
+
+/// Specifies a start of Merkle path verification computation or absorption of a new path node
+/// into the hasher state.
+pub const MP_VERIFY: Selectors = [Felt::ONE, Felt::ZERO, Felt::ONE];
+
+/// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
+/// state for the "old" node value during Merkle root update computation.
+pub const MR_UPDATE_OLD: Selectors = [Felt::ONE, Felt::ONE, Felt::ZERO];
+
+/// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
+/// state for the "new" node value during Merkle root update computation.
+pub const MR_UPDATE_NEW: Selectors = [Felt::ONE, Felt::ONE, Felt::ONE];
+
+/// Specifies a completion of a computation such that only the hash result (values in h0, h1, h2
+/// h3) is returned.
+pub const RETURN_HASH: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ZERO];
+
+/// Specifies a completion of a computation such that the entire hasher state (values in h0 through
+/// h11) is returned.
+pub const RETURN_STATE: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ONE];
 
 // PASS-THROUGH FUNCTIONS
 // ================================================================================================

--- a/docs/src/design/aux_table/hasher.md
+++ b/docs/src/design/aux_table/hasher.md
@@ -1,3 +1,408 @@
-# Hash Processor
+# Hash processor
 
-TODO
+This note assumes some familiarity with [permutation checks](https://hackmd.io/@arielg/ByFgSDA7D).
+
+Miden VM "offloads" all hash-related computations to a separate _hash processor_. This processor supports executing [Rescue Prime](https://eprint.iacr.org/2020/1143) hash function (or rather a [specific instantiation](https://docs.rs/winter-crypto/0.3.2/winter_crypto/hashers/struct.Rp64_256.html) of it) in the following settings:
+
+- A single permutation of Rescue Prime.
+- A simple 2-to-1 hash.
+- A linear hash of $n$ field elements.
+- Merkle path verification.
+- Merkle root update.
+
+The processor can be thought of as having a small instruction set of $11$ instructions. These instructions are listed below, and examples of how these instructions are used by the processor are described in the following sections.
+
+| Instruction | Description                                                                                                                                                                                                                                                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `RPR`       | Executes a single round of Rescue Prime. All cycles which are not one less than a multiple of $8$ execute this instruction. That is, the processor executes this instruction on cycles $0, 1, 2, 3, 4, 5, 6$, but not $7$, and then again, $8, 9, 10, 11, 12, 13, 14$, but not $15$ etc.                           |
+| `BP`        | Initiates computation of a single permutation, a 2-to-1 hash, or a linear hash of many elements. This instruction can be executed only on cycles which are multiples of $8$, and it can also be executed concurrently with `RPR` instruction.                                                                      |
+| `MP`        | Initiates Merkle path verification computation. This instruction can be executed only on cycles which are multiples of $8$, and it can also be executed concurrently with `RPR` instruction.                                                                                                                       |
+| `MV`        | Initiates Merkle path verification for the "old" node value during Merkle root update computaiton. This instruction can be executed only on cycles which are multiples of $8$, and it can also be executed concurrently with `RPR` instruction.                                                                    |
+| `MU`        | Initiates Merkle path verification for the "new" node value during Merkle root update computaiton. This instruction can be executed only on cycles which are multiples of $8$, and it can also be executed concurrently with `RPR` instruction.                                                                    |
+| `HOUT`      | Returns the result of the currently running computation. This instruction can be executed only on cycles which are one less than a multiple of $8$ (e.g. $7$, $15$ etc.).                                                                                                                                          |
+| `SOUT`      | Returns the whole hasher state. This instruction can be executed only on cycles which are one less than a multiple of $8$, and only if the computation was started using `BP` instruction.                                                                                                                         |
+| `ABP`       | Absorbs a new set of elements into the hasher state when computing a linear hash of many elements. This instruction can be executed only on cycles which are one less than a multiple of $8$, and only if the computation was started using `BP` instruction.                                                      |
+| `MPA`       | Absorbs the next Merkle path node into the hasher state during Merkle path verification computation. This instruction can be executed only on cycles which are one less than a multiple of $8$, and only if the computation was started using `MP` instruction.                                                    |
+| `MVA`       | Absorbs the next Merkle path node into the hasher state during Merkle path verification for the "old" node value during Merkle root update computation. This instruction can be executed only on cycles which are one less than a multiple of $8$, and only if the computation was started using `MV` instruction. |
+| `MUA`       | Absorbs the next Merkle path node into the hasher state during Merkle path verification for the "new" node value during Merkle root update computation. This instruction can be executed only on cycles which are one less than a multiple of $8$, and only if the computation was started using `Mu` instruction. |
+
+## Processor trace
+
+Execution trace table of the processor consists of $17$ trace columns and $2$ periodic columns. The structure of the table is such that a single permutation of the hash function can be computed using $8$ table rows. The layout of the table is illustrated below.
+
+![](https://hackmd.io/_uploads/HyMaT4URt.png)
+
+The meaning of the columns is as follows:
+
+- Two periodic columns $k_0$ and $k_1$ are used to help select the instruction executed at a given row. Both of these columns contain patterns which repeats every $8$ rows. For $k_0$ the pattern is $7$ zeros followed by $1$ one. For $k_1$ the pattern is one $1$ followed by $7$ zeros.
+- Three selector columns $s_0$, $s_1$, and $s_2$. These columns can contain only binary values (ones or zeros), and they are also used to help select the instruction to execute at a given row.
+- One row address column $r$. This column starts out at $0$ and gets incremented by $1$ with every row.
+- Twelve hasher state columns $h_0, ..., h_{11}$. These columns are used to hold the hasher state for each round of Rescue Prime permutation. The state is laid out as follows:
+  - The first four columns ($h_0, ..., h_3$) are reserved for capacity elements of the state. When the state is initialized for hash computations, $h_0$ should be set to the number of elements to be hashed. All other capacity elements should be set to $0$'s.
+  - The next eight columns ($h_4, ..., h_{11}$) are reserved for the rate elements of the state. These are used to absorb the values to be hashed. Once the permutation is complete, hash output is located in the first four rate columns ($h_4, ..., h_7$).
+- One index column $i$. This column is used to help with Merkle path verification and Merkle root update computations.
+
+In addition to the columns described above, the table relies on two running product columns which are used to facilitate permutation checks. These columns are:
+
+- $p_0$ - which is used to tie the processor table with with the main VM's stack. That is, inputs consumed by the processor and outputs produced by the processor are added to $p_0$, while the main VM stack removes them from $p_0$. Thus, if the sets of inputs and outputs between the main VM stack and hash processor are the same, value of $p_0$ should be equal to $1$ at the start and the end of the execution trace.
+- $p_1$ - which is used to as a _virtual_ helper table for Merkle root update computations.
+
+## Instruction flags
+
+As mentioned above, processor instructions are encoded using a combination of periodic and selector columns. These columns can be used to compute a binary flag for each instruction. Thus, when a flag for a given instruction is set to $1$, the processor executes this instruction. Formulas for computing instruction flags are listed below.
+
+| Flag       | Value                                                 | Notes                                                                                             |
+| ---------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| $f_{rpr}$  | $1 - k_0$                                             | Set to $1$ on the first $7$ steps of every $8$-step cycle.                                        |
+| $f_{bp}$   | $k_1 \cdot s_0 \cdot (1 - s_1) \cdot (1 - s_2)$       | Set to $1$ when selector flags are $(1, 0, 0)$ on rows which are multiples of $8$.                |
+| $f_{mp}$   | $k_1 \cdot s_0 \cdot (1 - s_1) \cdot s_2$             | Set to $1$ when selector flags are $(1, 0, 1)$ on rows which are multiples of $8$.                |
+| $f_{mv}$   | $k_1 \cdot s_0 \cdot s_1 \cdot (1 - s_2)$             | Set to $1$ when selector flags are $(1, 1, 0)$ on rows which are multiples of $8$.                |
+| $f_{mu}$   | $k_1 \cdot s_0 \cdot s_1 \cdot s_2$                   | Set to $1$ when selector flags are $(1, 1, 1)$ on rows which are multiples of $8$.                |
+| $f_{hout}$ | $k_0 \cdot (1 - s_0) \cdot (1 - s_1) \cdot (1 - s_2)$ | Set to $1$ when selector flags are $(0, 0, 0)$ on rows which are $1$ less than a multiple of $8$. |
+| $f_{sout}$ | $k_0 \cdot (1 - s_0) \cdot (1 - s_1) \cdot s_2$       | Set to $1$ when selector flags are $(0, 0, 1)$ on rows which are $1$ less than a multiple of $8$. |
+| $f_{abp}$  | $k_0 \cdot s_0 \cdot (1 - s_1) \cdot (1 - s_2)$       | Set to $1$ when selector flags are $(1, 0, 0)$ on rows which are $1$ less than a multiple of $8$. |
+| $f_{mpa}$  | $k_0 \cdot s_0 \cdot (1 - s_1) \cdot s_2$             | Set to $1$ when selector flags are $(1, 0, 1)$ on rows which are $1$ less than a multiple of $8$. |
+| $f_{mva}$  | $k_0 \cdot s_0 \cdot s_1 \cdot (1 - s_2)$             | Set to $1$ when selector flags are $(1, 1, 0)$ on rows which are $1$ less than a multiple of $8$. |
+| $f_{mua}$  | $k_0 \cdot s_0 \cdot s_1 \cdot s_2$                   | Set to $1$ when selector flags are $(1, 1, 1)$ on rows which are $1$ less than a multiple of $8$. |
+
+A few additional notes about flag values:
+
+- With the exception of $f_{rpr}$, all flags are mutually exclusive. That is, if one flag is set to $1$, all other flats are set to $0$.
+- With the exception of $f_{rpr}$, computing flag values involves $3$ multiplications, and thus the degree of these flags is $4$.
+- We can also define a flag $f_{out} = k_0 \cdot (1 - s_0) \cdot (1 - s_1)$. This flag will be set to $1$ when either $f_{hout}=1$ or $f_{sout}=1$.
+
+We also impose the following restrictions on how values in selector columns can be updated:
+
+- Values in columns $s_1$ and $s_2$ must be copied over from one row to the next, unless $f_{out} = 1$ for the current or the next row.
+- Value in $s_0$ must be set to $1$ if $f_{out}=1$ for the previous row, and to $0$ if any of the flags $f_{abp}$, $f_{mpa}$, $f_{mva}$, or $f_{mua}$ are set to $1$ for the previous row.
+
+The above rules ensure that we must finish one computation before starting another, and we can't change the type of the computation before the computation is finished.
+
+## Computation examples
+
+### Single permutation
+
+Computing a single permutation of Rescue Prime hash function involves the following steps:
+
+1. Initialize hasher state with $12$ field elements.
+2. Apply Rescue Prime permutation.
+3. Return the entire hasher state as output.
+
+The processor accomplishes the above by executing the following instructions:
+
+```
+[BP, RPR]                // init state and execute Rescue round (concurrently)
+RPR RPR RPR RPR RPR RPR  // execute 6 more Rescue rounds
+SOUT                     // return the entire state as output
+```
+
+Execution trace for this computation would look as illustrated below.
+
+![](https://hackmd.io/_uploads/rkrZJhD0F.png)
+
+In the above $\{a_0, ..., a_{11}\}$ is the input state of the hasher, and $\{b_0, ..., b_{11}\}$ is the output state of the hasher.
+
+### Simple 2-to-1 hash
+
+Computing a 2-to-1 hash involves the following steps:
+
+1. Initialize hasher state with $8$ field elements, setting the first capacity element to $8$, and the remaining capacity elements to $0$
+2. Apply Rescue Prime permutation.
+3. Return elements ${4, ..., 7}$ of the hasher state as output.
+
+The processor accomplishes the above by executing the following instructions:
+
+```
+[BP, RPR]                // init state and execute Rescue round (concurrently)
+RPR RPR RPR RPR RPR RPR  // execute 6 more Rescue rounds
+HOUT                     // return elements 4, 5, 6, 7 of the state as output
+```
+
+Execution trace for this computation would look as illustrated below.
+
+![](https://hackmd.io/_uploads/Hyb1RE8RF.png)
+
+In the above, we compute the following:
+
+$$
+\{c_0, c_1, c_2, c_3\} \leftarrow hash(\{a_0, a_1, a_2, a_3\}, \{b_0, b_1, b_2, b_3\})
+$$
+
+### Linear hash of n elements
+
+Computing a linear hash of $n$ elements consists of the following steps:
+
+1. Initialize hasher state with the first $8$ elements, setting the first capacity register to $n$, and the remaining capacity elements to $0$.
+2. Apply Rescue Prime permutation.
+3. Absorb the next set of elements into the state (up to $8$ elements), while keeping capacity elements unchanged.
+4. Repeat steps 2 and 3 until all $n$ elements have been absorbed.
+5. Return elements ${4, ..., 7}$ of the hasher state as output.
+
+The processor accomplishes the above by executing the following instructions (for hashing $16$ elements):
+
+```
+[BP, RPR]                   // init state and execute Rescue round (concurrently)
+RPR RPR RPR RPR RPR RPR     // execute 6 more Rescue rounds
+ABP                         // absorb the next set of elements into the state
+RPR RPR RPR RPR RPR RPR RPR // execute 7 Rescue rounds
+HOUT                        // return elements 4, 5, 6, 7 of the state as output
+```
+
+Execution trace for this computation would look as illustrated below.
+
+![](https://hackmd.io/_uploads/Hy_xAEUAF.png)
+
+In the above, the value absorbed into hasher state between rows $7$ and $8$ is the delta between values $t_i$ and $s_i$. Thus, if we define $b_i = t_i - s_i$ for $i \in \{0, ..., 7\}$, the above computes the following:
+
+$$
+\{r_0, r_1, r_2, r_3\} \leftarrow hash(a_0, ..., a_7, b_0, ..., b_7)
+$$
+
+### Verify Merkle path
+
+Verifying a Merkle path involves the following steps:
+
+1. Initialize hasher state with the leaf and the first node of the path, setting the first capacity element to $8$, and the remaining capacity elements to $0$s.
+   a. Also, initialize the index register to the leaf's index value.
+2. Apply Rescue Prime permutation.
+   a. Make sure the index value doesn't change during this step.
+3. Copy the result of the hash to the next row, and absorb the next node of the Merkle path into the hasher state.
+   a. Remove a single bit from the index, and use it to determine how to place the copied result and absorbed node in the state.
+4. Repeat steps 2 and 3 until all nodes of the Merkle path have been absorbed.
+5. Return elements ${4, ..., 7}$ of the hasher state as output.
+   a. Also, make sure the index value has been reduced to $0$.
+
+The processor accomplishes the above by executing the following instructions (for Merkle tree of depth $3$):
+
+```
+[MP, RPR]                   // init state and execute Rescue round (concurrently)
+RPR RPR RPR RPR RPR RPR     // execute 6 more Rescue rounds
+MPA                         // copy result & absorb the next node into the state
+RPR RPR RPR RPR RPR RPR RPR // execute 7 Rescue rounds
+HOUT                        // return elements 4, 5, 6, 7 of the state as output
+```
+
+Suppose we have a Merkle tree as illustrated below. This Merkle tree has $4$ leaves, each of which consists of $4$ field elements. For example, leaf $a$ consists of elements $a_0, a_1, a_2, a_3$, leaf be consists of elements $b_0, b_1, b_2, b_3$ etc.
+
+![](https://hackmd.io/_uploads/Hk4txKNAY.png)
+
+If we wanted to verify that leaf $d$ is in fact in the tree, we'd need to compute the following hashes:
+
+$$
+r \leftarrow hash(e, hash(c, d))
+$$
+
+And if $r = g$, we can be convinced that $d$ is in fact in the tree at position $3$. Execution trace for this computation would look as illustrated below.
+
+![](https://hackmd.io/_uploads/rkPdgK40t.png)
+
+In the above, the prover provides values for nodes $c$ and $e$ non-deterministically.
+
+### Update Merkle root
+
+Updating a node in a Merkle tree (which also updates the root of the tree) can be simulated by verifying two Merkle paths: the path that starts with the old leaf and the path that starts with the new leaf.
+
+Suppose we have the same Merkle tree as in the previous example, and we want to replace node $d$ with node $d'$. The computations we'd need to perform are:
+
+$$
+r \leftarrow hash(e, hash(c, d)) \\
+r' \leftarrow hash(e, hash(c, d'))
+$$
+
+Then, as long as $r = g$, and the same values were used for $c$ and $e$ in both computations, we can be convinced that the new root of the tree is $r'$.
+
+The processor accomplishes the above by executing the following instructions:
+
+```
+// verify the old merkle path
+[MV, RPR]                   // init state and execute Rescue round (concurrently)
+RPR RPR RPR RPR RPR RPR     // execute 6 more Rescue rounds
+MPV                         // copy result & absorb the next node into the state
+RPR RPR RPR RPR RPR RPR RPR // execute 7 Rescue rounds
+HOUT                        // return elements 4, 5, 6, 7 of the state as output
+
+// verify the new merkle path
+[MU, RPR]                   // init state and execute Rescue round (concurrently)
+RPR RPR RPR RPR RPR RPR     // execute 6 more Rescue rounds
+MPU                         // copy result & absorb the next node into the state
+RPR RPR RPR RPR RPR RPR RPR // execute 7 Rescue rounds
+HOUT                        // return elements 4, 5, 6, 7 of the state as output
+```
+
+The semantics of `MV` and `MU` instructions are similar to the semantics of `MP` instruction from the previous example (and `MVA` and `MUA` are similar to `MPA`) with one important difference: `MV*` instructions add the absorbed node (together with its index in the tree) to permutation column $p_1$, while `MU*` instructions remove the absorbed node (together with its index in the tree) from $p_1$. Thus, if the same nodes were used during both Merkle path verification, the state of $p_1$ should not change. This mechanism is used to ensure that the same internal nodes were used in both computations.
+
+## AIR constraints
+
+When describing AIR constraints, we adopt the following notation: for column $x$, we denote the value in the current row simply as $x$, and the value in the next row of the column as $x′$. Thus, all transition constraints described in this note work with two consecutive rows of the execution trace.
+
+### Row address constraint
+
+As mentioned above, row address $r$ starts at $0$, and is incremented by $1$ with every row. The first condition can be enforced with a boundary constraint which specifies $r=0$ at the first row. The second condition can be enforced via the following transition constraint:
+
+$$
+r' - r - 1 = 0
+$$
+
+### Selector columns constraints
+
+For selector columns, first we must ensure that only binary values are allowed in these columns. This can be done with the following constraints:
+
+$$
+s_0^2 - s_0 = 0 \\
+s_1^2 - s_1 = 0 \\
+s_2^2 - s_2 = 0
+$$
+
+Next, we need to make sure that unless $f_{out}=1$ at the current or at the next row, the values in columns $s_1$ and $s_2$ are copied over to the next row. This can be done with the following constraints:
+
+$$
+(s_1' - s_1) \cdot (1 - f_{out}') \cdot (1 - f_{out}) = 0 \\
+(s_2' - s_2) \cdot (1 - f_{out}') \cdot (1 - f_{out})= 0
+$$
+
+Next, we need to enforce when $f_{out}=1$ the next value of $s_0$ is unconstrained, but if any of $f_{abp}, f_{mpa}, f_{mva}, f_{mua}$ flags is set to $1$, the next value of $s_0$ must be $0$. This can be done with the following constraint:
+
+$$
+s_0' \cdot (f_{abp} + f_{mpa} + f_{mva} + f_{mua} + 1 - f_{out})= 0
+$$
+
+Lastly, we need to make sure that no invalid combinations of flags are allowed. This can be done with the following constraints:
+
+$$
+k_0 \cdot (1 - s_0) \cdot s_1 = 0
+$$
+
+The above constraints enforce that on every step which is one less than a multiple of $8$, if $s_0 = 0$, then $s_1$ must also be set to $0$. Basically, if we set $s_0=0$, then we must make sure that either $f_{hout}=1$ or $f_{sout}=1$.
+
+### Node index constraints
+
+Node index column $i$ is relevant only for Merkle path verification and Merkle root update computations, but to simplify the overall constraint system, the same constraints will be imposed on this column for all computations.
+
+Overall, we want values in the index column to behave as follows:
+
+- When we start a new computation, we should be able to set $i$ to an arbitrary value.
+- When a computation is finished, value in $i$ must be $0$.
+- When we absorb a new node into the hasher state we must shift the value in $i$ by one bit to the right.
+- In all other cases value in $i$ should not change.
+
+A shift by one bit to the right can be described with the following equation: $i = 2 \cdot i' + b$, where $b$ is the value of the bit which is discarded. Thus, as long as $b$ is a binary value, the shift to the right is performed correctly, and this can be enforced with the following constraint:
+
+$$
+b^2 - b = 0
+$$
+
+Since we want to enforce this constraint only when a new node is absorbed into the hasher state, we'll define a flag for when this should happen as follows:
+
+$$
+f_{an} = f_{mp} + f_{mv} + f_{mu} + f_{mpa} + f_{mva} + f_{mua}
+$$
+
+And then the full constraint would looks as follows:
+
+$$
+f_{an} \cdot (b^2 - b) = 0
+$$
+
+Next, to make sure when a computation is finished $i=0$, we can use the following constraint:
+
+$$
+f_{out} \cdot i = 0
+$$
+
+Finally, to make sure that the value in $i$ is copied over to the next row unless we are absorbing a new row or the computation is finished, we impose the following contraint:
+
+$$
+(1 - f_{an} - f_{out}) \cdot (i' - i) = 0
+$$
+
+To satisfy these constraints for computations not related to Merkle paths (i.e., 2-to-1 hash and liner hash of elements), we can set $i = 0$ at the start of the computation. This guarantees that $i$ will remain $0$ until the end of the computation.
+
+### Hasher state constraints
+
+Hasher state columns $h_0, ..., h_{11}$ should behave as follows:
+
+- For the first $7$ row of every $8$-row cycle (i.e., when $k_0=0$), we need to apply [Rescue Prime](https://eprint.iacr.org/2020/1143) round constraints to the hasher state. For brevity, we omit these constraints from this note.
+- On the $8$th row of every $8$-row cycle, we apply the constraints based on which transition flag is set as described in the table below.
+
+| Condition\_                                      | Constraint                                                                                                      | Description                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| $f_{out}=1$                                      | none                                                                                                            | When a computation is completed, the next hasher state is unconstrained.                                                                                                                                                                                                              |
+| $f_{abp}=1$                                      | $h'_j - h_j = 0$ for $j \in \{0, ..., 3\}$                                                                      | When absorbing the next set of elements into the state during linear hash computation, the first $4$ elements (the capacity portion) is carried over to the next row.                                                                                                                 |
+| $f_{mp}=1$ or <br> $f_{mv}=1$ or <br> $f_{mu}=1$ | $(1 - b) \cdot (h_{j +4}' - h_{j+4})+$ <br> $b \cdot (h_{j + 8}' - h_{j + 4})=0$ <br> for $j \in \{0, ..., 3\}$ | When absorbing the next node during Merkle path computation, the result of the previous hash ($h_4, ..., h_7$) are copied over either to $(h_4', ..., h_7')$ or to $(h_8', ..., h_{11}')$ depending on the value of $b$, which is defined in the same was as in the previous section. |
+
+The above can be translated into a set of constraint straightforwardly like so:
+
+$$
+f_{abp} \cdot (h'_j - h_j) = 0 \\
+(f_{mp} + f_{mv} + f_{mu}) \cdot \left( (1 - b) \cdot (h_{j +4}' - h_{j+4})+ b \cdot (h_{j + 8}' - h_{j + 4}) \right)=0
+$$
+
+### Permutation product constraints
+
+This section describes constraints which enforce updates for permutation product columns $p_0$ and $p_1$. These columns can be updated only on rows which are multiples of $8$ or one less than a multiple of $8$. On all other rows the values in the columns remain the same.
+
+To simplify description of constraints, we define the following variables. Below $\alpha$ and $\beta$ are random values sent by the verifier to the prover after the prover commits to the execution trace described by the main $17$ columns.
+
+$$
+m = k_0 + 2 \cdot k_1 + \sum_{j=0}^2 (2^{j+2} \cdot s_j) \\
+v_h = \beta + \alpha \cdot m + \alpha^2 \cdot r + \alpha^3 \cdot i \\
+v_a = \sum_{j=0}^{3}(\alpha^{j+4} \cdot h_j) \\
+v_b = \sum_{j=4}^{7}(\alpha^{j+4} \cdot h_j) \\
+v_c = \sum_{j=8}^{11}(\alpha^{j+4} \cdot h_j) \\
+v_d = \sum_{j=8}^{11}(\alpha^j \cdot h_j)
+$$
+
+In the above:
+
+- $m$ is a _transition label_ which uniquely identifies each transition function.
+- $v_h$ is a _common header_ which is a combination of transition label, row address, and node index.
+- $v_a$, $v_b$, $v_c$ are the first, second, and third words (4 elements) of the hasher state.
+- $v_d$ is the third word in the hasher state, but with the same $\alpha$ coefficients as used for the second word.
+
+Armed with the above notation, we can describe constraints for updating column $p_0$ as follows.
+
+| Condition\_                                      | Constraint                                               | Description                                                                                                                                                                          |
+| ------------------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| $f_{bp}=1$                                       | $p_0' = p_0 \cdot (v_h + v_a + v_b + v_c)$               | When starting a new simple or linear hash computation, the entire hasher state is included into $p_0$.                                                                               |
+| $f_{mp}=1$ or <br> $f_{mv}=1$ or <br> $f_{mu}=1$ | $p_0' = p_0 \cdot (v_h + (1-b) \cdot v_b + b \cdot v_d)$ | When starting a Merkle path computation, we include the leaf of the path into $p_0$. The leaf is selected from the state based on value of $b$ (defined as in the previous section). |
+| $f_{abp}=1$                                      | $p_0' = p_0 \cdot (v_h + v'_b + v'_c - (v_b + v_c))$     | When absorbing a new set of elements into the state while computing a linear hash, we include deltas between the last $8$ elements of the hasher state (the rate) into $p_0$.        |
+| $f_{hout}=1$                                     | $p_0' = p_0 \cdot (v_h + v_b)$                           | When a computation is complete, we include the second word of the hasher state (the result) into $p_0$                                                                               |
+| $f_{sout}=1$                                     | $p_0' = p_0 \cdot (v_h + v_a + v_b + v_c)$               | When we want to return the entire state of the hasher, we include the whole state into $p_0$                                                                                         |
+| otherwise                                        | $p_0' = p_0$                                             | $p_0$ does not change.                                                                                                                                                               |
+
+We can combine the above constraints into a single expression like so:
+
+$$
+p_0' = p_0 \cdot ([(f_{bp} + f_{sout}) \cdot (v_h + v_a + v_b + v_c)] + \\
+[(f_{mp} + f_{mv} + f_{mu}) \cdot (v_h + (1-b) \cdot v_b + b \cdot v_d)] + \\
+[f_{abp} \cdot (v_h + v'_b + v'_c - (v_b + v_c)] + [f_{hout} \cdot (v_h + v_b)] + \\
+1 - (f_{bp} + f_{mp} + f_{mv} + f_{mu} + f_{abp} + f_{out})
+)
+$$
+
+Note that the degree of the above constraint is $7$.
+
+To describe constraints for column $p_1$, we will change the definition of the _common header_ as follows:
+
+$$
+v_g = \beta + \alpha^3 \cdot i
+$$
+
+Then, the constraints can be described as follows:
+
+| Condition\_                 | Constraint                                               | Description                                                                                                                        |
+| --------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| $f_{mv}=1$ <br> $f_{mva}=1$ | $p_1' = p_1 \cdot (v_g + b \cdot v_b + (1-b) \cdot v_d)$ | When starting a Merkle root update or absorbing a new node into the hasher state, the non-leaf node should be included into $p_1$. |
+| $f_{mu}=1$ <br> $f_{mua}=1$ | $p_1' \cdot (v_g + b \cdot v_b + (1-b) \cdot v_d) = p_1$ | When starting a Merkle root update or absorbing a new node into the hasher state, the non-leaf node should be removed from $p_1$.  |
+| otherwise                   | $p_1' = p_1$                                             | $p_1$ does not change.                                                                                                             |
+
+We can combine the above constraints into a single expression like so:
+
+$$
+p_1' \cdot \left( (f_{mv} + f_{mva}) \cdot (v_g + b \cdot v_b + (1-b) \cdot v_d) + 1 - (f_{mv} + f_{mva}) \right) = \\
+p_1 \cdot \left( (f_{mu} + f_{mua}) \cdot (v_g + b \cdot v_b + (1-b) \cdot v_d) + 1 - (f_{mu} + f_{mua}) \right)
+$$
+
+Note that the degree of the above constraint is $7$.
+
+Together with boundary constraints enforcing that $p_1=1$ at the first and last rows, the above constraint ensures that if a node was included into $p_1$ as a part of verifying the old Merkle path, the same node must be removed from $p_1$ as a part of verifying the new Merkle path.

--- a/miden/tests/integration/air/hasher.rs
+++ b/miden/tests/integration/air/hasher.rs
@@ -1,0 +1,90 @@
+use crate::build_op_test;
+use crate::helpers::crypto::{init_merkle_leaf, init_merkle_leaves};
+use rand_utils::rand_vector;
+use vm_core::{AdviceSet, StarkField};
+
+#[test]
+fn rpperm() {
+    let asm_op = "rpperm";
+    let pub_inputs = rand_vector::<u64>(8);
+
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+}
+
+#[test]
+fn rphash() {
+    let asm_op = "rphash";
+    let pub_inputs = rand_vector::<u64>(8);
+
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+}
+
+#[test]
+fn mtree_get() {
+    let asm_op = "mtree.get";
+
+    let index = 3usize;
+    let leaves = init_merkle_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
+    let tree = AdviceSet::new_merkle_tree(leaves).unwrap();
+
+    let stack_inputs = [
+        tree.root()[0].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[3].as_int(),
+        index as u64,
+        tree.depth() as u64,
+    ];
+
+    build_op_test!(asm_op, &stack_inputs, &[], vec![tree]).prove_and_verify(
+        stack_inputs.to_vec(),
+        0,
+        false,
+    );
+}
+
+#[test]
+fn mtree_set() {
+    let asm_op = "mtree.set";
+    let (stack_inputs, tree) = build_mtree_update_test_inputs();
+
+    build_op_test!(asm_op, &stack_inputs, &[], vec![tree]).prove_and_verify(
+        stack_inputs.to_vec(),
+        0,
+        false,
+    );
+}
+
+#[test]
+fn mtree_cwm() {
+    let asm_op = "mtree.cwm";
+    let (stack_inputs, tree) = build_mtree_update_test_inputs();
+
+    build_op_test!(asm_op, &stack_inputs, &[], vec![tree]).prove_and_verify(stack_inputs, 0, false);
+}
+
+/// Helper function that builds a test stack and Merkle tree for testing mtree updates.
+fn build_mtree_update_test_inputs() -> (Vec<u64>, AdviceSet) {
+    let index = 5_usize;
+    let leaves = init_merkle_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
+    let tree = AdviceSet::new_merkle_tree(leaves.clone()).unwrap();
+
+    let new_node = init_merkle_leaf(9);
+    let mut new_leaves = leaves;
+    new_leaves[index] = new_node;
+
+    let stack_inputs = vec![
+        tree.root()[0].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[3].as_int(),
+        new_node[0].as_int(),
+        new_node[1].as_int(),
+        new_node[2].as_int(),
+        new_node[3].as_int(),
+        index as u64,
+        tree.depth() as u64,
+    ];
+
+    (stack_inputs, tree)
+}

--- a/miden/tests/integration/air/mod.rs
+++ b/miden/tests/integration/air/mod.rs
@@ -2,6 +2,7 @@ use crate::build_test;
 use rand_utils::rand_vector;
 
 mod bitwise;
+mod hasher;
 mod memory;
 
 #[test]

--- a/miden/tests/integration/helpers/crypto.rs
+++ b/miden/tests/integration/helpers/crypto.rs
@@ -1,0 +1,13 @@
+use super::Felt;
+use vm_core::{FieldElement, Word};
+
+// CRYPTO HELPER FUNCTIONS
+// ================================================================================================
+
+pub fn init_merkle_leaves(values: &[u64]) -> Vec<Word> {
+    values.iter().map(|&v| init_merkle_leaf(v)).collect()
+}
+
+pub fn init_merkle_leaf(value: u64) -> Word {
+    [Felt::new(value), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+}

--- a/miden/tests/integration/helpers/mod.rs
+++ b/miden/tests/integration/helpers/mod.rs
@@ -3,6 +3,8 @@ use processor::{ExecutionError, ExecutionTrace, Process, VmStateIterator};
 use proptest::prelude::*;
 pub use vm_core::{program::Script, Felt, FieldElement, ProgramInputs, MIN_STACK_DEPTH};
 
+pub mod crypto;
+
 // CONSTANTS
 // ================================================================================================
 pub const WORD_LEN: usize = 4;

--- a/miden/tests/integration/operations/crypto_ops.rs
+++ b/miden/tests/integration/operations/crypto_ops.rs
@@ -1,10 +1,11 @@
 use rand_utils::rand_vector;
 use vm_core::{
     hasher::{apply_permutation, hash_elements, STATE_WIDTH},
-    AdviceSet, Felt, FieldElement, StarkField, Word,
+    AdviceSet, Felt, FieldElement, StarkField,
 };
 
 use crate::build_op_test;
+use crate::helpers::crypto::{init_merkle_leaf, init_merkle_leaves};
 
 // TESTS
 // ================================================================================================
@@ -94,7 +95,7 @@ fn mtree_get() {
     let asm_op = "mtree.get";
 
     let index = 3usize;
-    let leaves = init_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
+    let leaves = init_merkle_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
     let tree = AdviceSet::new_merkle_tree(leaves.clone()).unwrap();
 
     let stack_inputs = [
@@ -124,10 +125,10 @@ fn mtree_get() {
 #[test]
 fn mtree_update() {
     let index = 5usize;
-    let leaves = init_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
+    let leaves = init_merkle_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
     let tree = AdviceSet::new_merkle_tree(leaves.clone()).unwrap();
 
-    let new_node = init_leaf(9);
+    let new_node = init_merkle_leaf(9);
     let mut new_leaves = leaves;
     new_leaves[index] = new_node;
     let new_tree = AdviceSet::new_merkle_tree(new_leaves).unwrap();
@@ -208,12 +209,4 @@ fn build_expected_hash(values: &[u64]) -> [Felt; 4] {
     expected.reverse();
 
     expected
-}
-
-fn init_leaves(values: &[u64]) -> Vec<Word> {
-    values.iter().map(|&v| init_leaf(v)).collect()
-}
-
-fn init_leaf(value: u64) -> Word {
-    [Felt::new(value), Felt::ZERO, Felt::ZERO, Felt::ZERO]
 }

--- a/processor/src/aux_table/tests.rs
+++ b/processor/src/aux_table/tests.rs
@@ -1,11 +1,12 @@
 use super::{
-    super::{
-        hasher::{LINEAR_HASH, RETURN_STATE},
-        ExecutionTrace, Operation, Process,
-    },
+    super::{ExecutionTrace, Operation, Process},
     AuxTableTrace,
 };
-use vm_core::{bitwise::BITWISE_OR, Felt, FieldElement, ProgramInputs, AUX_TRACE_RANGE};
+use vm_core::{
+    bitwise::BITWISE_OR,
+    hasher::{LINEAR_HASH, RETURN_STATE},
+    Felt, FieldElement, ProgramInputs, AUX_TRACE_RANGE,
+};
 
 #[test]
 fn hasher_aux_trace() {

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -1,6 +1,9 @@
 use super::{Felt, FieldElement, StarkField, TraceFragment, Word};
 use core::ops::Range;
-use vm_core::hasher::STATE_WIDTH;
+use vm_core::hasher::{
+    Selectors, LINEAR_HASH, MP_VERIFY, MR_UPDATE_NEW, MR_UPDATE_OLD, RETURN_HASH, RETURN_STATE,
+    STATE_WIDTH, TRACE_WIDTH,
+};
 
 mod trace;
 use trace::HasherTrace;
@@ -14,43 +17,10 @@ mod tests;
 /// Elements of the hasher state which are returned as hash result.
 const HASH_RESULT_RANGE: Range<usize> = Range { start: 4, end: 8 };
 
-/// Number of selector columns in the trace.
-const NUM_SELECTORS: usize = 3;
-
-/// Number of columns in Hasher execution trace. Additional two columns are for row address and
-/// node index columns.
-const TRACE_WIDTH: usize = NUM_SELECTORS + STATE_WIDTH + 2;
-
-/// Specifies a start of a new linear hash computation or absorption of new elements into an
-/// executing linear hash computation. These selectors can also be used for a simple 2-to-1 hash
-/// computation.
-pub const LINEAR_HASH: Selectors = [Felt::ONE, Felt::ZERO, Felt::ZERO];
-
-/// Specifies a start of Merkle path verification computation or absorption of a new path node
-/// into the hasher state.
-pub const MP_VERIFY: Selectors = [Felt::ONE, Felt::ZERO, Felt::ONE];
-
-/// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
-/// state for the "old" node value during Merkle root update computation.
-pub const MR_UPDATE_OLD: Selectors = [Felt::ONE, Felt::ONE, Felt::ZERO];
-
-/// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
-/// state for the "new" node value during Merkle root update computation.
-pub const MR_UPDATE_NEW: Selectors = [Felt::ONE, Felt::ONE, Felt::ONE];
-
-/// Specifies a completion of a computation such that only the hash result (values in h0, h1, h2
-/// h3) is returned.
-pub const RETURN_HASH: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ZERO];
-
-/// Specifies a completion of a computation such that the entire hasher state (values in h0 through
-/// h11) is returned.
-pub const RETURN_STATE: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ONE];
-
 // TYPE ALIASES
 // ================================================================================================
 
 type HasherState = [Felt; STATE_WIDTH];
-type Selectors = [Felt; NUM_SELECTORS];
 
 // HASH PROCESSOR
 // ================================================================================================


### PR DESCRIPTION
This PR closes #179 , finishing all AIR constraints for the auxiliary table.

It contains the following changes:
- adds the original design docs for the hash processor
- updates the hash processor design with some required constraint changes
- implements the air constraints
- adds integration tests and basic unit test for the hash processor's AIR constraints