### PR TITLE
Implement running product column `p0` in the range checker

### DIFF
--- a/air/src/range.rs
+++ b/air/src/range.rs
@@ -1,4 +1,8 @@
-use vm_core::range::{S0_COL_IDX, S1_COL_IDX, T_COL_IDX, V_COL_IDX};
+use vm_core::{
+    range::{P0_COL_IDX, S0_COL_IDX, S1_COL_IDX, T_COL_IDX, V_COL_IDX},
+    ExtensionOf,
+};
+use winter_air::AuxTraceRandElements;
 
 use super::{
     utils::{binary_not, is_binary},
@@ -8,7 +12,11 @@ use super::{
 // CONSTANTS
 // ================================================================================================
 
-/// The number of constraints required by the Range Checker.
+// --- Main constraints ---------------------------------------------------------------------------
+
+/// The number of boundary constraints required by the Range Checker
+pub const NUM_ASSERTIONS: usize = 2;
+/// The number of transition constraints required by the Range Checker.
 pub const NUM_CONSTRAINTS: usize = 7;
 /// The degrees of the range checker's constraints, in the order they'll be added to the the result
 /// array when a transition is evaluated.
@@ -19,24 +27,48 @@ pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
     3, 3, // Enforce values of column v before and after 8-bit to 16-bit transition.
 ];
 
-pub const NUM_ASSERTIONS: usize = 2;
+// --- Auxiliary column constraints for multiset checks -------------------------------------------
+
+/// The number of auxiliary assertions for multiset checks.
+pub const NUM_AUX_ASSERTIONS: usize = 2;
+/// The number of transition constraints required by multiset checks for the Range Checker.
+pub const NUM_AUX_CONSTRAINTS: usize = 1;
+/// The degrees of the Range Checker's auxiliary column constraints, used for multiset checks.
+pub const AUX_CONSTRAINT_DEGREES: [usize; NUM_AUX_CONSTRAINTS] = [8];
 
 // BOUNDARY CONSTRAINTS
 // ================================================================================================
 
-/// Returns the range checker's boundary assertions for the first step.
+// --- MAIN TRACE ---------------------------------------------------------------------------------
+
+/// Returns the range checker's boundary assertions for the main trace at the first step.
 pub fn get_assertions_first_step(result: &mut Vec<Assertion<Felt>>) {
     let step = 0;
     result.push(Assertion::single(V_COL_IDX, step, Felt::ZERO));
 }
 
-/// Returns the range checker's boundary assertions for the last step.
+/// Returns the range checker's boundary assertions for the main trace at the last step.
 pub fn get_assertions_last_step(result: &mut Vec<Assertion<Felt>>, step: usize) {
     result.push(Assertion::single(V_COL_IDX, step, Felt::new(65535)));
 }
 
+// --- AUXILIARY COLUMNS (FOR MULTISET CHECKS) ----------------------------------------------------
+
+/// Returns the range checker's boundary assertions for auxiliary columns at the first step.
+pub fn get_aux_assertions_first_step<E: FieldElement>(result: &mut Vec<Assertion<E>>) {
+    let step = 0;
+    result.push(Assertion::single(P0_COL_IDX, step, E::ONE));
+}
+
+/// Returns the range checker's boundary assertions for auxiliary columns at the last step.
+pub fn get_aux_assertions_last_step<E: FieldElement>(result: &mut Vec<Assertion<E>>, step: usize) {
+    result.push(Assertion::single(P0_COL_IDX, step, E::ONE));
+}
+
 // TRANSITION CONSTRAINTS
 // ================================================================================================
+
+// --- MAIN TRACE ---------------------------------------------------------------------------------
 
 /// Builds the transition constraint degrees for the range checker.
 pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
@@ -63,8 +95,37 @@ pub fn enforce_constraints<E: FieldElement>(frame: &EvaluationFrame<E>, result: 
     enforce_16bit(frame, &mut result[index..]);
 }
 
+// --- AUXILIARY COLUMNS (FOR MULTISET CHECKS) ----------------------------------------------------
+
+/// Returns the transition constraint degrees for the range checker's auxiliary columns, used for
+/// multiset checks.
+pub fn get_aux_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    AUX_CONSTRAINT_DEGREES
+        .iter()
+        .map(|&degree| TransitionConstraintDegree::new(degree))
+        .collect()
+}
+
+/// Enforces constraints on the range checker's auxiliary columns.
+pub fn enforce_aux_constraints<F, E>(
+    main_frame: &EvaluationFrame<F>,
+    aux_frame: &EvaluationFrame<E>,
+    aux_rand_elements: &AuxTraceRandElements<E>,
+    result: &mut [E],
+) where
+    F: FieldElement<BaseField = Felt>,
+    E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
+{
+    let alpha = aux_rand_elements.get_segment_elements(0)[0];
+
+    // Enforce p0.
+    enforce_running_product_p0(main_frame, aux_frame, alpha, result);
+}
+
 // TRANSITION CONSTRAINT HELPERS
 // ================================================================================================
