### PR TITLE
Filling in helper registers for memory operations

### DIFF
--- a/core/src/decoder/mod.rs
+++ b/core/src/decoder/mod.rs
@@ -24,6 +24,13 @@ pub const HASHER_STATE_OFFSET: usize = OP_BITS_OFFSET + NUM_OP_BITS;
 /// Number of hasher columns in the decoder trace.
 pub const NUM_HASHER_COLUMNS: usize = 8;
 
+/// Number of helper registers available to user ops.
+pub const NUM_USER_OP_HELPERS: usize = 6;
+
+/// Index at which helper registers available to user ops start.
+/// The first two helper registers are used by the decoder itself.
+pub const USER_OP_HELPERS_OFFSET: usize = HASHER_STATE_OFFSET + 2;
+
 /// Location of hasher columns in the decoder trace.
 pub const HASHER_STATE_RANGE: Range<usize> = range(HASHER_STATE_OFFSET, NUM_HASHER_COLUMNS);
 

--- a/miden/tests/integration/air/memory.rs
+++ b/miden/tests/integration/air/memory.rs
@@ -1,4 +1,5 @@
 use crate::{build_op_test, build_test};
+use vm_core::utils::ToElements;
 
 #[test]
 fn push() {
@@ -25,11 +26,52 @@ fn pop() {
 }
 
 #[test]
+fn helper_pop() {
+    // Sequence of operations: [Span, Pad, MStore, Drop, Pad, Mstore, Drop, Pad, Mstore, Drop]
+    let asm_op = "begin pop.mem.0 pop.mem.0 pop.mem.0 end";
+    let pub_inputs = vec![1, 2];
+
+    let trace = build_test!(asm_op, &pub_inputs).execute().unwrap();
+    // Since the MStore operation stores in helper registers the value that was previously in
+    // memory, after the first call to MStore, the helper registers will be filled with zeros
+    // (since memory is initialized with zeros by default). And an element taken from the
+    // top of the stack, that is, 2, will be written to memory. On the second call, the memory will
+    // be overwritten by 1, and the previous value that was in memory, that is, 2, will be written
+    // to the helper registers.
+    let helper_regs = [2, 0, 0, 0, 0, 0].to_elements();
+    // We need to check helper registers state after second MStore, which index is 5
+    assert_eq!(helper_regs, trace.get_user_op_helpers_at(5));
+    // The next time the MStore operation is called, the memory will be overwritten again, and the
+    // 1 lying there before that will be written to the helper register
+    let helper_regs = [1, 0, 0, 0, 0, 0].to_elements();
+    // We need to check helper registers state after third MStore, which index is 8
+    assert_eq!(helper_regs, trace.get_user_op_helpers_at(8));
+}
+
+#[test]
 fn popw() {
     let asm_op = "popw.mem.0";
     let pub_inputs = vec![1, 2, 3, 4];
 
     build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+}
+
+#[test]
+fn helper_popow() {
+    // Sequence of operations: [Span, Pad, MStorew, Drop, Drop, Drop, Drop, Pad, Mstore, Drop,
+    //                          Drop, Drop, Drop, Pad, Mstore, Drop, Drop, Drop, Drop]
+    let asm_op = "begin popw.mem.0 popw.mem.0 popw.mem.0 end";
+    let pub_inputs = vec![213, 214, 215, 216, 217, 218, 219, 220];
+
+    let trace = build_test!(asm_op, &pub_inputs).execute().unwrap();
+    // Filling in helper registers is similar to the helper_pop test, with the difference that not
+    // one element is written to the registers, but the whole word
+    let helper_regs1 = [217, 218, 219, 220, 0, 0].to_elements();
+    // We need to check helper registers state after second MStore, which index is 8
+    assert_eq!(helper_regs1, trace.get_user_op_helpers_at(8));
+    let helper_regs1 = [213, 214, 215, 216, 0, 0].to_elements();
+    // We need to check helper registers state after second MStore, which index is 14
+    assert_eq!(helper_regs1, trace.get_user_op_helpers_at(14));
 }
 
 #[test]
@@ -54,6 +96,21 @@ fn write_read() {
     let pub_inputs = vec![4, 3, 2, 1];
 
     build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+}
+
+#[test]
+fn helper_write_read() {
+    // drop's are added at the end to make sure stack overflow is empty on exit
+    // Sequence of operations: [Span, Pad, MStorew, Drop, Drop, Drop, Drop, Pad, MLoad, ... ]
+    let source = "begin popw.mem.0 push.mem.0 swapw drop end";
+    let pub_inputs = vec![4, 3, 2, 1];
+
+    let trace = build_test!(source, &pub_inputs).execute().unwrap();
+    // When the MLoad operation is called, word elements that were not pushed on the stack
+    // are written to helper registers. So, 3, 2 and 1 will be written after this operation
+    let helper_regs = [3, 2, 1, 0, 0, 0].to_elements();
+    // We need to check helper registers state after first MLoad, which index is 8
+    assert_eq!(helper_regs, trace.get_user_op_helpers_at(8));
 }
 
 #[test]

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -4,8 +4,9 @@ use super::{
     Digest, Felt, FieldElement, Process, StackTopState, Vec,
 };
 use vm_core::{
-    AUX_TRACE_RAND_ELEMENTS, AUX_TRACE_WIDTH, MIN_STACK_DEPTH, MIN_TRACE_LEN, STACK_TRACE_OFFSET,
-    TRACE_WIDTH, ZERO,
+    decoder::{NUM_USER_OP_HELPERS, USER_OP_HELPERS_OFFSET},
+    AUX_TRACE_RAND_ELEMENTS, AUX_TRACE_WIDTH, DECODER_TRACE_OFFSET, MIN_STACK_DEPTH, MIN_TRACE_LEN,
+    STACK_TRACE_OFFSET, TRACE_WIDTH, ZERO,
 };
 use winterfell::{EvaluationFrame, Matrix, Serializable, Trace, TraceLayout};
 
@@ -105,6 +106,17 @@ impl ExecutionTrace {
         let mut result = [ZERO; MIN_STACK_DEPTH];
         for (i, result) in result.iter_mut().enumerate() {
             *result = self.main_trace.get_column(i + STACK_TRACE_OFFSET)[last_step];
+        }
+        result
+    }
+
+    /// Returns helper registers state at the specified `clk` of the VM
+    pub fn get_user_op_helpers_at(&self, clk: usize) -> [Felt; NUM_USER_OP_HELPERS] {
+        let mut result = [ZERO; NUM_USER_OP_HELPERS];
+        for (i, result) in result.iter_mut().enumerate() {
+            *result = self
+                .main_trace
+                .get_column(DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + i)[clk];
         }
         result
     }


### PR DESCRIPTION
Filling in helper registers for `MLoad`, `MLoadW`, `MStore` and `MStoreW` memory operations.