### PR TITLE
feat(air): add new constraint to bitwise_pow2 aux_table 

### DIFF
--- a/air/src/aux_table/bitwise_pow2/bitwise/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/bitwise/mod.rs
@@ -11,7 +11,7 @@ use vm_core::{
 use winter_air::TransitionConstraintDegree;
 
 #[cfg(test)]
-mod tests;
+pub mod tests;
 
 // CONSTANTS
 // ================================================================================================

--- a/air/src/aux_table/bitwise_pow2/bitwise/tests.rs
+++ b/air/src/aux_table/bitwise_pow2/bitwise/tests.rs
@@ -194,7 +194,7 @@ pub fn get_test_frame(
 /// Generates the trace frame of an customised two consecutive cycle row. Accepts decomposed input
 /// containing bits wise component of both a and b for the consecutive cycle row and two selectors.
 /// Returns the frame with these two consecutive cycle row.  
-fn get_test_frame_with_two_selectors(
+pub fn get_test_frame_with_two_selectors(
     curr: &[Felt],
     next: &[Felt],
     operation1: Selectors,

--- a/air/src/aux_table/bitwise_pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/mod.rs
@@ -6,19 +6,25 @@ use vm_core::{bitwise::NUM_SELECTORS, utils::range as create_range, Felt};
 mod bitwise;
 mod pow2;
 
+#[cfg(test)]
+pub mod tests;
+
 // CONSTANTS
 // ================================================================================================
 
 /// The number of rows required to compute an operation in the Bitwise & Power of Two co-processor.
 pub const OP_CYCLE_LEN: usize = 8;
+/// Index of CONSTRAINT_DEGREES array after which all constraints use periodic columns.
+const PERIODIC_CONSTRAINTS_START: usize = 2;
 /// The number of shared constraints on the combined trace of the Bitwise and Power of Two
 /// operation execution traces.
-pub const NUM_CONSTRAINTS: usize = 2;
+pub const NUM_CONSTRAINTS: usize = 4;
 /// The degrees of constraints on the combined trace of the Bitwise and Power of Two traces. The
 /// degree of all constraints is increased by 2 due to the co-processor selector flag from the
 /// Auxiliary Table.
 pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
     4, 4, // Selector flags must be binary.
+    4, 4, // Selector flags should remain the same throughout the cycle.
 ];
 /// The range of indices for selector columns in the trace.
 const SELECTOR_COL_RANGE: Range<usize> = create_range(BITWISE_TRACE_OFFSET, NUM_SELECTORS);
@@ -31,10 +37,20 @@ const POW2_TRACE_OFFSET: usize = SELECTOR_COL_RANGE.end;
 /// Builds the transition constraint degrees for the combined bitwise and power of two trace,
 /// including the shared constraints and the constraints for each of the co-processors.
 pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    // Add the degrees of non-periodic constraints.
     let mut degrees: Vec<TransitionConstraintDegree> = CONSTRAINT_DEGREES
+        [..PERIODIC_CONSTRAINTS_START]
         .iter()
         .map(|&degree| TransitionConstraintDegree::new(degree))
         .collect();
+
+    // Add the degrees of periodic constraints.
+    degrees.append(
+        &mut CONSTRAINT_DEGREES[PERIODIC_CONSTRAINTS_START..]
+            .iter()
+            .map(|&degree| TransitionConstraintDegree::with_cycles(degree - 1, vec![OP_CYCLE_LEN]))
+            .collect(),
+    );
 
     degrees.append(&mut bitwise::get_transition_constraint_degrees());
 
@@ -60,7 +76,7 @@ pub fn enforce_constraints<E: FieldElement>(
     processor_flag: E,
 ) {
     // Selector transition constraints applying to both bitwise and power of two operations.
-    enforce_selectors(frame, result, processor_flag);
+    enforce_selectors(frame, periodic_values, result, processor_flag);
 
     let mut constraint_offset = NUM_CONSTRAINTS;
     // bitwise transition constraints
@@ -85,15 +101,32 @@ pub fn enforce_constraints<E: FieldElement>(
 // ================================================================================================
 
 /// Constraint evaluation function to enforce that the Bitwise and Power of Two selector columns
-/// must be binary.
+/// must be binary and they remain the same throughout the cycle.
 fn enforce_selectors<E: FieldElement>(
     frame: &EvaluationFrame<E>,
+    periodic_values: &[E],
     result: &mut [E],
     processor_flag: E,
 ) {
+    let k1 = periodic_values[1];
+    let mut constraint_offset = 0;
+
     // All selectors must be binary for the entire table.
     for (idx, result) in result.iter_mut().enumerate().take(NUM_SELECTORS) {
         *result = processor_flag * is_binary(frame.selector(idx));
+    }
+
+    constraint_offset += NUM_SELECTORS;
+
+    // Selector values should stay the same for the entire cycle. In other words, the value can
+    // only change when there is a transition to a new cycle i.e. from last row of a cycle and the
+    // first row of the new cycle, when periodic column k1=0.
+    for (idx, result) in result[constraint_offset..]
+        .iter_mut()
+        .enumerate()
+        .take(NUM_SELECTORS)
+    {
+        *result = processor_flag * k1 * (frame.selector(idx) - frame.selector_next(idx));
     }
 }
 
@@ -108,6 +141,9 @@ trait EvaluationFrameExt<E: FieldElement> {
     /// Accessor for the selector column of the current row at the specified index.
     fn selector(&self, index: usize) -> E;
 
+    /// Accessor for the selector column of the next row at the specified index.
+    fn selector_next(&self, index: usize) -> E;
+
     // --- Co-processor selector flags ------------------------------------------------------------
 
     /// Flag to indicate if the frame is executing a power of two operation.
@@ -120,6 +156,11 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     #[inline(always)]
     fn selector(&self, index: usize) -> E {
         self.current()[SELECTOR_COL_RANGE.start + index]
+    }
+
+    #[inline(always)]
+    fn selector_next(&self, index: usize) -> E {
+        self.next()[SELECTOR_COL_RANGE.start + index]
     }
 
     // --- Co-processor selector flags ------------------------------------------------------------

--- a/air/src/aux_table/bitwise_pow2/tests.rs
+++ b/air/src/aux_table/bitwise_pow2/tests.rs
@@ -1,0 +1,50 @@
+use super::super::bitwise_pow2;
+use super::bitwise::tests::get_test_frame_with_two_selectors;
+use super::{bitwise, pow2};
+use crate::{Felt, FieldElement};
+use vm_core::bitwise::{BITWISE_OR, BITWISE_XOR};
+
+// UNIT TESTS
+// ================================================================================================
+
+pub const NUM_CONSTRAINTS: usize =
+    bitwise_pow2::NUM_CONSTRAINTS + bitwise::NUM_CONSTRAINTS + pow2::NUM_CONSTRAINTS;
+
+#[test]
+/// Tests that the bitwise constraints do not all evaluate to zero if the operation selectors change
+/// within a cycle even when the output column will be same for both of them.
+fn test_bitwise_pow2_selectors_fail() {
+    let current_bitwise = vec![
+        Felt::ONE,
+        Felt::ONE,
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ONE,
+        Felt::ZERO,
+        Felt::ONE,
+        Felt::ONE,
+    ];
+
+    let next_bitwise = vec![
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ONE,
+        Felt::ONE,
+        Felt::ONE,
+        Felt::ONE,
+    ];
+    let cycle = 1;
+    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    let frame =
+        get_test_frame_with_two_selectors(&current_bitwise, &next_bitwise, BITWISE_OR, BITWISE_XOR);
+
+    let periodic_values = bitwise_pow2::get_periodic_values(cycle);
+    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    bitwise_pow2::enforce_constraints(&frame, &periodic_values, &mut result, Felt::ONE);
+
+    assert_ne!(result, expected);
+}

--- a/docs/src/design/aux_table/main.md
+++ b/docs/src/design/aux_table/main.md
@@ -95,9 +95,11 @@ The selectors for each operation are as follows:
 - `U32XOR`: $s_0 = 1$, $s_1 = 0$
 - `POW2`: $s_0 = 1$, $s_1 = 1$
 
-The constraints must require that the selectors be binary:
+The constraints must require that the selectors be binary and stay the same throughout the cycle:
 $$s_0^2 - s_0 = 0$$
 $$s_1^2 - s_1 = 0$$
+$$s_{0,i}' -s_{0,i} = 0\  \forall\ i \in \{0, 1, ..., 6\}$$
+$$s_{1,i}' -s_{1,i} = 0\  \forall\ i \in \{0, 1, ..., 6\}$$
 
 ## Challenge: the last row problem
 


### PR DESCRIPTION
This PR address #206.

New constraints have been added to bitwise_pow2 aux_table to assert that the selector values remain same throughout the cycle.