### PR TITLE
Assembly instruction rationalization

### DIFF
--- a/assembly/src/parsers/crypto_ops.rs
+++ b/assembly/src/parsers/crypto_ops.rs
@@ -116,29 +116,31 @@ pub fn parse_mtree(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Asse
 /// After the operations are executed, the stack will be arranged as follows:
 /// - node V, 4 elements
 /// - root of the tree, 4 elements
+///
+/// This operation takes 24 VM cycles.
 fn mtree_get(span_ops: &mut Vec<Operation>) {
     // stack: [d, i, R, ...]
     // inject the node value we're looking for at the head of the advice tape
     span_ops.push(Operation::Advice(AdviceInjector::MerkleNode));
 
     // temporarily move d and i out of the way to make future stack manipulations easier
-    // => [R, d, i, ...]
-    span_ops.push(Operation::MovDn5);
-    span_ops.push(Operation::MovDn5);
+    // => [R, 0, 0, d, i, ...]
+    span_ops.push(Operation::Pad);
+    span_ops.push(Operation::Pad);
+    span_ops.push(Operation::SwapW);
 
-    // read node value from advice tape => [V, R, d, i, ...]
+    // read node value from advice tape => [V, R, 0, 0, d, i, ...]
     span_ops.push_many(Operation::Read, 4);
 
-    // Duplicate the node value at the top of the stack and save a copy deeper in the stack. This
-    // allows the new copy of the node to be used in MPVERIFY and keeps a copy to return at the end
-    // swap root and node => [R, V, d, i, ...]
-    span_ops.push(Operation::SwapW);
-    // copy the node value for use in MPVERIFY => [V, R, V, d, i ...]
-    span_ops.push_many(Operation::Dup7, 4);
+    // Duplicate the node value at the top of the stack. This allows the new copy of the node to be
+    // used in MPVERIFY and keeps a copy to return at the end
+    // copy the node value for use in MPVERIFY => [V, V, R, 0, 0, d, i ...]
+    span_ops.push_many(Operation::Dup3, 4);
 
     // move d, i back to the top of the stack => [d, i, V, R, V, ...]
-    span_ops.push(Operation::MovUp13);
-    span_ops.push(Operation::MovUp13);
+    span_ops.push(Operation::SwapW3);
+    span_ops.push(Operation::Drop);
+    span_ops.push(Operation::Drop);
 
     // verify the node V for root R with depth d and index i
     // => [d, i, R_computed, R, V, ...] where R_computed is the computed root for node V at d, i
@@ -167,6 +169,8 @@ fn mtree_get(span_ops: &mut Vec<Operation>) {
 /// After the operations are executed, the stack will be arranged as follows:
 /// - new value of the node, 4 elements
 /// - new root of the tree after the update, 4 elements
+///
+/// This operation takes 38 VM cycles.
 fn mtree_set(span_ops: &mut Vec<Operation>) {
     // Duplicate the new value and reorder the stack as required for the call to MRUPDATE.
     // [d, i, V_new, R, ...] => [d, i, V_old, V_new, R, V_new_0, V_new_1] (overflowed)
@@ -201,6 +205,8 @@ fn mtree_set(span_ops: &mut Vec<Operation>) {
 /// - new value of the node V, 4 elements
 /// - root of the new tree with the updated node value, 4 elements
 /// - root of the old tree which was copied, 4 elements
+///
+/// This operation takes 34 VM cycles.
 fn mtree_cwm(span_ops: &mut Vec<Operation>) {
     // Duplicate the new value and reorder the stack as required for the call to MRUPDATE.
     // [d, i, V_new, R, ...] => [d, i, V_old, V_new, R, V_new_0, V_new_1] (overflowed)
@@ -223,6 +229,8 @@ fn mtree_cwm(span_ops: &mut Vec<Operation>) {
 /// duplicate. The stack is expected to be arranged as follows (from the top):
 /// - root of a Merkle tree, 4 elements
 /// - root of a Merkle tree, 4 elements
+///
+/// This operation takes 6 VM cycles.
 fn validate_and_drop_root(span_ops: &mut Vec<Operation>) {
     // verify the provided root and the computed root are equal
     span_ops.push(Operation::Eqw);
@@ -248,33 +256,49 @@ fn validate_and_drop_root(span_ops: &mut Vec<Operation>) {
 /// - new value of the node, 4 elements
 /// - root of the Merkle tree, 4 elements
 /// - copy of the new value of the node, 4 elements
+///
+/// This operation takes 22 VM cycles.
 fn prep_stack_for_mrupdate(span_ops: &mut Vec<Operation>) {
     // stack: [d, i, V_new, R, ...]
-    // temporarily move d and i out of the way to make future stack manipulations easier
-    // => [V_new, R, d, i, ...]
-    span_ops.push(Operation::MovDn9);
-    span_ops.push(Operation::MovDn9);
 
-    // move the root R to the top of the stack to prepare for reading from the advice set
-    // => [R, V_new, d, i, ...]
+    // temporarily add two zeroes to the top of the stack to create word with d and i to make
+    // future stack manipulations easier
+    // => [0, 0, d, i, V_new, R, ...]
+    span_ops.push(Operation::Pad);
+    span_ops.push(Operation::Pad);
+
+    // copy the new node value for use in the MRUPDATE op => [V_new, 0, 0, d, i, V_new, R, ...]
+    span_ops.push_many(Operation::Dup7, 4);
+
+    // move d, i and R to the top of the stack => [0, 0, d, i, R, V_new, V_new, ...]
+    span_ops.push(Operation::SwapW3);
     span_ops.push(Operation::SwapW);
 
-    // move d, i back to the top of the stack => [d, i, R, V_new, ...]
-    span_ops.push(Operation::MovUp9);
-    span_ops.push(Operation::MovUp9);
+    // drop excess zeroes to be able to inject the node value to the advice tape
+    // => [d, i, R, V_new, V_new, ...]
+    span_ops.push(Operation::Drop);
+    span_ops.push(Operation::Drop);
 
     // inject the node value we're looking for at the head of the advice tape
     span_ops.push(Operation::Advice(AdviceInjector::MerkleNode));
 
-    // copy the new node value for use in the MRUPDATE op => [V_new, d, i, R, V_new, ...]
-    span_ops.push_many(Operation::Dup9, 4);
+    // temporarily add two zeroes to the top of the stack again
+    // => [0, 0, d, i, R, V_new, V_new, ...]
+    span_ops.push(Operation::Pad);
+    span_ops.push(Operation::Pad);
 
-    // read old node value from advice tape => [V_old, V_new, d, i,  R, V_new_0, V_new_1] (overflow)
+    // read old node value from advice tape => [V_old, 0, 0, d, i, R, V_new, V_new, ...]
     span_ops.push_many(Operation::Read, 4);
 
-    // move d, i to the top of the stack => [d, i, V_old, V_new, R, V_new_0, V_new_1]
-    span_ops.push(Operation::MovUp9);
-    span_ops.push(Operation::MovUp9);
+    // create the required order of elements => [0, 0, d, i, V_old, V_new, R, V_new, ...]
+    span_ops.push(Operation::SwapW);
+    span_ops.push(Operation::SwapDW);
+    span_ops.push(Operation::SwapW);
+    span_ops.push(Operation::SwapDW);
+
+    // drop excess zeroes => [d, i, V_old, V_new, R, V_new, ...]
+    span_ops.push(Operation::Drop);
+    span_ops.push(Operation::Drop);
 }
 
 /// This is a helper function for assembly operations that update the Merkle tree. It validates
@@ -290,6 +314,8 @@ fn prep_stack_for_mrupdate(span_ops: &mut Vec<Operation>) {
 /// After the operations are executed, the stack will be arranged as follows:
 /// - old Merkle tree root, 4 elements
 /// - new Merkle tree root, 4 elements
+///
+/// This operation takes 10 VM cycles.
 fn validate_root_after_mrupdate(span_ops: &mut Vec<Operation>) {
     // drop d, i => [R_computed, R_new, R, ...]
     span_ops.push(Operation::Drop);

--- a/assembly/src/parsers/stack_ops.rs
+++ b/assembly/src/parsers/stack_ops.rs
@@ -160,55 +160,62 @@ pub fn parse_swap(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assem
             }
             "8" => {
                 span_ops.push(Operation::MovDn7);
-                // MovUp8
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp9);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::MovUp8);
             }
             "9" => {
-                span_ops.push(Operation::MovDn9);
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp9);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::Swap);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
             "10" => {
-                span_ops.push(Operation::MovDn9);
-                // MovUp10
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp11);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::Swap);
+                span_ops.push(Operation::MovUp2);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
             "11" => {
-                span_ops.push(Operation::MovDn11);
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp11);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn2);
+                span_ops.push(Operation::MovUp3);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
             "12" => {
-                span_ops.push(Operation::MovDn11);
-                // MovUp12
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp13);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn3);
+                span_ops.push(Operation::MovUp4);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
             "13" => {
-                span_ops.push(Operation::MovDn13);
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp13);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn4);
+                span_ops.push(Operation::MovUp5);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
             "14" => {
-                span_ops.push(Operation::MovDn13);
-                // MovUp14
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp15);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn5);
+                span_ops.push(Operation::MovUp6);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
             "15" => {
-                span_ops.push(Operation::MovDn15);
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp15);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn6);
+                span_ops.push(Operation::MovUp7);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
             _ => return Err(AssemblyError::invalid_param(op, 1)),
         },
@@ -239,12 +246,7 @@ pub fn parse_swapw(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Asse
 pub fn parse_swapdw(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
     match op.num_parts() {
         0 => return Err(AssemblyError::missing_param(op)),
-        1 => {
-            span_ops.push(Operation::SwapW);
-            span_ops.push(Operation::SwapW3);
-            span_ops.push(Operation::SwapW);
-            span_ops.push(Operation::SwapW2)
-        }
+        1 => span_ops.push(Operation::SwapDW),
         _ => return Err(AssemblyError::extra_param(op)),
     }
 
@@ -265,30 +267,49 @@ pub fn parse_movup(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Asse
             "5" => span_ops.push(Operation::MovUp5),
             "6" => span_ops.push(Operation::MovUp6),
             "7" => span_ops.push(Operation::MovUp7),
-            "8" => {
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp9);
-                span_ops.push(Operation::Add);
+            "8" => span_ops.push(Operation::MovUp8),
+            "9" => {
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::Swap);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
-            "9" => span_ops.push(Operation::MovUp9),
             "10" => {
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp11);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp2);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
-            "11" => span_ops.push(Operation::MovUp11),
+            "11" => {
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp3);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
+            }
             "12" => {
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp13);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp4);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
-            "13" => span_ops.push(Operation::MovUp13),
+            "13" => {
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp5);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
+            }
             "14" => {
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::MovUp15);
-                span_ops.push(Operation::Add);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp6);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
             }