+
+// --- MAIN TRACE ---------------------------------------------------------------------------------
 
 /// Constrain the selector flags to binary values.
 fn enforce_flags<E: FieldElement>(frame: &EvaluationFrame<E>, result: &mut [E]) -> usize {
@@ -103,6 +164,63 @@ fn enforce_16bit<E: FieldElement>(frame: &EvaluationFrame<E>, result: &mut [E]) 
     constraint_count
 }
 
+// --- AUXILIARY COLUMNS (FOR MULTISET CHECKS) ----------------------------------------------------
+
+/// Ensures that the running product auxiliary column `p0` is correctly built up during the 8-bit
+/// section of the range check table and then correctly reduced in the 16-bit section of the table.
+///
+/// In the 8-bit section, when `t=0` the value of `z` is included in the running product at each
+/// step, and the constraint reduces to p0' = p0 * z.
+/// In the 16-bit section, when `t=1`, the running product is reduced by the difference between the
+/// current and next value, and the constraint reduces to p0' * (alpha + v' - v) = p0.
+fn enforce_running_product_p0<E, F>(
+    main_frame: &EvaluationFrame<F>,
+    aux_frame: &EvaluationFrame<E>,
+    alpha: E,
+    result: &mut [E],
+) -> usize
+where
+    F: FieldElement<BaseField = Felt>,
+    E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
+{
+    let mut constraint_offset = 0;
+
+    let z = get_z(main_frame, alpha);
+    let t = main_frame.t().into();
+    let p0_term = aux_frame.p0() * (z - z * t + t);
+    let p0_next_term = aux_frame.p0_next()
+        * ((alpha + main_frame.v_next().into() - main_frame.v().into()) * t - t + E::ONE);
+    result[constraint_offset] = p0_next_term - p0_term;
+    constraint_offset += 1;
+
+    constraint_offset
+}
+
+/// Returns the value `z` which is included in the running product columns at each step. `z` causes
+/// the row's value to be included 0, 1, 2, or 4 times, according to the row's selector flags row.
+fn get_z<E, F>(main_frame: &EvaluationFrame<F>, alpha: E) -> E
+where
+    F: FieldElement<BaseField = Felt>,
+    E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
+{
+    // Get the selectors and the value from the main frame.
+    let s0: E = main_frame.s0().into();
+    let s1: E = main_frame.s1().into();
+    let v: E = main_frame.v().into();
+
+    // Define the flags.
+    let f0: E = binary_not(s0) * binary_not(s1);
+    let f1: E = s0 * binary_not(s1);
+    let f2: E = binary_not(s0) * s1;
+    let f3: E = s0 * s1;
+
+    // Compute z.
+    let v_alpha = v + alpha;
+    let v_alpha2 = v_alpha.square();
+    let v_alpha4 = v_alpha2.square();
+    f3 * v_alpha4 + f2 * v_alpha2 + f1 * v_alpha + f0
+}
+
 // RANGE CHECKER FRAME EXTENSION TRAIT
 // ================================================================================================
 
@@ -123,12 +241,18 @@ trait EvaluationFrameExt<E: FieldElement> {
     fn v(&self) -> E;
     /// The next value in column V.
     fn v_next(&self) -> E;
+    /// The current value in auxiliary column p0.
+    fn p0(&self) -> E;
+    /// The next value in auxiliary column p0.
+    fn p0_next(&self) -> E;
 
     // --- Intermediate variables & helpers -------------------------------------------------------
 
     /// The change between the current value in the specified column and the next value, calculated
     /// as `next - current`.
     fn change(&self, column: usize) -> E;
+
+    // --- Flags ----------------------------------------------------------------------------------
 
     /// A flag set to 1 when column t changes for 0 to 1 indicating the transition from the 8-bit to
     /// 16-bit sections of the range checker table.
@@ -168,6 +292,16 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
         self.next()[V_COL_IDX]
     }
 
