### PR TITLE
u32 addition, subtraction and multiplication operations refactoring

### DIFF
--- a/assembly/src/parsers/io_ops/adv_ops.rs
+++ b/assembly/src/parsers/io_ops/adv_ops.rs
@@ -1,4 +1,4 @@
-use super::{parse_int_param, validate_operation, AssemblyError, Operation, Token, Vec};
+use super::{parse_u32_param, validate_operation, AssemblyError, Operation, Token, Vec};
 use vm_core::utils::PushMany;
 
 // CONSTANTS
@@ -25,7 +25,7 @@ pub fn parse_push_adv(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), A
 
     // parse and validate the parameter as the number of items to read from the advice tape
     // it must be between 1 and ADVICE_READ_LIMIT, inclusive, since adv.push.0 is a no-op
-    let n = parse_int_param(op, 2, 1, ADVICE_READ_LIMIT)?;
+    let n = parse_u32_param(op, 2, 1, ADVICE_READ_LIMIT)?;
 
     // read n items from the advice tape and push then onto the stack
     span_ops.push_many(Operation::Read, n as usize);

--- a/assembly/src/parsers/io_ops/env_ops.rs
+++ b/assembly/src/parsers/io_ops/env_ops.rs
@@ -1,5 +1,5 @@
 use super::{
-    parse_int_param, push_value, validate_operation, AssemblyError, Felt, Operation, Token, Vec,
+    parse_u32_param, push_value, validate_operation, AssemblyError, Felt, Operation, Token, Vec,
 };
 
 // ENVIRONMENT INPUTS
@@ -35,7 +35,7 @@ pub fn parse_push_env(
                 ));
             }
             validate_operation!(@only_params op, "push.env.locaddr", 1);
-            let index = parse_int_param(op, 3, 0, num_proc_locals - 1)?;
+            let index = parse_u32_param(op, 3, 0, num_proc_locals - 1)?;
 
             push_value(span_ops, -Felt::new(index as u64));
             span_ops.push(Operation::FmpAdd);

--- a/assembly/src/parsers/io_ops/local_ops.rs
+++ b/assembly/src/parsers/io_ops/local_ops.rs
@@ -1,5 +1,5 @@
 use super::{
-    parse_int_param, push_value, validate_operation, AssemblyError, Felt, Operation, Token, Vec,
+    parse_u32_param, push_value, validate_operation, AssemblyError, Felt, Operation, Token, Vec,
 };
 use vm_core::utils::PushMany;
 
@@ -118,7 +118,7 @@ fn push_local_addr(
     }
 
     // parse the provided local memory index
-    let index = parse_int_param(op, 2, 0, num_proc_locals - 1)?;
+    let index = parse_u32_param(op, 2, 0, num_proc_locals - 1)?;
 
     // put the absolute memory address on the stack
     // negate the value to use it as an offset from the fmp

--- a/assembly/src/parsers/io_ops/mod.rs
+++ b/assembly/src/parsers/io_ops/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     super::validate_operation, parse_decimal_param, parse_element_param, parse_hex_param,
-    parse_int_param, push_value, AssemblyError, Felt, Operation, Token, Vec,
+    parse_u32_param, push_value, AssemblyError, Felt, Operation, Token, Vec,
 };
 use vm_core::{AdviceInjector, Decorator, DecoratorList};
 

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -1,5 +1,6 @@
 use super::{AssemblyContext, AssemblyError, Token, TokenStream};
 pub use blocks::{combine_blocks, parse_code_blocks};
