### PR TITLE
Swap order of memory and padding in the auxiliary table execution trace

### DIFF
--- a/air/src/aux_table/memory/mod.rs
+++ b/air/src/aux_table/memory/mod.rs
@@ -1,7 +1,9 @@
-use super::{EvaluationFrame, FieldElement, Vec, MEMORY_TRACE_OFFSET};
+use super::{EvaluationFrame, FieldElement, Vec};
 use crate::utils::{binary_not, is_binary, EvaluationResult};
-use core::ops::Range;
-use vm_core::utils::range as create_range;
+use vm_core::aux_table::memory::{
+    ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, D0_COL_IDX, D1_COL_IDX, D_INV_COL_IDX, NUM_ELEMENTS,
+    U_COL_RANGE, V_COL_RANGE,
+};
 use winter_air::TransitionConstraintDegree;
 
 #[cfg(test)]
@@ -20,31 +22,6 @@ pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
     8, 8, 8,
     8, // Ensure next old values equal current new values when ctx and addr don't change.
 ];
-/// The number of elements accessible in one read or write memory access.
-const NUM_ELEMENTS: usize = 4;
-/// Column to hold the context ID of the current memory context.
-const CTX_COL_IDX: usize = MEMORY_TRACE_OFFSET;
-/// Column to hold the memory address.
-const ADDR_COL_IDX: usize = CTX_COL_IDX + 1;
-/// Column for the clock cycle in which the memory operation occurred.
-const CLK_COL_IDX: usize = ADDR_COL_IDX + 1;
-/// Columns to hold the old values stored at a given memory context, address, and clock cycle prior
-/// to the memory operation. When reading from a new address, these are initialized to zero. When
-/// reading or updating previously accessed memory, these values are set to equal the "new" values
-/// of the previous row in the trace.
-const U_COL_RANGE: Range<usize> = create_range(CLK_COL_IDX + 1, NUM_ELEMENTS);
-/// Columns to hold the new values stored at a given memory context, address, and clock cycle after
-/// the memory operation.
-const V_COL_RANGE: Range<usize> = create_range(U_COL_RANGE.end, NUM_ELEMENTS);
-/// Column for the lower 16-bits of the delta between two consecutive context IDs, addresses, or
-/// clock cycles.
-const D0_COL_IDX: usize = V_COL_RANGE.end;
-/// Column for the upper 16-bits of the delta between two consecutive context IDs, addresses, or
-/// clock cycles.
-const D1_COL_IDX: usize = D0_COL_IDX + 1;
-/// Column for the inverse of the delta between two consecutive context IDs, addresses, or clock
-/// cycles, used to enforce that changes are correctly constrained.
-const D_INV_COL_IDX: usize = D1_COL_IDX + 1;
 
 // MEMORY TRANSITION CONSTRAINTS
 // ================================================================================================

--- a/air/src/aux_table/mod.rs
+++ b/air/src/aux_table/mod.rs
@@ -1,5 +1,5 @@
 use super::{Assertion, EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree, Vec};
-use crate::utils::{binary_not, is_binary};
+use crate::utils::{are_equal, binary_not, is_binary};
 use vm_core::{
     aux_table::{BITWISE_TRACE_OFFSET, HASHER_TRACE_OFFSET},
     AUX_TABLE_OFFSET,
@@ -16,21 +16,13 @@ mod memory;
 pub const NUM_ASSERTIONS: usize = hasher::NUM_ASSERTIONS;
 /// The number of constraints on the management of the Auxiliary Table. This does not include
 /// constraints for the co-processors.
-pub const NUM_CONSTRAINTS: usize = 3;
+pub const NUM_CONSTRAINTS: usize = 6;
 /// The degrees of constraints on the management of the Auxiliary Table. This does not include
 /// constraint degrees for the co-processors
 pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
     2, 3, 4, // Selector flags must be binary.
+    2, 3, 4, // Selector flags can only change from 0 -> 1.
 ];
-
-/// The first selector column, used as a selector for the entire auxiliary table.
-pub const S0_COL_IDX: usize = AUX_TABLE_OFFSET;
-/// The second selector column, used as a selector for the bitwise, memory, and padding segments
-/// after the hasher trace ends.
-pub const S1_COL_IDX: usize = AUX_TABLE_OFFSET + 1;
-/// The third selector column, used as a selector for the memory and padding segments after the
-/// bitwise trace ends.
-pub const S2_COL_IDX: usize = AUX_TABLE_OFFSET + 2;
 
 // PERIODIC COLUMNS
 // ================================================================================================
