### PR TITLE
Add u32 operation hint values to the decoder trace

### DIFF
--- a/air/src/aux_table/bitwise_pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/mod.rs
@@ -1,7 +1,11 @@
 use super::{EvaluationFrame, FieldElement, TransitionConstraintDegree, BITWISE_TRACE_OFFSET};
 use crate::utils::is_binary;
 use core::ops::Range;
-use vm_core::{bitwise::NUM_SELECTORS, utils::range as create_range, Felt};
+use vm_core::{
+    bitwise::{NUM_SELECTORS, OP_CYCLE_LEN},
+    utils::range as create_range,
+    Felt,
+};
 
 mod bitwise;
 mod pow2;
@@ -12,8 +16,6 @@ pub mod tests;
 // CONSTANTS
 // ================================================================================================
 
-/// The number of rows required to compute an operation in the Bitwise & Power of Two co-processor.
-pub const OP_CYCLE_LEN: usize = 8;
 /// Index of CONSTRAINT_DEGREES array after which all constraints use periodic columns.
 const PERIODIC_CONSTRAINTS_START: usize = 2;
 /// The number of shared constraints on the combined trace of the Bitwise and Power of Two

--- a/core/src/bitwise/mod.rs
+++ b/core/src/bitwise/mod.rs
@@ -9,6 +9,9 @@ pub const NUM_SELECTORS: usize = 2;
 /// Number of columns needed to record an execution trace of the bitwise and power of two helper.
 pub const TRACE_WIDTH: usize = NUM_SELECTORS + 12;
 
