### PR TITLE
Create AuxTableBus and build b_aux auxiliary trace column

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -96,9 +96,9 @@ pub const TRACE_WIDTH: usize = AUX_TABLE_OFFSET + AUX_TABLE_WIDTH;
 // AUXILIARY COLUMNS LAYOUT
 // ------------------------------------------------------------------------------------------------
 
-//      decoder         stack       range checks      hasher
-//    (3 columns)     (1 column)     (3 columns)    (1 columns)
-// ├───────────────┴──────────────┴──────────────┴───────────────┤
+//      decoder         stack       range checks      hasher      auxiliary table
+//    (3 columns)     (1 column)     (3 columns)    (1 column)       (1 column)
+// ├───────────────┴──────────────┴──────────────┴───────────────┴───────────────┤
 
 // Decoder auxiliary columns
 pub const DECODER_AUX_TRACE_OFFSET: usize = 0;
@@ -124,7 +124,13 @@ pub const HASHER_AUX_TRACE_WIDTH: usize = 1;
 pub const HASHER_AUX_TRACE_RANGE: Range<usize> =
     range(HASHER_AUX_TRACE_OFFSET, HASHER_AUX_TRACE_WIDTH);
 
-pub const AUX_TRACE_WIDTH: usize = HASHER_AUX_TRACE_RANGE.end;
+// Auxiliary Table auxiliary columns
+pub const AUX_TABLE_AUX_TRACE_OFFSET: usize = HASHER_AUX_TRACE_RANGE.end;
+pub const AUX_TABLE_AUX_TRACE_WIDTH: usize = 1;
+pub const AUX_TABLE_AUX_TRACE_RANGE: Range<usize> =
+    range(AUX_TABLE_AUX_TRACE_OFFSET, AUX_TABLE_AUX_TRACE_WIDTH);
+
+pub const AUX_TRACE_WIDTH: usize = AUX_TABLE_AUX_TRACE_RANGE.end;
 
 /// Number of random elements available to the prover after the commitment to the main trace
 /// segment.

--- a/docs/src/design/aux_table/memory.md
+++ b/docs/src/design/aux_table/memory.md
@@ -243,10 +243,10 @@ Notice that the maximum degree for all constraints described above is $5$.
 To use the above table in permutation checks, we need to reduce each row of the memory table to a single value. This can be done like so:
 
 $$
-v = \beta + \alpha \cdot c + \alpha^2 \cdot a + \alpha^3 \cdot i + \sum_{j=0}^3(\alpha^{j+4} \cdot u_j) + \sum_{j=0}^3(\alpha^{j+8} \cdot v_j)
+v = \alpha_0 + \alpha_1 \cdot c + \alpha_2 \cdot a + \alpha_3 \cdot i + \sum_{j=0}^3(\alpha_{j+4} \cdot u_j) + \sum_{j=0}^3(\alpha_{j+8} \cdot v_j)
 $$
 
-where $\alpha$ and $\beta$ are random values sent from the verifier to the prover for use in permutation checks.
+where $\alpha_0$, $\alpha_1$, $\alpha_2$, etc. are random values sent from the verifier to the prover for use in permutation checks.
 
 ### Load and store operations
 
@@ -269,10 +269,10 @@ Note that as a result of this operation the stack is shifted to the left by one.
 Denoting stack registers as $s_j$, clock cycle register as $i$, and context register as $c$, we can compute the lookup row value as follows:
 
 $$
-v = \beta + \alpha \cdot c + \alpha^2 \cdot s_0 + \alpha^3 \cdot i + \sum_{j=0}^3(\alpha^{j+4} \cdot s_j') + \sum_{j=0}^3(\alpha^{j+8} \cdot s_j')
+v = \alpha_0 + \alpha_1 \cdot c + \alpha_2 \cdot s_0 + \alpha_3 \cdot i + \sum_{j=0}^3(\alpha_{j+4} \cdot s_j') + \sum_{j=0}^3(\alpha_{j+8} \cdot s_j')
 $$
 