+    #[inline(always)]
+    fn p0(&self) -> E {
+        self.current()[P0_COL_IDX]
+    }
+
+    #[inline(always)]
+    fn p0_next(&self) -> E {
+        self.next()[P0_COL_IDX]
+    }
+
     // --- Intermediate variables & helpers -------------------------------------------------------
 
     #[inline(always)]
@@ -175,7 +309,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
         self.next()[column] - self.current()[column]
     }
 
-    // --- Flags -------------------------------------------------------------------------
+    // --- Flags ----------------------------------------------------------------------------------
 
     #[inline(always)]
     fn flip_to_16bit_flag(&self) -> E {

--- a/air/src/range.rs
+++ b/air/src/range.rs
@@ -1,4 +1,4 @@
-use vm_core::RANGE_CHECK_TRACE_OFFSET;
+use vm_core::range::{S0_COL_IDX, S1_COL_IDX, T_COL_IDX, V_COL_IDX};
 
 use super::{
     utils::{binary_not, is_binary},
@@ -18,17 +18,6 @@ pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
     2, // Transition from 8-bit to 16-bit section of range check table occurs at most once.
     3, 3, // Enforce values of column v before and after 8-bit to 16-bit transition.
 ];
-/// A binary selector column to track whether a transition currently in the 8-bit or 16-bit portion
-/// of the range checker table.
-pub const T_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET;
-/// A binary selector column to help specify whether or not the value should be included in the
-/// running product.
-pub const S0_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 1;
-/// A binary selector column to help specify whether or not the value should be included in the
-/// running product.
-pub const S1_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 2;
-/// A column to hold the values being range-checked.
-pub const V_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 3;
 
 pub const NUM_ASSERTIONS: usize = 2;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,9 +2,12 @@ use core::ops::Range;
 
 pub mod bitwise;
 pub mod decoder;
+pub mod errors;
 pub mod hasher;
 pub mod program;
-pub use math::{fields::f64::BaseElement as Felt, FieldElement, StarkField};
+pub mod range;
+
+pub use math::{fields::f64::BaseElement as Felt, ExtensionOf, FieldElement, StarkField};
 
 mod operations;
 pub use operations::{AdviceInjector, DebugOptions, Operation};
@@ -14,8 +17,6 @@ pub use inputs::{AdviceSet, ProgramInputs};
 
 pub mod utils;
 use utils::range;
-
-pub mod errors;
 
 // TYPE ALIASES
 // ================================================================================================
@@ -37,7 +38,7 @@ pub const MIN_STACK_DEPTH: usize = 16;
 /// Number of bookkeeping and helper columns in the stack trace.
 pub const NUM_STACK_HELPER_COLS: usize = 3;
 
-// TRACE LAYOUT
+// MAIN TRACE LAYOUT
 // ------------------------------------------------------------------------------------------------
 
 //      system          decoder           stack      range checks    auxiliary table
@@ -73,3 +74,13 @@ pub const AUX_TRACE_WIDTH: usize = 18;
 pub const AUX_TRACE_RANGE: Range<usize> = range(AUX_TRACE_OFFSET, AUX_TRACE_WIDTH);
 
 pub const TRACE_WIDTH: usize = AUX_TRACE_OFFSET + AUX_TRACE_WIDTH;
+
+// AUXILIARY COLUMNS LAYOUT
+// ------------------------------------------------------------------------------------------------
+
+//   range checks
+//    (2 columns)
+// ├───────────────┤
+
+// Range check auxiliary columns
+pub const RANGE_CHECK_AUX_TRACE_OFFSET: usize = 0;

--- a/core/src/range.rs
+++ b/core/src/range.rs
@@ -1,0 +1,25 @@
+use crate::{RANGE_CHECK_AUX_TRACE_OFFSET, RANGE_CHECK_TRACE_OFFSET};
+
+// CONSTANTS
+// ================================================================================================
+
+// --- Column accessors in the main trace ---------------------------------------------------------
+
+/// A binary selector column to track whether a transition currently in the 8-bit or 16-bit portion
+/// of the range checker table.
+pub const T_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET;
+/// A binary selector column to help specify whether or not the value should be included in the
+/// running product.
+pub const S0_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 1;
+/// A binary selector column to help specify whether or not the value should be included in the
+/// running product.
+pub const S1_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 2;
+/// A column to hold the values being range-checked.
+pub const V_COL_IDX: usize = RANGE_CHECK_TRACE_OFFSET + 3;
+
+// --- Column accessors in the auxiliary columns --------------------------------------------------
+
+/// The 8-bit running product column used for multiset checks.
+pub const P0_COL_IDX: usize = RANGE_CHECK_AUX_TRACE_OFFSET;
+/// The 16-bit running product column used for multiset checks.
+pub const P1_COL_IDX: usize = P0_COL_IDX + 1;

--- a/docs/src/design/range.md
+++ b/docs/src/design/range.md
@@ -213,7 +213,7 @@ $$
 p'_0 \cdot ((\alpha + v' - v) \cdot t - t + 1) = p_0 \cdot (z - z \cdot t + t)
 $$
 
