### PR TITLE
Add op batch flags to decoder trace

### DIFF
--- a/core/src/decoder/mod.rs
+++ b/core/src/decoder/mod.rs
@@ -1,4 +1,4 @@
-use super::{range, Operation};
+use super::{range, Felt, Operation, ONE, ZERO};
 use core::ops::Range;
 
 // CONSTANTS
@@ -44,3 +44,15 @@ pub const NUM_OP_BATCH_FLAGS: usize = 3;
 
 /// Location of operation batch flag columns in the decoder trace.
 pub const OP_BATCH_FLAGS_RANGE: Range<usize> = range(OP_BATCH_FLAGS_OFFSET, NUM_OP_BATCH_FLAGS);
+
+/// Operation batch consists of 8 operation groups.
+pub const OP_BATCH_8_GROUPS: [Felt; NUM_OP_BATCH_FLAGS] = [ONE, ZERO, ZERO];
+
+/// Operation batch consists of 4 operation groups.
+pub const OP_BATCH_4_GROUPS: [Felt; NUM_OP_BATCH_FLAGS] = [ZERO, ONE, ZERO];
+
+/// Operation batch consists of 2 operation groups.
+pub const OP_BATCH_2_GROUPS: [Felt; NUM_OP_BATCH_FLAGS] = [ZERO, ZERO, ONE];
+
+/// Operation batch consists of 1 operation group.
+pub const OP_BATCH_1_GROUPS: [Felt; NUM_OP_BATCH_FLAGS] = [ZERO, ONE, ONE];

--- a/core/src/decoder/mod.rs
+++ b/core/src/decoder/mod.rs
@@ -10,7 +10,7 @@ pub const ADDR_COL_IDX: usize = 0;
 /// Index at which operation bit columns start in the decoder trace.
 pub const OP_BITS_OFFSET: usize = ADDR_COL_IDX + 1;
 
-/// Number of columns needed to hold a binary representation of of opcodes.
+/// Number of columns needed to hold a binary representation of opcodes.
 pub const NUM_OP_BITS: usize = Operation::OP_BITS;
 
 /// Location of operation bits columns in the decoder trace.

--- a/core/src/decoder/mod.rs
+++ b/core/src/decoder/mod.rs
@@ -8,27 +8,39 @@ use core::ops::Range;
 pub const ADDR_COL_IDX: usize = 0;
 
 /// Index at which operation bit columns start in the decoder trace.
-pub const OP_BITS_OFFSET: usize = 1;
+pub const OP_BITS_OFFSET: usize = ADDR_COL_IDX + 1;
+
+/// Number of columns needed to hold a binary representation of of opcodes.
+pub const NUM_OP_BITS: usize = Operation::OP_BITS;
 
 /// Location of operation bits columns in the decoder trace.
-pub const OP_BITS_RANGE: Range<usize> = range(OP_BITS_OFFSET, Operation::OP_BITS);
-
-/// Index of the in_span column in the decoder trace.
-pub const IN_SPAN_COL_IDX: usize = 8;
-
-/// Index of the operation group count column in the decoder trace.
-pub const GROUP_COUNT_COL_IDX: usize = 17;
-
-/// Index of the operation index column in the decoder trace.
-pub const OP_INDEX_COL_IDX: usize = 18;
+pub const OP_BITS_RANGE: Range<usize> = range(OP_BITS_OFFSET, NUM_OP_BITS);
 
 // TODO: probably rename "hasher state" to something like "shared columns".
 
 /// Index at which hasher state columns start in the decoder trace.
-pub const HASHER_STATE_OFFSET: usize = 9;
+pub const HASHER_STATE_OFFSET: usize = OP_BITS_OFFSET + NUM_OP_BITS;
 
 /// Number of hasher columns in the decoder trace.
 pub const NUM_HASHER_COLUMNS: usize = 8;
 
 /// Location of hasher columns in the decoder trace.
 pub const HASHER_STATE_RANGE: Range<usize> = range(HASHER_STATE_OFFSET, NUM_HASHER_COLUMNS);
+
+/// Index of the in_span column in the decoder trace.
+pub const IN_SPAN_COL_IDX: usize = HASHER_STATE_OFFSET + NUM_HASHER_COLUMNS;
+
+/// Index of the operation group count column in the decoder trace.
+pub const GROUP_COUNT_COL_IDX: usize = IN_SPAN_COL_IDX + 1;
+
+/// Index of the operation index column in the decoder trace.
+pub const OP_INDEX_COL_IDX: usize = GROUP_COUNT_COL_IDX + 1;
+
+/// Index at which operation batch flag columns start in the decoder trace.
+pub const OP_BATCH_FLAGS_OFFSET: usize = OP_INDEX_COL_IDX + 1;
+
+/// Number of operation batch flag columns.
+pub const NUM_OP_BATCH_FLAGS: usize = 3;
+
+/// Location of operation batch flag columns in the decoder trace.
+pub const OP_BATCH_FLAGS_RANGE: Range<usize> = range(OP_BATCH_FLAGS_OFFSET, NUM_OP_BATCH_FLAGS);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,6 +34,12 @@ pub type StackTopState = [Felt; MIN_STACK_DEPTH];
 // CONSTANTS
 // ================================================================================================
 
+/// Field element representing ZERO in the base field of the VM.
+pub const ZERO: Felt = Felt::ZERO;
+
+/// Field element representing ONE in the base field of the VM.
+pub const ONE: Felt = Felt::ONE;
+
 /// The minimum length of the execution trace. This is the minimum required to support range checks.
 pub const MIN_TRACE_LEN: usize = 1024;
 
@@ -48,7 +54,7 @@ pub const NUM_STACK_HELPER_COLS: usize = 3;
 // ------------------------------------------------------------------------------------------------
 
 //      system          decoder           stack      range checks    auxiliary table
-//    (2 columns)     (19 columns)    (19 columns)    (4 columns)     (18 columns)
+//    (2 columns)     (22 columns)    (19 columns)    (4 columns)     (18 columns)
 // ├───────────────┴───────────────┴───────────────┴───────────────┴─────────────────┤
 
 pub const SYS_TRACE_OFFSET: usize = 0;
@@ -60,7 +66,7 @@ pub const FMP_COL_IDX: usize = SYS_TRACE_OFFSET + 1;
 
 // decoder trace
 pub const DECODER_TRACE_OFFSET: usize = SYS_TRACE_OFFSET + SYS_TRACE_WIDTH;
-pub const DECODER_TRACE_WIDTH: usize = 19;
+pub const DECODER_TRACE_WIDTH: usize = 22;
 pub const DECODER_TRACE_RANGE: Range<usize> = range(DECODER_TRACE_OFFSET, DECODER_TRACE_WIDTH);
 
 // Stack trace

--- a/core/src/program/blocks/mod.rs
+++ b/core/src/program/blocks/mod.rs
@@ -12,7 +12,10 @@ pub use call_block::Call;
 pub use join_block::Join;
 pub use loop_block::Loop;
 pub use proxy_block::Proxy;
