### PR TITLE
Introduction of MLOAD and MSTORE instructions

### DIFF
--- a/assembly/src/parsers/crypto_ops.rs
+++ b/assembly/src/parsers/crypto_ops.rs
@@ -59,7 +59,7 @@ pub fn parse_rphash(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
 /// Appends an RPPERM operation to the span block, which performs a Rescue Prime permutation on the
 /// top 12 elements of the stack.
 ///
-/// This operation takes 1 cycle.
+/// This operation takes 1 VM cycle.
 ///
 /// # Errors
 /// Returns an AssemblyError if:

--- a/assembly/src/parsers/io_ops/local_ops.rs
+++ b/assembly/src/parsers/io_ops/local_ops.rs
@@ -63,7 +63,7 @@ pub fn parse_read_local(
     }
 
     push_local_addr(span_ops, op, num_proc_locals)?;
-    span_ops.push(Operation::LoadW);
+    span_ops.push(Operation::MLoadW);
 
     Ok(())
 }
@@ -88,7 +88,7 @@ pub fn parse_write_local(
     validate_operation!(@only_params op, "popw|storew.local", 1);
 
     push_local_addr(span_ops, op, num_proc_locals)?;
-    span_ops.push(Operation::StoreW);
+    span_ops.push(Operation::MStoreW);
 
     if !retain_stack_top {
         span_ops.push_many(Operation::Drop, 4);

--- a/assembly/src/parsers/io_ops/mem_ops.rs
+++ b/assembly/src/parsers/io_ops/mem_ops.rs
@@ -1,36 +1,49 @@
 use super::{parse_element_param, validate_operation, AssemblyError, Operation, Token, Vec};
-use vm_core::utils::PushMany;
+use vm_core::{utils::PushMany, Felt, FieldElement};
 
 // RANDOM ACCESS MEMORY
 // ================================================================================================
 
 /// Pushes the first element of the word at the specified memory address onto the stack. The
 /// memory address may be provided directly as an immediate value or via the stack.
+///
+/// This operation takes:
+/// - 2 VM cycles when the addresses is provided a an immediate value.
+/// - 1 VM cycle when the address is provided via the stack.
 pub fn parse_push_mem(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
     validate_operation!(op, "push.mem", 0..1);
 
-    // read from memory with overwrite_stack_top set to false so the rest of the stack is kept
-    parse_read_mem(span_ops, op, false)?;
+    if op.num_parts() == 3 {
+        // parse the provided memory address and push it onto the stack
+        push_mem_addr(span_ops, op)?;
+    }
 
-    span_ops.push_many(Operation::Drop, 3);
+    // load from the memory address on top of the stack
+    span_ops.push(Operation::MLoad);
 
     Ok(())
 }
 
 /// Pops the top element off the stack and saves it at the specified memory address. The memory
 /// address may be provided directly as an immediate value or via the stack.
+///
+/// This operation takes:
+/// - 3 VM cycles when the addresses is provided a an immediate value.
+/// - 2 VM cycle when the address is provided via the stack.
 pub fn parse_pop_mem(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
     validate_operation!(op, "pop.mem", 0..1);
 
-    // pad to word length before calling STOREW
-    span_ops.push_many(Operation::Pad, 3);
-
     // if the destination memory address was on top of the stack, restore it to the top
-    if op.num_parts() == 2 {
-        span_ops.push(Operation::MovUp3);
+    if op.num_parts() == 3 {
+        push_mem_addr(span_ops, op)?;
     }
 
-    parse_write_mem(span_ops, op, false)
+    span_ops.push(Operation::MStore);
+
+    // remove the remaining value from the top of the stack
+    span_ops.push(Operation::Drop);
+
+    Ok(())
 }
 
 /// Translates the `pushw.mem` and `loadw.mem` assembly ops to the system's `LOADW` memory read
@@ -47,6 +60,11 @@ pub fn parse_pop_mem(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), As
 /// Then, if the memory address was provided via the stack (not as part of the memory op) it must be
 /// moved to the top.
 ///
+/// This operation takes:
+///  - pushw: 6 VM cycles.
+///  - loadw: 2 VM cycles when the addresses is provided a an immediate value.
+///  - loadw: 1 VM cecle when the address is provided via the stack.
+///
 /// # Errors
 ///
 /// This function expects a memory read assembly operation that has already been validated. If
@@ -56,7 +74,7 @@ pub fn parse_read_mem(
     op: &Token,
     overwrite_stack_top: bool,
 ) -> Result<(), AssemblyError> {
-    validate_operation!(@only_params op, "push|pushw|loadw.mem", 0..1);
+    validate_operation!(@only_params op, "pushw|loadw.mem", 0..1);
 
     if !overwrite_stack_top {
         // make space for the new elements
@@ -68,15 +86,14 @@ pub fn parse_read_mem(
             span_ops.push(Operation::MovUp4);
         } else {
             // parse the provided memory address and push it onto the stack
-            let address = parse_element_param(op, 2)?;
-            span_ops.push(Operation::Push(address));
+            push_mem_addr(span_ops, op)?;
         }
     } else if op.num_parts() == 3 {
         push_mem_addr(span_ops, op)?;
     }
 
     // load from the memory address on top of the stack
-    span_ops.push(Operation::LoadW);
+    span_ops.push(Operation::MLoadW);
 
     Ok(())
 }
@@ -93,6 +110,12 @@ pub fn parse_read_mem(
 /// which is removed by `STOREW`. When `retain_stack_top` is false, values should be dropped from
 /// the stack (as required by `popw`).
 ///
+/// This operation takes:
+///  - popw: 6 VM cycles when the addresses is provided a an immediate value.
+///  - popw: 5 VM cycles when the address is provided via the stack.
+///  - storew: 2 VM cycles  when the addresses is provided a an immediate value.
+///  - storew: 1 VM cycles  when the address is provided via the stack.
+///
 /// # Errors
 ///
 /// This function expects a memory write assembly operation that has already been validated. If
@@ -102,13 +125,13 @@ pub fn parse_write_mem(
     op: &Token,
     retain_stack_top: bool,
 ) -> Result<(), AssemblyError> {
-    validate_operation!(@only_params op, "pop|popw|storew.mem", 0..1);
+    validate_operation!(@only_params op, "popw|storew.mem", 0..1);
 
     if op.num_parts() == 3 {
         push_mem_addr(span_ops, op)?;
     }
 
-    span_ops.push(Operation::StoreW);
+    span_ops.push(Operation::MStoreW);
 
     if !retain_stack_top {
         span_ops.push_many(Operation::Drop, 4);
@@ -119,12 +142,18 @@ pub fn parse_write_mem(
 
 /// Parses a provided memory address and pushes it onto the stack.
 ///
+/// This operation takes 1 VM cycle.
+///
 /// # Errors
 ///
 /// This function will return an `AssemblyError` if the address parameter does not exist.
 fn push_mem_addr(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
     let address = parse_element_param(op, 2)?;
-    span_ops.push(Operation::Push(address));
+    if address == Felt::ZERO {
+        span_ops.push(Operation::Pad);
+    } else {
+        span_ops.push(Operation::Push(address));
+    }
 
     Ok(())
 }
@@ -136,14 +165,49 @@ fn push_mem_addr(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assemb
 mod tests {
     use super::{
         super::{
-            parse_loadw, parse_popw, parse_pushw, parse_storew, tests::get_parsing_error, Felt,
+            parse_loadw, parse_pop, parse_popw, parse_push, parse_pushw, parse_storew,
+            tests::get_parsing_error, Felt,
         },
         AssemblyError, Operation, Token,
     };
-    use crate::parsers::FieldElement;
 
     // TESTS FOR PUSHING VALUES ONTO THE STACK (PUSH)
     // ============================================================================================
+
+    #[test]
+    fn push_mem() {
+        let num_proc_locals = 0;
+        // reads the first element of the word from memory and pushes it onto the stack
+
+        // test push with memory address on top of stack
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_push = Token::new("push.mem", 0);
+        let expected = vec![Operation::MLoad];
+
+        parse_push(&mut span_ops, &op_push, num_proc_locals).expect("Failed to parse push.mem");
+
+        assert_eq!(&span_ops, &expected);
+
+        // test push with memory address provided directly (address 0)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_push_addr = Token::new("push.mem.0", 0);
+        let expected_addr = vec![Operation::Pad, Operation::MLoad];
+
+        parse_push(&mut span_ops_addr, &op_push_addr, num_proc_locals)
+            .expect("Failed to parse push.mem.0 (address provided by op)");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+
+        // test push with memory address provided directly (address 2)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_push_addr = Token::new("push.mem.2", 0);
+        let expected_addr = vec![Operation::Push(Felt::new(2)), Operation::MLoad];
+
+        parse_push(&mut span_ops_addr, &op_push_addr, num_proc_locals)
+            .expect("Failed to parse push.mem.2 (address provided by op)");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+    }
 
     #[test]
     fn push_mem_invalid() {
@@ -164,7 +228,7 @@ mod tests {
             Operation::Pad,
             Operation::Pad,
             Operation::MovUp4,
-            Operation::LoadW,
+            Operation::MLoadW,
         ];
 
         parse_pushw(&mut span_ops, &op_push, num_proc_locals).expect("Failed to parse pushw.mem");
@@ -179,12 +243,29 @@ mod tests {
             Operation::Pad,
             Operation::Pad,
             Operation::Pad,
-            Operation::Push(Felt::ZERO),
-            Operation::LoadW,
+            Operation::Pad,
+            Operation::MLoadW,
         ];
 
         parse_pushw(&mut span_ops_addr, &op_push_addr, num_proc_locals)
             .expect("Failed to parse pushw.mem.0 (address provided by op)");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+
+        // test push with memory address provided directly (address 2)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_push_addr = Token::new("pushw.mem.2", 0);
+        let expected_addr = vec![
+            Operation::Pad,
+            Operation::Pad,
+            Operation::Pad,
+            Operation::Pad,
+            Operation::Push(Felt::new(2)),
+            Operation::MLoadW,
+        ];
+
+        parse_pushw(&mut span_ops_addr, &op_push_addr, num_proc_locals)
+            .expect("Failed to parse pushw.mem.2 (address provided by op)");
 
         assert_eq!(&span_ops_addr, &expected_addr);
     }
@@ -203,6 +284,45 @@ mod tests {
     }
 
     #[test]
+    fn pop_mem() {
+        let num_proc_locals = 0;
+
+        // stores top element of the stack in memory
+        // then removes this element from the top of the stack
+
+        // test pop with memory address on top of the stack
+        let mut span_ops: Vec<Operation> = Vec::new();
+        let op_mem_pop = Token::new("pop.mem", 0);
+        let expected = vec![Operation::MStore, Operation::Drop];
+        parse_pop(&mut span_ops, &op_mem_pop, num_proc_locals).expect("Failed to parse pop.mem");
+        assert_eq!(&span_ops, &expected);
+
+        // test pop with memory address provided directly (address 0)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_pop_addr = Token::new("pop.mem.0", 0);
+        let expected_addr = vec![Operation::Pad, Operation::MStore, Operation::Drop];
+
+        parse_pop(&mut span_ops_addr, &op_pop_addr, num_proc_locals)
+            .expect("Failed to parse pop.mem.0");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+
+        // test pop with memory address provided directly (address 2)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_pop_addr = Token::new("pop.mem.2", 0);
+        let expected_addr = vec![
+            Operation::Push(Felt::new(2)),
+            Operation::MStore,
+            Operation::Drop,
+        ];
+
+        parse_pop(&mut span_ops_addr, &op_pop_addr, num_proc_locals)
+            .expect("Failed to parse pop.mem.2");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+    }
+
+    #[test]
     fn popw_mem() {
         let num_proc_locals = 0;
 
@@ -213,7 +333,7 @@ mod tests {
         let mut span_ops: Vec<Operation> = Vec::new();
         let op_mem_pop = Token::new("popw.mem", 0);
         let expected = vec![
-            Operation::StoreW,
+            Operation::MStoreW,
             Operation::Drop,
             Operation::Drop,
             Operation::Drop,
@@ -226,8 +346,8 @@ mod tests {
         let mut span_ops_addr: Vec<Operation> = Vec::new();
         let op_pop_addr = Token::new("popw.mem.0", 0);
         let expected_addr = vec![
-            Operation::Push(Felt::ZERO),
-            Operation::StoreW,
+            Operation::Pad,
+            Operation::MStoreW,
             Operation::Drop,
             Operation::Drop,
             Operation::Drop,
@@ -236,6 +356,23 @@ mod tests {
 
         parse_popw(&mut span_ops_addr, &op_pop_addr, num_proc_locals)
             .expect("Failed to parse popw.mem.0");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+
+        // test pop with memory address provided directly (address 2)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_pop_addr = Token::new("popw.mem.2", 0);
+        let expected_addr = vec![
+            Operation::Push(Felt::new(2)),
+            Operation::MStoreW,
+            Operation::Drop,
+            Operation::Drop,
+            Operation::Drop,
+            Operation::Drop,
+        ];
+
+        parse_popw(&mut span_ops_addr, &op_pop_addr, num_proc_locals)
+            .expect("Failed to parse popw.mem.2");
 
         assert_eq!(&span_ops_addr, &expected_addr);
     }
@@ -257,7 +394,7 @@ mod tests {
         // test load with memory address on top of stack
         let mut span_ops: Vec<Operation> = Vec::new();
         let op_push = Token::new("loadw.mem", 0);
-        let expected = vec![Operation::LoadW];
+        let expected = vec![Operation::MLoadW];
 
         parse_loadw(&mut span_ops, &op_push, num_proc_locals).expect("Failed to parse loadw.mem");
 
@@ -266,10 +403,20 @@ mod tests {
         // test load with memory address provided directly (address 0)
         let mut span_ops_addr: Vec<Operation> = Vec::new();
         let op_load_addr = Token::new("loadw.mem.0", 0);
-        let expected_addr = vec![Operation::Push(Felt::ZERO), Operation::LoadW];
+        let expected_addr = vec![Operation::Pad, Operation::MLoadW];
 
         parse_loadw(&mut span_ops_addr, &op_load_addr, num_proc_locals)
             .expect("Failed to parse loadw.mem.0 (address provided by op)");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+
+        // test load with memory address provided directly (address 2)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_load_addr = Token::new("loadw.mem.2", 0);
+        let expected_addr = vec![Operation::Push(Felt::new(2)), Operation::MLoadW];
+
+        parse_loadw(&mut span_ops_addr, &op_load_addr, num_proc_locals)
+            .expect("Failed to parse loadw.mem.2 (address provided by op)");
 
         assert_eq!(&span_ops_addr, &expected_addr);
     }
@@ -290,7 +437,7 @@ mod tests {
         // test store with memory address on top of the stack
         let mut span_ops: Vec<Operation> = Vec::new();
         let op_store = Token::new("storew.mem", 0);
-        let expected = vec![Operation::StoreW];
+        let expected = vec![Operation::MStoreW];
 
         parse_storew(&mut span_ops, &op_store, num_proc_locals)
             .expect("Failed to parse storew.mem");
@@ -300,10 +447,20 @@ mod tests {
         // test store with memory address provided directly (address 0)
         let mut span_ops_addr: Vec<Operation> = Vec::new();
         let op_store_addr = Token::new("storew.mem.0", 0);
-        let expected_addr = vec![Operation::Push(Felt::ZERO), Operation::StoreW];
+        let expected_addr = vec![Operation::Pad, Operation::MStoreW];
 
         parse_storew(&mut span_ops_addr, &op_store_addr, num_proc_locals)
             .expect("Failed to parse storew.mem.0 with adddress (address provided by op)");
+
+        assert_eq!(&span_ops_addr, &expected_addr);
+
+        // test store with memory address provided directly (address 2)
+        let mut span_ops_addr: Vec<Operation> = Vec::new();
+        let op_store_addr = Token::new("storew.mem.2", 0);
+        let expected_addr = vec![Operation::Push(Felt::new(2)), Operation::MStoreW];
+
+        parse_storew(&mut span_ops_addr, &op_store_addr, num_proc_locals)
+            .expect("Failed to parse storew.mem.2 with adddress (address provided by op)");
 
         assert_eq!(&span_ops_addr, &expected_addr);
     }

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -127,9 +127,9 @@ fn script_with_proc_locals() {
             span \
                 push(4) push(3) push(2) \
                 push(1) fmpupdate \
-                pad pad pad pad fmpadd storew drop drop drop drop \
+                pad pad pad pad fmpadd mstorew drop drop drop drop \
                 add \
-                pad pad pad pad pad fmpadd loadw drop drop drop \
+                pad pad pad pad pad fmpadd mloadw drop drop drop \
                 mul \
                 push(18446744069414584320) fmpupdate \
             end \

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -302,11 +302,20 @@ pub enum Operation {
 
     /// Pops an element off the stack, interprets it as a memory address, and replaces the
     /// remaining 4 elements at the top of the stack with values located at the specified address.
-    LoadW,
+    MLoadW,
 
     /// Pops an element off the stack, interprets it as a memory address, and writes the remaining
     /// 4 elements at the top of the stack into memory at the specified address.
-    StoreW,
+    MStoreW,
+
+    /// Pops an element off the stack, interprets it as a memory address, and pushes the first
+    /// element of the word located at the specified address to the stack.
+    MLoad,
+
+    /// Pops an element off the stack, interprets it as a memory address, and writes the remaining
+    /// element at the top of the stack into the first element of the word located at the specified
+    /// memory address. The remaining 3 elements of the word are not affected.
+    MStore,
 
     /// Pushes the current depth of the stack onto the stack.
     SDepth,
@@ -457,8 +466,8 @@ impl Operation {
             Self::U32or => Some(0b0100_1110),
             Self::U32xor => Some(0b0100_1111),
 
-            Self::LoadW => Some(52),
-            Self::StoreW => Some(53),
+            Self::MLoadW => Some(52),
+            Self::MStoreW => Some(53),
 
             Self::Read => Some(54),
             Self::ReadW => Some(55),
@@ -477,6 +486,9 @@ impl Operation {
             Self::Respan => Some(81),
             Self::Span => Some(82),
             Self::Halt => Some(83),
+
+            Self::MLoad => Some(84),
+            Self::MStore => Some(85),
 
             Self::Debug(_) => None,
             Self::Advice(_) => None,
@@ -615,8 +627,11 @@ impl fmt::Display for Operation {
             Self::Read => write!(f, "read"),
             Self::ReadW => write!(f, "readw"),
 
-            Self::LoadW => write!(f, "loadw"),
-            Self::StoreW => write!(f, "storew"),
+            Self::MLoadW => write!(f, "mloadw"),
+            Self::MStoreW => write!(f, "mstorew"),
+
+            Self::MLoad => write!(f, "mload"),
+            Self::MStore => write!(f, "mstore"),
 
             Self::SDepth => write!(f, "sdepth"),
 

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -40,7 +40,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 3,
-            op: Some(Operation::StoreW),
+            op: Some(Operation::MStoreW),
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
             fmp: fmp,
             memory: mem.clone(),
@@ -162,7 +162,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 16,
-            op: Some(Operation::StoreW),
+            op: Some(Operation::MStoreW),
             stack: [0, 0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: vec![

--- a/processor/src/aux_table/tests.rs
+++ b/processor/src/aux_table/tests.rs
@@ -43,7 +43,7 @@ fn bitwise_aux_trace() {
 fn memory_aux_trace() {
     // --- single memory operation with no stack manipulation -------------------------------------
     let stack = [1, 2, 3, 4];
-    let operations = vec![Operation::Push(Felt::new(2)), Operation::StoreW];
+    let operations = vec![Operation::Push(Felt::new(2)), Operation::MStoreW];
     let (aux_table_trace, trace_len) = build_trace(&stack, operations);
     let memory_trace_len = 1;
 
@@ -68,7 +68,7 @@ fn stacked_aux_trace() {
     let operations = vec![
         Operation::U32or,
         Operation::Push(Felt::ZERO),
-        Operation::StoreW,
+        Operation::MStoreW,
         Operation::RpPerm,
     ];
     let (aux_table_trace, trace_len) = build_trace(&stack, operations);

--- a/processor/src/memory/mod.rs
+++ b/processor/src/memory/mod.rs
@@ -8,7 +8,7 @@ mod tests;
 // ================================================================================================
 
 /// Initial value of every memory cell.
-const INIT_MEM_VALUE: Word = [Felt::ZERO; 4];
+pub const INIT_MEM_VALUE: Word = [Felt::ZERO; 4];
 
 // RANDOM ACCESS MEMORY
 // ================================================================================================

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -116,8 +116,11 @@ impl Process {
             Operation::Read => self.op_read()?,
             Operation::ReadW => self.op_readw()?,
 
-            Operation::LoadW => self.op_loadw()?,
-            Operation::StoreW => self.op_storew()?,
+            Operation::MLoadW => self.op_mloadw()?,
+            Operation::MStoreW => self.op_mstorew()?,
+
+            Operation::MLoad => self.op_mload()?,
+            Operation::MStore => self.op_mstore()?,
 
             Operation::FmpAdd => self.op_fmpadd()?,
             Operation::FmpUpdate => self.op_fmpupdate()?,


### PR DESCRIPTION
`MLOAD` and `MSTORE` instructions were introduced to work with individual elements. Using them, the `push.mem` and `pop.mem` operations were optimized.