+use u32_ops::U32OpMode;
 use vm_core::{
     program::blocks::CodeBlock,
     utils::{
@@ -71,11 +72,22 @@ fn parse_op_token(
         "u32cast" => u32_ops::parse_u32cast(span_ops, op),
         "u32split" => u32_ops::parse_u32split(span_ops, op),
 
-        "u32add" => u32_ops::parse_u32add(span_ops, op),
-        "u32add3" => u32_ops::parse_u32add3(span_ops, op),
-        "u32sub" => u32_ops::parse_u32sub(span_ops, op),
-        "u32mul" => u32_ops::parse_u32mul(span_ops, op),
-        "u32madd" => u32_ops::parse_u32madd(span_ops, op),
+        "u32checked_add" => u32_ops::parse_u32add(span_ops, op, U32OpMode::Checked),
+        "u32wrapping_add" => u32_ops::parse_u32add(span_ops, op, U32OpMode::Wrapping),
+        "u32overflowing_add" => u32_ops::parse_u32add(span_ops, op, U32OpMode::Overflowing),
+
+        "u32unchecked_add3" => u32_ops::parse_u32add3(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_sub" => u32_ops::parse_u32sub(span_ops, op, U32OpMode::Checked),
+        "u32wrapping_sub" => u32_ops::parse_u32sub(span_ops, op, U32OpMode::Wrapping),
+        "u32overflowing_sub" => u32_ops::parse_u32sub(span_ops, op, U32OpMode::Overflowing),
+
+        "u32checked_mul" => u32_ops::parse_u32mul(span_ops, op, U32OpMode::Checked),
+        "u32wrapping_mul" => u32_ops::parse_u32mul(span_ops, op, U32OpMode::Wrapping),
+        "u32overflowing_mul" => u32_ops::parse_u32mul(span_ops, op, U32OpMode::Overflowing),
+
+        "u32unchecked_madd" => u32_ops::parse_u32madd(span_ops, op, U32OpMode::Unchecked),
+
         "u32div" => u32_ops::parse_u32div(span_ops, op),
         "u32mod" => u32_ops::parse_u32mod(span_ops, op),
 
@@ -207,7 +219,7 @@ fn get_valid_felt(op: &Token, param_idx: usize, param: u64) -> Result<Felt, Asse
 /// Returns an invalid param AssemblyError if:
 /// - the parsing attempt fails.
 /// - the parameter is outside the specified lower and upper bounds.
-fn parse_int_param(
+fn parse_u32_param(
     op: &Token,
     param_idx: usize,
     lower_bound: u32,

--- a/miden/tests/integration/air/range.rs
+++ b/miden/tests/integration/air/range.rs
@@ -4,7 +4,7 @@ use crate::{build_op_test, build_test};
 /// the 32-bit result (2 and 0).
 #[test]
 fn range_check_once() {
-    let asm_op = "u32add.unsafe";
+    let asm_op = "u32overflowing_add";
     let stack = vec![1, 1];
 
     build_op_test!(asm_op, &stack).prove_and_verify(stack, 0, false);
@@ -14,7 +14,7 @@ fn range_check_once() {
 /// 5 is checked 3 times, 10 is checked twice, and 15 is checked once.
 #[test]
 fn range_check_multi() {
-    let source = "begin u32add u32add end";
+    let source = "begin u32checked_add u32checked_add end";
     let stack = vec![5, 5, 5];
     build_test!(source, &stack).prove_and_verify(stack, 0, false);
 }

--- a/stdlib/asm/crypto/hashes/blake3.masm
+++ b/stdlib/asm/crypto/hashes/blake3.masm
@@ -194,17 +194,17 @@ proc.columnar_mixing.1
 
     dup.4
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.1
     dup.6
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.2
     drop
@@ -212,9 +212,9 @@ proc.columnar_mixing.1
     dup.2
     dup.7
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
@@ -222,9 +222,9 @@ proc.columnar_mixing.1
     dup.3
     dup.8
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
@@ -273,24 +273,24 @@ proc.columnar_mixing.1
     dupw.1              # copy d
 
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     swap
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap
     
     movup.2
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     movdn.2
     
     movup.3
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     movdn.3
 
@@ -342,17 +342,17 @@ proc.columnar_mixing.1
 
     dup.4
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     
     dup.1
     dup.6
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.2
     drop
@@ -360,9 +360,9 @@ proc.columnar_mixing.1
     dup.2
     dup.7
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
@@ -370,9 +370,9 @@ proc.columnar_mixing.1
     dup.3
     dup.8
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
@@ -421,24 +421,24 @@ proc.columnar_mixing.1
     dupw.1              # copy d
     
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     
     swap
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap
     
     movup.2
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     movdn.2
     
     movup.3
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     movdn.3
 
@@ -525,17 +525,17 @@ proc.diagonal_mixing.1
 
     dup.5
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.1
     dup.7
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.2
     drop
@@ -543,9 +543,9 @@ proc.diagonal_mixing.1
     dup.2
     dup.8
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
@@ -553,9 +553,9 @@ proc.diagonal_mixing.1
     dup.3
     dup.5
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
@@ -603,25 +603,25 @@ proc.diagonal_mixing.1
 
     dup.2
     dup.8
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
 
     dup.3
     dup.5
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
 
     dup.5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     swap
     dup.6
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap
 
@@ -674,17 +674,17 @@ proc.diagonal_mixing.1
 
     dup.5
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.1
     dup.7
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.2
     drop
@@ -692,9 +692,9 @@ proc.diagonal_mixing.1
     dup.2
     dup.8
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
@@ -702,9 +702,9 @@ proc.diagonal_mixing.1
     dup.3
     dup.5
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
@@ -752,25 +752,25 @@ proc.diagonal_mixing.1
 
     dup.2
     dup.8
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
 
     dup.3
     dup.5
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
 
     dup.5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     swap
     dup.6
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap
 

--- a/stdlib/asm/crypto/hashes/sha256.masm
+++ b/stdlib/asm/crypto/hashes/sha256.masm
@@ -116,17 +116,17 @@ proc.gen_four_message_words.1
     exec.small_sigma_1
 
     dup.2
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.10
     exec.small_sigma_0
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     # compute message schedule msg[a + 1]
@@ -134,17 +134,17 @@ proc.gen_four_message_words.1
     exec.small_sigma_1
 
     dup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.12
     exec.small_sigma_0
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.11
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     # compute message schedule msg[a + 2]
@@ -152,17 +152,17 @@ proc.gen_four_message_words.1
     exec.small_sigma_1
 
     dup.6
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.14
     exec.small_sigma_0
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.13
-    u32add.unsafe
+    u32overflowing_add
     drop
     
     # compute message schedule msg[a + 3]
@@ -170,7 +170,7 @@ proc.gen_four_message_words.1
     exec.small_sigma_1
 
     dup.8
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     popw.local.0
@@ -179,13 +179,13 @@ proc.gen_four_message_words.1
     exec.small_sigma_0
 
     dup.12
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
     movup.4
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     # stack = [a + 3, a + 2, a + 1, a + 0, ...]
@@ -465,42 +465,42 @@ proc.update_hash_state
 
     movup.15
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = h
 
     movup.14
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = g
 
     movup.13
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = f
 
     movup.12
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = e
 
     movup.11
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = d
 
     movup.10
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = c
 
     movup.9
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = b
 
     movup.8
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = a
 
     # stack = [a, b, c, d, e, f, g, h]
@@ -515,14 +515,14 @@ proc.compute_next_working_variables
     movup.8             # = f
     dup.4
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop                # = e 
     movup.8             # = d
     movup.8             # = c
     movup.8             # = b
     movup.8
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = a
     movup.8
     drop
@@ -544,14 +544,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x428a2f98
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -565,7 +565,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -573,7 +573,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -582,14 +582,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x71374491
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -604,7 +604,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -612,7 +612,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -621,14 +621,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xb5c0fbcf
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -642,7 +642,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -650,7 +650,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -659,14 +659,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xe9b5dba5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -679,7 +679,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -687,7 +687,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -696,14 +696,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x3956c25b
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -718,7 +718,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -726,7 +726,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -735,14 +735,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x59f111f1
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -758,7 +758,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -766,7 +766,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -775,14 +775,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x923f82a4
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -797,7 +797,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -805,7 +805,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -814,14 +814,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xab1c5ed5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -835,7 +835,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -843,7 +843,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -852,14 +852,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xd807aa98
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -873,7 +873,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -881,7 +881,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -890,14 +890,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x12835b01
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -912,7 +912,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -920,7 +920,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -929,14 +929,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x243185be
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -950,7 +950,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -958,7 +958,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -967,14 +967,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x550c7dc3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -987,7 +987,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -995,7 +995,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1004,14 +1004,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x72be5d74
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -1024,7 +1024,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1032,7 +1032,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1041,14 +1041,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x80deb1fe
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -1062,7 +1062,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1070,7 +1070,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1079,14 +1079,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x9bdc06a7
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -1099,7 +1099,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1107,7 +1107,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1116,14 +1116,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc19bf174
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -1135,7 +1135,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1143,7 +1143,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1152,14 +1152,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xe49b69c1
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1173,7 +1173,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1181,7 +1181,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1190,14 +1190,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xefbe4786
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1212,7 +1212,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1220,7 +1220,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1229,14 +1229,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x0fc19dc6
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1250,7 +1250,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1258,7 +1258,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1267,14 +1267,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x240ca1cc
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1287,7 +1287,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1295,7 +1295,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1304,14 +1304,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x2de92c6f
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1326,7 +1326,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1334,7 +1334,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1343,14 +1343,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x4a7484aa
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1366,7 +1366,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1374,7 +1374,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1383,14 +1383,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x5cb0a9dc
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1405,7 +1405,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1413,7 +1413,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1422,14 +1422,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x76f988da
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1443,7 +1443,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1451,7 +1451,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1460,14 +1460,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x983e5152
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1481,7 +1481,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1489,7 +1489,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1498,14 +1498,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xa831c66d
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1520,7 +1520,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1528,7 +1528,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1537,14 +1537,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xb00327c8
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1558,7 +1558,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1566,7 +1566,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1575,14 +1575,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xbf597fc7
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1595,7 +1595,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1603,7 +1603,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1612,14 +1612,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc6e00bf3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1632,7 +1632,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1640,7 +1640,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1649,14 +1649,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xd5a79147
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1670,7 +1670,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1678,7 +1678,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1687,14 +1687,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x06ca6351
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1707,7 +1707,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1715,7 +1715,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1724,14 +1724,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x14292967
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -1743,7 +1743,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1751,7 +1751,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1760,14 +1760,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x27b70a85
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -1781,7 +1781,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1789,7 +1789,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1798,14 +1798,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x2e1b2138
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -1820,7 +1820,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1828,7 +1828,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1837,14 +1837,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x4d2c6dfc
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -1858,7 +1858,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1866,7 +1866,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1875,14 +1875,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x53380d13
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -1895,7 +1895,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1903,7 +1903,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1912,14 +1912,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x650a7354
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -1934,7 +1934,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1942,7 +1942,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1951,14 +1951,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x766a0abb
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -1974,7 +1974,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -1982,7 +1982,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -1991,14 +1991,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x81c2c92e
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2013,7 +2013,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2021,7 +2021,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2030,14 +2030,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x92722c85
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2051,7 +2051,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2059,7 +2059,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2068,14 +2068,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xa2bfe8a1
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2089,7 +2089,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2097,7 +2097,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2106,14 +2106,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xa81a664b
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2128,7 +2128,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2136,7 +2136,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2145,14 +2145,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc24b8b70
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2166,7 +2166,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2174,7 +2174,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2183,14 +2183,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc76c51a3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2203,7 +2203,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2211,7 +2211,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2220,14 +2220,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xd192e819
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2240,7 +2240,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2248,7 +2248,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2257,14 +2257,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xd6990624
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2278,7 +2278,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2286,7 +2286,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2295,14 +2295,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xf40e3585
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2315,7 +2315,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2323,7 +2323,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2332,14 +2332,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x106aa070
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -2351,7 +2351,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2359,7 +2359,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2368,14 +2368,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x19a4c116
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2389,7 +2389,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2397,7 +2397,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2406,14 +2406,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x1e376c08
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2428,7 +2428,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2436,7 +2436,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2445,14 +2445,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x2748774c
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2466,7 +2466,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2474,7 +2474,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2483,14 +2483,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x34b0bcb5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2503,7 +2503,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2511,7 +2511,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2520,14 +2520,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x391c0cb3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2542,7 +2542,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2550,7 +2550,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2559,14 +2559,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x4ed8aa4a
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2582,7 +2582,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2590,7 +2590,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2599,14 +2599,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x5b9cca4f
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2621,7 +2621,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2629,7 +2629,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2638,14 +2638,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x682e6ff3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2659,7 +2659,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2667,7 +2667,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2676,14 +2676,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x748f82ee
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2697,7 +2697,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2705,7 +2705,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2714,14 +2714,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x78a5636f
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2736,7 +2736,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2744,7 +2744,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2753,14 +2753,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x84c87814
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2774,7 +2774,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2782,7 +2782,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2791,14 +2791,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x8cc70208
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2811,7 +2811,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2819,7 +2819,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2828,14 +2828,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x90befffa
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2848,7 +2848,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2856,7 +2856,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2865,14 +2865,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xa4506ceb
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2886,7 +2886,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2894,7 +2894,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2903,14 +2903,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xbef9a3f7
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2923,7 +2923,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2931,7 +2931,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -2940,14 +2940,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc67178f2
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -2959,7 +2959,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -2967,7 +2967,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables

--- a/stdlib/asm/math/u256.masm
+++ b/stdlib/asm/math/u256.masm
@@ -2,31 +2,31 @@ export.add_unsafe
     swapw.3
     movup.3
     movup.7
-    u32add.unsafe
+    u32overflowing_add
     movup.4
     movup.7
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.6
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.5
-    u32add3.unsafe
+    u32unchecked_add3
     movdn.12
     swapw.2
     movup.12
     movup.4
     movup.8
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.7
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.6
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.5
-    u32add3.unsafe
+    u32unchecked_add3
     drop
 end
 
@@ -34,58 +34,58 @@ export.sub_unsafe
     swapw.3
     movup.3
     movup.7
-    u32sub.unsafe
+    u32overflowing_sub
     movup.7
-    u32add.unsafe
+    u32overflowing_add
     movup.5
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.6
-    u32add.unsafe
+    u32overflowing_add
     movup.5
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.5
-    u32add.unsafe
+    u32overflowing_add
     movup.5
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movdn.12
     swapw.2
     movup.12
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.8
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.7
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.6
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.5
     movup.5
     movup.2
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32sub.unsafe
+    u32overflowing_sub
     drop
 end
 
@@ -203,9 +203,9 @@ end
 
 proc.mulstep
     movdn.2
-    u32madd.unsafe
+    u32unchecked_madd
     movdn.2
-    u32add.unsafe
+    u32overflowing_add
     movup.2
     add
 end

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -22,10 +22,10 @@ end
 export.overflowing_add
     swap
     movup.3
-    u32add.unsafe
+    u32overflowing_add
     movup.3
     movup.3
-    u32add3.unsafe
+    u32unchecked_add3
 end
 
 # Performs addition of two unsigned 64 bit integers discarding the overflow.
@@ -57,13 +57,13 @@ end
 export.wrapping_sub
     movup.3
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.3
     movup.3
-    u32sub.unsafe
+    u32overflowing_sub
     drop
     swap
-    u32sub.unsafe
+    u32overflowing_sub
     drop
 end
 
@@ -75,14 +75,14 @@ export.checked_sub
     exec.u32assert4
     movup.3
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.3
     movup.3
-    u32sub.unsafe
+    u32overflowing_sub
     eq.0
     assert
     swap
-    u32sub.unsafe
+    u32overflowing_sub
     eq.0
     assert
 end
@@ -94,13 +94,13 @@ end
 export.overflowing_sub
     movup.3
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.3
     movup.3
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     or
 end
@@ -114,14 +114,14 @@ end
 export.wrapping_mul
     dup.3
     dup.2
-    u32mul.unsafe
+    u32overflowing_mul
     movup.4
     movup.4
-    u32madd.unsafe
+    u32unchecked_madd
     drop
     movup.3
     movup.3
-    u32madd.unsafe
+    u32unchecked_madd
     drop
 end
 
@@ -133,20 +133,20 @@ end
 export.overflowing_mul
     dup.3
     dup.2
-    u32mul.unsafe
+    u32overflowing_mul
     dup.4
     movup.4
-    u32madd.unsafe
+    u32unchecked_madd
     swap
     movup.5
     dup.4
-    u32madd.unsafe
+    u32unchecked_madd
     movup.5
     movup.5
-    u32madd.unsafe
+    u32unchecked_madd
     movup.3
     movup.2
-    u32add.unsafe
+    u32overflowing_add
     movup.2
     add
 end
@@ -172,10 +172,10 @@ end
 export.unchecked_lt
     movup.3
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movdn.3
     drop
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     eq.0
     movup.2
@@ -199,10 +199,10 @@ end
 # This takes 11 cycles.
 export.unchecked_gt
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     movup.3
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     drop
     movup.2
@@ -393,15 +393,15 @@ export.unchecked_div
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
     dup.2               # fits into 2 32-bit limbs
-    u32mul.unsafe
+    u32overflowing_mul
     dup.4
     dup.4
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.5
     dup.3
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.4
@@ -424,10 +424,10 @@ export.unchecked_div
 
     swap                # add remainder to the previous result; this also consumes the remainder
     movup.3
-    u32add.unsafe
+    u32overflowing_add
     movup.3
     movup.3
-    u32add3.unsafe
+    u32unchecked_add3
     eq.0
     assert
 
@@ -462,15 +462,15 @@ export.unchecked_mod
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
     dup.2               # fits into 2 32-bit limbs
-    u32mul.unsafe
+    u32overflowing_mul
     dup.4
     movup.4
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.4
     dup.3
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.3
@@ -493,10 +493,10 @@ export.unchecked_mod
 
     dup.1               # add remainder to the previous result
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.4
     dup.3
-    u32add3.unsafe
+    u32unchecked_add3
     eq.0
     assert
 
@@ -531,15 +531,15 @@ export.unchecked_divmod
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
     dup.2               # fits into 2 32-bit limbs
-    u32mul.unsafe
+    u32overflowing_mul
     dup.4
     dup.4
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.5
     dup.3
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.4
@@ -562,10 +562,10 @@ export.unchecked_divmod
 
     dup.1               # add remainder to the previous result
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.4
     dup.3
-    u32add3.unsafe
+    u32unchecked_add3
     eq.0
     assert
 
@@ -657,7 +657,7 @@ export.unchecked_shr
     movup.3
     dup
     eq.0
-    u32sub.unsafe
+    u32overflowing_sub
     not
     movdn.4
     dup
@@ -731,7 +731,7 @@ end
 export.unchecked_rotl
     push.31
     dup.1
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     drop
     movdn.3
@@ -742,12 +742,12 @@ export.unchecked_rotl
     pow2.unsafe
     dup
     movup.3
-    u32mul.unsafe
+    u32overflowing_mul
 
     # Shift the high limb.
     movup.3
     movup.3
-    u32madd.unsafe
+    u32unchecked_madd
 
     # Carry the overflow shift to the low bits.
     movup.2
@@ -768,7 +768,7 @@ end
 export.unchecked_rotr
     push.31
     dup.1
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     drop
     movdn.3
@@ -778,17 +778,17 @@ export.unchecked_rotr
     u32and
     push.32
     swap
-    u32sub.unsafe
+    u32overflowing_sub
     drop
     pow2.unsafe
     dup
     movup.3
-    u32mul.unsafe
+    u32overflowing_mul
 
     # Shift the high limb left by 32-b.
     movup.3
     movup.3
-    u32madd.unsafe
+    u32unchecked_madd
 
     # Carry the overflow shift to the low bits.
     movup.2

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -202,17 +202,17 @@ proc.columnar_mixing.1
 
     dup.4
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.1
     dup.6
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.2
     drop
@@ -220,9 +220,9 @@ proc.columnar_mixing.1
     dup.2
     dup.7
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
@@ -230,9 +230,9 @@ proc.columnar_mixing.1
     dup.3
     dup.8
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
@@ -281,24 +281,24 @@ proc.columnar_mixing.1
     dupw.1              # copy d
 
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     swap
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap
     
     movup.2
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     movdn.2
     
     movup.3
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     movdn.3
 
@@ -350,17 +350,17 @@ proc.columnar_mixing.1
 
     dup.4
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     
     dup.1
     dup.6
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.2
     drop
@@ -368,9 +368,9 @@ proc.columnar_mixing.1
     dup.2
     dup.7
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
@@ -378,9 +378,9 @@ proc.columnar_mixing.1
     dup.3
     dup.8
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
@@ -429,24 +429,24 @@ proc.columnar_mixing.1
     dupw.1              # copy d
     
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     
     swap
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap
     
     movup.2
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     movdn.2
     
     movup.3
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
     movdn.3
 
@@ -533,17 +533,17 @@ proc.diagonal_mixing.1
 
     dup.5
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.1
     dup.7
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.2
     drop
@@ -551,9 +551,9 @@ proc.diagonal_mixing.1
     dup.2
     dup.8
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
@@ -561,9 +561,9 @@ proc.diagonal_mixing.1
     dup.3
     dup.5
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
@@ -611,25 +611,25 @@ proc.diagonal_mixing.1
 
     dup.2
     dup.8
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
 
     dup.3
     dup.5
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
 
     dup.5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     swap
     dup.6
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap
 
@@ -682,17 +682,17 @@ proc.diagonal_mixing.1
 
     dup.5
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.1
     dup.7
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.2
     drop
@@ -700,9 +700,9 @@ proc.diagonal_mixing.1
     dup.2
     dup.8
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
@@ -710,9 +710,9 @@ proc.diagonal_mixing.1
     dup.3
     dup.5
     movup.10
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
@@ -760,25 +760,25 @@ proc.diagonal_mixing.1
 
     dup.2
     dup.8
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.3
     drop
 
     dup.3
     dup.5
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap.4
     drop
 
     dup.5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     swap
     dup.6
-    u32add.unsafe
+    u32overflowing_add
     drop
     swap
 
@@ -6379,17 +6379,17 @@ proc.gen_four_message_words.1
     exec.small_sigma_1
 
     dup.2
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.10
     exec.small_sigma_0
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.9
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     # compute message schedule msg[a + 1]
@@ -6397,17 +6397,17 @@ proc.gen_four_message_words.1
     exec.small_sigma_1
 
     dup.4
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.12
     exec.small_sigma_0
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.11
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     # compute message schedule msg[a + 2]
@@ -6415,17 +6415,17 @@ proc.gen_four_message_words.1
     exec.small_sigma_1
 
     dup.6
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.14
     exec.small_sigma_0
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dup.13
-    u32add.unsafe
+    u32overflowing_add
     drop
     
     # compute message schedule msg[a + 3]
@@ -6433,7 +6433,7 @@ proc.gen_four_message_words.1
     exec.small_sigma_1
 
     dup.8
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     popw.local.0
@@ -6442,13 +6442,13 @@ proc.gen_four_message_words.1
     exec.small_sigma_0
 
     dup.12
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
     movup.4
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     # stack = [a + 3, a + 2, a + 1, a + 0, ...]
@@ -6728,42 +6728,42 @@ proc.update_hash_state
 
     movup.15
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = h
 
     movup.14
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = g
 
     movup.13
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = f
 
     movup.12
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = e
 
     movup.11
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = d
 
     movup.10
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = c
 
     movup.9
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = b
 
     movup.8
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = a
 
     # stack = [a, b, c, d, e, f, g, h]
@@ -6778,14 +6778,14 @@ proc.compute_next_working_variables
     movup.8             # = f
     dup.4
     movup.9
-    u32add.unsafe
+    u32overflowing_add
     drop                # = e 
     movup.8             # = d
     movup.8             # = c
     movup.8             # = b
     movup.8
     movup.8
-    u32add.unsafe
+    u32overflowing_add
     drop                # = a
     movup.8
     drop
@@ -6807,14 +6807,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x428a2f98
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -6828,7 +6828,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -6836,7 +6836,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -6845,14 +6845,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x71374491
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -6867,7 +6867,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -6875,7 +6875,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -6884,14 +6884,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xb5c0fbcf
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -6905,7 +6905,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -6913,7 +6913,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -6922,14 +6922,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xe9b5dba5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -6942,7 +6942,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -6950,7 +6950,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -6959,14 +6959,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x3956c25b
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -6981,7 +6981,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -6989,7 +6989,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -6998,14 +6998,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x59f111f1
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7021,7 +7021,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7029,7 +7029,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7038,14 +7038,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x923f82a4
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7060,7 +7060,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7068,7 +7068,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7077,14 +7077,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xab1c5ed5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7098,7 +7098,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7106,7 +7106,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7115,14 +7115,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xd807aa98
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7136,7 +7136,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7144,7 +7144,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7153,14 +7153,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x12835b01
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7175,7 +7175,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7183,7 +7183,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7192,14 +7192,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x243185be
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7213,7 +7213,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7221,7 +7221,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7230,14 +7230,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x550c7dc3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7250,7 +7250,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7258,7 +7258,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7267,14 +7267,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x72be5d74
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7287,7 +7287,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7295,7 +7295,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7304,14 +7304,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x80deb1fe
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7325,7 +7325,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7333,7 +7333,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7342,14 +7342,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x9bdc06a7
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7362,7 +7362,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7370,7 +7370,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7379,14 +7379,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc19bf174
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.0
@@ -7398,7 +7398,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7406,7 +7406,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7415,14 +7415,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xe49b69c1
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7436,7 +7436,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7444,7 +7444,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7453,14 +7453,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xefbe4786
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7475,7 +7475,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7483,7 +7483,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7492,14 +7492,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x0fc19dc6
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7513,7 +7513,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7521,7 +7521,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7530,14 +7530,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x240ca1cc
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7550,7 +7550,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7558,7 +7558,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7567,14 +7567,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x2de92c6f
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7589,7 +7589,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7597,7 +7597,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7606,14 +7606,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x4a7484aa
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7629,7 +7629,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7637,7 +7637,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7646,14 +7646,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x5cb0a9dc
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7668,7 +7668,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7676,7 +7676,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7685,14 +7685,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x76f988da
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7706,7 +7706,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7714,7 +7714,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7723,14 +7723,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x983e5152
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7744,7 +7744,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7752,7 +7752,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7761,14 +7761,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xa831c66d
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7783,7 +7783,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7791,7 +7791,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7800,14 +7800,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xb00327c8
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7821,7 +7821,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7829,7 +7829,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7838,14 +7838,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xbf597fc7
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7858,7 +7858,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7866,7 +7866,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7875,14 +7875,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc6e00bf3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7895,7 +7895,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7903,7 +7903,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7912,14 +7912,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xd5a79147
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7933,7 +7933,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7941,7 +7941,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7950,14 +7950,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x06ca6351
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -7970,7 +7970,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -7978,7 +7978,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -7987,14 +7987,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x14292967
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.1
@@ -8006,7 +8006,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8014,7 +8014,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8023,14 +8023,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x27b70a85
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8044,7 +8044,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8052,7 +8052,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8061,14 +8061,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x2e1b2138
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8083,7 +8083,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8091,7 +8091,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8100,14 +8100,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x4d2c6dfc
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8121,7 +8121,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8129,7 +8129,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8138,14 +8138,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x53380d13
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8158,7 +8158,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8166,7 +8166,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8175,14 +8175,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x650a7354
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8197,7 +8197,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8205,7 +8205,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8214,14 +8214,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x766a0abb
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8237,7 +8237,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8245,7 +8245,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8254,14 +8254,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x81c2c92e
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8276,7 +8276,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8284,7 +8284,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8293,14 +8293,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x92722c85
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8314,7 +8314,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8322,7 +8322,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8331,14 +8331,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xa2bfe8a1
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8352,7 +8352,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8360,7 +8360,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8369,14 +8369,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xa81a664b
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8391,7 +8391,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8399,7 +8399,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8408,14 +8408,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc24b8b70
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8429,7 +8429,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8437,7 +8437,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8446,14 +8446,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc76c51a3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8466,7 +8466,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8474,7 +8474,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8483,14 +8483,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xd192e819
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8503,7 +8503,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8511,7 +8511,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8520,14 +8520,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xd6990624
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8541,7 +8541,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8549,7 +8549,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8558,14 +8558,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xf40e3585
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8578,7 +8578,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8586,7 +8586,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8595,14 +8595,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x106aa070
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.2
@@ -8614,7 +8614,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8622,7 +8622,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8631,14 +8631,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x19a4c116
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8652,7 +8652,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8660,7 +8660,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8669,14 +8669,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x1e376c08
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8691,7 +8691,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8699,7 +8699,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8708,14 +8708,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x2748774c
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8729,7 +8729,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8737,7 +8737,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8746,14 +8746,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x34b0bcb5
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8766,7 +8766,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8774,7 +8774,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8783,14 +8783,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x391c0cb3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8805,7 +8805,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8813,7 +8813,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8822,14 +8822,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x4ed8aa4a
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8845,7 +8845,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8853,7 +8853,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8862,14 +8862,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x5b9cca4f
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8884,7 +8884,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8892,7 +8892,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8901,14 +8901,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x682e6ff3
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8922,7 +8922,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8930,7 +8930,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8939,14 +8939,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x748f82ee
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8960,7 +8960,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -8968,7 +8968,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -8977,14 +8977,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x78a5636f
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -8999,7 +8999,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -9007,7 +9007,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -9016,14 +9016,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x84c87814
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -9037,7 +9037,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -9045,7 +9045,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -9054,14 +9054,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x8cc70208
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -9074,7 +9074,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -9082,7 +9082,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -9091,14 +9091,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0x90befffa
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -9111,7 +9111,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -9119,7 +9119,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -9128,14 +9128,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xa4506ceb
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -9149,7 +9149,7 @@ proc.mix.4
         drop
     end
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -9157,7 +9157,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -9166,14 +9166,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xbef9a3f7
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -9186,7 +9186,7 @@ proc.mix.4
     swap
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -9194,7 +9194,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -9203,14 +9203,14 @@ proc.mix.4
 
     dupw.1
     exec.ch
-    u32add.unsafe
+    u32overflowing_add
     drop
     dup.5
     exec.cap_sigma_1
-    u32add.unsafe
+    u32overflowing_add
     drop
     push.0xc67178f2
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     pushw.local.3
@@ -9222,7 +9222,7 @@ proc.mix.4
     drop
     drop
 
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     dupw
@@ -9230,7 +9230,7 @@ proc.mix.4
     exec.maj
     dup.2
     exec.cap_sigma_0
-    u32add.unsafe
+    u32overflowing_add
     drop
 
     exec.compute_next_working_variables
@@ -9363,31 +9363,31 @@ end
     swapw.3
     movup.3
     movup.7
-    u32add.unsafe
+    u32overflowing_add
     movup.4
     movup.7
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.6
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.5
-    u32add3.unsafe
+    u32unchecked_add3
     movdn.12
     swapw.2
     movup.12
     movup.4
     movup.8
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.7
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.6
-    u32add3.unsafe
+    u32unchecked_add3
     movup.4
     movup.5
-    u32add3.unsafe
+    u32unchecked_add3
     drop
 end
 
@@ -9395,58 +9395,58 @@ export.sub_unsafe
     swapw.3
     movup.3
     movup.7
-    u32sub.unsafe
+    u32overflowing_sub
     movup.7
-    u32add.unsafe
+    u32overflowing_add
     movup.5
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.6
-    u32add.unsafe
+    u32overflowing_add
     movup.5
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.5
-    u32add.unsafe
+    u32overflowing_add
     movup.5
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movdn.12
     swapw.2
     movup.12
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.8
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.7
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.6
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     add
     movup.5
     movup.5
     movup.2
-    u32add.unsafe
+    u32overflowing_add
     drop
-    u32sub.unsafe
+    u32overflowing_sub
     drop
 end
 
@@ -9564,9 +9564,9 @@ end
 
 proc.mulstep
     movdn.2
-    u32madd.unsafe
+    u32unchecked_madd
     movdn.2
-    u32add.unsafe
+    u32overflowing_add
     movup.2
     add
 end
@@ -9924,10 +9924,10 @@ end
 export.overflowing_add
     swap
     movup.3
-    u32add.unsafe
+    u32overflowing_add
     movup.3
     movup.3
-    u32add3.unsafe
+    u32unchecked_add3
 end
 
 # Performs addition of two unsigned 64 bit integers discarding the overflow.
@@ -9959,13 +9959,13 @@ end
 export.wrapping_sub
     movup.3
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.3
     movup.3
-    u32sub.unsafe
+    u32overflowing_sub
     drop
     swap
-    u32sub.unsafe
+    u32overflowing_sub
     drop
 end
 
@@ -9977,14 +9977,14 @@ export.checked_sub
     exec.u32assert4
     movup.3
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.3
     movup.3
-    u32sub.unsafe
+    u32overflowing_sub
     eq.0
     assert
     swap
-    u32sub.unsafe
+    u32overflowing_sub
     eq.0
     assert
 end
@@ -9996,13 +9996,13 @@ end
 export.overflowing_sub
     movup.3
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.3
     movup.3
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     or
 end
@@ -10016,14 +10016,14 @@ end
 export.wrapping_mul
     dup.3
     dup.2
-    u32mul.unsafe
+    u32overflowing_mul
     movup.4
     movup.4
-    u32madd.unsafe
+    u32unchecked_madd
     drop
     movup.3
     movup.3
-    u32madd.unsafe
+    u32unchecked_madd
     drop
 end
 
@@ -10035,20 +10035,20 @@ end
 export.overflowing_mul
     dup.3
     dup.2
-    u32mul.unsafe
+    u32overflowing_mul
     dup.4
     movup.4
-    u32madd.unsafe
+    u32unchecked_madd
     swap
     movup.5
     dup.4
-    u32madd.unsafe
+    u32unchecked_madd
     movup.5
     movup.5
-    u32madd.unsafe
+    u32unchecked_madd
     movup.3
     movup.2
-    u32add.unsafe
+    u32overflowing_add
     movup.2
     add
 end
@@ -10074,10 +10074,10 @@ end
 export.unchecked_lt
     movup.3
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movdn.3
     drop
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     eq.0
     movup.2
@@ -10101,10 +10101,10 @@ end
 # This takes 11 cycles.
 export.unchecked_gt
     movup.2
-    u32sub.unsafe
+    u32overflowing_sub
     movup.2
     movup.3
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     drop
     movup.2
@@ -10295,15 +10295,15 @@ export.unchecked_div
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
     dup.2               # fits into 2 32-bit limbs
-    u32mul.unsafe
+    u32overflowing_mul
     dup.4
     dup.4
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.5
     dup.3
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.4
@@ -10326,10 +10326,10 @@ export.unchecked_div
 
     swap                # add remainder to the previous result; this also consumes the remainder
     movup.3
-    u32add.unsafe
+    u32overflowing_add
     movup.3
     movup.3
-    u32add3.unsafe
+    u32unchecked_add3
     eq.0
     assert
 
@@ -10364,15 +10364,15 @@ export.unchecked_mod
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
     dup.2               # fits into 2 32-bit limbs
-    u32mul.unsafe
+    u32overflowing_mul
     dup.4
     movup.4
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.4
     dup.3
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.3
@@ -10395,10 +10395,10 @@ export.unchecked_mod
 
     dup.1               # add remainder to the previous result
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.4
     dup.3
-    u32add3.unsafe
+    u32unchecked_add3
     eq.0
     assert
 
@@ -10433,15 +10433,15 @@ export.unchecked_divmod
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
     dup.2               # fits into 2 32-bit limbs
-    u32mul.unsafe
+    u32overflowing_mul
     dup.4
     dup.4
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.5
     dup.3
-    u32madd.unsafe
+    u32unchecked_madd
     eq.0
     assert
     dup.4
@@ -10464,10 +10464,10 @@ export.unchecked_divmod
 
     dup.1               # add remainder to the previous result
     movup.4
-    u32add.unsafe
+    u32overflowing_add
     movup.4
     dup.3
-    u32add3.unsafe
+    u32unchecked_add3
     eq.0
     assert
 
@@ -10559,7 +10559,7 @@ export.unchecked_shr
     movup.3
     dup
     eq.0
-    u32sub.unsafe
+    u32overflowing_sub
     not
     movdn.4
     dup
@@ -10633,7 +10633,7 @@ end
 export.unchecked_rotl
     push.31
     dup.1
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     drop
     movdn.3
@@ -10644,12 +10644,12 @@ export.unchecked_rotl
     pow2.unsafe
     dup
     movup.3
-    u32mul.unsafe
+    u32overflowing_mul
 
     # Shift the high limb.
     movup.3
     movup.3
-    u32madd.unsafe
+    u32unchecked_madd
 
     # Carry the overflow shift to the low bits.
     movup.2
@@ -10670,7 +10670,7 @@ end
 export.unchecked_rotr
     push.31
     dup.1
-    u32sub.unsafe
+    u32overflowing_sub
     swap
     drop
     movdn.3
@@ -10680,17 +10680,17 @@ export.unchecked_rotr
     u32and
     push.32
     swap
-    u32sub.unsafe
+    u32overflowing_sub
     drop
     pow2.unsafe
     dup
     movup.3
-    u32mul.unsafe
+    u32overflowing_mul
 
     # Shift the high limb left by 32-b.
     movup.3
     movup.3
-    u32madd.unsafe
+    u32unchecked_madd
 
     # Carry the overflow shift to the low bits.
     movup.2


### PR DESCRIPTION
Refactoring of the `u32add`, `u32sub`, `u32mul`, `u32add3` and `u32madd` operations to match stdlib underscoring style.