### PR TITLE
 (fix)[assembly]: make the u32assert error clearer

### DIFF
--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -34,11 +34,11 @@ fn u32add_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if a + b >= 2^32
     let a = u32::MAX;
@@ -77,7 +77,7 @@ fn u32add_b_fail() {
 
     // should fail during execution if a >= 2^32
     let test = build_op_test!(build_asm_op(0).as_str(), &[U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32
     test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);
@@ -105,11 +105,11 @@ fn u32add_full_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -139,11 +139,11 @@ fn u32addc_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[0, 0, U32_BOUND, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[0, U32_BOUND, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if c > 1
     let test = build_op_test!(asm_op, &[2, 0, 0]);
@@ -217,11 +217,11 @@ fn u32sub_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if a < b
     let a = 1_u64;
@@ -268,7 +268,7 @@ fn u32sub_b_fail() {
 
     // should fail during execution if a >= 2^32
     let test = build_op_test!(build_asm_op(0).as_str(), &[U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32
     test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);
@@ -295,11 +295,11 @@ fn u32sub_full_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -349,11 +349,11 @@ fn u32mul_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if a * b  >= 2^32
     let a = u32::MAX as u64;
@@ -397,7 +397,7 @@ fn u32mul_b_fail() {
 
     // should fail during execution if a >= 2^32
     let test = build_op_test!(build_asm_op(0).as_str(), &[U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32
     test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);
@@ -424,11 +424,11 @@ fn u32mul_full_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -458,15 +458,15 @@ fn u32madd_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[0, 0, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[0, U32_BOUND, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if c  >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 0, 0]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -518,11 +518,11 @@ fn u32div_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[1, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b == 0
     let test = build_op_test!(asm_op, &[1, 0]);
@@ -568,7 +568,7 @@ fn u32div_b_fail() {
 
     // should fail during execution if a >= 2^32
     let test = build_op_test!(build_asm_op(1).as_str(), &[U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32
     test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);
@@ -593,11 +593,11 @@ fn u32div_full_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[1, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b == 0
     let test = build_op_test!(asm_op, &[1, 0]);
@@ -639,11 +639,11 @@ fn u32mod_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 2^32
     let test = build_op_test!(asm_op, &[1, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b == 0
     let test = build_op_test!(asm_op, &[1, 0]);
@@ -687,9 +687,9 @@ fn u32mod_b() {
 fn u32mod_b_fail() {
     let build_asm_op = |param: u64| format!("u32mod.{}", param);
 
-    // should fail during exeuction if a >= 2^32
+    // should fail during execution if a >= 2^32
     let test = build_op_test!(build_asm_op(1).as_str(), &[U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32
     test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);

--- a/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -207,11 +207,12 @@ fn u32shl_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 32
     let test = build_op_test!(asm_op, &[1, 32]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    // if b >= 32, 2^b >= 2^32 or not a u32
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -336,11 +337,11 @@ fn u32shr_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 32
     let test = build_op_test!(asm_op, &[1, 32]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -621,7 +622,7 @@ fn u32rotr_fail() {
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail if b >= 32
     let test = build_op_test!(asm_op, &[1, 32]);

--- a/miden/tests/integration/operations/u32_ops/comparison_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/comparison_ops.rs
@@ -90,7 +90,7 @@ fn u32eq_b_fail() {
     // should fail when b is a valid parameter but a is out of bounds
     let asm_op = format!("{}.{}", asm_op, 1);
     let test = build_op_test!(&asm_op, &[U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn u32neq_b_fail() {
     // should fail when b is a valid parameter but a is out of bounds
     let asm_op = format!("{}.{}", asm_op, 1);
     let test = build_op_test!(&asm_op, &[U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]

--- a/miden/tests/integration/operations/u32_ops/conversion_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/conversion_ops.rs
@@ -96,7 +96,7 @@ fn u32assert_fail() {
     // assertion fails if a >= 2^32
     let asm_op = "u32assert";
     let asm_op_1 = "u32assert.1";
-    let err = "FailedAssertion";
+    let err = "NotU32Value";
 
     // vars to test
     let equal = 1_u64 << 32;
@@ -178,7 +178,7 @@ fn u32assertw() {
 fn u32assertw_fail() {
     // fails if any element in the word >= 2^32
     let asm_op = "u32assertw";
-    let err = "FailedAssertion";
+    let err = "NotU32Value";
 
     // --- any one of the inputs inputs >= 2^32 (out of bounds) -----------------------------------
     test_inputs_out_of_bounds(asm_op, WORD_LEN);

--- a/miden/tests/integration/operations/u32_ops/mod.rs
+++ b/miden/tests/integration/operations/u32_ops/mod.rs
@@ -17,7 +17,7 @@ pub const U32_BOUND: u64 = u32::MAX as u64 + 1;
 /// ensure that it fails when the input is >= 2^32.
 pub fn test_input_out_of_bounds(asm_op: &str) {
     let test = build_op_test!(asm_op, &[U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 /// This helper function tests a provided u32 assembly operation, which takes multiple inputs, to
@@ -31,7 +31,7 @@ pub fn test_inputs_out_of_bounds(asm_op: &str, input_count: usize) {
         i_inputs[i] = U32_BOUND;
 
         let test = build_op_test!(asm_op, &i_inputs);
-        test.expect_error(TestError::ExecutionError("FailedAssertion"));
+        test.expect_error(TestError::ExecutionError("NotU32Value"));
     }
 }
 

--- a/miden/tests/integration/stdlib/math/u64_mod.rs
+++ b/miden/tests/integration/stdlib/math/u64_mod.rs
@@ -75,7 +75,7 @@ fn checked_add_fail() {
     let b1 = u32::MAX as u64 + 1;
 
     let test = build_test!(source, &[a0, a1, b0, b1]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -184,7 +184,7 @@ fn checked_sub_fail() {
     let b1 = u32::MAX as u64 + 1;
 
     let test = build_test!(source, &[a0, a1, b0, b1]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 }
 
 #[test]
@@ -306,7 +306,7 @@ fn checked_mul_fail() {
     let b1 = u32::MAX as u64 + 1;
 
     let test = build_test!(source, &[a0, a1, b0, b1]);
-    test.expect_error(TestError::ExecutionError("FailedAssertion"));
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // Higher bits assertion failure (a_hi * b_hi != 0)
 


### PR DESCRIPTION
Change the `u32assert` assembly instruction from `U32SPLIT EQZ ASSERT`
to `PAD U32ASSERT2 DROP` to give the better error message `NotU32Value`
instead of `FailedAssertion`. Update associated tests.

Closes #213 