-pub use span_block::{OpBatch, Span, BATCH_SIZE as OP_BATCH_SIZE, GROUP_SIZE as OP_GROUP_SIZE};
+pub use span_block::{
+    get_span_op_group_count, OpBatch, Span, BATCH_SIZE as OP_BATCH_SIZE,
+    GROUP_SIZE as OP_GROUP_SIZE,
+};
 pub use split_block::Split;
 
 // PROGRAM BLOCK

--- a/core/src/program/blocks/span_block.rs
+++ b/core/src/program/blocks/span_block.rs
@@ -68,15 +68,6 @@ impl Span {
         &self.op_batches
     }
 
-    /// Returns a list of operations contained in this span block.
-    pub fn get_ops(&self) -> Vec<Operation> {
-        let mut ops = Vec::with_capacity(self.op_batches.len() * MAX_OPS_PER_BATCH);
-        for batch in self.op_batches.iter() {
-            ops.extend_from_slice(&batch.ops);
-        }
-        ops
-    }
-
     // SPAN MUTATORS
     // --------------------------------------------------------------------------------------------
 
@@ -90,6 +81,18 @@ impl Span {
             ops.extend_from_slice(&own_ops);
         }
         Self::new(ops)
+    }
+
+    // HELPER METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a list of operations contained in this span block.
+    fn get_ops(&self) -> Vec<Operation> {
+        let mut ops = Vec::with_capacity(self.op_batches.len() * MAX_OPS_PER_BATCH);
+        for batch in self.op_batches.iter() {
+            ops.extend_from_slice(&batch.ops);
+        }
+        ops
     }
 }
 
@@ -324,7 +327,20 @@ fn batch_ops(ops: Vec<Operation>) -> (Vec<OpBatch>, Digest) {
         batches.push(batch);
     }
 
-    let hash = hasher::hash_elements(flatten_slice_elements(&batch_groups));
+    // compute total number of operation groups in all batches. This is done as follows:
+    // - For all batches but the last one we set the number of groups to 8, regardless of the
+    //   actual number of groups in the batch. The reason for this is that when operation
+    //   batches are concatenated together each batch contributes 8 elements to the hash.
+    // - For the last batch, we take the number of actual batches and round it up to the next
+    //   power of two. The reason for rounding is that the VM always executes a number of
+    //   operation groups which is a power of two.
+    let num_batches = batches.len();
+    let last_batch_num_groups = batches[num_batches - 1].num_groups().next_power_of_two();
+    let num_op_groups = (num_batches - 1) * BATCH_SIZE + last_batch_num_groups;
+
+    // compute the hash of all operation groups
+    let op_groups = &flatten_slice_elements(&batch_groups)[..num_op_groups];
+    let hash = hasher::hash_elements(op_groups);
 
     (batches, hash)
 }