-            "15" => span_ops.push(Operation::MovUp15),
+            "15" => {
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp7);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovUp8);
+            }
             _ => return Err(AssemblyError::invalid_param(op, 1)),
         },
         _ => return Err(AssemblyError::extra_param(op)),
@@ -337,34 +358,49 @@ pub fn parse_movdn(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Asse
             "5" => span_ops.push(Operation::MovDn5),
             "6" => span_ops.push(Operation::MovDn6),
             "7" => span_ops.push(Operation::MovDn7),
-            "8" => {
-                span_ops.push(Operation::Pad);
+            "8" => span_ops.push(Operation::MovDn8),
+            "9" => {
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
                 span_ops.push(Operation::Swap);
-                span_ops.push(Operation::MovDn9);
-                span_ops.push(Operation::Drop);
+                span_ops.push(Operation::SwapDW);
             }
-            "9" => span_ops.push(Operation::MovDn9),
             "10" => {
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::Swap);
-                span_ops.push(Operation::MovDn11);
-                span_ops.push(Operation::Drop);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn2);
+                span_ops.push(Operation::SwapDW);
             }
-            "11" => span_ops.push(Operation::MovDn11),
+            "11" => {
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn3);
+                span_ops.push(Operation::SwapDW);
+            }
             "12" => {
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::Swap);
-                span_ops.push(Operation::MovDn13);
-                span_ops.push(Operation::Drop);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn4);
+                span_ops.push(Operation::SwapDW);
             }
