### PR TITLE
Minor cleanup: small refactors, clippy warnings, mdbook fix

### DIFF
--- a/air/src/aux_table/mod.rs
+++ b/air/src/aux_table/mod.rs
@@ -1,6 +1,9 @@
 use super::{Assertion, EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree, Vec};
 use crate::utils::{binary_not, is_binary};
-use vm_core::AUX_TABLE_OFFSET;
+use vm_core::{
+    aux_table::{BITWISE_TRACE_OFFSET, HASHER_TRACE_OFFSET, MEMORY_TRACE_OFFSET},
+    AUX_TABLE_OFFSET,
+};
 
 mod bitwise_pow2;
 mod hasher;
@@ -28,13 +31,6 @@ pub const S1_COL_IDX: usize = AUX_TABLE_OFFSET + 1;
 /// The third selector column, used as a selector for the memory and padding segments after the
 /// bitwise trace ends.
 pub const S2_COL_IDX: usize = AUX_TABLE_OFFSET + 2;
-
-/// The first column of the bitwise co-processor.
-pub const BITWISE_TRACE_OFFSET: usize = S1_COL_IDX + 1;
-/// The first column of the hash co-processor.
-pub const HASHER_TRACE_OFFSET: usize = S0_COL_IDX + 1;
-/// The first column of the memory co-processor.
-pub const MEMORY_TRACE_OFFSET: usize = S2_COL_IDX + 1;
 
 // PERIODIC COLUMNS
 // ================================================================================================

--- a/core/src/aux_table.rs
+++ b/core/src/aux_table.rs
@@ -1,0 +1,18 @@
+use super::AUX_TABLE_OFFSET;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The number of columns in the auxiliary table which are used as selectors for the hasher segment.
+pub const NUM_HASHER_SELECTORS: usize = 1;
+/// The number of columns in the aux table which are used as selectors for the bitwise/pow2 segment.
+pub const NUM_BITWISE_SELECTORS: usize = 2;
+/// The number of columns in the auxiliary table which are used as selectors for the memory segment.
+pub const NUM_MEMORY_SELECTORS: usize = 3;
+
+/// The first column of the hash co-processor.
+pub const HASHER_TRACE_OFFSET: usize = AUX_TABLE_OFFSET + NUM_HASHER_SELECTORS;
+/// The first column of the bitwise co-processor.
+pub const BITWISE_TRACE_OFFSET: usize = AUX_TABLE_OFFSET + NUM_BITWISE_SELECTORS;
+/// The first column of the memory co-processor.
+pub const MEMORY_TRACE_OFFSET: usize = AUX_TABLE_OFFSET + NUM_MEMORY_SELECTORS;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 
 use core::ops::Range;
 
+pub mod aux_table;
 pub mod bitwise;
 pub mod decoder;
 pub mod errors;

--- a/docs/src/design/aux_table/main.md
+++ b/docs/src/design/aux_table/main.md
@@ -8,8 +8,8 @@ The co-processors in the auxiliary table are:
 
 - [Hash Processor](./hasher.md) (17 columns; degree 8)
 - Bitwise & Power of Two Processor, which combines 2 co-processors:
