### PR TITLE
Implement running product column `p1` in the range checker

### DIFF
--- a/air/src/range.rs
+++ b/air/src/range.rs
@@ -1,5 +1,5 @@
 use vm_core::{
-    range::{P0_COL_IDX, S0_COL_IDX, S1_COL_IDX, T_COL_IDX, V_COL_IDX},
+    range::{P0_COL_IDX, P1_COL_IDX, S0_COL_IDX, S1_COL_IDX, T_COL_IDX, V_COL_IDX},
     ExtensionOf,
 };
 use winter_air::AuxTraceRandElements;
@@ -30,11 +30,11 @@ pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
 // --- Auxiliary column constraints for multiset checks -------------------------------------------
 
 /// The number of auxiliary assertions for multiset checks.
-pub const NUM_AUX_ASSERTIONS: usize = 2;
+pub const NUM_AUX_ASSERTIONS: usize = 3;
 /// The number of transition constraints required by multiset checks for the Range Checker.
-pub const NUM_AUX_CONSTRAINTS: usize = 1;
+pub const NUM_AUX_CONSTRAINTS: usize = 2;
 /// The degrees of the Range Checker's auxiliary column constraints, used for multiset checks.
-pub const AUX_CONSTRAINT_DEGREES: [usize; NUM_AUX_CONSTRAINTS] = [8];
+pub const AUX_CONSTRAINT_DEGREES: [usize; NUM_AUX_CONSTRAINTS] = [8, 8];
 
 // BOUNDARY CONSTRAINTS
 // ================================================================================================
@@ -58,11 +58,14 @@ pub fn get_assertions_last_step(result: &mut Vec<Assertion<Felt>>, step: usize) 
 pub fn get_aux_assertions_first_step<E: FieldElement>(result: &mut Vec<Assertion<E>>) {
     let step = 0;
     result.push(Assertion::single(P0_COL_IDX, step, E::ONE));
+    result.push(Assertion::single(P1_COL_IDX, step, E::ONE));
 }
 
 /// Returns the range checker's boundary assertions for auxiliary columns at the last step.
 pub fn get_aux_assertions_last_step<E: FieldElement>(result: &mut Vec<Assertion<E>>, step: usize) {
     result.push(Assertion::single(P0_COL_IDX, step, E::ONE));
+    // TODO: Add assertion that p1 is ONE at the last step after changes to update p1 from the
+    // operations processor are completed.
 }
 
 // TRANSITION CONSTRAINTS
@@ -116,10 +119,19 @@ pub fn enforce_aux_constraints<F, E>(
     F: FieldElement<BaseField = Felt>,
     E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
 {
+    // Get the first random element for this segment.
     let alpha = aux_rand_elements.get_segment_elements(0)[0];
 
     // Enforce p0.
-    enforce_running_product_p0(main_frame, aux_frame, alpha, result);
+    let constraint_offset = enforce_running_product_p0(main_frame, aux_frame, alpha, result);
+
+    // Enforce p1.
+    enforce_running_product_p1(
+        main_frame,
+        aux_frame,
+        alpha,
+        &mut result[constraint_offset..],
+    );
 }
 
 // TRANSITION CONSTRAINT HELPERS
@@ -196,6 +208,25 @@ where
     constraint_offset
 }
 
+/// Ensures that the 16-bit running product is computed correctly in the column `p1`. It enforces
+/// that the value only changes during the 16-bit section of the table, where the value of `z` is
+/// included at each step, ensuring that the values in the 16-bit section are multiplied into `p1`
+/// 0, 1, 2, or 4 times, according to the selector flags.
+fn enforce_running_product_p1<E, F>(
+    main_frame: &EvaluationFrame<F>,
+    aux_frame: &EvaluationFrame<E>,
+    alpha: E,
+    result: &mut [E],
+) where
+    F: FieldElement<BaseField = Felt>,
+    E: FieldElement<BaseField = Felt> + ExtensionOf<F>,
+{
+    let z = get_z(main_frame, alpha);
+    let t: E = main_frame.t().into();
+
+    result[0] = aux_frame.p1_next() - aux_frame.p1() * (z * t - t + E::ONE);
+}
+
 /// Returns the value `z` which is included in the running product columns at each step. `z` causes
 /// the row's value to be included 0, 1, 2, or 4 times, according to the row's selector flags row.
 fn get_z<E, F>(main_frame: &EvaluationFrame<F>, alpha: E) -> E