-            "13" => span_ops.push(Operation::MovDn13),
+            "13" => {
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn5);
+                span_ops.push(Operation::SwapDW);
+            }
             "14" => {
-                span_ops.push(Operation::Pad);
-                span_ops.push(Operation::Swap);
-                span_ops.push(Operation::MovDn15);
-                span_ops.push(Operation::Drop);
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn6);
+                span_ops.push(Operation::SwapDW);
             }
-            "15" => span_ops.push(Operation::MovDn15),
+            "15" => {
+                span_ops.push(Operation::MovDn8);
+                span_ops.push(Operation::SwapDW);
+                span_ops.push(Operation::MovDn7);
+                span_ops.push(Operation::SwapDW);
+            }
             _ => return Err(AssemblyError::invalid_param(op, 1)),
         },
         _ => return Err(AssemblyError::extra_param(op)),

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -231,6 +231,9 @@ pub enum Operation {
     /// Swaps stack elements 0, 1, 2, and 3, with elements 12, 13, 14, and 15.
     SwapW3,
 
+    /// Swaps stack elements 0, 1, 2, 3, 4, 5, 6, and 7 with elements 8, 9, 10, 11, 12, 13, 14, and 15.
+    SwapDW,
+
     /// Moves stack element 2 to the top of the stack.
     MovUp2,
 
@@ -249,17 +252,8 @@ pub enum Operation {
     /// Moves stack element 7 to the top of the stack.
     MovUp7,
 
-    /// Moves stack element 9 to the top of the stack.
-    MovUp9,
-
-    /// Moves stack element 11 to the top of the stack.
-    MovUp11,
-
-    /// Moves stack element 13 to the top of the stack.
-    MovUp13,
-
-    /// Moves stack element 15 to the top of the stack.
-    MovUp15,
+    /// Moves stack element 8 to the top of the stack.
+    MovUp8,
 
     /// Moves the top stack element to position 2 on the stack.
     MovDn2,
@@ -279,17 +273,8 @@ pub enum Operation {
     /// Moves the top stack element to position 7 on the stack.
     MovDn7,
 
-    /// Moves the top stack element to position 9 on the stack.
-    MovDn9,
-
-    /// Moves the top stack element to position 11 on the stack.
-    MovDn11,
-
-    /// Moves the top stack element to position 13 on the stack.
-    MovDn13,
-
-    /// Moves the top stack element to position 15 on the stack.
-    MovDn15,
+    /// Moves the top stack element to position 8 on the stack.
+    MovDn8,
 
     /// Pops an element off the stack, and if the element is 1, swaps the top two remaining
     /// elements on the stack. If the popped element is 0, the stack remains unchanged.
@@ -438,17 +423,15 @@ impl Operation {
             Self::SwapW => Some(27),
             Self::SwapW2 => Some(28),
             Self::SwapW3 => Some(29),
+            Self::SwapDW => Some(30),
 
-            Self::MovUp2 => Some(30),
-            Self::MovUp3 => Some(31),
-            Self::MovUp4 => Some(32),
-            Self::MovUp5 => Some(33),
-            Self::MovUp6 => Some(34),
-            Self::MovUp7 => Some(35),
-            Self::MovUp9 => Some(36),
-            Self::MovUp11 => Some(37),
-            Self::MovUp13 => Some(38),
-            Self::MovUp15 => Some(39),
+            Self::MovUp2 => Some(31),
+            Self::MovUp3 => Some(32),
+            Self::MovUp4 => Some(33),
+            Self::MovUp5 => Some(34),
+            Self::MovUp6 => Some(35),
+            Self::MovUp7 => Some(36),
+            Self::MovUp8 => Some(37),
 
             Self::MovDn2 => Some(40),
             Self::MovDn3 => Some(41),
@@ -456,10 +439,7 @@ impl Operation {
             Self::MovDn5 => Some(43),
             Self::MovDn6 => Some(44),
             Self::MovDn7 => Some(45),
-            Self::MovDn9 => Some(46),
-            Self::MovDn11 => Some(47),
-            Self::MovDn13 => Some(48),
-            Self::MovDn15 => Some(49),
+            Self::MovDn8 => Some(46),
 
             Self::CSwap => Some(50),
             Self::CSwapW => Some(51),
@@ -608,6 +588,7 @@ impl fmt::Display for Operation {
             Self::SwapW => write!(f, "swapw"),
             Self::SwapW2 => write!(f, "swapw2"),
             Self::SwapW3 => write!(f, "swapw3"),
+            Self::SwapDW => write!(f, "swapdw"),
 
             Self::MovUp2 => write!(f, "movup2"),
             Self::MovUp3 => write!(f, "movup3"),
@@ -615,10 +596,7 @@ impl fmt::Display for Operation {
             Self::MovUp5 => write!(f, "movup5"),
             Self::MovUp6 => write!(f, "movup6"),
             Self::MovUp7 => write!(f, "movup7"),
-            Self::MovUp9 => write!(f, "movup9"),
-            Self::MovUp11 => write!(f, "movup11"),
-            Self::MovUp13 => write!(f, "movup13"),
-            Self::MovUp15 => write!(f, "movup15"),
+            Self::MovUp8 => write!(f, "movup8"),
 
             Self::MovDn2 => write!(f, "movdn2"),
             Self::MovDn3 => write!(f, "movdn3"),
@@ -626,10 +604,7 @@ impl fmt::Display for Operation {
             Self::MovDn5 => write!(f, "movdn5"),
             Self::MovDn6 => write!(f, "movdn6"),
             Self::MovDn7 => write!(f, "movdn7"),
-            Self::MovDn9 => write!(f, "movdn9"),
-            Self::MovDn11 => write!(f, "movdn11"),
-            Self::MovDn13 => write!(f, "movdn13"),
-            Self::MovDn15 => write!(f, "movdn15"),
+            Self::MovDn8 => write!(f, "movdn8"),
 
             Self::CSwap => write!(f, "cswap"),
             Self::CSwapW => write!(f, "cswapw"),

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -89,6 +89,7 @@ impl Process {
             Operation::SwapW => self.op_swapw()?,
             Operation::SwapW2 => self.op_swapw2()?,
             Operation::SwapW3 => self.op_swapw3()?,
+            Operation::SwapDW => self.op_swapdw()?,
 
             Operation::MovUp2 => self.op_movup(2)?,
             Operation::MovUp3 => self.op_movup(3)?,
@@ -96,10 +97,7 @@ impl Process {
             Operation::MovUp5 => self.op_movup(5)?,
             Operation::MovUp6 => self.op_movup(6)?,
             Operation::MovUp7 => self.op_movup(7)?,
-            Operation::MovUp9 => self.op_movup(9)?,
-            Operation::MovUp11 => self.op_movup(11)?,
-            Operation::MovUp13 => self.op_movup(13)?,
-            Operation::MovUp15 => self.op_movup(15)?,
+            Operation::MovUp8 => self.op_movup(8)?,
 
             Operation::MovDn2 => self.op_movdn(2)?,
             Operation::MovDn3 => self.op_movdn(3)?,
@@ -107,10 +105,7 @@ impl Process {
             Operation::MovDn5 => self.op_movdn(5)?,
             Operation::MovDn6 => self.op_movdn(6)?,
             Operation::MovDn7 => self.op_movdn(7)?,
-            Operation::MovDn9 => self.op_movdn(9)?,
-            Operation::MovDn11 => self.op_movdn(11)?,
-            Operation::MovDn13 => self.op_movdn(13)?,
-            Operation::MovDn15 => self.op_movdn(15)?,
+            Operation::MovDn8 => self.op_movdn(8)?,
 
             Operation::CSwap => self.op_cswap()?,
             Operation::CSwapW => self.op_cswapw()?,

--- a/processor/src/operations/stack_ops.rs
+++ b/processor/src/operations/stack_ops.rs
@@ -129,6 +129,45 @@ impl Process {
         Ok(())
     }
 
+    /// Swaps stack elements 0, 1, 2, 3, 4, 5, 6, and 7 with elements 8, 9, 10, 11, 12, 13, 14, and 15.
+    pub(super) fn op_swapdw(&mut self) -> Result<(), ExecutionError> {
+        let a0 = self.stack.get(0);
+        let a1 = self.stack.get(1);
+        let a2 = self.stack.get(2);
+        let a3 = self.stack.get(3);
+        let b0 = self.stack.get(4);
+        let b1 = self.stack.get(5);
+        let b2 = self.stack.get(6);
+        let b3 = self.stack.get(7);
+        let c0 = self.stack.get(8);
+        let c1 = self.stack.get(9);
+        let c2 = self.stack.get(10);
+        let c3 = self.stack.get(11);
+        let d0 = self.stack.get(12);
+        let d1 = self.stack.get(13);
+        let d2 = self.stack.get(14);
+        let d3 = self.stack.get(15);
+
+        self.stack.set(0, c0);
+        self.stack.set(1, c1);
+        self.stack.set(2, c2);
+        self.stack.set(3, c3);
+        self.stack.set(4, d0);
+        self.stack.set(5, d1);
+        self.stack.set(6, d2);
+        self.stack.set(7, d3);
+        self.stack.set(8, a0);
+        self.stack.set(9, a1);
+        self.stack.set(10, a2);
+        self.stack.set(11, a3);
+        self.stack.set(12, b0);
+        self.stack.set(13, b1);
+        self.stack.set(14, b2);
+        self.stack.set(15, b3);
+
+        Ok(())
+    }
+
     /// Moves n-th element to the top of the stack. n is 0-based.
     ///
     /// Elements between 0 and n are shifted right by one slot.
@@ -448,9 +487,9 @@ mod tests {
         let expected = build_expected(&[8, 4, 3, 1, 2, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15, 16]);
         assert_eq!(expected, process.stack.trace_state());
 
-        // movup15
-        process.execute_op(Operation::MovUp15).unwrap();
-        let expected = build_expected(&[16, 8, 4, 3, 1, 2, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15]);
+        // movup8
+        process.execute_op(Operation::MovUp8).unwrap();
+        let expected = build_expected(&[9, 8, 4, 3, 1, 2, 5, 6, 7, 10, 11, 12, 13, 14, 15, 16]);
         assert_eq!(expected, process.stack.trace_state());
 
         // executing movup with a minimum stack depth should be ok
@@ -483,8 +522,8 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // movdn15
-        process.execute_op(Operation::MovDn15).unwrap();
-        let expected = build_expected(&[4, 2, 5, 6, 7, 8, 3, 9, 10, 11, 12, 13, 14, 15, 16, 1]);
+        process.execute_op(Operation::MovDn8).unwrap();
+        let expected = build_expected(&[4, 2, 5, 6, 7, 8, 3, 9, 1, 10, 11, 12, 13, 14, 15, 16]);
         assert_eq!(expected, process.stack.trace_state());
 
         // executing movdn with a minimum stack depth should be ok


### PR DESCRIPTION
1. Native operations `SwapDW`, `MovUp8` and `MovDn8` were added.
2. Native operations `MovUp9`, `MovUp11`, `MovUp13`, `MovUp15`, `MovDn9`, `MovDn11`, `MovDn13`, and `MovDn15` were removed.
3. `movup.n` and `movdn.n` operations for n > 8 were emulated.