-Thsu, when $t = 0$ (we are in the 8-bit section), the above expression reduces to:
+Thus, when $t = 0$ (we are in the 8-bit section), the above expression reduces to:
 
 $$
 p'_0 = p_0 \cdot z

--- a/miden/tests/integration/air/mod.rs
+++ b/miden/tests/integration/air/mod.rs
@@ -4,6 +4,7 @@ use rand_utils::rand_vector;
 mod bitwise;
 mod hasher;
 mod memory;
+mod range;
 
 #[test]
 fn aux_table() {

--- a/miden/tests/integration/air/range.rs
+++ b/miden/tests/integration/air/range.rs
@@ -1,0 +1,20 @@
+use crate::{build_op_test, build_test};
+
+/// Range checks the result of 1 + 1. This results in 2 range checks, one for each 16-bit limb of
+/// the 32-bit result (2 and 0).
+#[test]
+fn range_check_once() {
+    let asm_op = "u32add.unsafe";
+    let stack = vec![1, 1];
+
+    build_op_test!(asm_op, &stack).prove_and_verify(stack, 0, false);
+}
+
+/// Range checks multiple values a varying number of times, since each value is checked as an input.
+/// 5 is checked 3 times, 10 is checked twice, and 15 is checked once.
+#[test]
+fn range_check_multi() {
+    let source = "begin u32add u32add end";
+    let stack = vec![5, 5, 5];
+    build_test!(source, &stack).prove_and_verify(stack, 0, false);
+}

--- a/processor/src/aux_table/tests.rs
+++ b/processor/src/aux_table/tests.rs
@@ -101,7 +101,7 @@ fn build_trace(stack: &[u64], operations: Vec<Operation>) -> AuxTableTrace {
         process.execute_op(*operation).unwrap();
     }
 
-    let trace = ExecutionTrace::test_finalize_trace(process);
+    let (trace, _) = ExecutionTrace::test_finalize_trace(process);
     trace[AUX_TRACE_RANGE]
         .to_vec()
         .try_into()

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -548,7 +548,7 @@ fn build_trace(stack: &[u64], program: &CodeBlock) -> (DecoderTrace, usize) {
     let mut process = Process::new(inputs);
     process.execute_code_block(program).unwrap();
 
-    let trace = ExecutionTrace::test_finalize_trace(process);
+    let (trace, _) = ExecutionTrace::test_finalize_trace(process);
     let trace_len = trace.len() - ExecutionTrace::NUM_RAND_ROWS;
 
     (

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -56,8 +56,12 @@ pub use debug::{VmState, VmStateIterator};
 type SysTrace = [Vec<Felt>; SYS_TRACE_WIDTH];
 type DecoderTrace = [Vec<Felt>; DECODER_TRACE_WIDTH];
 type StackTrace = [Vec<Felt>; STACK_TRACE_WIDTH];
-type RangeCheckTrace = [Vec<Felt>; RANGE_CHECK_TRACE_WIDTH];
 type AuxTableTrace = [Vec<Felt>; AUX_TRACE_WIDTH]; // TODO: potentially rename to AuxiliaryTrace
+
+pub struct RangeCheckTrace {
+    trace: [Vec<Felt>; RANGE_CHECK_TRACE_WIDTH],
+    aux_trace_hints: range::AuxTraceHints,
+}
 
 // EXECUTOR
 // ================================================================================================

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -1,7 +1,12 @@
-use super::{Digest, Felt, FieldElement, Process, StackTopState};
+use super::{
+    range::AuxTraceHints as RangeCheckerAuxTraceHints, Digest, Felt, FieldElement, Process,
+    StackTopState,
+};
 use core::slice;
 use vm_core::{StarkField, MIN_STACK_DEPTH, MIN_TRACE_LEN, STACK_TRACE_OFFSET, TRACE_WIDTH};
 use winterfell::{EvaluationFrame, Matrix, Serializable, Trace, TraceLayout};
+
+mod range;
 
 // CONSTANTS
 // ================================================================================================
@@ -17,12 +22,17 @@ type RandomCoin = vm_core::utils::RandomCoin<Felt, vm_core::hasher::Hasher>;
 // VM EXECUTION TRACE
 // ================================================================================================
 
+pub struct AuxTraceHints {
+    range: RangeCheckerAuxTraceHints,
+}
+
 /// TODO: for now this consists only of system register trace, stack trace, range check trace, and
 /// auxiliary table trace, but will also need to include the decoder trace.
 pub struct ExecutionTrace {
     meta: Vec<u8>,
     layout: TraceLayout,
     main_trace: Matrix<Felt>,
+    aux_trace_hints: AuxTraceHints,
     // TODO: program hash should be retrieved from decoder trace, but for now we store it explicitly
     program_hash: Digest,
 }
@@ -43,12 +53,13 @@ impl ExecutionTrace {
         // we are using random values only to stabilize constraint degree, and not to achieve
         // perfect zero knowledge.
         let rng = RandomCoin::new(&program_hash.to_bytes());
-        let main_trace = finalize_trace(process, rng);
+        let (main_trace, aux_trace_hints) = finalize_trace(process, rng);
 
         Self {
             meta: Vec::new(),
-            layout: TraceLayout::new(TRACE_WIDTH, [0], [0]),
+            layout: TraceLayout::new(TRACE_WIDTH, [1], [1]),
             main_trace: Matrix::new(main_trace),
+            aux_trace_hints,
             program_hash,
         }
     }
@@ -94,7 +105,7 @@ impl ExecutionTrace {
     }
 
     #[cfg(test)]
-    pub fn test_finalize_trace(process: Process) -> Vec<Vec<Felt>> {
+    pub fn test_finalize_trace(process: Process) -> (Vec<Vec<Felt>>, AuxTraceHints) {
         let rng = RandomCoin::new(&[0; 32]);
         finalize_trace(process, rng)
     }
@@ -124,11 +135,33 @@ impl Trace for ExecutionTrace {
 
     fn build_aux_segment<E: FieldElement<BaseField = Felt>>(
         &mut self,
-        _aux_segments: &[Matrix<E>],
-        _rand_elements: &[E],
+        aux_segments: &[Matrix<E>],
+        rand_elements: &[E],
     ) -> Option<Matrix<E>> {
-        // TODO: implement
-        unimplemented!()
+        // We only have one auxiliary segment.
+        if !aux_segments.is_empty() {
+            return None;
+        }
+
+        let mut aux_columns = vec![vec![E::ZERO; self.length()]; self.aux_trace_width()];
+
+        // Add the range checker's running product column p0.
+        range::build_aux_col_p0(
+            &mut aux_columns[range::P0_COL_IDX],
+            &self.aux_trace_hints.range,
+            rand_elements,
+            self.main_trace.get_column(range::V_COL_IDX),
+        );
+
+        // Inject random values into the last rows of the trace.
+        let mut rng = RandomCoin::new(&self.program_hash.to_bytes());
+        for i in self.length() - NUM_RAND_ROWS..self.length() {
+            for column in aux_columns.iter_mut() {
+                column[i] = rng.draw().expect("failed to draw a random value");
+            }
+        }
+
+        Some(Matrix::new(aux_columns))
     }
 
     fn read_main_frame(&self, row_idx: usize, frame: &mut EvaluationFrame<Felt>) {
@@ -215,7 +248,7 @@ impl<'a> TraceFragment<'a> {
 /// - Inserting random values in the last row of all columns. This helps ensure that there
 ///   are no repeating patterns in each column and each column contains a least two distinct
 ///   values. This, in turn, ensures that polynomial degrees of all columns are stable.
-fn finalize_trace(process: Process, mut rng: RandomCoin) -> Vec<Vec<Felt>> {
+fn finalize_trace(process: Process, mut rng: RandomCoin) -> (Vec<Vec<Felt>>, AuxTraceHints) {
     let (system, decoder, stack, range, aux_table) = process.to_components();
 
     let clk = system.clk();
@@ -252,7 +285,7 @@ fn finalize_trace(process: Process, mut rng: RandomCoin) -> Vec<Vec<Felt>> {
         .into_iter()
         .chain(decoder_trace)
         .chain(stack_trace)
-        .chain(range_check_trace)
+        .chain(range_check_trace.trace)
         .chain(aux_table_trace)
         .collect::<Vec<_>>();
 
@@ -263,5 +296,9 @@ fn finalize_trace(process: Process, mut rng: RandomCoin) -> Vec<Vec<Felt>> {
         }
     }
 
-    trace
+    let aux_trace_hints = AuxTraceHints {
+        range: range_check_trace.aux_trace_hints,
+    };
+
+    (trace, aux_trace_hints)
 }

--- a/processor/src/trace/range.rs
+++ b/processor/src/trace/range.rs
@@ -1,0 +1,80 @@
+use super::{Felt, FieldElement, NUM_RAND_ROWS};
+use crate::range::{AuxColumnHint, AuxTraceHints};
+
+pub use vm_core::range::{P0_COL_IDX, P1_COL_IDX, T_COL_IDX, V_COL_IDX};
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Builds the execution trace of the range checker's `p0` auxiliary column used for multiset
+/// checks. The running product is built up in the 8-bit section of the table and reduced in the
+/// 16-bit section of the table so that the starting and ending value are both one.
+pub fn build_aux_col_p0<E: FieldElement<BaseField = Felt>>(
+    aux_column: &mut [E],
+    aux_trace_hints: &AuxTraceHints,
+    rand_elements: &[E],
+    v_col: &[Felt],
+) {
+    let alpha = rand_elements[0];
+    aux_column[0] = E::ONE;
+
+    // Build the execution trace of the 8-bit running product.
+    for (row_idx, hint) in aux_trace_hints
+        .aux_column_hints
+        .iter()
+        .enumerate()
+        .take(aux_trace_hints.start_16bit)
+    {
+        // This is the 8-bit section, where the running product must be built up.
+        let v: E = v_col[row_idx].into();
+
+        // Define variable z as: z = f3​*(α+v)^4 + f2*(α+v)^2 ​+ f1*(α+v) ​+ f0​
+        let z = match hint {
+            AuxColumnHint::F0 => E::ONE,
+            AuxColumnHint::F1 => v + alpha,
+            AuxColumnHint::F2 => (v + alpha).square(),
+            AuxColumnHint::F3 => ((v + alpha).square()).square(),
+        };
+
+        aux_column[row_idx + 1] = aux_column[row_idx] * z;
+    }
+
+    // Accumulate the value differences for each transition and their product in preparation for
+    // using a modified batch inversion to build the execution trace of the 16-bit section where the
+    // running product must be reduced by the value difference at each row with offset alpha:
+    // (alpha + v' - v).
+    let mut diff_values =
+        Vec::with_capacity(v_col.len() - aux_trace_hints.start_16bit - NUM_RAND_ROWS);
+    let mut acc = E::ONE;
+    for (row_idx, &v) in v_col
+        .iter()
+        .enumerate()
+        .take(v_col.len() - 1)
+        .skip(aux_trace_hints.start_16bit)
+    {
+        // This is the 16-bit section, where the running product must be reduced.
+        let v_next = v_col[row_idx + 1].into();
+        let value = alpha + v_next - v.into();
+
+        // Accumulate the transition difference values by which the running product must be reduced.
+        diff_values.push(value);
+
+        // Accumulate the product of the differences.
+        if value != E::ZERO {
+            acc *= value;
+        }
+    }
+
+    // Invert the accumulated product and multiply it by the result from the 8-bit section.
+    acc = acc.inv() * aux_column[aux_trace_hints.start_16bit];
+
+    // Do a modified version of batch inversion. We don't actually want an array of inverted
+    // diff_values [1/a, 1/b, 1/c, ...], we want an array of inverted products all of which are
+    // multiplied by the same 8-bit result `res`, e.g. [res/a, res/ab, res/abc, ...].
+    for idx in (0..diff_values.len()).rev() {
+        aux_column[aux_trace_hints.start_16bit + idx + 1] = acc;
+        if diff_values[idx] != E::ZERO {
+            acc *= diff_values[idx];
+        }
+    }
+}

--- a/processor/src/trace/range/mod.rs
+++ b/processor/src/trace/range/mod.rs
@@ -3,6 +3,9 @@ use crate::range::{AuxColumnHint, AuxTraceHints};
 
 pub use vm_core::range::{P0_COL_IDX, P1_COL_IDX, T_COL_IDX, V_COL_IDX};
 
+#[cfg(test)]
+mod tests;
+
 // HELPER FUNCTIONS
 // ================================================================================================
 

--- a/processor/src/trace/range/tests.rs
+++ b/processor/src/trace/range/tests.rs
@@ -1,0 +1,62 @@
+use super::{
+    super::{Digest, ExecutionTrace, Process, NUM_RAND_ROWS},
+    Felt, FieldElement, P0_COL_IDX,
+};
+use rand_utils::rand_value;
+use vm_core::{Operation, ProgramInputs};
+use winterfell::Trace;
+
+// TODO: when all u32 operations are updated to use 4 range checks, this test will need to be
+// updated.
+#[test]
+fn p0_trace() {
+    // --- Range check 256_u32 (2 16-bit range checks: 0 and 256) -----------------------------------
+    let stack = [1, 255];
+    let operations = vec![Operation::U32add];
+
+    let inputs = ProgramInputs::new(&stack, &[], vec![]).unwrap();
+    let mut process = Process::new(inputs);
+
+    for operation in operations.iter() {
+        process.execute_op(*operation).unwrap();
+    }
+
+    let mut trace = ExecutionTrace::new(process, Digest::new([Felt::ZERO; 4]));
+    let alpha = rand_value::<Felt>();
+    let rand_elements = vec![alpha];
+    let aux_columns = trace.build_aux_segment(&[], &rand_elements).unwrap();
+    let p0 = aux_columns.get_column(P0_COL_IDX);
+
+    assert_eq!(trace.length(), p0.len());
+
+    // 256 8-bit rows are needed to for each value 0-255. 64 8-bit rows are needed to check 256
+    // increments of 255 in the 16-bit portion of the table, for a total of 256 + 63 = 319 rows.
+    let len_8bit = 319;
+    // 259 16-bit rows are needed for 0, 255, 256, ... 255 increments of 255 ..., 65535. (0 and 256
+    // are range-checked, 65535 is the max, and the rest are "bridge" values.)
+    let len_16bit = 259;
+    // The range checker is padded at the beginning, so the padding must be skipped.
+    let start_8bit = trace.length() - len_8bit - len_16bit - NUM_RAND_ROWS;
+    let start_16bit = trace.length() - len_16bit - NUM_RAND_ROWS;
+
+    // The padded portion of the column should be all ones.
+    let expected_padding = vec![Felt::ONE; start_8bit];
+    assert_eq!(expected_padding, p0[..start_8bit]);
+
+    // The first value in the 8-bit portion should be one.
+    assert_eq!(Felt::ONE, p0[start_8bit]);
+
+    // At the start of the 16-bit portion, the value of `p0` should include all the 8-bit lookups:
+    // 1 lookup of one; 1 lookup of 254; 256 lookups of 255.
+    // Therefore, the value should be: (alpha + 1) * (alpha + 254) + (alpha + 255)^256
+    let mut acc_255 = alpha + Felt::new(255);
+    for _ in 0..8 {
+        acc_255 *= acc_255;
+    }
+    let expected_acc = (alpha + Felt::ONE) * (alpha + Felt::new(254)) * acc_255;
+    assert_eq!(expected_acc, p0[start_16bit]);
+
+    // The final value at the end of the 16-bit portion should be 1. This will be the last row
+    // before the random row.
+    assert_eq!(Felt::ONE, p0[p0.len() - 1 - NUM_RAND_ROWS]);
+}


### PR DESCRIPTION
This PR adds handling of auxiliary trace segments to the ExecutionTrace and the ProcessorAir, and implements the range checker's first running product column `p0` as described in the [docs](https://maticnetwork.github.io/miden/design/range.html).

- add range checker integration tests
- refactor range checker constants
- add auxiliary segment handling to the execution trace
- implement the execution trace for the range checker's running product column `p0`
- add constraint handling for auxiliary columns + constraints for running product column `p0`
- add unit test for the execution trace of the range checker's running product column `p0`