@@ -245,6 +276,10 @@ trait EvaluationFrameExt<E: FieldElement> {
     fn p0(&self) -> E;
     /// The next value in auxiliary column p0.
     fn p0_next(&self) -> E;
+    /// The current value in auxiliary column p1.
+    fn p1(&self) -> E;
+    /// The next value in auxiliary column p1.
+    fn p1_next(&self) -> E;
 
     // --- Intermediate variables & helpers -------------------------------------------------------
 
@@ -300,6 +335,16 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     #[inline(always)]
     fn p0_next(&self) -> E {
         self.next()[P0_COL_IDX]
+    }
+
+    #[inline(always)]
+    fn p1(&self) -> E {
+        self.current()[P1_COL_IDX]
+    }
+
+    #[inline(always)]
+    fn p1_next(&self) -> E {
+        self.next()[P1_COL_IDX]
     }
 
     // --- Intermediate variables & helpers -------------------------------------------------------

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -57,7 +57,7 @@ impl ExecutionTrace {
 
         Self {
             meta: Vec::new(),
-            layout: TraceLayout::new(TRACE_WIDTH, [1], [1]),
+            layout: TraceLayout::new(TRACE_WIDTH, [2], [1]),
             main_trace: Matrix::new(main_trace),
             aux_trace_hints,
             program_hash,
@@ -143,17 +143,15 @@ impl Trace for ExecutionTrace {
             return None;
         }
 
-        let mut aux_columns = vec![vec![E::ZERO; self.length()]; self.aux_trace_width()];
-
-        // Add the range checker's running product column p0.
-        range::build_aux_col_p0(
-            &mut aux_columns[range::P0_COL_IDX],
+        // Add the range checker's running product columns.
+        let mut aux_columns = range::build_aux_columns(
+            self.length(),
             &self.aux_trace_hints.range,
             rand_elements,
             self.main_trace.get_column(range::V_COL_IDX),
         );
 
-        // Inject random values into the last rows of the trace.
+        // inject random values into the last rows of the trace
         let mut rng = RandomCoin::new(&self.program_hash.to_bytes());
         for i in self.length() - NUM_RAND_ROWS..self.length() {
             for column in aux_columns.iter_mut() {

--- a/processor/src/trace/range/tests.rs
+++ b/processor/src/trace/range/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     super::{Digest, ExecutionTrace, Process, NUM_RAND_ROWS},
-    Felt, FieldElement, P0_COL_IDX,
+    Felt, FieldElement, P0_COL_IDX, P1_COL_IDX,
 };
 use rand_utils::rand_value;
 use vm_core::{Operation, ProgramInputs};
@@ -59,4 +59,51 @@ fn p0_trace() {
     // The final value at the end of the 16-bit portion should be 1. This will be the last row
     // before the random row.
     assert_eq!(Felt::ONE, p0[p0.len() - 1 - NUM_RAND_ROWS]);
+}
+
+#[test]
+fn p1_trace() {
+    // --- Range check 256_u32 (2 16-bit range checks: 0 and 1) -----------------------------------
+    let stack = [1, 255];
+    let operations = vec![Operation::U32add];
+
+    let inputs = ProgramInputs::new(&stack, &[], vec![]).unwrap();
+    let mut process = Process::new(inputs);
+
+    for operation in operations.iter() {
+        process.execute_op(*operation).unwrap();
+    }
+
+    let mut trace = ExecutionTrace::new(process, Digest::new([Felt::ZERO; 4]));
+    let alpha = rand_value::<Felt>();
+    let rand_elements = vec![alpha];
+    let aux_columns = trace.build_aux_segment(&[], &rand_elements).unwrap();
+    let p1 = aux_columns.get_column(P1_COL_IDX);
+
+    assert_eq!(trace.length(), p1.len());
+
+    // 256 8-bit rows are needed to for each value 0-255. 64 8-bit rows are needed to check 256
+    // increments of 255 in the 16-bit portion of the table, for a total of 256 + 63 = 319 rows.
+    let len_8bit = 319;
+    // 259 16-bit rows are needed for 0, 255, 256, ... 255 increments of 255 ..., 65535. (0 and 256
+    // are range-checked, 65535 is the max, and the rest are "bridge" values.
+    let len_16bit = 259;
+    // The range checker is padded at the beginning, so the padding must be skipped.
+    let padding_end = trace.length() - len_8bit - len_16bit - NUM_RAND_ROWS;
+    let start_16bit = trace.length() - len_16bit - NUM_RAND_ROWS;
+
+    // The values in p1 should be one for the length of the 8-bit table.
+    let expected_8bit = vec![Felt::ONE; len_8bit];
+    assert_eq!(expected_8bit, p1[padding_end..start_16bit]);
+
+    // Once the 16-bit portion of the table starts, the first value will be one.
+    assert_eq!(p1[start_16bit], Felt::ONE);
+    // We include 1 lookup of 0, so the next value should be multiplied by alpha.
+    let mut expected = alpha;
+    assert_eq!(expected, p1[start_16bit + 1]);
+    // Then we have a bridge row for 255 where the value does not change
+    assert_eq!(expected, p1[start_16bit + 2]);
+    // Then we include 1 lookup of 256, so it should be multiplied by alpha + 256.
+    expected *= alpha + Felt::new(256);
+    assert_eq!(expected, p1[start_16bit + 3]);
 }


### PR DESCRIPTION
This PR adds the execution trace for the range checker's auxiliary column `p1`, as well as transition AIR constraints and one of the two required boundary assertions.