-where $\alpha$ and $\beta$ are random values sent from the verifier to the prover for use in permutation checks.
+where $\alpha_0$, $\alpha_1$, $\alpha_2$, etc. are random values sent from the verifier to the prover for use in permutation checks.
 
 Note that the values from the top of the stack are added into the row twice: once for "old" values and once for "new" values. We can do this because old and new values in the memory table row corresponding the load operation are the same.
 
@@ -292,10 +292,10 @@ Note that as a result of this operation the stack is shifted to the left by one,
 Denoting stack registers as $s_j$, helper registers as $h_j$, clock cycle register as $i$, and context register as $c$, we can compute the lookup row value as follows:
 
 $$
-v = \beta + \alpha \cdot c + \alpha^2 \cdot s_0 + \alpha^3 \cdot i + \sum_{j=0}^3(\alpha^{j+4} \cdot h_j) + \sum_{j=0}^3(\alpha^{j+8} \cdot s_j)
+v = \alpha_0 + \alpha_1 \cdot c + \alpha_2 \cdot s_0 + \alpha_3 \cdot i + \sum_{j=0}^3(\alpha_{j+4} \cdot h_j) + \sum_{j=0}^3(\alpha_{j+8} \cdot s_j')
 $$
 
-where $\alpha$ and $\beta$ are random values sent from the verifier to the prover for use in permutation checks. Values for the helper registers $h_0, ...,  h_3$ are provided by the VM non-deterministically.
+where $\alpha_0$, $\alpha_1$, $\alpha_2$ etc... are random values sent from the verifier to the prover for use in permutation checks. Values for the helper registers $h_0, ...,  h_3$ are provided by the VM non-deterministically.
 
 We also need to make sure that the saved values remained on the stack. This can be done with the following constraint:
 

--- a/processor/src/aux_table_bus/aux_trace.rs
+++ b/processor/src/aux_table_bus/aux_trace.rs
@@ -1,0 +1,94 @@
+use super::{AuxTableLookup, AuxTableLookupRow, Felt, FieldElement};
+use crate::{
+    trace::{build_lookup_table_row_values, AuxColumnBuilder, LookupTableRow},
+    Vec,
+};
+use winterfell::Matrix;
+
+// AUXILIARY TRACE BUILDER
+// ================================================================================================
+
+/// Describes how to construct execution traces of auxiliary trace columns that depend on multiple
+/// co-processors in the Auxiliary Table (used in multiset checks).
+pub struct AuxTraceBuilder {
+    pub(super) lookup_hints: Vec<(usize, AuxTableLookup)>,
+    pub(super) request_rows: Vec<AuxTableLookupRow>,
+    pub(super) response_rows: Vec<AuxTableLookupRow>,
+}
+
+impl AuxTraceBuilder {
+    // COLUMN TRACE CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+
+    /// Builds and returns the Auxiliary Table's auxiliary trace columns. Currently this consists of
+    /// a single bus column `b_aux` describing co-processor lookups requested by the stack and
+    /// provided by the co-processors in the Auxiliary Table.
+    pub fn build_aux_columns<E: FieldElement<BaseField = Felt>>(
+        &self,
+        main_trace: &Matrix<Felt>,
+        rand_elements: &[E],
+    ) -> Vec<Vec<E>> {
+        let b_aux = self.build_aux_column(main_trace, rand_elements);
+        vec![b_aux]
+    }
+}
+
+// AUXILIARY TABLE LOOKUPS
+// ================================================================================================
+
+impl AuxColumnBuilder<AuxTableLookup, AuxTableLookupRow> for AuxTraceBuilder {
+    /// This method is required, but because it is only called inside `build_row_values` which is
+    /// overridden below, it is not used here and should not be called.
+    fn get_table_rows(&self) -> &[AuxTableLookupRow] {
+        unimplemented!()
+    }
+
+    /// Returns hints which describe the [AuxTable] lookup requests and responses during program
+    /// execution. Each update hint is accompanied by a clock cycle at which the update happened.
+    ///
+    /// Internally, each update hint also contains an index of the row into the full list of request
+    /// rows or response rows, depending on whether it is a request, a response, or both (in which
+    /// case it contains 2 indices).
+    fn get_table_hints(&self) -> &[(usize, AuxTableLookup)] {
+        &self.lookup_hints
+    }
+
+    /// Returns the value by which the running product column should be multiplied for the provided
+    /// hint value.
+    fn get_multiplicand<E: FieldElement<BaseField = Felt>>(
+        &self,
+        hint: AuxTableLookup,
+        row_values: &[E],
+        inv_row_values: &[E],
+    ) -> E {
+        match hint {
+            AuxTableLookup::Request(request_row) => inv_row_values[request_row],
+            AuxTableLookup::Response(response_row) => row_values[response_row],
+            AuxTableLookup::RequestAndResponse((request_row, response_row)) => {
+                inv_row_values[request_row] * row_values[response_row]
+            }
+        }
+    }
+
+    /// Build the row values and inverse values used to build the auxiliary column.
+    ///
+    /// The row values to be included come from the responses and the inverse values come from
+    /// requests. Since responses are grouped by the segments of the auxiliary table, the operation
+    /// order for the requests and responses will be permutations of each other rather than sharing
+    /// the same order. Therefore, the `row_values` and `inv_row_values` must be built separately.
+    fn build_row_values<E>(&self, _main_trace: &Matrix<Felt>, alphas: &[E]) -> (Vec<E>, Vec<E>)
+    where
+        E: FieldElement<BaseField = Felt>,
+    {
+        // get the row values from the resonse rows
+        let row_values = self
+            .response_rows
+            .iter()
+            .map(|response| response.to_value(alphas))
+            .collect();
+        // get the inverse values from the request rows
+        let (_, inv_row_values) = build_lookup_table_row_values(&self.request_rows, alphas);
+
+        (row_values, inv_row_values)
+    }
+}

--- a/processor/src/aux_table_bus/mod.rs
+++ b/processor/src/aux_table_bus/mod.rs
@@ -1,0 +1,172 @@
+use super::{BTreeMap, Felt, FieldElement, StarkField, Vec, Word};
+use crate::{memory::MemoryLookup, trace::LookupTableRow};
+
+mod aux_trace;
+pub use aux_trace::AuxTraceBuilder;
+
+// AUXILIARY TABLE BUS
+// ================================================================================================
+
+/// The Auxiliary Table Bus tracks data requested from or provided by co-processors in the
+/// Auxiliary Table. It processes lookup requests from the stack and response data from the
+/// co-processors in the Auxiliary Table.
+///
+/// For correct execution, the lookup data used by the stack for each co-processor must be a
+/// permutation of the lookups executed by that co-processor so that they cancel out. This is
+/// ensured by the `b_aux` bus column. When the `b_aux` column is built, requests from the stack
+/// must be divided out and lookup results provided by the co-processors must be multiplied in. To
+/// ensure that all lookups are attributed to the correct co-processor and operation, a unique
+/// co-processor operation selector must be included in the lookup row value when it is computed.
+///
+/// TODO: document the AuxTableBus components and their types.
+
+#[derive(Default)]
+pub struct AuxTableBus {
+    lookup_hints: BTreeMap<usize, AuxTableLookup>,
+    request_rows: Vec<AuxTableLookupRow>,
+    response_rows: Vec<AuxTableLookupRow>,
+}
+
+impl AuxTableBus {
+    // LOOKUP MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Requests a memory access with the specified data. When `old_word` and `new_word` are the
+    /// same, this is a read request. When they are different, it's a write request. The memory
+    /// value is requested at cycle `clk`. This is expected to be called by operation executors.
+    pub fn request_memory_operation(
+        &mut self,
+        addr: Felt,
+        clk: usize,
+        old_word: Word,
+        new_word: Word,
+    ) {
+        // all requests are sent from the stack before responses are provided (during AuxTable trace
+        // finalization). requests are guaranteed not to share cycles with other requests, since
+        // only one operation will be executed at a time.
+        let request_idx = self.request_rows.len();
+        self.lookup_hints
+            .insert(clk, AuxTableLookup::Request(request_idx));
+
+        let memory_lookup = MemoryLookup::new(addr, clk as u64, old_word, new_word);
+        self.request_rows
+            .push(AuxTableLookupRow::Memory(memory_lookup));
+    }
+
+    /// Provides the data of a memory read or write contained in the [Memory] table.  When
+    /// `old_word` and `new_word` are the same, this is a read request. When they are different,
+    /// it's a write  request. The memory value is provided at cycle `response_cycle`, which is the
+    /// row of the execution trace that contains this Memory row.
+    pub fn provide_memory_operation(
+        &mut self,
+        addr: Felt,
+        clk: Felt,
+        old_word: Word,
+        new_word: Word,
+        response_cycle: usize,
+    ) {
+        // results are guaranteed not to share cycles with other results, but they might share
+        // a cycle with a request which has already been sent.
+        let response_idx = self.response_rows.len();
+        self.lookup_hints
+            .entry(response_cycle)
+            .and_modify(|lookup| {
+                if let AuxTableLookup::Request(request_idx) = *lookup {
+                    *lookup = AuxTableLookup::RequestAndResponse((request_idx, response_idx));
+                }
+            })
+            .or_insert_with(|| AuxTableLookup::Response(response_idx));
+
+        let memory_lookup = MemoryLookup::new(addr, clk.as_int(), old_word, new_word);
+        self.response_rows
+            .push(AuxTableLookupRow::Memory(memory_lookup));
+    }
+
+    // AUX TRACE BUILDER GENERATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Converts this [AuxTableBus] into an auxiliary trace builder which can be used to construct
+    /// the auxiliary trace column describing the [AuxTable] lookups at every cycle.
+    pub fn into_aux_builder(self) -> AuxTraceBuilder {
+        let lookup_hints = self.lookup_hints.into_iter().collect();
+
+        AuxTraceBuilder {
+            lookup_hints,
+            request_rows: self.request_rows,
+            response_rows: self.response_rows,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns an option with the lookup hint for the specified cycle.
+    #[cfg(test)]
+    pub(super) fn get_lookup_hint(&self, cycle: usize) -> Option<&AuxTableLookup> {
+        self.lookup_hints.get(&cycle)
+    }
+
+    /// Returns the ith lookup response provided by the AuxTable co-processors.
+    #[cfg(test)]
+    pub(super) fn get_response_row(&self, i: usize) -> AuxTableLookupRow {
+        self.response_rows[i]
+    }
+}
+
+// AUXILIARY TABLE LOOKUPS
+// ================================================================================================
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) enum AuxTableLookup {
+    Request(usize),
+    Response(usize),
+    RequestAndResponse((usize, usize)),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(super) enum AuxTableLookupRow {
+    Hasher(HasherLookupRow),
+    Bitwise(BitwiseLookupRow),
+    Memory(MemoryLookup),
+}
+
+impl LookupTableRow for AuxTableLookupRow {
+    fn to_value<E: FieldElement<BaseField = Felt>>(&self, alphas: &[E]) -> E {
+        match self {
+            AuxTableLookupRow::Hasher(row) => row.to_value(alphas),
+            AuxTableLookupRow::Bitwise(row) => row.to_value(alphas),
+            AuxTableLookupRow::Memory(row) => row.to_value(alphas),
+        }
+    }
+}
+
+// HASH PROCESSOR LOOKUPS
+// ================================================================================================
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) struct HasherLookupRow {}
+
+impl LookupTableRow for HasherLookupRow {
+    /// Reduces this row to a single field element in the field specified by E. This requires
+    /// at least 12 alpha values.
+    fn to_value<E: FieldElement<BaseField = Felt>>(&self, _alphas: &[E]) -> E {
+        unimplemented!()
+    }
+}
+
+// BITWISE PROCESSOR LOOKUPS
+// ================================================================================================
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) struct BitwiseLookupRow {}
+
+impl LookupTableRow for BitwiseLookupRow {
+    /// Reduces this row to a single field element in the field specified by E. This requires
+    /// at least 12 alpha values.
+    fn to_value<E: FieldElement<BaseField = Felt>>(&self, _alphas: &[E]) -> E {
+        unimplemented!()
+    }
+}

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -78,7 +78,7 @@ pub struct StackTrace {
 
 pub struct RangeCheckTrace {
     trace: [Vec<Felt>; RANGE_CHECK_TRACE_WIDTH],
-    aux_trace_builder: range::AuxTraceBuilder,
+    aux_builder: range::AuxTraceBuilder,
 }
 
 pub struct AuxTableTrace {

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -49,6 +49,9 @@ use advice::AdviceProvider;
 mod aux_table;
 use aux_table::AuxTable;
 
+mod aux_table_bus;
+use aux_table_bus::AuxTableBus;
+
 mod trace;
 pub use trace::ExecutionTrace;
 use trace::TraceFragment;
@@ -84,6 +87,7 @@ pub struct RangeCheckTrace {
 pub struct AuxTableTrace {
     trace: [Vec<Felt>; AUX_TABLE_WIDTH],
     hasher_aux_builder: hasher::AuxTraceBuilder,
+    aux_builder: aux_table_bus::AuxTraceBuilder,
 }
 
 // EXECUTOR
@@ -129,6 +133,7 @@ pub struct Process {
     hasher: Hasher,
     bitwise: Bitwise,
     memory: Memory,
+    aux_table_bus: AuxTableBus,
     advice: AdviceProvider,
 }
 
@@ -154,6 +159,7 @@ impl Process {
             hasher: Hasher::default(),
             bitwise: Bitwise::new(),
             memory: Memory::new(),
+            aux_table_bus: AuxTableBus::default(),
             advice: AdviceProvider::new(inputs),
         }
     }
@@ -356,7 +362,7 @@ impl Process {
     }
 
     pub fn to_components(self) -> (System, Decoder, Stack, RangeChecker, AuxTable) {
-        let aux_table = AuxTable::new(self.hasher, self.bitwise, self.memory);
+        let aux_table = AuxTable::new(self.hasher, self.bitwise, self.memory, self.aux_table_bus);
         (self.system, self.decoder, self.stack, self.range, aux_table)
     }
 }

--- a/processor/src/range/mod.rs
+++ b/processor/src/range/mod.rs
@@ -227,11 +227,7 @@ impl RangeChecker {
 
         RangeCheckTrace {
             trace,
-            aux_trace_builder: AuxTraceBuilder::new(
-                self.cycle_range_checks,
-                row_flags,
-                start_16bit,
-            ),
+            aux_builder: AuxTraceBuilder::new(self.cycle_range_checks, row_flags, start_16bit),
         }
     }
 

--- a/processor/src/range/tests.rs
+++ b/processor/src/range/tests.rs
@@ -16,7 +16,7 @@ fn range_checks() {
 
     let RangeCheckTrace {
         trace,
-        aux_trace_builder: _,
+        aux_builder: _,
     } = checker.into_trace(1024, 0);
     validate_trace(&trace, &values);
 
@@ -55,7 +55,7 @@ fn range_checks_rand() {
     let trace_len = checker.trace_len().next_power_of_two();
     let RangeCheckTrace {
         trace,
-        aux_trace_builder: _,
+        aux_builder: _,
     } = checker.into_trace(trace_len, 0);
     validate_trace(&trace, &values);
 }

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -307,7 +307,7 @@ fn finalize_trace(process: Process, mut rng: RandomCoin) -> (Vec<Vec<Felt>>, Aux
     let aux_trace_hints = AuxTraceHints {
         decoder: decoder_trace.aux_trace_hints,
         stack: stack_trace.aux_builder,
-        range: range_check_trace.aux_trace_builder,
+        range: range_check_trace.aux_builder,
         hasher: aux_table_trace.hasher_aux_builder,
     };
 

--- a/processor/src/trace/tests/aux_table.rs
+++ b/processor/src/trace/tests/aux_table.rs
@@ -1,0 +1,145 @@
+use super::{
+    super::{Trace, NUM_RAND_ROWS},
+    build_trace_from_ops, rand_array, ExecutionTrace, Felt, FieldElement, Operation, Word, ONE,
+    ZERO,
+};
+use vm_core::{
+    aux_table::memory::{
+        ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, NUM_ELEMENTS, U_COL_RANGE, V_COL_RANGE,
+    },
+    AUX_TABLE_AUX_TRACE_OFFSET, AUX_TRACE_RAND_ELEMENTS,
+};
+
+/// Tests the generation of the `b_aux` bus column when only memory lookups are included. It ensures
+/// that trace generation is correct when all of the following are true.
+///
+/// - All possible memory operations are called by the stack.
+/// - Some requests from the Stack and responses from Memory occur at the same cycle.
+/// - Multiple memory addresses are used.
+#[test]
+#[allow(clippy::needless_range_loop)]
+fn b_aux_trace_mem() {
+    let stack = [1, 2, 3, 4, 0];
+    let word = [ONE, Felt::new(2), Felt::new(3), Felt::new(4)];
+    let operations = vec![
+        Operation::MStoreW, // store [1, 2, 3, 4]
+        Operation::Drop,    // clear the stack
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::MLoad,     // read the first value of the word
+        Operation::MovDn5,    // put address 0 and space for a full word at top of stack
+        Operation::MLoadW,    // load word from address 0 to stack
+        Operation::Push(ONE), // push a new value onto the stack
+        Operation::Push(ONE), // push a new address on to the stack
+        Operation::MStore,    // store 1 at address 1
+        Operation::Drop,      // ensure the stack overflow table is empty
+    ];
+    let mut trace = build_trace_from_ops(operations, &stack);
+
+    let rand_elements = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
+    let aux_columns = trace.build_aux_segment(&[], &rand_elements).unwrap();
+    let b_aux = aux_columns.get_column(AUX_TABLE_AUX_TRACE_OFFSET);
+
+    assert_eq!(trace.length(), b_aux.len());
+    assert_eq!(ONE, b_aux[0]);
+    assert_eq!(ONE, b_aux[1]);
+
+    // The first memory request from the stack is sent when the `MStoreW` operation is executed, at
+    // cycle 1, so the request is included in the next row. (The trace begins by executing `span`).
+    let value = build_expected_memory(&rand_elements, ZERO, ZERO, Felt::new(1), [ZERO; 4], word);
+    let mut expected = value.inv();
+    assert_eq!(expected, b_aux[2]);
+
+    // Nothing changes after user operations that don't make requests to the Auxiliary Table.
+    for row in 3..7 {
+        assert_eq!(expected, b_aux[row]);
+    }
+
+    // The next memory request from the stack is sent when `MLoad` is executed at cycle 6 and
+    // included at row 7
+    let value = build_expected_memory(&rand_elements, ZERO, ZERO, Felt::new(6), word, word);
+    expected *= value.inv();
+    assert_eq!(expected, b_aux[7]);
+
+    // Nothing changes in row 8.
+    assert_eq!(expected, b_aux[8]);
+
+    // Memory responses will be provided during the memory segment of the Auxiliary Table trace,
+    // which starts after the hash for the span block at row 8. There will be 4 rows, corresponding
+    // to the four Memory operations.
+
+    // At cycle 8 `MLoadW` is requested by the stack and `MStoreW` is provided by memory
+    let value = build_expected_memory(&rand_elements, ZERO, ZERO, Felt::new(8), word, word);
+    expected *= value.inv();
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 8);
+    assert_eq!(expected, b_aux[9]);
+
+    // At cycle 9, `MLoad` is provided by memory.
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 9);
+    assert_eq!(expected, b_aux[10]);
+
+    // At cycle 10,  `MLoadW` is provided by memory.
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 10);
+    assert_eq!(expected, b_aux[11]);
+
+    // At cycle 11, `MStore` is requested by the stack and provided by memory.
+    let value = build_expected_memory(
+        &rand_elements,
+        ZERO,
+        ONE,
+        Felt::new(11),
+        [ZERO; 4],
+        [ONE, ZERO, ZERO, ZERO],
+    );
+    expected *= value.inv();
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 11);
+    assert_eq!(expected, b_aux[12]);
+
+    // The value in b_aux should be ONE now and for the rest of the trace.
+    for row in 12..trace.length() - NUM_RAND_ROWS {
+        assert_eq!(ONE, b_aux[row]);
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+fn build_expected_memory(
+    alphas: &[Felt],
+    ctx: Felt,
+    addr: Felt,
+    clk: Felt,
+    old_word: Word,
+    new_word: Word,
+) -> Felt {
+    let mut old_word_value = ZERO;
+    let mut new_word_value = ZERO;
+
+    for i in 0..NUM_ELEMENTS {
+        old_word_value += alphas[i + 4] * old_word[i];
+        new_word_value += alphas[i + 8] * new_word[i];
+    }
+
+    alphas[0]
+        + alphas[1] * ctx
+        + alphas[2] * addr
+        + alphas[3] * clk
+        + old_word_value
+        + new_word_value
+}
+
+fn build_expected_memory_from_trace(trace: &ExecutionTrace, alphas: &[Felt], row: usize) -> Felt {
+    let ctx = trace.main_trace.get_column(CTX_COL_IDX)[row];
+    let addr = trace.main_trace.get_column(ADDR_COL_IDX)[row];
+    let clk = trace.main_trace.get_column(CLK_COL_IDX)[row];
+    let mut old_word = [ZERO; NUM_ELEMENTS];
+    let mut new_word = [ZERO; NUM_ELEMENTS];
+
+    for i in 0..NUM_ELEMENTS {
+        old_word[i] = trace.main_trace.get_column(U_COL_RANGE.start + i)[row];
+        new_word[i] = trace.main_trace.get_column(V_COL_RANGE.start + i)[row];
+    }
+
+    build_expected_memory(alphas, ctx, addr, clk, old_word, new_word)
+}

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -2,6 +2,7 @@ use super::{ExecutionTrace, Felt, FieldElement, LookupTableRow, Process, Trace, 
 use rand_utils::rand_array;
 use vm_core::{program::blocks::CodeBlock, Operation, ProgramInputs, Word, ONE, ZERO};
 
+mod aux_table;
 mod hasher;
 mod range;
 mod stack;


### PR DESCRIPTION
This PR creates the b_aux auxiliary trace bus column for the aux table and adds memory lookups (hasher and bitwise lookups are left for a future PR). 

It includes the following changes:

- `AuxTableBus` component is created and added to the `Process` struct, with memory lookups included from the stack and the Memory processor
- Memory unit tests are updated to include ensuring lookups are provided correctly
- `b_aux` auxiliary trace column execution trace column is built
- unit test for the `b_aux` column for memory is added
- memory design documentation is corrected (constraint error) and updated (notation changes)

Note: I haven't included the Memory selector in the `to_value` function yet, but this can be added when other co-processors are handled