+/// The number of rows required to compute an operation in the Bitwise & Power of Two co-processor.
+pub const OP_CYCLE_LEN: usize = 8;
+
 // --- OPERATION SELECTORS ------------------------------------------------------------------------
 
 /// Specifies a bitwise AND operation.

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -520,6 +520,21 @@ impl Operation {
     pub fn is_decorator(&self) -> bool {
         matches!(self, Self::Debug(_) | Self::Advice(_))
     }
+
+    /// Returns true if this operation is a control operation.
+    pub fn is_control_op(&self) -> bool {
+        matches!(
+            self,
+            Self::End
+                | Self::Join
+                | Self::Split
+                | Self::Loop
+                | Self::Repeat
+                | Self::Respan
+                | Self::Span
+                | Self::Halt
+        )
+    }
 }
 
 impl fmt::Display for Operation {

--- a/processor/src/aux_table/tests.rs
+++ b/processor/src/aux_table/tests.rs
@@ -3,8 +3,9 @@ use super::{
     AuxTableTrace,
 };
 use vm_core::{
-    bitwise::BITWISE_OR,
-    hasher::{LINEAR_HASH, RETURN_STATE},
+    bitwise::{BITWISE_OR, OP_CYCLE_LEN},
+    hasher::{HASH_CYCLE_LEN, LINEAR_HASH, RETURN_STATE},
+    program::blocks::CodeBlock,
     Felt, FieldElement, ProgramInputs, AUX_TRACE_RANGE,
 };
 
@@ -13,14 +14,15 @@ fn hasher_aux_trace() {
     // --- single hasher permutation with no stack manipulation -----------------------------------
     let stack = [2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0];
     let operations = vec![Operation::RpPerm];
-    let aux_table_trace = build_trace(&stack, operations);
-    let trace_len = aux_table_trace[0].len();
+    let (aux_table_trace, trace_len) = build_trace(&stack, operations);
 
-    let expected_len = 8;
-    validate_hasher_trace(&aux_table_trace, 0, expected_len);
+    // Skip the hash of the span block generated while building the trace to check only the RpPerm.
+    let hasher_start = HASH_CYCLE_LEN;
+    let hasher_end = hasher_start + HASH_CYCLE_LEN;
+    validate_hasher_trace(&aux_table_trace, hasher_start, hasher_end);
 
-    // validate that the table was padded correctly (accounting for random row)
-    validate_padding(&aux_table_trace, 8, trace_len - 1);
+    // Validate that the table was padded correctly.
+    validate_padding(&aux_table_trace, hasher_end, trace_len);
 }
 
 #[test]
@@ -28,14 +30,13 @@ fn bitwise_aux_trace() {
     // --- single bitwise operation with no stack manipulation ------------------------------------
     let stack = [4, 8];
     let operations = vec![Operation::U32or];
-    let aux_table_trace = build_trace(&stack, operations);
-    let trace_len = aux_table_trace[0].len();
+    let (aux_table_trace, trace_len) = build_trace(&stack, operations);
 
-    let expected_len = 8;
-    validate_bitwise_trace(&aux_table_trace, 0, expected_len);
+    let bitwise_end = HASH_CYCLE_LEN + OP_CYCLE_LEN;
+    validate_bitwise_trace(&aux_table_trace, HASH_CYCLE_LEN, bitwise_end);
 
-    // validate that the table was padded correctly (accounting for random row)
-    validate_padding(&aux_table_trace, 8, trace_len - 1);
+    // Validate that the table was padded correctly.
+    validate_padding(&aux_table_trace, bitwise_end, trace_len - 1);
 }
 
 #[test]
@@ -43,15 +44,15 @@ fn memory_aux_trace() {
     // --- single memory operation with no stack manipulation -------------------------------------
     let stack = [1, 2, 3, 4];
     let operations = vec![Operation::Push(Felt::new(2)), Operation::StoreW];
-    let aux_table_trace = build_trace(&stack, operations);
-    let trace_len = aux_table_trace[0].len();
+    let (aux_table_trace, trace_len) = build_trace(&stack, operations);
     let memory_trace_len = 1;
 
-    // validate that the table was padded correctly (accounting for random row)
-    let padding_end = trace_len - memory_trace_len - 1;
-    validate_padding(&aux_table_trace, 0, padding_end);
+    // Validate that the table was padded correctly.
+    let padding_end = trace_len - memory_trace_len;
+    // Skip the hash cycle created by the span block when building the trace.
+    validate_padding(&aux_table_trace, HASH_CYCLE_LEN, padding_end);
 
-    // check the memory trace
+    // Check the memory trace.
     validate_memory_trace(
         &aux_table_trace,
         padding_end,
@@ -70,20 +71,20 @@ fn stacked_aux_trace() {
         Operation::StoreW,
         Operation::RpPerm,
     ];
-    let aux_table_trace = build_trace(&stack, operations);
-    let trace_len = aux_table_trace[0].len();
+    let (aux_table_trace, trace_len) = build_trace(&stack, operations);
     let memory_len = 1;
 
-    // expect 8 rows of hasher trace
-    let hasher_end = 8;
-    validate_hasher_trace(&aux_table_trace, 0, hasher_end);
+    // Skip the hash of the span block generated while building the trace to check only the RpPerm.
+    let hasher_start = HASH_CYCLE_LEN;
+    let hasher_end = hasher_start + HASH_CYCLE_LEN;
+    validate_hasher_trace(&aux_table_trace, hasher_start, hasher_end);
 
-    // expect 8 rows of bitwise trace
-    let bitwise_end = hasher_end + 8;
+    // Expect 1 operation cycle in the bitwise trace
+    let bitwise_end = hasher_end + OP_CYCLE_LEN;
     validate_bitwise_trace(&aux_table_trace, hasher_end, bitwise_end);
 
-    // validate that the table was padded correctly (accounting for random row)
-    let padding_end = trace_len - memory_len - 1;
+    // Validate that the table was padded correctly.
+    let padding_end = trace_len - memory_len;
     validate_padding(&aux_table_trace, bitwise_end, padding_end);
 
     // expect 1 row of memory trace
@@ -93,19 +94,24 @@ fn stacked_aux_trace() {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-fn build_trace(stack: &[u64], operations: Vec<Operation>) -> AuxTableTrace {
+/// Builds a sample trace by executing a span block containing the specified operations. This
+/// results in 1 additional hash cycle at the beginning of the hasher coprocessor.
+fn build_trace(stack: &[u64], operations: Vec<Operation>) -> (AuxTableTrace, usize) {
     let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
     let mut process = Process::new(inputs);
-
-    for operation in operations.iter() {
-        process.execute_op(*operation).unwrap();
-    }
+    let program = CodeBlock::new_span(operations);
+    process.execute_code_block(&program).unwrap();
 
     let (trace, _) = ExecutionTrace::test_finalize_trace(process);
-    trace[AUX_TRACE_RANGE]
-        .to_vec()
-        .try_into()
-        .expect("failed to convert vector to array")
+    let trace_len = trace[0].len() - ExecutionTrace::NUM_RAND_ROWS;
+
+    (
+        trace[AUX_TRACE_RANGE]
+            .to_vec()
+            .try_into()
+            .expect("failed to convert vector to array"),
+        trace_len,
+    )
 }
 
 /// Validate the hasher trace output by the rpperm operation. The full hasher trace is tested in
@@ -117,7 +123,7 @@ fn validate_hasher_trace(aux_table: &AuxTableTrace, start: usize, end: usize) {
         // The selectors should match the selectors for the hasher segment
         assert_eq!(Felt::ZERO, aux_table[0][row]);
 
-        match row {
+        match row % HASH_CYCLE_LEN {
             0 => {
                 // in the first row, the expected start of the trace should hold the initial selectors
                 assert_eq!(
@@ -162,6 +168,22 @@ fn validate_bitwise_trace(aux_table: &AuxTableTrace, start: usize, end: usize) {
     }
 }
 
+/// Checks that the middle section of the auxiliary trace table before the memory coprocessor is
+/// padded and has the correct selectors.
+fn validate_padding(aux_table: &AuxTableTrace, start: usize, end: usize) {
+    for row in start..end {
+        // selectors
+        assert_eq!(Felt::ONE, aux_table[0][row]);
+        assert_eq!(Felt::ONE, aux_table[1][row]);
+        assert_eq!(Felt::ZERO, aux_table[2][row]);
+
+        // padding
+        aux_table.iter().skip(3).for_each(|column| {
+            assert_eq!(Felt::ZERO, column[row]);
+        });
+    }
+}
+
 /// Validate the bitwise trace output by the storew operation. The full memory trace is tested in
 /// the Memory module, so this just tests the AuxTableTrace selectors, the initial columns
 /// of the memory trace, and the final column after the memory trace.
@@ -178,20 +200,5 @@ fn validate_memory_trace(aux_table: &AuxTableTrace, start: usize, end: usize, ad
 
         // the final column should be padded
         assert_eq!(Felt::ZERO, aux_table[17][row]);
-    }
-}
-
-/// Checks that the end of the auxiliary trace table is padded and has the correct selectors.
-fn validate_padding(aux_table: &AuxTableTrace, start: usize, end: usize) {
-    for row in start..end {
-        // selectors
-        assert_eq!(Felt::ONE, aux_table[0][row]);
-        assert_eq!(Felt::ONE, aux_table[1][row]);
-        assert_eq!(Felt::ZERO, aux_table[2][row]);
-
-        // padding
-        aux_table.iter().skip(3).for_each(|column| {
-            assert_eq!(Felt::ZERO, column[row]);
-        });
     }
 }

--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -120,12 +120,14 @@ impl Bitwise {
     // TRACE MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// Computes a bitwise AND of `a` and `b` and returns the result. We assume that `a` and `b`
-    /// are 32-bit values. If that's not the case, the result of the computation is undefined.
+    /// Computes a bitwise AND of `a` and `b` and returns the result along with the index of the
+    /// result row, which is used for the lookup product column used for multiset checks. We assume
+    /// that `a` and `b` are 32-bit values. If that's not the case, the result of the computation is
+    /// undefined.
     ///
     /// This also adds 8 rows to the internal execution trace table required for computing the
     /// operation.
-    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
+    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
         let a = assert_u32(a)?.as_int();
         let b = assert_u32(b)?.as_int();
         let mut result = 0u64;
@@ -150,15 +152,20 @@ impl Bitwise {
             self.trace[12].push(Felt::new(result));
         }
 
-        Ok(Felt::new(result))
+        // Return the result row for calculating the lookup product.
+        let result_row = self.trace_len() - 1;
+
+        Ok((Felt::new(result), Felt::new(result_row as u64)))
     }
 
-    /// Computes a bitwise OR of `a` and `b` and returns the result. We assume that `a` and `b`
-    /// are 32-bit values. If that's not the case, the result of the computation is undefined.
+    /// Computes a bitwise OR of `a` and `b` and returns the result along with the index of the
+    /// result row, which is used for the lookup product column used for multiset checks. We assume
+    /// that `a` and `b` are 32-bit values. If that's not the case, the result of the computation is
+    /// undefined.
     ///
     /// This also adds 8 rows to the internal execution trace table required for computing the
     /// operation.
-    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
+    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
         let a = assert_u32(a)?.as_int();
         let b = assert_u32(b)?.as_int();
         let mut result = 0u64;
@@ -183,15 +190,20 @@ impl Bitwise {
             self.trace[12].push(Felt::new(result));
         }
 
-        Ok(Felt::new(result))
+        // Return the result row for calculating the lookup product.
+        let result_row = self.trace_len() - 1;
+
+        Ok((Felt::new(result), Felt::new(result_row as u64)))
     }
 
-    /// Computes a bitwise XOR of `a` and `b` and returns the result. We assume that `a` and `b`
-    /// are 32-bit values. If that's not the case, the result of the computation is undefined.
+    /// Computes a bitwise XOR of `a` and `b` and returns the result along with the index of the
+    /// result row, which is used for the lookup product column used for multiset checks. We assume
+    /// that `a` and `b` are 32-bit values. If that's not the case, the result of the computation is
+    /// undefined.
     ///
     /// This also adds 8 rows to the internal execution trace table required for computing the
     /// operation.
-    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
+    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
         let a = assert_u32(a)?.as_int();
         let b = assert_u32(b)?.as_int();
         let mut result = 0u64;
@@ -216,7 +228,10 @@ impl Bitwise {
             self.trace[12].push(Felt::new(result));
         }
 
-        Ok(Felt::new(result))
+        // Return the result row for calculating the lookup product.
+        let result_row = self.trace_len() - 1;
+
+        Ok((Felt::new(result), Felt::new(result_row as u64)))
     }
 
     /// Returns 2^exponent for the provided exponent value and adds the operation execution to the

--- a/processor/src/bitwise/tests.rs
+++ b/processor/src/bitwise/tests.rs
@@ -3,6 +3,7 @@ use super::{
     POW2_AGG_OUTPUT_COL, TRACE_WIDTH,
 };
 use rand_utils::rand_value;
+use vm_core::bitwise::OP_CYCLE_LEN;
 
 #[test]
 fn bitwise_init() {
@@ -17,8 +18,10 @@ fn bitwise_and() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let result = bitwise.u32and(a, b).unwrap();
+    let (result, row_idx) = bitwise.u32and(a, b).unwrap();
+    let expected_row = OP_CYCLE_LEN - 1;
     assert_eq!(a.as_int() & b.as_int(), result.as_int());
+    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
@@ -64,8 +67,10 @@ fn bitwise_or() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let result = bitwise.u32or(a, b).unwrap();
+    let (result, row_idx) = bitwise.u32or(a, b).unwrap();
+    let expected_row = OP_CYCLE_LEN - 1;
     assert_eq!(a.as_int() | b.as_int(), result.as_int());
+    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
@@ -111,8 +116,10 @@ fn bitwise_xor() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let result = bitwise.u32xor(a, b).unwrap();
+    let (result, row_idx) = bitwise.u32xor(a, b).unwrap();
+    let expected_row = OP_CYCLE_LEN - 1;
     assert_eq!(a.as_int() ^ b.as_int(), result.as_int());
+    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
@@ -159,20 +166,28 @@ fn bitwise_multiple() {
     let b = [rand_u32(), rand_u32(), rand_u32(), rand_u32()];
 
     // first operation: AND
-    let result0 = bitwise.u32and(a[0], b[0]).unwrap();
+    let (result0, row_idx) = bitwise.u32and(a[0], b[0]).unwrap();
+    let mut expected_row = OP_CYCLE_LEN - 1;
     assert_eq!(a[0].as_int() & b[0].as_int(), result0.as_int());
+    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // second operation: OR
-    let result1 = bitwise.u32or(a[1], b[1]).unwrap();
+    let (result1, row_idx) = bitwise.u32or(a[1], b[1]).unwrap();
+    expected_row += OP_CYCLE_LEN;
     assert_eq!(a[1].as_int() | b[1].as_int(), result1.as_int());
+    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // third operation: XOR
-    let result2 = bitwise.u32xor(a[2], b[2]).unwrap();
+    let (result2, row_idx) = bitwise.u32xor(a[2], b[2]).unwrap();
+    expected_row += OP_CYCLE_LEN;
     assert_eq!(a[2].as_int() ^ b[2].as_int(), result2.as_int());
+    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // fourth operation: AND
-    let result3 = bitwise.u32and(a[3], b[3]).unwrap();
+    let (result3, row_idx) = bitwise.u32and(a[3], b[3]).unwrap();
+    expected_row += OP_CYCLE_LEN;
     assert_eq!(a[3].as_int() & b[3].as_int(), result3.as_int());
+    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 32;

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -370,6 +370,16 @@ impl Decoder {
         }
     }
 
+    /// Sets the helper registers in the trace to the user-provided helper values. This is expected
+    /// to be called during the execution of a user operation.
+    ///
+    /// TODO: it might be better to get the operation information from the decoder trace, rather
+    /// than passing it in as a parameter.
+    pub fn set_user_op_helpers(&mut self, op: Operation, values: &[Felt]) {
+        debug_assert!(!op.is_control_op(), "op is a control operation");
+        self.trace.set_user_op_helpers(values);
+    }
+
     /// Ends decoding of a SPAN block.
     pub fn end_span(&mut self, block_hash: Word) {
         let is_loop_body = self.block_stack.pop().is_loop_body;

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -399,6 +399,15 @@ impl Decoder {
             .try_into()
             .expect("failed to convert vector to array")
     }
+
+    // TEST METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Adds a row of zeros to the decoder trace for testing purposes.
+    #[cfg(test)]
+    pub fn add_dummy_trace_row(&mut self) {
+        self.trace.add_dummy_row();
+    }
 }
 
 impl Default for Decoder {

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1,9 +1,10 @@
 use super::{super::DecoderTrace, Felt, Operation, Word, NUM_OP_BITS};
 use crate::{ExecutionTrace, Process, ProgramInputs};
+use rand_utils::rand_value;
 use vm_core::{
     decoder::{
-        ADDR_COL_IDX, GROUP_COUNT_COL_IDX, HASHER_STATE_RANGE, IN_SPAN_COL_IDX, OP_BITS_OFFSET,
-        OP_BITS_RANGE, OP_INDEX_COL_IDX,
+        ADDR_COL_IDX, GROUP_COUNT_COL_IDX, HASHER_STATE_RANGE, IN_SPAN_COL_IDX, NUM_HASHER_COLUMNS,
+        OP_BITS_OFFSET, OP_BITS_RANGE, OP_INDEX_COL_IDX,
     },
     program::blocks::{CodeBlock, Span},
     FieldElement, StarkField, DECODER_TRACE_RANGE,
@@ -540,6 +541,54 @@ fn loop_block_repeat() {
     }
 }
 
+// HELPER REGISTERS TESTS
+// ================================================================================================
+#[test]
+fn set_user_op_helpers_one() {
+    // --- user operation with 1 helper value -----------------------------------------------------
+    let ops = vec![Operation::U32and, Operation::U32and];
+    let program = CodeBlock::new_span(ops);
+    let (trace, _) = build_trace(&[2, 6, 1], &program);
+
+    // Check the hasher state of the final user operation which was executed.
+    let hasher_state = get_hasher_state(&trace, 2);
+
+    // h0 holds the number of ops left in the group, which is 0. h1 holds the parent addr, which is
+    // ZERO. h2 holds one helper value, which is the lookup row in the bitwise trace. everything
+    // else is unused.
+    let expected = build_expected_hasher_state(&[ZERO, ZERO, Felt::new(15)]);
+
+    assert_eq!(expected, hasher_state);
+}
+
+#[test]
+fn set_user_op_helpers_many() {
+    // --- user operation with 4 helper values ----------------------------------------------------
+    let program = CodeBlock::new_span(vec![Operation::U32div]);
+    let a = rand_value();
+    let b = rand_value();
+    let (dividend, divisor) = if a > b { (a, b) } else { (b, a) };
+    let (trace, _) = build_trace(&[dividend, divisor], &program);
+    let hasher_state = get_hasher_state(&trace, 1);
+
+    // Check the hasher state of the user operation which was executed.
+    // h2 to h5 are expected to hold the values for range checks.
+    let quot = dividend / divisor;
+    let rem = dividend - quot * divisor;
+    let check_1 = dividend - quot;
+    let check_2 = divisor - rem - 1;
+    let expected = build_expected_hasher_state(&[
+        ZERO,
+        ZERO,
+        Felt::new((check_1 as u16).into()),
+        Felt::new(((check_1 >> 16) as u16).into()),
+        Felt::new((check_2 as u16).into()),
+        Felt::new(((check_2 >> 16) as u16).into()),
+    ]);
+
+    assert_eq!(expected, hasher_state);
+}
+
 // HELPER FUNCTIONS
 // ================================================================================================
 
@@ -620,8 +669,8 @@ fn check_hasher_state(trace: &DecoderTrace, expected: Vec<Vec<Felt>>) {
     }
 }
 
-fn get_hasher_state(trace: &DecoderTrace, row_idx: usize) -> [Felt; 8] {
-    let mut result = [ZERO; 8];
+fn get_hasher_state(trace: &DecoderTrace, row_idx: usize) -> [Felt; NUM_HASHER_COLUMNS] {
+    let mut result = [ZERO; NUM_HASHER_COLUMNS];
     for (result, column) in result.iter_mut().zip(trace[HASHER_STATE_RANGE].iter()) {
         *result = column[row_idx];
     }
@@ -647,8 +696,8 @@ fn get_hasher_state2(trace: &DecoderTrace, row_idx: usize) -> Word {
     result
 }
 
-fn build_expected_hasher_state(values: &[Felt]) -> [Felt; 8] {
-    let mut result = [ZERO; 8];
+fn build_expected_hasher_state(values: &[Felt]) -> [Felt; NUM_HASHER_COLUMNS] {
+    let mut result = [ZERO; NUM_HASHER_COLUMNS];
     for (i, value) in values.iter().enumerate() {
         result[i] = *value;
     }

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -598,7 +598,7 @@ fn build_trace(stack: &[u64], program: &CodeBlock) -> (DecoderTrace, usize) {
     process.execute_code_block(program).unwrap();
 
     let (trace, _) = ExecutionTrace::test_finalize_trace(process);
-    let trace_len = trace.len() - ExecutionTrace::NUM_RAND_ROWS;
+    let trace_len = trace[0].len() - ExecutionTrace::NUM_RAND_ROWS;
 
     (
         trace[DECODER_TRACE_RANGE]

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -332,10 +332,7 @@ impl DecoderTrace {
         for (i, mut column) in self.hasher_trace.into_iter().enumerate() {
             debug_assert_eq!(own_len, column.len());
             if i < 4 {
-                // TODO: ideally, we should use `expect()` instead of `unwrap_or()` but aux_table
-                // unit tests fail if we do that as they don't expect build the decoder portion of
-                // the trace. in the future we should refactor aux_table unit tests.
-                let last_value = *column.last().unwrap_or(&ZERO);
+                let last_value = *column.last().expect("no last hasher trace value");
                 column.resize(trace_len, last_value);
             } else {
                 column.resize(trace_len, ZERO);

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -402,4 +402,22 @@ impl DecoderTrace {
             *self.last_helper_mut(idx) = *value;
         }
     }
+
+    // TEST METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Adds a new decoder trace row of zeros for testing purposes.
+    #[cfg(test)]
+    pub fn add_dummy_row(&mut self) {
+        self.addr_trace.push(ZERO);
+        for column in self.op_bits_trace.iter_mut() {
+            column.push(ZERO);
+        }
+        self.in_span_trace.push(ZERO);
+        for column in self.hasher_trace.iter_mut() {
+            column.push(ZERO);
+        }
+        self.group_count_trace.push(ZERO);
+        self.op_idx_trace.push(ZERO);
+    }
 }

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -176,6 +176,15 @@ impl Process {
         let inputs = super::ProgramInputs::new(&[], advice_tape, vec![]).unwrap();
         Self::new(inputs)
     }
+
+    /// Instantiates a new blank process with one decoder trace row for testing purposes. This
+    /// allows for setting helpers in the decoder when executing operations during tests.
+    #[cfg(test)]
+    fn new_dummy_with_decoder_helpers() -> Self {
+        let mut process = Self::new(super::ProgramInputs::none());
+        process.decoder.add_dummy_trace_row();
+        process
+    }
 }
 
 // TEST HELPERS

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -285,7 +285,7 @@ mod tests {
     fn op_u32split() {
         // --- test a random value ---------------------------------------------
         let a: u64 = rand_value();
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         init_stack_with(&mut process, &[a]);
         let hi = a >> 32;
         let lo = (a as u32) as u64;
@@ -298,7 +298,7 @@ mod tests {
 
         // --- test the rest of the stack is not modified -----------------------
         let b: u64 = rand_value();
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         init_stack_with(&mut process, &[a, b]);
         let hi = b >> 32;
         let lo = (b as u32) as u64;
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn op_u32assert2() {
         // --- test random values ensuring other elements are still values are still intact ----------
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         let (a, b, c, d) = init_stack_rand(&mut process);
 
         process.execute_op(Operation::U32assert2).unwrap();
@@ -328,7 +328,7 @@ mod tests {
     #[test]
     fn op_u32add() {
         // --- test random values ---------------------------------------------
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         let (a, b, c, d) = init_stack_rand(&mut process);
         let (result, over) = a.overflowing_add(b);
 
@@ -340,7 +340,7 @@ mod tests {
         let a = u32::MAX - 1;
         let b = 2u32;
 
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         init_stack_with(&mut process, &[a as u64, b as u64]);
         let (result, over) = a.overflowing_add(b);
 
@@ -356,7 +356,7 @@ mod tests {
         let c = rand_value::<u32>() as u64;
         let d = rand_value::<u32>() as u64;
 
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         init_stack_with(&mut process, &[d, c, b, a]);
 
         let result = a + b + c;
@@ -369,14 +369,14 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test with minimum stack depth ----------------------------------
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         assert!(process.execute_op(Operation::U32add3).is_ok());
     }
 
     #[test]
     fn op_u32sub() {
         // --- test random values ---------------------------------------------
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         let (a, b, c, d) = init_stack_rand(&mut process);
         let (result, under) = b.overflowing_sub(a);
 
@@ -388,7 +388,7 @@ mod tests {
         let a = 10u32;
         let b = 11u32;
 
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         init_stack_with(&mut process, &[a as u64, b as u64]);
         let (result, under) = a.overflowing_sub(b);
 
@@ -399,7 +399,7 @@ mod tests {
 
     #[test]
     fn op_u32mul() {
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         let (a, b, c, d) = init_stack_rand(&mut process);
         let result = (a as u64) * (b as u64);
         let hi = (result >> 32) as u32;
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn op_u32madd() {
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         let (a, b, c, d) = init_stack_rand(&mut process);
         let result = (a as u64) * (b as u64) + (c as u64);
         let hi = (result >> 32) as u32;
@@ -423,13 +423,13 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test with minimum stack depth ----------------------------------
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         assert!(process.execute_op(Operation::U32madd).is_ok());
     }
 
     #[test]
     fn op_u32div() {
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         let (a, b, c, d) = init_stack_rand(&mut process);
         let q = b / a;
         let r = b % a;
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn op_u32and() {
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         let (a, b, c, d) = init_stack_rand(&mut process);
 
         process.execute_op(Operation::U32and).unwrap();
@@ -452,13 +452,13 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test with minimum stack depth ----------------------------------
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         assert!(process.execute_op(Operation::U32and).is_ok());
     }
 
     #[test]
     fn op_u32or() {
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         let (a, b, c, d) = init_stack_rand(&mut process);
 
         process.execute_op(Operation::U32or).unwrap();
@@ -466,13 +466,13 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test with minimum stack depth ----------------------------------
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         assert!(process.execute_op(Operation::U32or).is_ok());
     }
 
     #[test]
     fn op_u32xor() {
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         let (a, b, c, d) = init_stack_rand(&mut process);
 
         process.execute_op(Operation::U32xor).unwrap();
@@ -480,7 +480,7 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test with minimum stack depth ----------------------------------
-        let mut process = Process::new_dummy();
+        let mut process = Process::new_dummy_with_decoder_helpers();
         assert!(process.execute_op(Operation::U32xor).is_ok());
     }
 

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -24,19 +24,14 @@ impl Process {
         let a = self.stack.get(0);
         let b = self.stack.get(1);
 
-        let (lo_a, hi_a) = split_element(a);
-        let (lo_b, hi_b) = split_element(b);
-
-        if hi_a != Felt::ZERO {
+        if a.as_int() >> 32 != 0 {
             return Err(ExecutionError::NotU32Value(a));
         }
-
-        if hi_b != Felt::ZERO {
+        if b.as_int() >> 32 != 0 {
             return Err(ExecutionError::NotU32Value(b));
         }
 
-        self.add_range_checks(Operation::U32assert2, lo_a, hi_a, false);
-        self.add_range_checks(Operation::U32assert2, lo_b, hi_b, false);
+        self.add_range_checks(Operation::U32assert2, a, b, false);
 
         self.stack.copy_state(0);
         Ok(())


### PR DESCRIPTION
This PR updates the u32 op executors so that they now set helper registers in the decoder trace with the hint values required for their constraints. As part of this, the following small changes were made:

- fixes a bug in the u32assert2 operation which resulted in 4 extra unnecessary range checks
- refactor the aux_table unit tests so they still pass with the new changes
- update the code & remove the inline TODO that was waiting for the aux table unit test refactor
- add unit tests for the new helper method that sets the helper columns in the decoder trace
- refactors the u32 executor unit tests and the range checker auxiliary column execution trace unit tests, adding a new dummy process for testing with a dummy decoder containing one trace row