### PR TITLE
no_std support

### DIFF
--- a/air/src/aux_table/bitwise_pow2/bitwise/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/bitwise/mod.rs
@@ -1,4 +1,4 @@
-use super::{EvaluationFrame, FieldElement, BITWISE_TRACE_OFFSET, OP_CYCLE_LEN};
+use super::{EvaluationFrame, FieldElement, Vec, BITWISE_TRACE_OFFSET, OP_CYCLE_LEN};
 use crate::utils::{binary_not, is_binary, EvaluationResult};
 use core::ops::Range;
 use vm_core::{

--- a/air/src/aux_table/bitwise_pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/mod.rs
@@ -1,4 +1,4 @@
-use super::{EvaluationFrame, FieldElement, TransitionConstraintDegree, BITWISE_TRACE_OFFSET};
+use super::{EvaluationFrame, FieldElement, TransitionConstraintDegree, Vec, BITWISE_TRACE_OFFSET};
 use crate::utils::is_binary;
 use core::ops::Range;
 use vm_core::{

--- a/air/src/aux_table/bitwise_pow2/pow2/mod.rs
+++ b/air/src/aux_table/bitwise_pow2/pow2/mod.rs
@@ -1,6 +1,6 @@
 use crate::utils::{binary_not, is_binary};
 
-use super::{EvaluationFrame, FieldElement, OP_CYCLE_LEN, POW2_TRACE_OFFSET};
+use super::{EvaluationFrame, FieldElement, Vec, OP_CYCLE_LEN, POW2_TRACE_OFFSET};
 use core::ops::Range;
 use vm_core::{bitwise::POW2_POWERS_PER_ROW, utils::range as create_range};
 use winter_air::TransitionConstraintDegree;

--- a/air/src/aux_table/hasher/mod.rs
+++ b/air/src/aux_table/hasher/mod.rs
@@ -1,6 +1,6 @@
 use crate::utils::{are_equal, binary_not, is_binary, EvaluationResult};
 
-use super::{EvaluationFrame, Felt, FieldElement, HASHER_TRACE_OFFSET};
+use super::{EvaluationFrame, Felt, FieldElement, Vec, HASHER_TRACE_OFFSET};
 use core::ops::Range;
 use vm_core::{
     hasher::{

--- a/air/src/aux_table/memory/mod.rs
+++ b/air/src/aux_table/memory/mod.rs
@@ -1,4 +1,4 @@
-use super::{EvaluationFrame, FieldElement, MEMORY_TRACE_OFFSET};
+use super::{EvaluationFrame, FieldElement, Vec, MEMORY_TRACE_OFFSET};
 use crate::utils::{binary_not, is_binary, EvaluationResult};
 use core::ops::Range;
 use vm_core::utils::range as create_range;

--- a/air/src/aux_table/mod.rs
+++ b/air/src/aux_table/mod.rs
@@ -1,4 +1,4 @@
-use super::{EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree};
+use super::{EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree, Vec};
 use crate::utils::{binary_not, is_binary};
 use vm_core::AUX_TRACE_OFFSET;
 

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -1,6 +1,12 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
 use vm_core::{
     hasher::Digest,
-    utils::{ByteWriter, Serializable},
+    utils::{collections::Vec, ByteWriter, Serializable},
     ExtensionOf, CLK_COL_IDX, FMP_COL_IDX, MIN_STACK_DEPTH, STACK_TRACE_OFFSET,
 };
 use winter_air::{

--- a/air/src/range.rs
+++ b/air/src/range.rs
@@ -1,5 +1,6 @@
 use vm_core::{
     range::{P0_COL_IDX, P1_COL_IDX, S0_COL_IDX, S1_COL_IDX, T_COL_IDX, V_COL_IDX},
+    utils::collections::Vec,
     ExtensionOf,
 };
 use winter_air::AuxTraceRandElements;

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -1,6 +1,6 @@
 use super::FieldElement;
 use core::ops::Range;
-use vm_core::utils::range as create_range;
+use vm_core::{utils::collections::Vec, utils::range as create_range};
 
 // BASIC CONSTRAINT OPERATORS
 // ================================================================================================

--- a/assembly/src/context/mod.rs
+++ b/assembly/src/context/mod.rs
@@ -1,5 +1,4 @@
-use super::{CodeBlock, ProcMap, Procedure, MODULE_PATH_DELIM};
-use vm_core::utils::collections::BTreeMap;
+use super::{BTreeMap, CodeBlock, ProcMap, Procedure, String, ToString, MODULE_PATH_DELIM};
 
 // ASSEMBLY CONTEXT
 // ================================================================================================

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -1,4 +1,4 @@
-use super::Token;
+use super::{String, ToString, Token};
 use core::fmt;
 
 // ASSEMBLY ERROR

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -1,6 +1,15 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
 use vm_core::{
     program::{blocks::CodeBlock, Library, Script},
-    utils::collections::BTreeMap,
+    utils::{
+        collections::{BTreeMap, Vec},
+        string::{String, ToString},
+    },
 };
 use vm_stdlib::StdLibrary;
 

--- a/assembly/src/parsers/blocks.rs
+++ b/assembly/src/parsers/blocks.rs
@@ -1,7 +1,8 @@
 use super::{
-    parse_op_token, AssemblyContext, AssemblyError, CodeBlock, Operation, Token, TokenStream,
+    parse_op_token, AssemblyContext, AssemblyError, CodeBlock, Operation, String, Token,
+    TokenStream, Vec,
 };
-use vm_core::utils::{collections::Vec, group_vector_elements};
+use vm_core::utils::group_vector_elements;
 
 // BLOCK PARSER
 // ================================================================================================

--- a/assembly/src/parsers/crypto_ops.rs
+++ b/assembly/src/parsers/crypto_ops.rs
@@ -1,4 +1,4 @@
-use super::{super::validate_operation, AssemblyError, Felt, Operation, Token};
+use super::{super::validate_operation, AssemblyError, Felt, Operation, Token, Vec};
 use vm_core::{utils::PushMany, AdviceInjector};
 
 // HASHING

--- a/assembly/src/parsers/field_ops.rs
+++ b/assembly/src/parsers/field_ops.rs
@@ -1,6 +1,6 @@
 use super::{
     super::validate_operation, parse_element_param, AssemblyError, Felt, FieldElement, Operation,
-    Token,
+    Token, Vec,
 };
 
 // ASSERTIONS AND TESTS

--- a/assembly/src/parsers/io_ops/adv_ops.rs
+++ b/assembly/src/parsers/io_ops/adv_ops.rs
@@ -1,4 +1,4 @@
-use super::{parse_int_param, validate_operation, AssemblyError, Operation, Token};
+use super::{parse_int_param, validate_operation, AssemblyError, Operation, Token, Vec};
 use vm_core::utils::PushMany;
 
 // CONSTANTS

--- a/assembly/src/parsers/io_ops/constant_ops.rs
+++ b/assembly/src/parsers/io_ops/constant_ops.rs
@@ -1,6 +1,6 @@
 use super::{
     parse_decimal_param, parse_element_param, parse_hex_param, push_value, validate_operation,
-    AssemblyError, Felt, Operation, Token,
+    AssemblyError, Felt, Operation, Token, Vec,
 };
 
 // CONSTANTS

--- a/assembly/src/parsers/io_ops/env_ops.rs
+++ b/assembly/src/parsers/io_ops/env_ops.rs
@@ -1,5 +1,5 @@
 use super::{
-    parse_int_param, push_value, validate_operation, AssemblyError, Felt, Operation, Token,
+    parse_int_param, push_value, validate_operation, AssemblyError, Felt, Operation, Token, Vec,
 };
 
 // ENVIRONMENT INPUTS

--- a/assembly/src/parsers/io_ops/local_ops.rs
+++ b/assembly/src/parsers/io_ops/local_ops.rs
@@ -1,5 +1,5 @@
 use super::{
-    parse_int_param, push_value, validate_operation, AssemblyError, Felt, Operation, Token,
+    parse_int_param, push_value, validate_operation, AssemblyError, Felt, Operation, Token, Vec,
 };
 use vm_core::utils::PushMany;
 

--- a/assembly/src/parsers/io_ops/mem_ops.rs
+++ b/assembly/src/parsers/io_ops/mem_ops.rs
@@ -1,4 +1,4 @@
-use super::{parse_element_param, validate_operation, AssemblyError, Operation, Token};
+use super::{parse_element_param, validate_operation, AssemblyError, Operation, Token, Vec};
 use vm_core::utils::PushMany;
 
 // RANDOM ACCESS MEMORY

--- a/assembly/src/parsers/io_ops/mod.rs
+++ b/assembly/src/parsers/io_ops/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     super::validate_operation, parse_decimal_param, parse_element_param, parse_hex_param,
-    parse_int_param, push_value, AdviceInjector, AssemblyError, Felt, Operation, Token,
+    parse_int_param, push_value, AdviceInjector, AssemblyError, Felt, Operation, Token, Vec,
 };
 
 mod adv_ops;

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -1,7 +1,9 @@
 use super::{AssemblyContext, AssemblyError, Token, TokenStream};
 pub use blocks::{combine_blocks, parse_code_blocks};
 use vm_core::{
-    program::blocks::CodeBlock, AdviceInjector, Felt, FieldElement, Operation, StarkField,
+    program::blocks::CodeBlock,
+    utils::{collections::Vec, string::String},
+    AdviceInjector, Felt, FieldElement, Operation, StarkField,
 };
 
 mod blocks;

--- a/assembly/src/parsers/stack_ops.rs
+++ b/assembly/src/parsers/stack_ops.rs
@@ -1,4 +1,4 @@
-use super::{AssemblyError, Operation, Token};
+use super::{AssemblyError, Operation, Token, Vec};
 use vm_core::utils::PushMany;
 
 // STACK MANIPULATION

--- a/assembly/src/parsers/u32_ops.rs
+++ b/assembly/src/parsers/u32_ops.rs
@@ -1,4 +1,4 @@
-use super::{parse_int_param, push_value, AssemblyError, Felt, Operation, Token};
+use super::{parse_int_param, push_value, AssemblyError, Felt, Operation, Token, Vec};
 
 // CONVERSIONS AND TESTS
 // ================================================================================================

--- a/assembly/src/procedures/mod.rs
+++ b/assembly/src/procedures/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    combine_blocks, parse_code_blocks, AssemblyContext, AssemblyError, CodeBlock, Token,
-    TokenStream,
+    combine_blocks, parse_code_blocks, AssemblyContext, AssemblyError, CodeBlock, String, Token,
+    TokenStream, Vec,
 };
 use vm_core::{Felt, Operation};
 

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -1,4 +1,4 @@
-use super::AssemblyError;
+use super::{AssemblyError, String, ToString, Vec};
 use core::fmt;
 
 mod stream;

--- a/assembly/src/tokens/stream.rs
+++ b/assembly/src/tokens/stream.rs
@@ -1,5 +1,6 @@
 use super::{AssemblyError, Token};
 use core::fmt;
+use vm_core::utils::collections::Vec;
 
 // TOKEN STREAM
 // ================================================================================================

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["math/std", "winter-utils/std"]
+std = ["math/std", "winter-utils/std", "crypto/std"]
 
 [dependencies]
 crypto = { package = "winter-crypto", version = "0.4", default-features = false }

--- a/core/src/decoder/mod.rs
+++ b/core/src/decoder/mod.rs
@@ -1,5 +1,5 @@
 use super::{range, Operation};
-use std::ops::Range;
+use core::ops::Range;
 
 // CONSTANTS
 // ================================================================================================

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -1,4 +1,5 @@
 use super::Word;
+use crate::utils::{collections::Vec, string::String};
 
 #[derive(Clone, Debug)]
 pub enum InputError {

--- a/core/src/hasher/mod.rs
+++ b/core/src/hasher/mod.rs
@@ -1,8 +1,8 @@
 //! TODO: add docs
 
 use super::{Felt, FieldElement, Word};
+use core::ops::Range;
 use crypto::{ElementHasher, Hasher as HashFn};
-use std::ops::Range;
 
 pub use crypto::hashers::Rp64_256 as Hasher;
 

--- a/core/src/inputs/advice/merkle_path_set.rs
+++ b/core/src/inputs/advice/merkle_path_set.rs
@@ -1,5 +1,5 @@
 use super::{hasher, AdviceSetError, Felt, FieldElement, Word};
-use std::collections::BTreeMap;
+use crate::utils::collections::{BTreeMap, Vec};
 
 // MERKLE PATH SET
 // ================================================================================================

--- a/core/src/inputs/advice/merkle_tree.rs
+++ b/core/src/inputs/advice/merkle_tree.rs
@@ -2,6 +2,7 @@ use super::{
     hasher::{self, Digest},
     AdviceSetError, Felt, FieldElement, Word,
 };
+use crate::utils::collections::Vec;
 use core::slice;
 use math::log2;
 use winter_utils::uninit_vector;

--- a/core/src/inputs/advice/mod.rs
+++ b/core/src/inputs/advice/mod.rs
@@ -1,4 +1,5 @@
 use super::{hasher, AdviceSetError, Felt, FieldElement, Word};
+use crate::utils::collections::Vec;
 
 mod merkle_tree;
 use merkle_tree::MerkleTree;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,9 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
 use core::ops::Range;
 
 pub mod bitwise;

--- a/core/src/program/blocks/join_block.rs
+++ b/core/src/program/blocks/join_block.rs
@@ -1,4 +1,4 @@
-use super::{fmt, hasher, CodeBlock, Digest};
+use super::{fmt, hasher, Box, CodeBlock, Digest};
 
 // JOIN BLOCKS
 // ================================================================================================

--- a/core/src/program/blocks/loop_block.rs
+++ b/core/src/program/blocks/loop_block.rs
@@ -1,4 +1,4 @@
-use super::{fmt, hasher, CodeBlock, Digest};
+use super::{fmt, hasher, Box, CodeBlock, Digest};
 
 // LOOP BLOCK
 // ================================================================================================

--- a/core/src/program/blocks/mod.rs
+++ b/core/src/program/blocks/mod.rs
@@ -1,4 +1,4 @@
-use super::{hasher, Digest, Felt, FieldElement, Operation};
+use super::{hasher, Box, Digest, Felt, FieldElement, Operation, Vec};
 use core::fmt;
 
 mod call_block;

--- a/core/src/program/blocks/span_block.rs
+++ b/core/src/program/blocks/span_block.rs
@@ -1,4 +1,4 @@
-use super::{fmt, hasher, Digest, Felt, FieldElement, Operation};
+use super::{fmt, hasher, Digest, Felt, FieldElement, Operation, Vec};
 use winter_utils::flatten_slice_elements;
 
 // CONSTANTS

--- a/core/src/program/blocks/split_block.rs
+++ b/core/src/program/blocks/split_block.rs
@@ -1,4 +1,4 @@
-use super::{fmt, hasher, CodeBlock, Digest};
+use super::{fmt, hasher, Box, CodeBlock, Digest};
 
 // SPLIT BLOCK
 // ================================================================================================

--- a/core/src/program/mod.rs
+++ b/core/src/program/mod.rs
@@ -1,9 +1,12 @@
 use super::{
     hasher::{self, Digest},
+    utils::{
+        collections::{BTreeMap, Vec},
+        Box,
+    },
     Felt, FieldElement, Operation,
 };
 use core::fmt;
-use winter_utils::collections::BTreeMap;
 
 pub mod blocks;
 use blocks::CodeBlock;

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -1,12 +1,22 @@
 use super::{Felt, StarkField};
 use core::{fmt::Debug, ops::Range};
+use winter_utils::collections::Vec;
+
+// FEATURE BASED RE-EXPORT
+// ================================================================================================
+
+#[cfg(not(feature = "std"))]
+pub use alloc::boxed::Box;
+
+#[cfg(feature = "std")]
+pub use std::boxed::Box;
 
 // RE-EXPORTS
 // ================================================================================================
 
 pub use winter_utils::{
-    collections, group_vector_elements, uninit_vector, ByteReader, ByteWriter, Deserializable,
-    DeserializationError, Serializable, SliceReader,
+    collections, group_vector_elements, string, uninit_vector, ByteReader, ByteWriter,
+    Deserializable, DeserializationError, Serializable, SliceReader,
 };
 
 pub use crypto::{RandomCoin, RandomCoinError};

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 [features]
 concurrent = ["prover/concurrent", "std"]
 default = ["std"]
-std = ["air/std", "assembly/std", "hex/std", "processor/std", "prover/std", "verifier/std"]
+std = ["air/std", "assembly/std", "processor/std", "prover/std", "hex/std", "log/std", "verifier/std", "vm-core/std"]
 
 [dependencies]
 air = { package = "miden-air", path = "../air", version = "0.2", default-features = false }

--- a/miden/src/lib.rs
+++ b/miden/src/lib.rs
@@ -1,7 +1,9 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use air::{ProcessorAir, PublicInputs};
 use processor::{ExecutionError, ExecutionTrace};
 use prover::Prover;
-use vm_core::{Felt, StarkField, MIN_STACK_DEPTH};
+use vm_core::{utils::collections::Vec, Felt, StarkField, MIN_STACK_DEPTH};
 
 #[cfg(feature = "std")]
 use log::debug;

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["vm-core/std", "winterfell/std"]
+std = ["vm-core/std", "winterfell/std", "log/std"]
 
 [dependencies]
 log = "0.4.14"

--- a/processor/src/aux_table/mod.rs
+++ b/processor/src/aux_table/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    AuxTableTrace, Bitwise, Felt, FieldElement, Hasher, Memory, TraceFragment, AUX_TRACE_WIDTH,
+    AuxTableTrace, Bitwise, Felt, FieldElement, Hasher, Memory, TraceFragment, Vec, AUX_TRACE_WIDTH,
 };
 
 #[cfg(test)]

--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -1,4 +1,4 @@
-use super::{ExecutionError, Felt, FieldElement, StarkField, TraceFragment};
+use super::{ExecutionError, Felt, FieldElement, StarkField, TraceFragment, Vec};
 use vm_core::bitwise::{
     BITWISE_AND, BITWISE_OR, BITWISE_XOR, NUM_SELECTORS, POW2_POWERS_PER_ROW, POWER_OF_TWO,
     TRACE_WIDTH,

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -1,4 +1,4 @@
-use crate::{ExecutionError, Felt, Process, StarkField};
+use crate::{ExecutionError, Felt, Process, StarkField, Vec};
 use core::fmt;
 use vm_core::Word;
 

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     ExecutionError, Felt, FieldElement, Join, Loop, OpBatch, Operation, Process, Span, Split,
-    StarkField, Word, MIN_TRACE_LEN, OP_BATCH_SIZE,
+    StarkField, Vec, Word, MIN_TRACE_LEN, OP_BATCH_SIZE,
 };
 use vm_core::decoder::NUM_HASHER_COLUMNS;
 

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -1,5 +1,5 @@
-use super::{Felt, Operation, Word, MIN_TRACE_LEN, NUM_HASHER_COLUMNS, NUM_OP_BITS};
-use std::ops::Range;
+use super::{Felt, Operation, Vec, Word, MIN_TRACE_LEN, NUM_HASHER_COLUMNS, NUM_OP_BITS};
+use core::ops::Range;
 use vm_core::{program::blocks::OP_BATCH_SIZE, utils::new_array_vec, FieldElement, StarkField};
 
 // CONSTANTS

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -1,4 +1,4 @@
-use super::{Felt, FieldElement, StarkField, TraceFragment, Word};
+use super::{Felt, FieldElement, StarkField, TraceFragment, Vec, Word};
 use vm_core::{
     hasher::{
         absorb_into_state, get_digest, init_state, init_state_from_words, Selectors, LINEAR_HASH,

--- a/processor/src/hasher/trace.rs
+++ b/processor/src/hasher/trace.rs
@@ -1,4 +1,4 @@
-use super::{Felt, FieldElement, HasherState, Selectors, TraceFragment, TRACE_WIDTH};
+use super::{Felt, FieldElement, HasherState, Selectors, TraceFragment, Vec, TRACE_WIDTH};
 use vm_core::hasher::{apply_round, NUM_ROUNDS, STATE_WIDTH};
 
 // HASHER TRACE

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -1,3 +1,9 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
 use vm_core::{
     errors::AdviceSetError,
     hasher::Digest,
@@ -5,6 +11,7 @@ use vm_core::{
         blocks::{CodeBlock, Join, Loop, OpBatch, Span, Split, OP_BATCH_SIZE, OP_GROUP_SIZE},
         Script,
     },
+    utils::collections::{BTreeMap, Vec},
     AdviceInjector, DebugOptions, Felt, FieldElement, Operation, ProgramInputs, StackTopState,
     StarkField, Word, AUX_TRACE_WIDTH, DECODER_TRACE_WIDTH, MIN_STACK_DEPTH, MIN_TRACE_LEN,
     NUM_STACK_HELPER_COLS, RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH, SYS_TRACE_WIDTH,

--- a/processor/src/memory/mod.rs
+++ b/processor/src/memory/mod.rs
@@ -1,6 +1,5 @@
-use super::{Felt, FieldElement, StarkField, TraceFragment, Word};
+use super::{BTreeMap, Felt, FieldElement, StarkField, TraceFragment, Vec, Word};
 use core::ops::RangeInclusive;
-use vm_core::utils::collections::BTreeMap;
 
 #[cfg(test)]
 mod tests;

--- a/processor/src/operations/decorators/mod.rs
+++ b/processor/src/operations/decorators/mod.rs
@@ -1,6 +1,10 @@
 use super::{AdviceInjector, DebugOptions, ExecutionError, Felt, Process, StarkField, Word};
 use core::ops::RangeInclusive;
 use log::info;
+use vm_core::utils::{
+    collections::Vec,
+    string::{String, ToString},
+};
 
 #[cfg(test)]
 mod debug_tests;

--- a/processor/src/range/mod.rs
+++ b/processor/src/range/mod.rs
@@ -1,7 +1,7 @@
 use crate::RangeCheckTrace;
 
-use super::{Felt, FieldElement};
-use vm_core::utils::{collections::BTreeMap, uninit_vector};
+use super::{BTreeMap, Felt, FieldElement, Vec};
+use vm_core::utils::uninit_vector;
 
 #[cfg(test)]
 mod tests;

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    Felt, FieldElement, ProgramInputs, StackTopState, MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS,
-    STACK_TRACE_WIDTH,
+    BTreeMap, Felt, FieldElement, ProgramInputs, StackTopState, Vec, MIN_STACK_DEPTH,
+    NUM_STACK_HELPER_COLS, STACK_TRACE_WIDTH,
 };
 use core::cmp;
 

--- a/processor/src/stack/overflow.rs
+++ b/processor/src/stack/overflow.rs
@@ -1,5 +1,4 @@
-use super::{Felt, FieldElement};
-use vm_core::utils::collections::BTreeMap;
+use super::{BTreeMap, Felt, FieldElement, Vec};
 
 // OVERFLOW TABLE
 // ================================================================================================

--- a/processor/src/stack/trace.rs
+++ b/processor/src/stack/trace.rs
@@ -1,9 +1,8 @@
-use vm_core::StarkField;
-
 use super::{
-    Felt, FieldElement, ProgramInputs, StackTopState, MAX_TOP_IDX, MIN_STACK_DEPTH,
+    Felt, FieldElement, ProgramInputs, StackTopState, Vec, MAX_TOP_IDX, MIN_STACK_DEPTH,
     NUM_STACK_HELPER_COLS, STACK_TRACE_WIDTH,
 };
+use vm_core::StarkField;
 
 // STACK TRACE
 // ================================================================================================

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -1,4 +1,4 @@
-use super::{Felt, FieldElement, SysTrace};
+use super::{Felt, FieldElement, SysTrace, Vec};
 
 // CONSTANTS
 // ================================================================================================

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -1,10 +1,13 @@
 use super::{
     range::AuxTraceHints as RangeCheckerAuxTraceHints, Digest, Felt, FieldElement, Process,
-    StackTopState,
+    StackTopState, Vec,
 };
 use core::slice;
-use vm_core::{StarkField, MIN_STACK_DEPTH, MIN_TRACE_LEN, STACK_TRACE_OFFSET, TRACE_WIDTH};
+use vm_core::{MIN_STACK_DEPTH, MIN_TRACE_LEN, STACK_TRACE_OFFSET, TRACE_WIDTH};
 use winterfell::{EvaluationFrame, Matrix, Serializable, Trace, TraceLayout};
+
+#[cfg(feature = "std")]
+use vm_core::StarkField;
 
 mod range;
 
@@ -94,7 +97,7 @@ impl ExecutionTrace {
 
     // TEST HELPERS
     // --------------------------------------------------------------------------------------------
-
+    #[cfg(feature = "std")]
     #[allow(dead_code)]
     pub fn print(&self) {
         let mut row = [Felt::ZERO; TRACE_WIDTH];

--- a/processor/src/trace/range/mod.rs
+++ b/processor/src/trace/range/mod.rs
@@ -1,4 +1,4 @@
-use super::{Felt, FieldElement, NUM_RAND_ROWS};
+use super::{Felt, FieldElement, Vec, NUM_RAND_ROWS};
 use crate::range::{AuxColumnHint, AuxTraceHints};
 
 pub use vm_core::range::{P0_COL_IDX, P1_COL_IDX, T_COL_IDX, V_COL_IDX};

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -16,4 +16,4 @@ bench = false
 doctest = false
 
 [dependencies]
-vm-core = { package = "miden-core", path = "../core", version = "0.2" }
+vm-core = { package = "miden-core", default-features = false, path = "../core", version = "0.2" }

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -1,4 +1,10 @@
-use vm_core::{errors::LibraryError, program::Library, utils::collections::BTreeMap};
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use vm_core::{
+    errors::LibraryError,
+    program::Library,
+    utils::{collections::BTreeMap, string::ToString},
+};
 
 mod asm;
 use asm::MODULES;

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["air/std", "assembly/std", "winterfell/std"]
+std = ["air/std", "assembly/std", "vm-core/std", "winterfell/std"]
 
 [dependencies]
 air = { package = "miden-air", path = "../air", version = "0.2", default-features = false }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -1,6 +1,8 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use air::{ProcessorAir, PublicInputs};
 use core::fmt;
-use vm_core::MIN_STACK_DEPTH;
+use vm_core::{utils::collections::Vec, MIN_STACK_DEPTH};
 use winterfell::VerifierError;
 
 // EXPORTS


### PR DESCRIPTION
This PR introduces compatibility with no_std targets. Where possible (`collections` / `string`) re-exports of `winter_utils` have been used.  `winter_utils` did not support `Box` and therefore a feature based re-export has been introduced in `core/src/utils/mod.rs`:

```
// FEATURE BASED RE-EXPORT
// ================================================================================================

#[cfg(not(feature = "std"))]
pub use alloc::boxed::Box;

#[cfg(feature = "std")]
pub use std::boxed::Box;
```

closes: #241 