### PR TITLE
feat(processor): add operation to VmState

### DIFF
--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -1,6 +1,6 @@
 use super::build_test;
 use processor::VmState;
-use vm_core::{utils::ToElements, Felt, FieldElement};
+use vm_core::{utils::ToElements, Felt, FieldElement, Operation};
 
 // EXEC ITER TESTS
 // =================================================================
@@ -19,78 +19,91 @@ fn test_exec_iter() {
     let expected_states = vec![
         VmState {
             clk: 0,
+            op: Operation::Span,
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
             fmp: fmp,
             memory: Vec::new(),
         },
         VmState {
             clk: 1,
+            op: Operation::Push(Felt::new(1)),
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1].to_elements(),
             fmp: fmp,
             memory: Vec::new(),
         },
         VmState {
             clk: 2,
+            op: Operation::StoreW,
             stack: [1, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2].to_elements(),
             fmp: fmp,
             memory: Vec::new(),
         },
         VmState {
             clk: 3,
+            op: Operation::Drop,
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
             fmp: fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 4,
+            op: Operation::Drop,
             stack: [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].to_elements(),
             fmp: fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 5,
+            op: Operation::Drop,
             stack: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0].to_elements(),
             fmp: fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 6,
+            op: Operation::Drop,
             stack: [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp: fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 7,
+            op: Operation::Push(Felt::new(17)),
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp: fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 8,
+            op: Operation::Push(Felt::new(1)),
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp: fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 9,
+            op: Operation::FmpUpdate,
             stack: [1, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp: fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 10,
+            op: Operation::Pad,
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 11,
+            op: Operation::Pad,
             stack: [0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 12,
+            op: Operation::Pad,
             stack: [
                 0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0,
             ]
@@ -100,6 +113,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 13,
+            op: Operation::Pad,
             stack: [
                 0, 0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1, 0, 0, 0, 0,
             ]
@@ -109,6 +123,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 14,
+            op: Operation::FmpAdd,
             stack: [
                 0, 0, 0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0,
             ]
@@ -118,6 +133,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 15,
+            op: Operation::StoreW,
             stack: [
                 2u64.pow(30) + 1,
                 0,
@@ -146,6 +162,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 16,
+            op: Operation::Drop,
             stack: [0, 0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: vec![
@@ -155,6 +172,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 17,
+            op: Operation::Drop,
             stack: [0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: vec![

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -1,11 +1,12 @@
 use crate::{ExecutionError, Felt, Process, StarkField};
 use core::fmt;
-use vm_core::Word;
+use vm_core::{Operation, Word};
 
 /// VmState holds a current process state information at a specific clock cycle.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VmState {
     pub clk: usize,
+    pub op: Operation,
     pub fmp: Felt,
     pub stack: Vec<Felt>,
     pub memory: Vec<(u64, Word)>,
@@ -64,6 +65,7 @@ impl Iterator for VmStateIterator {
 
         let result = Some(Ok(VmState {
             clk: self.clk,
+            op: self.process.decoder.get_operation_at(self.clk),
             fmp: self.process.system.get_fmp_at(self.clk),
             stack: self.process.stack.get_state_at(self.clk),
             memory: self

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -98,11 +98,11 @@ pub struct Process {
 }
 
 impl Process {
-    fn initialize(inputs: ProgramInputs, keep_overflow_trace: bool) -> Self {
+    fn initialize(inputs: ProgramInputs, in_debug_mode: bool) -> Self {
         Self {
             system: System::new(MIN_TRACE_LEN),
-            decoder: Decoder::new(),
-            stack: Stack::new(&inputs, MIN_TRACE_LEN, keep_overflow_trace),
+            decoder: Decoder::new(in_debug_mode),
+            stack: Stack::new(&inputs, MIN_TRACE_LEN, in_debug_mode),
             range: RangeChecker::new(),
             hasher: Hasher::new(),
             bitwise: Bitwise::new(),


### PR DESCRIPTION
Addresses #235.
Adds an `operations` vector to `Decoder` struct and use it to track operation at each VmState. This vector is only populated when programs are executed via `execute_iter()` function.