@@ -353,7 +369,7 @@ mod tests {
 
         assert_eq!(batch_groups, batch.groups);
         assert_eq!([1_usize, 0, 0, 0, 0, 0, 0, 0], batch.op_counts);
-        assert_eq!(hasher::hash_elements(&batch_groups), hash);
+        assert_eq!(hasher::hash_elements(&batch_groups[..1]), hash);
 
         // --- two operations ---------------------------------------------------------------------
         let ops = vec![Operation::Add, Operation::Mul];
@@ -369,7 +385,7 @@ mod tests {
 
         assert_eq!(batch_groups, batch.groups);
         assert_eq!([2_usize, 0, 0, 0, 0, 0, 0, 0], batch.op_counts);
-        assert_eq!(hasher::hash_elements(&batch_groups), hash);
+        assert_eq!(hasher::hash_elements(&batch_groups[..1]), hash);
 
         // --- one group with one immediate value -------------------------------------------------
         let ops = vec![Operation::Add, Operation::Push(Felt::new(12345678))];
@@ -386,7 +402,7 @@ mod tests {
 
         assert_eq!(batch_groups, batch.groups);
         assert_eq!([2_usize, 0, 0, 0, 0, 0, 0, 0], batch.op_counts);
-        assert_eq!(hasher::hash_elements(&batch_groups), hash);
+        assert_eq!(hasher::hash_elements(&batch_groups[..2]), hash);
 
         // --- one group with 7 immediate values --------------------------------------------------
         let ops = vec![
@@ -467,7 +483,7 @@ mod tests {
         assert_eq!(batch1_groups, batch1.groups);
 
         let all_groups = [batch0_groups, batch1_groups].concat();
-        assert_eq!(hasher::hash_elements(&all_groups), hash);
+        assert_eq!(hasher::hash_elements(&all_groups[..10]), hash);
 
         // --- immediate values in-between groups -------------------------------------------------
         let ops = vec![
@@ -503,7 +519,7 @@ mod tests {
 
         assert_eq!([9_usize, 0, 0, 1, 0, 0, 0, 0], batch.op_counts);
         assert_eq!(batch_groups, batch.groups);
-        assert_eq!(hasher::hash_elements(&batch_groups), hash);
+        assert_eq!(hasher::hash_elements(&batch_groups[..4]), hash);
 
         // --- push at the end of a group is moved into the next group ----------------------------
         let ops = vec![
@@ -537,7 +553,7 @@ mod tests {
 
         assert_eq!(batch_groups, batch.groups);
         assert_eq!([8_usize, 1, 0, 0, 0, 0, 0, 0], batch.op_counts);
-        assert_eq!(hasher::hash_elements(&batch_groups), hash);
+        assert_eq!(hasher::hash_elements(&batch_groups[..4]), hash);
 
         // --- push at the end of a group is moved into the next group ----------------------------
         let ops = vec![
@@ -571,7 +587,7 @@ mod tests {
 
         assert_eq!(batch_groups, batch.groups);
         assert_eq!([8_usize, 0, 1, 0, 0, 0, 0, 0], batch.op_counts);
-        assert_eq!(hasher::hash_elements(&batch_groups), hash);
+        assert_eq!(hasher::hash_elements(&batch_groups[..4]), hash);
 
         // --- push at the end of the 7th group overflows to the next batch -----------------------
         let ops = vec![
@@ -635,7 +651,7 @@ mod tests {
         assert_eq!([2_usize, 0, 0, 0, 0, 0, 0, 0], batch1.op_counts);
 
         let all_groups = [batch0_groups, batch1_groups].concat();
-        assert_eq!(hasher::hash_elements(&all_groups), hash);
+        assert_eq!(hasher::hash_elements(&all_groups[..10]), hash);
     }
 
     #[test]
@@ -654,7 +670,7 @@ mod tests {
         batch_groups[0] = build_group(&ops);
         batch_groups[1] = Felt::ONE;
         assert_eq!(batch_groups, batch.groups);
-        assert_eq!(hasher::hash_elements(&batch_groups), hash);
+        assert_eq!(hasher::hash_elements(&batch_groups[..2]), hash);
     }
 
     // TEST HELPERS

--- a/core/src/program/mod.rs
+++ b/core/src/program/mod.rs
@@ -25,7 +25,6 @@ pub use library::Library;
 #[derive(Clone, Debug)]
 pub struct Script {
     root: CodeBlock,
-    hash: Digest,
 }
 
 impl Script {
@@ -33,8 +32,7 @@ impl Script {
     // --------------------------------------------------------------------------------------------
     /// Constructs a new program from the specified code block.
     pub fn new(root: CodeBlock) -> Self {
-        let hash = hasher::merge(&[root.hash(), Digest::default()]);
-        Self { root, hash }
+        Self { root }
     }
 
     // PUBLIC ACCESSORS
@@ -46,8 +44,8 @@ impl Script {
     }
 
     /// Returns a hash of this script.
-    pub fn hash(&self) -> &Digest {
-        &self.hash
+    pub fn hash(&self) -> Digest {
+        self.root.hash()
     }
 }
 

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -72,8 +72,8 @@ pub fn test_example(example: Example, fail: bool) {
 
     if fail {
         outputs[0] += 1;
-        assert!(miden::verify(*program.hash(), &pub_inputs, &outputs, proof).is_err())
+        assert!(miden::verify(program.hash(), &pub_inputs, &outputs, proof).is_err())
     } else {
-        assert!(miden::verify(*program.hash(), &pub_inputs, &outputs, proof).is_ok());
+        assert!(miden::verify(program.hash(), &pub_inputs, &outputs, proof).is_ok());
     }
 }

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -64,7 +64,7 @@ fn main() {
     // results in the expected output
     let proof = StarkProof::from_bytes(&proof_bytes).unwrap();
     let now = Instant::now();
-    match miden::verify(*program.hash(), &pub_inputs, &outputs, proof) {
+    match miden::verify(program.hash(), &pub_inputs, &outputs, proof) {
         Ok(_) => debug!("Execution verified in {} ms", now.elapsed().as_millis()),
         Err(err) => debug!("Failed to verify execution: {}", err),
     }

--- a/miden/tests/integration/helpers/mod.rs
+++ b/miden/tests/integration/helpers/mod.rs
@@ -163,9 +163,9 @@ impl Test {
 
         if test_fail {
             outputs[0] += 1;
-            assert!(miden::verify(*script.hash(), &pub_inputs, &outputs, proof).is_err());
+            assert!(miden::verify(script.hash(), &pub_inputs, &outputs, proof).is_err());
         } else {
-            assert!(miden::verify(*script.hash(), &pub_inputs, &outputs, proof).is_ok());
+            assert!(miden::verify(script.hash(), &pub_inputs, &outputs, proof).is_ok());
         }
     }
 

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -3,7 +3,10 @@ use super::{
     Word, MIN_TRACE_LEN, OP_BATCH_SIZE,
 };
 use vm_core::{
-    decoder::{NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS},
+    decoder::{
+        NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS, OP_BATCH_1_GROUPS, OP_BATCH_2_GROUPS,
+        OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS,
+    },
     ONE, ZERO,
 };
 

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -1,8 +1,11 @@
 use super::{
-    ExecutionError, Felt, FieldElement, Join, Loop, OpBatch, Operation, Process, Span, Split,
-    StarkField, Vec, Word, MIN_TRACE_LEN, OP_BATCH_SIZE,
+    ExecutionError, Felt, Join, Loop, OpBatch, Operation, Process, Span, Split, StarkField, Vec,
+    Word, MIN_TRACE_LEN, OP_BATCH_SIZE,
 };
-use vm_core::decoder::NUM_HASHER_COLUMNS;
+use vm_core::{
+    decoder::{NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS},
+    ONE, ZERO,
+};
 
 mod trace;
 use trace::DecoderTrace;
@@ -13,7 +16,6 @@ mod tests;
 // CONSTANTS
 // ================================================================================================
 
-const NUM_OP_BITS: usize = Operation::OP_BITS;
 const HASH_CYCLE_LEN: Felt = Felt::new(vm_core::hasher::HASH_CYCLE_LEN as u64);
 
 // DECODER PROCESS EXTENSION
@@ -95,7 +97,7 @@ impl Process {
         // hasher is used as the ID of the block; the result of the hash is expected to be in
         // row addr + 7.
         let body_hash = block.body().hash().into();
-        let (addr, _result) = self.hasher.merge(body_hash, [Felt::ZERO; 4]);
+        let (addr, _result) = self.hasher.merge(body_hash, [ZERO; 4]);
 
         // make sure the result computed by the hasher is the same as the expected block hash
         debug_assert_eq!(block.hash(), _result.into());
@@ -128,7 +130,7 @@ impl Process {
             #[cfg(debug_assertions)]
             {
                 let condition = self.stack.peek();
-                debug_assert_eq!(Felt::ZERO, condition);
+                debug_assert_eq!(ZERO, condition);
             }
 
             self.execute_op(Operation::Drop)
@@ -147,7 +149,8 @@ impl Process {
         // hashing operation batches. Thus, the result of the hash is expected to be in row
         // addr + (num_batches * 8) - 1.
         let op_batches = block.op_batches();
-        let (addr, _result) = self.hasher.hash_span_block(op_batches);
+        let num_op_groups = get_span_op_group_count(op_batches);
+        let (addr, _result) = self.hasher.hash_span_block(op_batches, num_op_groups);
 
         // make sure the result computed by the hasher is the same as the expected block hash
         debug_assert_eq!(block.hash(), _result.into());
@@ -155,8 +158,8 @@ impl Process {
         // start decoding the first operation batch; this also appends a row with SPAN operation
         // to the decoder trace. we also need the total number of operation groups so that we can
         // set the value of the group_count register at the beginning of the SPAN.
-        let num_op_groups = Felt::new((op_batches.len() * OP_BATCH_SIZE) as u64);
-        self.decoder.start_span(&op_batches[0], num_op_groups, addr);
+        self.decoder
+            .start_span(&op_batches[0], Felt::new(num_op_groups as u64), addr);
         self.execute_op(Operation::Noop)
     }
 
@@ -181,8 +184,8 @@ impl Process {
 /// Decoder execution trace currently consists of 19 columns as illustrated below (this will
 /// be increased to 24 columns in the future):
 ///
-///  addr  b0  b1  b2  b3  b4  b5  b6 in_span  h0  h1  h2  h3  h4  h5  h6  h7 g_count op_idx
-/// ├────┴───┴───┴───┴───┴───┴───┴───┴───────┴───┴───┴───┴───┴───┴───┴───┴───┴───────┴───────┤
+///  addr b0 b1 b2 b3 b4 b5 b6 h0 h1 h2 h3 h4 h5 h6 h7 in_span g_count op_idx c0 c1 c2
+/// ├────┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴───────┴───────┴──────┴──┴──┴──┤
 ///
 /// In the above, the meaning of the columns is as follows:
 /// * addr column contains address of the hasher for the current block (row index from the
@@ -190,8 +193,6 @@ impl Process {
 ///   convenient, because hasher addresses are guaranteed to be unique.
 /// * op_bits columns b0 through b6 are used to encode an operation to be executed by the VM.
 ///   Each of these columns contains a single binary value, which together form a single opcode.
-/// * in_span column is a binary flag set to ONE when we are inside a SPAN block, and to ZERO
-///   otherwise.
 /// * Hasher state columns h0 through h7. These are multi purpose columns used as follows:
 ///   - When starting decoding of a new code block (e.g., via JOIN, SPLIT, LOOP, SPAN operations)
 ///    these columns are used for providing inputs for the current block's hash computations.
@@ -201,11 +202,16 @@ impl Process {
 ///     operations in the current operation group, as well as the address of the parent code
 ///     block. The remaining 6 columns are unused by the decoder and, thus, can be used by the
 ///     VM as helper columns.
-/// * operation group count column is used to keep track of the number of un-executed operation
+/// * in_span column is a binary flag set to ONE when we are inside a SPAN block, and to ZERO
+///   otherwise.
+/// * Operation group count column is used to keep track of the number of un-executed operation
 ///   groups in the current SPAN block.
-/// * operation index column is used to keep track of the indexes of the currently executing
+/// * Operation index column is used to keep track of the indexes of the currently executing
 ///   operations within an operation group. Values in this column could be between 0 and 8
 ///   (both inclusive) as there could be at most 9 operations in an operation group.
+/// * Operation batch flag columns c0, c1, c2 which indicate how many operation groups are in
+///   a given operation batch. These flags are set only for SPAN or RESPAN operations, and are
+///   set to ZEROs otherwise.
 ///
 /// Also keeps track of operations executed when run in debug mode.
 pub struct Decoder {
@@ -238,7 +244,7 @@ impl Decoder {
     /// This pushes a block with ID=addr onto the block stack and appending execution of a JOIN
     /// operation to the trace.
     pub fn start_join(&mut self, left_child_hash: Word, right_child_hash: Word, addr: Felt) {
-        let parent_addr = self.block_stack.push(addr, Felt::ZERO);
+        let parent_addr = self.block_stack.push(addr, ZERO);
         self.trace.append_block_start(
             parent_addr,
             Operation::Join,
@@ -254,7 +260,7 @@ impl Decoder {
     /// This pushes a block with ID=addr onto the block stack and appending execution of a SPLIT
     /// operation to the trace.
     pub fn start_split(&mut self, left_child_hash: Word, right_child_hash: Word, addr: Felt) {
-        let parent_addr = self.block_stack.push(addr, Felt::ZERO);
+        let parent_addr = self.block_stack.push(addr, ZERO);
         self.trace.append_block_start(
             parent_addr,
             Operation::Split,
@@ -271,12 +277,8 @@ impl Decoder {
     /// operation to the trace. A block is marked as a loop block only if is_loop = ONE.
     pub fn start_loop(&mut self, loop_body_hash: Word, addr: Felt, is_loop: Felt) {
         let parent_addr = self.block_stack.push(addr, is_loop);
-        self.trace.append_block_start(
-            parent_addr,
-            Operation::Loop,
-            loop_body_hash,
-            [Felt::ZERO; 4],
-        );
+        self.trace
+            .append_block_start(parent_addr, Operation::Loop, loop_body_hash, [ZERO; 4]);
 
         self.append_operation(Operation::Loop);
     }
@@ -286,7 +288,7 @@ impl Decoder {
     /// This appends an execution of a REPEAT operation to the trace.
     pub fn repeat(&mut self) {
         let block_info = self.block_stack.peek();
-        debug_assert_eq!(Felt::ONE, block_info.is_loop);
+        debug_assert_eq!(ONE, block_info.is_loop);
         self.trace.append_loop_repeat(block_info.addr);
 
         self.append_operation(Operation::Repeat);
@@ -314,20 +316,16 @@ impl Decoder {
     /// Starts decoding of a SPAN block defined by the specified operation batches.
     pub fn start_span(&mut self, first_op_batch: &OpBatch, num_op_groups: Felt, addr: Felt) {
         debug_assert!(self.span_context.is_none(), "already in span");
-        let parent_addr = self.block_stack.push(addr, Felt::ZERO);
+        let parent_addr = self.block_stack.push(addr, ZERO);
 
         // add a SPAN row to the trace
         self.trace
             .append_span_start(parent_addr, first_op_batch.groups(), num_op_groups);
 
-        // after SPAN operation is executed, we decrement the number of remaining groups by the
-        // number of unused groups in the batch + 1. We add one because executing SPAN consumes
-        // the first group of the batch.
-        let num_unused_groups = get_num_unused_groups(first_op_batch);
-        let consumed_op_groups = Felt::from(num_unused_groups + 1);
-
+        // after SPAN operation is executed, we decrement the number of remaining groups by ONE
+        // because executing SPAN consumes the first group of the batch.
         self.span_context = Some(SpanContext {
-            num_groups_left: num_op_groups - consumed_op_groups,
+            num_groups_left: num_op_groups - ONE,
             group_ops_left: first_op_batch.groups()[0],
         });
 
@@ -344,14 +342,11 @@ impl Decoder {
         let block_info = self.block_stack.peek_mut();
         block_info.addr += HASH_CYCLE_LEN;
 
-        // after RESPAN operation is executed, we decrement the number of remaining groups by the
-        // number of unused groups in the batch + 1. We add one because executing RESPAN consumes
-        // the first group of the batch.
-        let num_unused_groups = get_num_unused_groups(op_batch);
-        let consumed_op_groups = Felt::from(num_unused_groups + 1);
-
         let ctx = self.span_context.as_mut().expect("not in span");
-        ctx.num_groups_left -= consumed_op_groups;
+
+        // after RESPAN operation is executed, we decrement the number of remaining groups by ONE
+        // because executing RESPAN consumes the first group of the batch
+        ctx.num_groups_left -= ONE;
         ctx.group_ops_left = op_batch.groups()[0];
 
         self.append_operation(Operation::Respan);
@@ -361,7 +356,7 @@ impl Decoder {
     pub fn start_op_group(&mut self, op_group: Felt) {
         let ctx = self.span_context.as_mut().expect("not in span");
         ctx.group_ops_left = op_group;
-        ctx.num_groups_left -= Felt::ONE;
+        ctx.num_groups_left -= ONE;
     }
 
     /// Decodes a user operation (i.e., not a control flow operation).
@@ -386,7 +381,7 @@ impl Decoder {
         // if the operation carries an immediate value, decrement the number of  operation
         // groups left to decode. this number will be inserted into the trace in the next row
         if op.imm_value().is_some() {
-            ctx.num_groups_left -= Felt::ONE
+            ctx.num_groups_left -= ONE
         }
 
         self.append_operation(op);
@@ -478,7 +473,7 @@ impl BlockStack {
     pub fn push(&mut self, addr: Felt, is_loop: Felt) -> Felt {
         let (parent_addr, is_loop_body) = if self.blocks.is_empty() {
             // if the stack is empty, the new block has no parent and cannot be a body of a LOOP
-            (Felt::ZERO, Felt::ZERO)
+            (ZERO, ZERO)
         } else {
             let parent = &self.blocks[self.blocks.len() - 1];
             (parent.addr, parent.is_loop)
@@ -534,8 +529,8 @@ struct SpanContext {
 impl Default for SpanContext {
     fn default() -> Self {
         Self {
-            group_ops_left: Felt::ZERO,
-            num_groups_left: Felt::ZERO,
+            group_ops_left: ZERO,
+            num_groups_left: ZERO,
         }
     }
 }
@@ -543,16 +538,18 @@ impl Default for SpanContext {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// Returns the number of unused operation groups in the specified batch.
+/// Returns the total number of operation groups in sequence of operation batches.
 ///
-/// The number of unused groups is computed as follows:
-/// - Number of op groups in the batch is rounded to the next power of two. This is done because
-///   the processor pads these op groups with NOOPs.
-/// - Next, the number of op groups is subtracted from max batch size.
-///
-/// Thus, for example, if a batch contains 3 op groups, the number of unused op groups will be 4.
-fn get_num_unused_groups(op_batch: &OpBatch) -> u8 {
-    (OP_BATCH_SIZE - op_batch.num_groups().next_power_of_two()) as u8
+/// The number of groups is computed as follows:
+/// - For all batches except for the last one we set the number of groups to 8.
+/// - For the last batch, we take the number of groups and round it up to the next power of two.
+fn get_span_op_group_count(op_batches: &[OpBatch]) -> usize {
+    let last_batch_num_groups = op_batches
+        .last()
+        .expect("no last group")
+        .num_groups()
+        .next_power_of_two();
+    (op_batches.len() - 1) * OP_BATCH_SIZE + last_batch_num_groups
 }
 
 /// Removes the specified operation from the op group and returns the resulting op group.

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -3,8 +3,8 @@ use rand_utils::rand_value;
 use vm_core::{
     decoder::{
         ADDR_COL_IDX, GROUP_COUNT_COL_IDX, HASHER_STATE_RANGE, IN_SPAN_COL_IDX, NUM_HASHER_COLUMNS,
-        NUM_OP_BATCH_FLAGS, NUM_OP_BITS, OP_BATCH_FLAGS_RANGE, OP_BITS_OFFSET, OP_BITS_RANGE,
-        OP_INDEX_COL_IDX,
+        NUM_OP_BATCH_FLAGS, NUM_OP_BITS, OP_BATCH_1_GROUPS, OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS,
+        OP_BATCH_8_GROUPS, OP_BATCH_FLAGS_RANGE, OP_BITS_OFFSET, OP_BITS_RANGE, OP_INDEX_COL_IDX,
     },
     program::blocks::{CodeBlock, Span, OP_BATCH_SIZE},
     utils::collections::Vec,
@@ -223,7 +223,7 @@ fn span_block_with_respan() {
     check_op_decoding(&trace, 8, INIT_ADDR, Operation::Noop, 4, 7, 1);
     // RESPAN since the previous batch is full
     let next_addr = INIT_ADDR + Felt::new(8);
-    check_op_decoding(&trace, 9, INIT_ADDR, Operation::Respan, 4, 0, 1);
+    check_op_decoding(&trace, 9, INIT_ADDR, Operation::Respan, 4, 0, 0);
     check_op_decoding(&trace, 10, next_addr, Operation::Push(iv[7]), 3, 0, 1);
     check_op_decoding(&trace, 11, next_addr, Operation::Add, 2, 1, 1);
     check_op_decoding(&trace, 12, next_addr, Operation::Push(iv[8]), 2, 2, 1);
@@ -671,10 +671,10 @@ fn build_op_group(ops: &[Operation]) -> Felt {
 
 fn build_op_batch_flags(num_groups: usize) -> [Felt; NUM_OP_BATCH_FLAGS] {
     match num_groups {
-        1 => [ZERO, ONE, ONE],
-        2 => [ZERO, ZERO, ONE],
-        4 => [ZERO, ONE, ZERO],
-        8 => [ONE, ZERO, ZERO],
+        1 => OP_BATCH_1_GROUPS,
+        2 => OP_BATCH_2_GROUPS,
+        4 => OP_BATCH_4_GROUPS,
+        8 => OP_BATCH_8_GROUPS,
         _ => panic!("invalid num groups: {}", num_groups),
     }
 }

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -1,12 +1,12 @@
-use super::{Felt, Operation, Vec, Word, MIN_TRACE_LEN, NUM_HASHER_COLUMNS, NUM_OP_BITS};
+use super::{
+    Felt, Operation, Vec, Word, MIN_TRACE_LEN, NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS,
+    ONE, ZERO,
+};
 use core::ops::Range;
-use vm_core::{program::blocks::OP_BATCH_SIZE, utils::new_array_vec, FieldElement, StarkField};
+use vm_core::{program::blocks::OP_BATCH_SIZE, utils::new_array_vec, StarkField};
 
 // CONSTANTS
 // ================================================================================================
-
-const ZERO: Felt = Felt::ZERO;
-const ONE: Felt = Felt::ONE;
 
 /// The range of columns in the decoder's `hasher_trace` which is available for use as helper
 /// registers during user operations.
@@ -20,23 +20,25 @@ pub const USER_OP_HELPERS: Range<usize> = Range {
 
 /// Execution trace of the decoder.
 ///
-/// The trace currently consists of 19 columns grouped logically as follows:
+/// The trace currently consists of 22 columns grouped logically as follows:
 /// - 1 column for code block ID / related hasher table row address.
 /// - 7 columns for the binary representation of an opcode.
-/// - 1 column for the flag indicating whether we are in a SPAN block or not.
 /// - 8 columns used for providing inputs to, and reading results from the hasher, but also used
 ///   for other purposes when inside a SPAN block.
+/// - 1 column for the flag indicating whether we are in a SPAN block or not.
 /// - 1 column to keep track of the number of operation groups left to decode in the current
 ///   SPAN block.
 /// - 1 column to keep track of the index of a currently executing operation within an operation
 ///   group.
+/// - 3 columns for keeping track of operation batch flags.
 pub struct DecoderTrace {
     addr_trace: Vec<Felt>,
     op_bits_trace: [Vec<Felt>; NUM_OP_BITS],
-    in_span_trace: Vec<Felt>,
     hasher_trace: [Vec<Felt>; NUM_HASHER_COLUMNS],
+    in_span_trace: Vec<Felt>,
     group_count_trace: Vec<Felt>,
     op_idx_trace: Vec<Felt>,
+    op_batch_flag_trace: [Vec<Felt>; NUM_OP_BATCH_FLAGS],
 }
 
 impl DecoderTrace {
@@ -47,10 +49,11 @@ impl DecoderTrace {
         Self {
             addr_trace: Vec::with_capacity(MIN_TRACE_LEN),
             op_bits_trace: new_array_vec(MIN_TRACE_LEN),
-            in_span_trace: Vec::with_capacity(MIN_TRACE_LEN),
             hasher_trace: new_array_vec(MIN_TRACE_LEN),
             group_count_trace: Vec::with_capacity(MIN_TRACE_LEN),
+            in_span_trace: Vec::with_capacity(MIN_TRACE_LEN),
             op_idx_trace: Vec::with_capacity(MIN_TRACE_LEN),
+            op_batch_flag_trace: new_array_vec(MIN_TRACE_LEN),
         }
     }
 
@@ -72,18 +75,18 @@ impl DecoderTrace {
     ///   address from the previous row because in a SPLIT block, the second child follows the
     ///   first child, rather than the parent.
     /// - Set op_bits to opcode of the specified block (e.g., JOIN, SPLIT, LOOP).
-    /// - Set is_span to ZERO.
     /// - Set the first half of the hasher state to the h1 parameter. For JOIN and SPLIT blocks
     ///   this will contain the hash of the left child; for LOOP block this will contain hash of
     ///   the loop's body.
     /// - Set the second half of the hasher state to the h2 parameter. For JOIN and SPLIT blocks
     ///   this will contain hash of the right child.
+    /// - Set is_span to ZERO.
     /// - Set op group count register to the ZERO.
     /// - Set operation index register to ZERO.
+    /// - Set op_batch_flags to ZEROs.
     pub fn append_block_start(&mut self, parent_addr: Felt, op: Operation, h1: Word, h2: Word) {
         self.addr_trace.push(parent_addr);
         self.append_opcode(op);
-        self.in_span_trace.push(ZERO);
 
         self.hasher_trace[0].push(h1[0]);
         self.hasher_trace[1].push(h1[1]);
@@ -95,8 +98,13 @@ impl DecoderTrace {
         self.hasher_trace[6].push(h2[2]);
         self.hasher_trace[7].push(h2[3]);
 
+        self.in_span_trace.push(ZERO);
         self.group_count_trace.push(ZERO);
         self.op_idx_trace.push(ZERO);
+
+        self.op_batch_flag_trace[0].push(ZERO);
+        self.op_batch_flag_trace[1].push(ZERO);
+        self.op_batch_flag_trace[2].push(ZERO);
     }
 
     /// Appends a trace row marking the end of a flow control block (JOIN, SPLIT, LOOP).
@@ -104,11 +112,12 @@ impl DecoderTrace {
     /// When a control block is ending, we do the following:
     /// - Set the block address to the specified address.
     /// - Set op_bits to END opcode.
-    /// - Set in_span to ZERO.
     /// - Put the provided block hash into the first 4 elements of the hasher state.
     /// - Set the remaining 4 elements of the hasher state to [is_loop_body, is_loop, 0, 0].
+    /// - Set in_span to ZERO.
     /// - Copy over op group count from the previous row. This group count must be ZERO.
     /// - Set operation index register to ZERO.
+    /// - Set op_batch_flags to ZEROs.
     pub fn append_block_end(
         &mut self,
         block_addr: Felt,
@@ -121,7 +130,6 @@ impl DecoderTrace {
 
         self.addr_trace.push(block_addr);
         self.append_opcode(Operation::End);
-        self.in_span_trace.push(ZERO);
 
         self.hasher_trace[0].push(block_hash[0]);
         self.hasher_trace[1].push(block_hash[1]);
@@ -133,11 +141,17 @@ impl DecoderTrace {
         self.hasher_trace[6].push(ZERO);
         self.hasher_trace[7].push(ZERO);
 
+        self.in_span_trace.push(ZERO);
+
         let last_group_count = self.last_group_count();
         debug_assert!(last_group_count == ZERO, "group count not zero");
         self.group_count_trace.push(last_group_count);
 
         self.op_idx_trace.push(ZERO);
+
+        self.op_batch_flag_trace[0].push(ZERO);
+        self.op_batch_flag_trace[1].push(ZERO);
+        self.op_batch_flag_trace[2].push(ZERO);
     }
 
     /// Appends a trace row marking the beginning of a new loop iteration.
@@ -145,24 +159,29 @@ impl DecoderTrace {
     /// When we start a new loop iteration, we do the following:
     /// - Set the block address to the address of the loop block.
     /// - Set op_bits to REPEAT opcode.
-    /// - Set in_span to ZERO.
     /// - Copy over the hasher state from the previous row. Technically, we need to copy over
     ///   only the first 5 elements of the hasher state, but it is easier to copy over the whole
     ///   row.
+    /// - Set in_span to ZERO.
     /// - Set op group count register to the ZERO.
     /// - Set operation index register to ZERO.
+    /// - Set op_batch_flags to ZEROs.
     pub fn append_loop_repeat(&mut self, loop_addr: Felt) {
         self.addr_trace.push(loop_addr);
         self.append_opcode(Operation::Repeat);
-        self.in_span_trace.push(ZERO);
 
         let last_row = self.hasher_trace[0].len() - 1;
         for column in self.hasher_trace.iter_mut() {
             column.push(column[last_row]);
         }
 
+        self.in_span_trace.push(ZERO);
         self.group_count_trace.push(ZERO);
         self.op_idx_trace.push(ZERO);
+
+        self.op_batch_flag_trace[0].push(ZERO);
+        self.op_batch_flag_trace[1].push(ZERO);
+        self.op_batch_flag_trace[2].push(ZERO);
     }
 
     /// Appends a trace row marking the start of a SPAN block.
@@ -172,10 +191,11 @@ impl DecoderTrace {
     ///   address from the previous row because in a SPLIT block, the second child follows the
     ///   first child, rather than the parent.
     /// - Set op_bits to SPAN opcode.
-    /// - Set is_span to ZERO. is_span will be set to one in the following row.
     /// - Set hasher state to op groups of the first op batch of the SPAN.
+    /// - Set is_span to ZERO. is_span will be set to one in the following row.
     /// - Set op group count to the total number of op groups in the SPAN.
     /// - Set operation index register to ZERO.
+    /// - Set the op_batch_flags based on the specified number of operation groups.
     pub fn append_span_start(
         &mut self,
         parent_addr: Felt,
@@ -184,12 +204,18 @@ impl DecoderTrace {
     ) {
         self.addr_trace.push(parent_addr);
         self.append_opcode(Operation::Span);
-        self.in_span_trace.push(ZERO);
         for (i, &op_group) in first_op_batch.iter().enumerate() {
             self.hasher_trace[i].push(op_group);
         }
+
+        self.in_span_trace.push(ZERO);
         self.group_count_trace.push(num_op_groups);
         self.op_idx_trace.push(ZERO);
+
+        let op_batch_flags = get_op_batch_flags(num_op_groups);
+        self.op_batch_flag_trace[0].push(op_batch_flags[0]);
+        self.op_batch_flag_trace[1].push(op_batch_flags[1]);
+        self.op_batch_flag_trace[2].push(op_batch_flags[2]);
     }
 
     /// Appends a trace row marking a RESPAN operation.
@@ -198,19 +224,27 @@ impl DecoderTrace {
     /// - Copy over the block address from the previous row. The SPAN address will be updated in
     ///   the following row.
     /// - Set op_bits to RESPAN opcode.
-    /// - Set in_span to ONE.
     /// - Set hasher state to op groups of the next op batch of the SPAN.
+    /// - Set in_span to ONE.
     /// - Copy over op group count from the previous row.
     /// - Set operation index register to ZERO.
+    /// - Set the op_batch_flags based on the current operation group count.
     pub fn append_respan(&mut self, op_batch: &[Felt; OP_BATCH_SIZE]) {
         self.addr_trace.push(self.last_addr());
         self.append_opcode(Operation::Respan);
-        self.in_span_trace.push(ONE);
         for (i, &op_group) in op_batch.iter().enumerate() {
             self.hasher_trace[i].push(op_group);
         }
-        self.group_count_trace.push(self.last_group_count());
+
+        let group_count = self.last_group_count();
+        self.in_span_trace.push(ONE);
+        self.group_count_trace.push(group_count);
         self.op_idx_trace.push(ZERO);
+
+        let op_batch_flags = get_op_batch_flags(group_count);
+        self.op_batch_flag_trace[0].push(op_batch_flags[0]);
+        self.op_batch_flag_trace[1].push(op_batch_flags[1]);
+        self.op_batch_flag_trace[2].push(op_batch_flags[2]);
     }
 
     /// Appends a trace row for a user operation.
@@ -218,15 +252,16 @@ impl DecoderTrace {
     /// When we execute a user operation in a SPAN block, we do the following:
     /// - Set the address of the row to the address of the span block.
     /// - Set op_bits to the opcode of the executed operation.
-    /// - Set is_span to ONE.
     /// - Set the first hasher state register to the aggregation of remaining operations to be
     ///   executed in the current operation group.
     /// - Set the second hasher state register to the address of the SPAN's parent block.
     /// - Set the remaining hasher state registers to ZEROs.
+    /// - Set is_span to ONE.
     /// - Set the number of groups remaining to be processed. This number of groups changes if
     ///   in the previous row an operation with an immediate value was executed or if this
     ///   operation is a start of a new operation group.
     /// - Set the operation's index within the current operation group.
+    /// - Set op_batch_flags to ZEROs.
     pub fn append_user_op(
         &mut self,
         op: Operation,
@@ -238,7 +273,6 @@ impl DecoderTrace {
     ) {
         self.addr_trace.push(span_addr);
         self.append_opcode(op);
-        self.in_span_trace.push(ONE);
 
         self.hasher_trace[0].push(group_ops_left);
         self.hasher_trace[1].push(parent_addr);
@@ -247,8 +281,13 @@ impl DecoderTrace {
             self.hasher_trace[idx].push(ZERO);
         }
 
+        self.in_span_trace.push(ONE);
         self.group_count_trace.push(num_groups_left);
         self.op_idx_trace.push(op_idx);
+
+        self.op_batch_flag_trace[0].push(ZERO);
+        self.op_batch_flag_trace[1].push(ZERO);
+        self.op_batch_flag_trace[2].push(ZERO);
     }
 
     /// Appends a trace row marking the end of a SPAN block.
@@ -256,18 +295,18 @@ impl DecoderTrace {
     /// When the SPAN block is ending, we do the following:
     /// - Copy over the block address from the previous row.
     /// - Set op_bits to END opcode.
-    /// - Set in_span to ZERO to indicate that the span block is completed.
     /// - Put the hash of the span block into the first 4 registers of the hasher state.
     /// - Put a flag indicating whether the SPAN block was a body of a loop into the 5th
     ///   register of the hasher state.
+    /// - Set in_span to ZERO to indicate that the span block is completed.
     /// - Copy over op group count from the previous row. This group count must be ZERO.
     /// - Set operation index register to ZERO.
+    /// - Set op_batch_flags to ZEROs.
     pub fn append_span_end(&mut self, span_hash: Word, is_loop_body: Felt) {
         debug_assert!(is_loop_body.as_int() <= 1, "invalid loop body");
 
         self.addr_trace.push(self.last_addr());
         self.append_opcode(Operation::End);
-        self.in_span_trace.push(ZERO);
 
         self.hasher_trace[0].push(span_hash[0]);
         self.hasher_trace[1].push(span_hash[1]);
@@ -280,11 +319,17 @@ impl DecoderTrace {
         self.hasher_trace[6].push(ZERO);
         self.hasher_trace[7].push(ZERO);
 
+        self.in_span_trace.push(ZERO);
+
         let last_group_count = self.last_group_count();
         debug_assert!(last_group_count == ZERO, "group count not zero");
         self.group_count_trace.push(last_group_count);
 
         self.op_idx_trace.push(ZERO);
+
+        self.op_batch_flag_trace[0].push(ZERO);
+        self.op_batch_flag_trace[1].push(ZERO);
+        self.op_batch_flag_trace[2].push(ZERO);
     }
 
     // TRACE GENERATION
@@ -322,11 +367,6 @@ impl DecoderTrace {
             trace.push(column);
         }
 
-        // put ZEROs into the unfilled rows of in_span column
-        debug_assert_eq!(own_len, self.in_span_trace.len());
-        self.in_span_trace.resize(trace_len, ZERO);
-        trace.push(self.in_span_trace);
-
         // for unfilled rows of hasher state columns, copy over values from the last row for the
         // first 4 columns, and pad the other 4 columns with ZEROs
         for (i, mut column) in self.hasher_trace.into_iter().enumerate() {
@@ -340,6 +380,11 @@ impl DecoderTrace {
             trace.push(column);
         }
 
+        // put ZEROs into the unfilled rows of in_span column
+        debug_assert_eq!(own_len, self.in_span_trace.len());
+        self.in_span_trace.resize(trace_len, ZERO);
+        trace.push(self.in_span_trace);
+
         // put ZEROs into the unfilled rows of operation group count column
         debug_assert_eq!(own_len, self.group_count_trace.len());
         self.group_count_trace.resize(trace_len, ZERO);
@@ -349,6 +394,13 @@ impl DecoderTrace {
         debug_assert_eq!(own_len, self.op_idx_trace.len());
         self.op_idx_trace.resize(trace_len, ZERO);
         trace.push(self.op_idx_trace);
+
+        // put ZEROs into the unfilled rows of op_batch_flags columns
+        for mut column in self.op_batch_flag_trace.into_iter() {
+            debug_assert_eq!(own_len, column.len());
+            column.resize(trace_len, ZERO);
+            trace.push(column);
+        }
 
         trace
     }
@@ -416,5 +468,24 @@ impl DecoderTrace {
         }
         self.group_count_trace.push(ZERO);
         self.op_idx_trace.push(ZERO);
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Returns op batch flags for the specified group count. If the group count is greater than 8,
+/// we assume that the operation batch is full - i.e., has 8 operation groups.
+fn get_op_batch_flags(group_count: Felt) -> [Felt; NUM_OP_BATCH_FLAGS] {
+    let num_groups = core::cmp::min(group_count.as_int() as usize, OP_BATCH_SIZE);
+    match num_groups {
+        8 => [ONE, ZERO, ZERO],
+        4 => [ZERO, ONE, ZERO],
+        2 => [ZERO, ZERO, ONE],
+        1 => [ZERO, ONE, ONE],
+        _ => panic!(
+            "invalid number of groups in a batch: {}, group count: {}",
+            num_groups, group_count
+        ),
     }
 }

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -1,6 +1,6 @@
 use super::{
     Felt, Operation, Vec, Word, MIN_TRACE_LEN, NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS,
-    ONE, ZERO,
+    ONE, ZERO, OP_BATCH_1_GROUPS, OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS
 };
 use core::ops::Range;
 use vm_core::{program::blocks::OP_BATCH_SIZE, utils::new_array_vec, StarkField};
@@ -225,7 +225,7 @@ impl DecoderTrace {
     ///   the following row.
     /// - Set op_bits to RESPAN opcode.
     /// - Set hasher state to op groups of the next op batch of the SPAN.
-    /// - Set in_span to ONE.
+    /// - Set in_span to ZERO.
     /// - Copy over op group count from the previous row.
     /// - Set operation index register to ZERO.
     /// - Set the op_batch_flags based on the current operation group count.
@@ -237,7 +237,7 @@ impl DecoderTrace {
         }
 
         let group_count = self.last_group_count();
-        self.in_span_trace.push(ONE);
+        self.in_span_trace.push(ZERO);
         self.group_count_trace.push(group_count);
         self.op_idx_trace.push(ZERO);
 
@@ -479,10 +479,10 @@ impl DecoderTrace {
 fn get_op_batch_flags(group_count: Felt) -> [Felt; NUM_OP_BATCH_FLAGS] {
     let num_groups = core::cmp::min(group_count.as_int() as usize, OP_BATCH_SIZE);
     match num_groups {
-        8 => [ONE, ZERO, ZERO],
-        4 => [ZERO, ONE, ZERO],
-        2 => [ZERO, ZERO, ONE],
-        1 => [ZERO, ONE, ONE],
+        8 => OP_BATCH_8_GROUPS,
+        4 => OP_BATCH_4_GROUPS,
+        2 => OP_BATCH_2_GROUPS,
+        1 => OP_BATCH_1_GROUPS,
         _ => panic!(
             "invalid number of groups in a batch: {}, group count: {}",
             num_groups, group_count

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -1,9 +1,10 @@
 use super::{
-    Felt, Operation, Vec, Word, MIN_TRACE_LEN, NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS,
-    ONE, ZERO, OP_BATCH_1_GROUPS, OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS
+    Felt, Operation, StarkField, Vec, Word, DIGEST_LEN, MIN_TRACE_LEN, NUM_HASHER_COLUMNS,
+    NUM_OP_BATCH_FLAGS, NUM_OP_BITS, ONE, OP_BATCH_1_GROUPS, OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS,
+    OP_BATCH_8_GROUPS, OP_BATCH_SIZE, ZERO,
 };
 use core::ops::Range;
-use vm_core::{program::blocks::OP_BATCH_SIZE, utils::new_array_vec, StarkField};
+use vm_core::utils::new_array_vec;
 
 // CONSTANTS
 // ================================================================================================
@@ -63,6 +64,15 @@ impl DecoderTrace {
     /// Returns the current length of columns in this trace.
     pub fn trace_len(&self) -> usize {
         self.addr_trace.len()
+    }
+
+    /// Returns the contents of the first 4 registers of the hasher state at the last row.
+    pub fn program_hash(&self) -> [Felt; DIGEST_LEN] {
+        let mut result = [ZERO; DIGEST_LEN];
+        for (i, element) in result.iter_mut().enumerate() {
+            *element = self.last_hasher_value(i);
+        }
+        result
     }
 
     // TRACE MUTATORS
@@ -416,6 +426,12 @@ impl DecoderTrace {
     /// Returns the last value of the operation group count.
     fn last_group_count(&self) -> Felt {
         *self.group_count_trace.last().expect("no group count")
+    }
+
+    /// Returns the last value in the specified hasher column.
+    fn last_hasher_value(&self, idx: usize) -> Felt {
+        debug_assert!(idx < NUM_HASHER_COLUMNS, "invalid hasher register index");
+        *self.hasher_trace[idx].last().expect("no last hasher value")
     }
 
     /// Returns a reference to the last value in the helper register at the specified index.

--- a/processor/src/hasher/mod.rs
+++ b/processor/src/hasher/mod.rs
@@ -5,7 +5,7 @@ use vm_core::{
         MP_VERIFY, MR_UPDATE_NEW, MR_UPDATE_OLD, RETURN_HASH, RETURN_STATE, STATE_WIDTH,
         TRACE_WIDTH,
     },
-    program::blocks::{OpBatch, OP_BATCH_SIZE},
+    program::blocks::OpBatch,
 };
 
 mod trace;
@@ -114,7 +114,11 @@ impl Hasher {
     ///
     /// The returned tuple also contains the row address of the execution trace at which hash
     /// computation started.
-    pub fn hash_span_block(&mut self, op_batches: &[OpBatch]) -> (Felt, Word) {
+    pub fn hash_span_block(
+        &mut self,
+        op_batches: &[OpBatch],
+        num_op_groups: usize,
+    ) -> (Felt, Word) {
         const START: Selectors = LINEAR_HASH;
         const RETURN: Selectors = RETURN_HASH;
         // absorb selectors are the same as linear hash selectors, but absorb selectors are
@@ -128,8 +132,7 @@ impl Hasher {
         let addr = self.trace.next_row_addr();
 
         // initialize the state and absorb the first operation batch into it
-        let num_elements = op_batches.len() * OP_BATCH_SIZE;
-        let mut state = init_state(op_batches[0].groups(), num_elements);
+        let mut state = init_state(op_batches[0].groups(), num_op_groups);
 
         let num_batches = op_batches.len();
         if num_batches == 1 {

--- a/processor/src/trace/range/tests.rs
+++ b/processor/src/trace/range/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{Digest, ExecutionTrace, Process, NUM_RAND_ROWS},
+    super::{ExecutionTrace, Process, NUM_RAND_ROWS},
     Felt, FieldElement, P0_COL_IDX, P1_COL_IDX,
 };
 use rand_utils::rand_value;
@@ -108,5 +108,5 @@ fn build_trace(stack: &[u64], operations: Vec<Operation>) -> ExecutionTrace {
     let program = CodeBlock::new_span(operations);
     process.execute_code_block(&program).unwrap();
 
-    ExecutionTrace::new(process, Digest::new([Felt::ZERO; 4]))
+    ExecutionTrace::new(process)
 }


### PR DESCRIPTION
This PR adds op batch flags to the decoder trace and makes a coupe of other small updates:

- [x] Add 3 `op_batch_flag` columns to the decoder trace.
- [x] Update the logic for how number of operation groups in the span is computed, and make related changes to trace generation.
- [x] Update the logic of how `in_span` flag is populated in the decoder trace.
- [x] Updated program hash computations to make them consistent between `Script` and execution trace.