@@ -91,7 +83,7 @@ pub fn enforce_constraints<E: FieldElement<BaseField = Felt>>(
         &periodic_values[..hasher::NUM_PERIODIC_COLUMNS],
         &mut result[constraint_offset..],
         frame.hasher_flag(),
-        binary_not(frame.s0_next()),
+        binary_not(frame.s_next(0)),
     );
     constraint_offset += hasher::get_transition_constraint_count();
 
@@ -105,7 +97,11 @@ pub fn enforce_constraints<E: FieldElement<BaseField = Felt>>(
     constraint_offset += bitwise_pow2::get_transition_constraint_count();
 
     // memory transition constraints
-    memory::enforce_constraints(frame, &mut result[constraint_offset..], frame.memory_flag());
+    memory::enforce_constraints(
+        frame,
+        &mut result[constraint_offset..],
+        frame.memory_flag(false),
+    );
 }
 
 // TRANSITION CONSTRAINT HELPERS
@@ -114,14 +110,27 @@ pub fn enforce_constraints<E: FieldElement<BaseField = Felt>>(
 /// Constraint evaluation function to enforce that the Auxiliary Table selector columns must be
 /// binary during the portion of the trace when they're being used as selectors.
 fn enforce_selectors<E: FieldElement>(frame: &EvaluationFrame<E>, result: &mut [E]) {
+    // --- Selector flags must be binary ----------------------------------------------------------
+
     // Selector flag s0 must be binary for the entire table.
-    result[0] = is_binary(frame.s0());
+    result[0] = is_binary(frame.s(0));
 
-    // Selector s1 is only used as a flag when s0 is set.
-    result[1] = frame.s0() * is_binary(frame.s1());
+    // When s0 is set, selector s1 is binary.
+    result[1] = frame.s(0) * is_binary(frame.s(1));
 
-    // Selector s2 is only used as a flag when both s0 and s1 are set.
-    result[2] = frame.s0() * frame.s1() * is_binary(frame.s2());
+    // When selectors s0 and s1 are set, s2 is binary.
+    result[2] = frame.s(0) * frame.s(1) * is_binary(frame.s(2));
+
+    // --- Selector flags can only stay the same or change from 0 -> 1 ----------------------------
+
+    // Selector flag s0 must either be 0 in the current row or 1 in both rows.
+    result[3] = frame.s(0) * are_equal(frame.s(0), frame.s_next(0));
+
+    // When s0 is set, selector flag s1 must either be 0 in the current row or 1 in both rows.
+    result[4] = frame.s(0) * frame.s(1) * are_equal(frame.s(1), frame.s_next(1));
+
+    // When selectors s0 and s1 are set, s2 must either be 0 in the current row or 1 in both rows.
+    result[5] = frame.s(0) * frame.s(1) * frame.s(2) * are_equal(frame.s(2), frame.s_next(2));
 }
 
 // AUXILIARY TABLE FRAME EXTENSION TRAIT
@@ -132,17 +141,13 @@ fn enforce_selectors<E: FieldElement>(frame: &EvaluationFrame<E>, result: &mut [
 trait EvaluationFrameExt<E: FieldElement> {
     // --- Column accessors -----------------------------------------------------------------------
 
-    /// Current value of the S0 selector column.
-    fn s0(&self) -> E;
+    /// Returns the current value of the specified selector column. It assumes that the index is a
+    /// valid selector index.
+    fn s(&self, idx: usize) -> E;
 
-    /// Value of the S0 selector column in the next row.
-    fn s0_next(&self) -> E;
-
-    /// Current value of the S1 selector column.
-    fn s1(&self) -> E;
-
-    /// Current value of the S2 selector column.
-    fn s2(&self) -> E;
+    /// Returns the value of the specified selector column at the next row. It assumes that the
+    /// index is a valid selector index.
+    fn s_next(&self, idx: usize) -> E;
 
     // --- Co-processor selector flags ------------------------------------------------------------
 
@@ -153,41 +158,40 @@ trait EvaluationFrameExt<E: FieldElement> {
     fn bitwise_flag(&self) -> E;
 
     /// Flag to indicate whether the frame is in the memory portion of the Auxiliary Table trace.
-    fn memory_flag(&self) -> E;
+    /// When `include_last_row` is true, the memory flag is true for every row where the memory
+    /// selectors are set. When false, the last row is excluded. When this flag is used for
+    /// transition constraints with `include_last_row = false`, they will not be applied to the
+    /// final row of the memory trace.
+    fn memory_flag(&self, include_last_row: bool) -> E;
 }
 
 impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     // --- Column accessors -----------------------------------------------------------------------
 
-    #[inline(always)]
-    fn s0(&self) -> E {
-        self.current()[S0_COL_IDX]
+    fn s(&self, idx: usize) -> E {
+        self.current()[AUX_TABLE_OFFSET + idx]
     }
-    #[inline(always)]
-    fn s0_next(&self) -> E {
-        self.next()[S0_COL_IDX]
-    }
-    #[inline(always)]
-    fn s1(&self) -> E {
-        self.current()[S1_COL_IDX]
-    }
-    #[inline(always)]
-    fn s2(&self) -> E {
-        self.current()[S2_COL_IDX]
+
+    fn s_next(&self, idx: usize) -> E {
+        self.next()[AUX_TABLE_OFFSET + idx]
     }
 
     // --- Co-processor selector flags ------------------------------------------------------------
 
     #[inline(always)]
     fn hasher_flag(&self) -> E {
-        binary_not(self.s0())
+        binary_not(self.s(0))
     }
     #[inline(always)]
     fn bitwise_flag(&self) -> E {
-        self.s0() * binary_not(self.s1())
+        self.s(0) * binary_not(self.s_next(1))
     }
     #[inline(always)]
-    fn memory_flag(&self) -> E {
-        self.s0() * self.s1() * self.s2()
+    fn memory_flag(&self, include_last_row: bool) -> E {
+        if include_last_row {
+            self.s(0) * self.s(1) * binary_not(self.s(2))
+        } else {
+            self.s(0) * self.s(1) * binary_not(self.s_next(2))
+        }
     }
 }

--- a/air/src/aux_table/mod.rs
+++ b/air/src/aux_table/mod.rs
@@ -1,7 +1,7 @@
 use super::{Assertion, EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree, Vec};
 use crate::utils::{binary_not, is_binary};
 use vm_core::{
-    aux_table::{BITWISE_TRACE_OFFSET, HASHER_TRACE_OFFSET, MEMORY_TRACE_OFFSET},
+    aux_table::{BITWISE_TRACE_OFFSET, HASHER_TRACE_OFFSET},
     AUX_TABLE_OFFSET,
 };
 

--- a/core/src/aux_table/memory.rs
+++ b/core/src/aux_table/memory.rs
@@ -1,0 +1,30 @@
+use super::{create_range, Range, MEMORY_TRACE_OFFSET};
+
+// CONSTANTS
+// ================================================================================================
+
+/// The number of elements accessible in one read or write memory access.
+pub const NUM_ELEMENTS: usize = 4;
+/// Column to hold the context ID of the current memory context.
+pub const CTX_COL_IDX: usize = MEMORY_TRACE_OFFSET;
+/// Column to hold the memory address.
+pub const ADDR_COL_IDX: usize = CTX_COL_IDX + 1;
+/// Column for the clock cycle in which the memory operation occurred.
+pub const CLK_COL_IDX: usize = ADDR_COL_IDX + 1;
+/// Columns to hold the old values stored at a given memory context, address, and clock cycle prior
+/// to the memory operation. When reading from a new address, these are initialized to zero. When
+/// reading or updating previously accessed memory, these values are set to equal the "new" values
+/// of the previous row in the trace.
+pub const U_COL_RANGE: Range<usize> = create_range(CLK_COL_IDX + 1, NUM_ELEMENTS);
+/// Columns to hold the new values stored at a given memory context, address, and clock cycle after
+/// the memory operation.
+pub const V_COL_RANGE: Range<usize> = create_range(U_COL_RANGE.end, NUM_ELEMENTS);
+/// Column for the lower 16-bits of the delta between two consecutive context IDs, addresses, or
+/// clock cycles.
+pub const D0_COL_IDX: usize = V_COL_RANGE.end;
+/// Column for the upper 16-bits of the delta between two consecutive context IDs, addresses, or
+/// clock cycles.
+pub const D1_COL_IDX: usize = D0_COL_IDX + 1;
+/// Column for the inverse of the delta between two consecutive context IDs, addresses, or clock
+/// cycles, used to enforce that changes are correctly constrained.
+pub const D_INV_COL_IDX: usize = D1_COL_IDX + 1;

--- a/core/src/aux_table/mod.rs
+++ b/core/src/aux_table/mod.rs
@@ -1,4 +1,7 @@
-use super::AUX_TABLE_OFFSET;
+use super::{utils::range as create_range, AUX_TABLE_OFFSET};
+use core::ops::Range;
+
+pub mod memory;
 
 // CONSTANTS
 // ================================================================================================

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -13,9 +13,9 @@ use vm_core::{
     },
     utils::collections::{BTreeMap, Vec},
     AdviceInjector, Decorator, DecoratorIterator, Felt, FieldElement, Operation, ProgramInputs,
-    StackTopState, StarkField, Word, AUX_TABLE_WIDTH, DECODER_TRACE_WIDTH, MEMORY_TRACE_WIDTH,
-    MIN_STACK_DEPTH, MIN_TRACE_LEN, NUM_STACK_HELPER_COLS, ONE, RANGE_CHECK_TRACE_WIDTH,
-    STACK_TRACE_WIDTH, SYS_TRACE_WIDTH, ZERO,
+    StackTopState, StarkField, Word, AUX_TABLE_WIDTH, DECODER_TRACE_WIDTH, MIN_STACK_DEPTH,
+    MIN_TRACE_LEN, NUM_STACK_HELPER_COLS, ONE, RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH,
+    SYS_TRACE_WIDTH, ZERO,
 };
 
 mod decorators;
@@ -32,7 +32,7 @@ mod stack;
 use stack::Stack;
 
 mod range;
-use range::{RangeCheckMap, RangeChecker};
+use range::RangeChecker;
 
 mod hasher;
 use hasher::Hasher;
@@ -82,11 +82,6 @@ pub struct RangeCheckTrace {
 }
 
 type AuxTableTrace = [Vec<Felt>; AUX_TABLE_WIDTH];
-
-pub struct MemoryTrace {
-    trace: [Vec<Felt>; MEMORY_TRACE_WIDTH],
-    range_checks: RangeCheckMap,
-}
 
 // EXECUTOR
 // ================================================================================================

--- a/processor/src/range/mod.rs
+++ b/processor/src/range/mod.rs
@@ -94,9 +94,10 @@ impl RangeChecker {
         self.lookups.add_value(value);
     }
 
-    /// Merges the provided map of range check lookups into the range checker's lookups.
-    pub fn add_lookups(&mut self, new_lookups: &RangeCheckMap) {
-        self.lookups.merge_lookups(new_lookups);
+    /// Adds the provided memory range check values at the specified clock cycle.
+    pub fn add_mem_checks(&mut self, _clk: usize, values: &[u16; 2]) {
+        self.add_value(values[0]);
+        self.add_value(values[1]);
     }
 
     // EXECUTION TRACE GENERATION

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -253,7 +253,7 @@ fn finalize_trace(process: Process, mut rng: RandomCoin) -> (Vec<Vec<Felt>>, Aux
     assert_eq!(clk, stack.trace_len(), "inconsistent stack trace lengths");
 
     // Add the range checks required by the auxiliary table to the range checker.
-    range.add_lookups(aux_table.get_range_checks());
+    aux_table.append_range_checks(&mut range);
 
     // Get the trace length required to hold all execution trace steps.
     let max_len = [clk, range.trace_len(), aux_table.trace_len()]


### PR DESCRIPTION
This PR reorders the auxiliary table, which is required by #286 which implements range checker `p1` and `q` auxiliary columns. For every row in the memory trace, the value of `p1` changes in the next row, which means that the memory trace rows cannot be placed at the end of the execution trace.

Updating the documentation for the auxiliary table is not addressed here. I propose updating documentation for the auxiliary table along with other changes required by #286 once it is finalized and merged.