-  - [Bitwise Processor](./bitwise.md) (13 columns; degree 6)
-  - [Power of Two Processor](./pow2.md) (13 columns; degree 3)
+  - [Bitwise Processor](./bitwise.md) (15 columns; degree 6)
+  - [Power of Two Processor](./pow2.md) (15 columns; degree 3)
 - [Memory Processor](./memory.md) (14 columns; degree 6)
 
 Each co-processor is identified by a set of selector columns which identify its segment in the auxiliary table and cause its constraints to be selectively applied.

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -11,7 +11,7 @@ fn test_exec_iter() {
     (1..=16).for_each(|i| {
         init_stack.push(i);
     });
-    let test = build_test!(source, &init_stack.clone());
+    let test = build_test!(source, &init_stack);
     let traces = test.execute_iter();
     let fmp = Felt::new(2u64.pow(30));
     let next_fmp = fmp + Felt::ONE;
@@ -21,70 +21,70 @@ fn test_exec_iter() {
             clk: 0,
             op: None,
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: Vec::new(),
         },
         VmState {
             clk: 1,
             op: Some(Operation::Span),
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: Vec::new(),
         },
         VmState {
             clk: 2,
             op: Some(Operation::Push(Felt::new(1))),
             stack: [1, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: Vec::new(),
         },
         VmState {
             clk: 3,
             op: Some(Operation::MStoreW),
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 4,
             op: Some(Operation::Drop),
             stack: [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 5,
             op: Some(Operation::Drop),
             stack: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 6,
             op: Some(Operation::Drop),
             stack: [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 7,
             op: Some(Operation::Drop),
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 8,
             op: Some(Operation::Push(Felt::new(17))),
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: mem.clone(),
         },
         VmState {
             clk: 9,
             op: Some(Operation::Push(Felt::new(1))),
             stack: [1, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
-            fmp: fmp,
+            fmp,
             memory: mem.clone(),
         },
         VmState {
@@ -158,7 +158,7 @@ fn test_exec_iter() {
             ]
             .to_elements(),
             fmp: next_fmp,
-            memory: mem.clone(),
+            memory: mem,
         },
         VmState {
             clk: 16,

--- a/miden/tests/integration/operations/u32_ops/conversion_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/conversion_ops.rs
@@ -139,19 +139,19 @@ fn u32assert2_fail() {
 
     // vars to test
     // -------- Case 1: a > 2^32 and b > 2^32 ---------------------------------------------------
-    let value_a = 1_u64 << 32 + 1;
+    let value_a = (1_u64 << 32) + 1;
     let value_b = value_a + 2;
     let test = build_op_test!(asm_op, &[value_a, value_b]);
     test.expect_error(TestError::ExecutionError(err));
 
     // -------- Case 2: a > 2^32 and b < 2^32 ---------------------------------------------------
-    let value_a = 1_u64 << 32 + 1;
+    let value_a = (1_u64 << 32) + 1;
     let value_b = 1_u64;
     let test = build_op_test!(asm_op, &[value_a, value_b]);
     test.expect_error(TestError::ExecutionError(err));
 
     // --------- Case 3: a < 2^32 and b > 2^32 --------------------------------------------------
-    let value_b = 1_u64 << 32 + 1;
+    let value_b = (1_u64 << 32) + 1;
     let value_a = 1_u64;
     let test = build_op_test!(asm_op, &[value_a, value_b]);
     test.expect_error(TestError::ExecutionError(err));

--- a/miden/tests/integration/stdlib/crypto/blake3.rs
+++ b/miden/tests/integration/stdlib/crypto/blake3.rs
@@ -56,5 +56,5 @@ fn from_le_bytes_to_words(le_bytes: &[u8]) -> u32 {
     ((le_bytes[3] as u32) << 24)
         | ((le_bytes[2] as u32) << 16)
         | ((le_bytes[1] as u32) << 8)
-        | ((le_bytes[0] as u32) << 0)
+        | (le_bytes[0] as u32)
 }

--- a/miden/tests/integration/stdlib/crypto/keccak256.rs
+++ b/miden/tests/integration/stdlib/crypto/keccak256.rs
@@ -84,7 +84,7 @@ fn to_stack(i_digest: &[u8], stack: &mut [u64]) {
             | (i_digest[(i << 3) + 3] as u64) << 24
             | (i_digest[(i << 3) + 2] as u64) << 16
             | (i_digest[(i << 3) + 1] as u64) << 8
-            | (i_digest[(i << 3) + 0] as u64) << 0;
+            | (i_digest[(i << 3)] as u64);
 
         // split into higher/ lower bits of u64
         let high = (word >> 32) as u32;
@@ -93,7 +93,7 @@ fn to_stack(i_digest: &[u8], stack: &mut [u64]) {
         // 64 -bit standard representation number kept as two 32 -bit numbers
         // where first one holds higher 32 -bits and second one holds remaining lower
         // 32 -bits of u64 word
-        stack[(i << 1) + 0] = high as u64;
+        stack[(i << 1)] = high as u64;
         stack[(i << 1) + 1] = low as u64;
     }
 }

--- a/miden/tests/integration/stdlib/crypto/sha256.rs
+++ b/miden/tests/integration/stdlib/crypto/sha256.rs
@@ -55,5 +55,5 @@ fn from_be_bytes_to_words(be_bytes: &[u8]) -> u32 {
     ((be_bytes[0] as u32) << 24)
         | ((be_bytes[1] as u32) << 16)
         | ((be_bytes[2] as u32) << 8)
-        | ((be_bytes[3] as u32) << 0)
+        | (be_bytes[3] as u32)
 }

--- a/processor/src/aux_table/tests.rs
+++ b/processor/src/aux_table/tests.rs
@@ -1,7 +1,5 @@
-use super::{
-    super::{ExecutionTrace, Operation, Process},
-    AuxTableTrace,
-};
+use super::AuxTableTrace;
+use crate::{utils::get_trace_len, ExecutionTrace, Operation, Process};
 use vm_core::{
     bitwise::{BITWISE_OR, OP_CYCLE_LEN},
     hasher::{HASH_CYCLE_LEN, LINEAR_HASH, RETURN_STATE},
@@ -103,7 +101,7 @@ fn build_trace(stack: &[u64], operations: Vec<Operation>) -> (AuxTableTrace, usi
     process.execute_code_block(&program).unwrap();
 
     let (trace, _) = ExecutionTrace::test_finalize_trace(process);
-    let trace_len = trace[0].len() - ExecutionTrace::NUM_RAND_ROWS;
+    let trace_len = get_trace_len(&trace) - ExecutionTrace::NUM_RAND_ROWS;
 
     (
         trace[AUX_TABLE_RANGE]

--- a/processor/src/bitwise/mod.rs
+++ b/processor/src/bitwise/mod.rs
@@ -1,4 +1,6 @@
-use super::{ExecutionError, Felt, FieldElement, StarkField, TraceFragment, Vec};
+use super::{
+    utils::get_trace_len, ExecutionError, Felt, FieldElement, StarkField, TraceFragment, Vec,
+};
 use vm_core::bitwise::{
     BITWISE_AND, BITWISE_OR, BITWISE_XOR, NUM_SELECTORS, POW2_POWERS_PER_ROW, POWER_OF_TWO,
     TRACE_WIDTH,
@@ -118,7 +120,7 @@ impl Bitwise {
     /// Returns length of execution trace required to describe bitwise operations executed on the
     /// VM.
     pub fn trace_len(&self) -> usize {
-        self.trace[0].len()
+        get_trace_len(&self.trace)
     }
 
     // TRACE MUTATORS

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -890,10 +890,10 @@ fn set_user_op_helpers_one() {
 fn set_user_op_helpers_many() {
     // --- user operation with 4 helper values ----------------------------------------------------
     let program = CodeBlock::new_span(vec![Operation::U32div]);
-    let a = rand_value();
-    let b = rand_value();
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>();
     let (dividend, divisor) = if a > b { (a, b) } else { (b, a) };
-    let (trace, _, _) = build_trace(&[dividend, divisor], &program);
+    let (trace, _, _) = build_trace(&[dividend as u64, divisor as u64], &program);
     let hasher_state = get_hasher_state(&trace, 1);
 
     // Check the hasher state of the user operation which was executed.

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -2,7 +2,7 @@ use super::{
     build_op_group, AuxTraceHints, BlockHashTableRow, BlockStackTableRow, BlockTableUpdate,
     OpGroupTableRow, OpGroupTableUpdate,
 };
-use crate::{ExecutionTrace, Felt, Operation, Process, ProgramInputs, Word};
+use crate::{utils::get_trace_len, ExecutionTrace, Felt, Operation, Process, ProgramInputs, Word};
 use rand_utils::rand_value;
 use vm_core::{
     decoder::{
@@ -923,7 +923,7 @@ fn build_trace(stack: &[u64], program: &CodeBlock) -> (DecoderTrace, AuxTraceHin
     process.execute_code_block(program).unwrap();
 
     let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
-    let trace_len = trace[0].len() - ExecutionTrace::NUM_RAND_ROWS;
+    let trace_len = get_trace_len(&trace) - ExecutionTrace::NUM_RAND_ROWS;
 
     (
         trace[DECODER_TRACE_RANGE]

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -3,6 +3,7 @@ use super::{
     MIN_TRACE_LEN, NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS, ONE, OP_BATCH_1_GROUPS,
     OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS, OP_BATCH_SIZE, ZERO,
 };
+use crate::utils::get_trace_len;
 use core::ops::Range;
 use vm_core::utils::new_array_vec;
 
@@ -180,7 +181,7 @@ impl DecoderTrace {
         self.addr_trace.push(loop_addr);
         self.append_opcode(Operation::Repeat);
 
-        let last_row = self.hasher_trace[0].len() - 1;
+        let last_row = get_trace_len(&self.hasher_trace) - 1;
         for column in self.hasher_trace.iter_mut() {
             column.push(column[last_row]);
         }

--- a/processor/src/hasher/tests.rs
+++ b/processor/src/hasher/tests.rs
@@ -243,16 +243,16 @@ fn check_merkle_path(
     init_selectors: Selectors,
 ) {
     // make sure row address is correct
-    check_row_addr_trace(&trace);
+    check_row_addr_trace(trace);
 
     // make sure selectors were set correctly
     let mid_selectors = [Felt::ZERO, init_selectors[1], init_selectors[2]];
-    check_selector_trace(&trace, row_idx, init_selectors, init_selectors);
+    check_selector_trace(trace, row_idx, init_selectors, init_selectors);
     for i in 1..path.len() - 1 {
-        check_selector_trace(&trace, row_idx + i * 8, mid_selectors, init_selectors);
+        check_selector_trace(trace, row_idx + i * 8, mid_selectors, init_selectors);
     }
     let last_perm_row_addr = row_idx + (path.len() - 1) * 8;
-    check_selector_trace(&trace, last_perm_row_addr, mid_selectors, RETURN_HASH);
+    check_selector_trace(trace, last_perm_row_addr, mid_selectors, RETURN_HASH);
 
     // make sure hasher states are correct
     let mut root = leaf;
@@ -266,7 +266,7 @@ fn check_merkle_path(
             root = hasher::merge(&[node.into(), root.into()]).into();
             hasher_merge_state(node, old_root)
         };
-        check_hasher_state_trace(&trace, row_idx + i * 8, init_state);
+        check_hasher_state_trace(trace, row_idx + i * 8, init_state);
     }
 
     // make sure node index is set correctly

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -54,6 +54,8 @@ use trace::TraceFragment;
 mod errors;
 pub use errors::ExecutionError;
 
+mod utils;
+
 mod debug;
 pub use debug::{VmState, VmStateIterator};
 

--- a/processor/src/memory/tests.rs
+++ b/processor/src/memory/tests.rs
@@ -283,7 +283,7 @@ fn build_trace_row(
             row[2] - prev_row[2] - Felt::ONE
         };
 
-        let (hi, lo) = super::split_u32_into_u16(delta);
+        let (hi, lo) = super::split_element_u32_into_u16(delta);
         row[11] = lo;
         row[12] = hi;
         row[13] = delta.inv();

--- a/processor/src/range/tests.rs
+++ b/processor/src/range/tests.rs
@@ -1,4 +1,4 @@
-use crate::RangeCheckTrace;
+use crate::{utils::get_trace_len, RangeCheckTrace};
 
 use super::{BTreeMap, Felt, FieldElement, RangeChecker};
 use rand_utils::rand_array;
@@ -81,7 +81,7 @@ fn validate_trace(trace: &[Vec<Felt>], lookups: &[Felt]) {
     assert_eq!(4, trace.len());
 
     // trace length must be a power of two
-    let trace_len = trace[0].len();
+    let trace_len = get_trace_len(trace);
     assert!(trace_len.is_power_of_two());
 
     // --- validate the 8-bit segment of the trace ----------------------------

--- a/processor/src/stack/trace.rs
+++ b/processor/src/stack/trace.rs
@@ -2,6 +2,7 @@ use super::{
     Felt, FieldElement, ProgramInputs, StackTopState, Vec, MAX_TOP_IDX, MIN_STACK_DEPTH,
     NUM_STACK_HELPER_COLS, STACK_TRACE_WIDTH,
 };
+use crate::utils::get_trace_len;
 use vm_core::StarkField;
 
 // STACK TRACE
@@ -207,7 +208,7 @@ impl StackTrace {
     ///
     /// Trace length is doubled every time it needs to be increased.
     pub fn ensure_trace_capacity(&mut self, clk: usize) {
-        let current_capacity = self.stack[0].len();
+        let current_capacity = get_trace_len(&self.stack);
         if clk + 1 >= current_capacity {
             let new_length = current_capacity * 2;
             for register in self.stack.iter_mut().chain(self.helpers.iter_mut()) {

--- a/processor/src/trace/decoder/tests.rs
+++ b/processor/src/trace/decoder/tests.rs
@@ -34,7 +34,7 @@ fn decoder_p1_span_with_respan() {
         Operation::Push(iv[8]),
         Operation::Add,
     ];
-    let mut trace = build_trace_from_ops(ops.clone(), &[]);
+    let mut trace = build_trace_from_ops(ops, &[]);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
     let aux_columns = trace.build_aux_segment(&[], &alphas).unwrap();
     let p1 = aux_columns.get_column(P1_COL_IDX);
@@ -78,7 +78,7 @@ fn decoder_p1_span_with_respan() {
 fn decoder_p1_join() {
     let span1 = CodeBlock::new_span(vec![Operation::Mul]);
     let span2 = CodeBlock::new_span(vec![Operation::Add]);
-    let program = CodeBlock::new_join([span1.clone(), span2.clone()]);
+    let program = CodeBlock::new_join([span1, span2]);
 
     let mut trace = build_trace_from_block(&program, &[]);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
@@ -138,7 +138,7 @@ fn decoder_p1_join() {
 fn decoder_p1_split() {
     let span1 = CodeBlock::new_span(vec![Operation::Mul]);
     let span2 = CodeBlock::new_span(vec![Operation::Add]);
-    let program = CodeBlock::new_split(span1.clone(), span2.clone());
+    let program = CodeBlock::new_split(span1, span2);
 
     let mut trace = build_trace_from_block(&program, &[1]);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
@@ -185,8 +185,8 @@ fn decoder_p1_split() {
 fn decoder_p1_loop_with_repeat() {
     let span1 = CodeBlock::new_span(vec![Operation::Pad]);
     let span2 = CodeBlock::new_span(vec![Operation::Drop]);
-    let body = CodeBlock::new_join([span1.clone(), span2.clone()]);
-    let program = CodeBlock::new_loop(body.clone());
+    let body = CodeBlock::new_join([span1, span2]);
+    let program = CodeBlock::new_loop(body);
 
     let mut trace = build_trace_from_block(&program, &[0, 1, 1]);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
@@ -397,7 +397,7 @@ fn decoder_p2_join() {
 fn decoder_p2_split_true() {
     let span1 = CodeBlock::new_span(vec![Operation::Mul]);
     let span2 = CodeBlock::new_span(vec![Operation::Add]);
-    let program = CodeBlock::new_split(span1.clone(), span2.clone());
+    let program = CodeBlock::new_split(span1.clone(), span2);
 
     let mut trace = build_trace_from_block(&program, &[1]);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
@@ -441,7 +441,7 @@ fn decoder_p2_split_true() {
 fn decoder_p2_split_false() {
     let span1 = CodeBlock::new_span(vec![Operation::Mul]);
     let span2 = CodeBlock::new_span(vec![Operation::Add]);
-    let program = CodeBlock::new_split(span1.clone(), span2.clone());
+    let program = CodeBlock::new_split(span1, span2.clone());
 
     let mut trace = build_trace_from_block(&program, &[0]);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
@@ -683,7 +683,7 @@ fn decoder_p3_trace_two_batches() {
         Operation::Push(iv[8]),
         Operation::Add,
     ];
-    let mut trace = build_trace_from_ops(ops.clone(), &[]);
+    let mut trace = build_trace_from_ops(ops, &[]);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
     let aux_columns = trace.build_aux_segment(&[], &alphas).unwrap();
     let p3 = aux_columns.get_column(P3_COL_IDX);

--- a/processor/src/trace/utils.rs
+++ b/processor/src/trace/utils.rs
@@ -130,7 +130,7 @@ pub fn build_lookup_table_row_values<E: FieldElement<BaseField = Felt>, R: Looku
 pub fn build_trace_from_block(program: &CodeBlock, stack: &[u64]) -> ExecutionTrace {
     let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
     let mut process = Process::new(inputs);
-    process.execute_code_block(&program).unwrap();
+    process.execute_code_block(program).unwrap();
     ExecutionTrace::new(process)
 }
 

--- a/processor/src/utils.rs
+++ b/processor/src/utils.rs
@@ -1,7 +1,13 @@
-use super::{Felt, StarkField};
+use super::{Felt, StarkField, Vec};
 
 // HELPER FUNCTIONS
 // ================================================================================================
+
+/// Returns the number of rows in the provided execution trace assumed to be in column-major form
+/// and contain at least one column.
+pub fn get_trace_len(trace: &[Vec<Felt>]) -> usize {
+    trace[0].len()
+}
 
 /// Splits an element into two field elements containing 32-bit integer values
 #[inline(always)]

--- a/processor/src/utils.rs
+++ b/processor/src/utils.rs
@@ -1,0 +1,35 @@
+use super::{Felt, StarkField};
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Splits an element into two field elements containing 32-bit integer values
+#[inline(always)]
+pub fn split_element(value: Felt) -> (Felt, Felt) {
+    let value = value.as_int();
+    let lo = (value as u32) as u64;
+    let hi = value >> 32;
+    (Felt::new(hi), Felt::new(lo))
+}
+
+/// Splits an element into two 16 bit integer limbs. It assumes that the field element contains a
+/// valid 32-bit integer value.
+pub fn split_element_u32_into_u16(value: Felt) -> (Felt, Felt) {
+    let (hi, lo) = split_u32_into_u16(value.as_int());
+    (Felt::new(hi as u64), Felt::new(lo as u64))
+}
+
+/// Splits a u64 integer assumed to contain a 32-bit value into two u64 integers containing 16-bit
+/// values.
+///
+/// # Errors
+/// Fails in debug mode if the provided value is not a 32-bit value.
+pub fn split_u32_into_u16(value: u64) -> (u16, u16) {
+    const U32MAX: u64 = u32::MAX as u64;
+    debug_assert!(value <= U32MAX, "not a 32-bit value");
+
+    let lo = value as u16;
+    let hi = (value >> 16) as u16;
+
+    (hi, lo)
+}


### PR DESCRIPTION
This PR groups together a few small cleanup/refactor tasks that came up while working on adding the memory range checks.

- fixes an error in the mdbook docs
- adds utils for splitting u32 to u16, since this was implemented in different ways in different processors. This also adds a u32 debug assertion for the values before splitting them.
- fixes a decoder test that started failing after the u32 debug assertion was added above
- moves some aux table co-processor constants to core
- creates a util helper function for getting the length of any trace in column-major form
- fixes clippy warnings in tests (these aren't checked during the PR run)