### PR TITLE
Pow2 safe mode fix

### DIFF
--- a/assembly/src/parsers/field_ops.rs
+++ b/assembly/src/parsers/field_ops.rs
@@ -134,7 +134,7 @@ pub fn parse_inv(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assemb
 /// we skip the check of verifying that the top element is less than 64 or not.
 ///
 /// VM cycles per mode:
-/// pow2: 43 cycles
+/// pow2: 44 cycles
 /// pow2.unsafe: 38 cycles
 pub fn parse_pow2(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
     let unsafe_mode = match op.num_parts() {
@@ -398,15 +398,18 @@ pub fn parse_gte(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Assemb
 /// After these operations, the stack state will be: [2^a, ...].
 ///
 /// VM cycles per mode:
-/// safe: 43 cycles
+/// safe: 44 cycles
 /// unsafe: 38 cycles
 pub fn aggregate_power_2(span_ops: &mut Vec<Operation>, unsafe_mode: bool) {
     const MOST_SIGNIFICANT_BIT: u32 = 5;
 
     // `safe` Mode
     if !unsafe_mode {
-        // Checks if the top element of the stack is less than 64 or not.
+        // Checks if the top element of the stack is less than 64 or not. U32assert2 will
+        // ensure if the element to which we are raising 2 to is u32 or not before u32div.
+        // U32div operates on only u32 values.
         span_ops.push(Operation::Push(Felt::new(64)));
+        span_ops.push(Operation::U32assert2);
         span_ops.push(Operation::U32div);
         span_ops.push(Operation::Swap);
         span_ops.push(Operation::Eqz);

--- a/assembly/src/parsers/u32_ops.rs
+++ b/assembly/src/parsers/u32_ops.rs
@@ -432,7 +432,7 @@ pub fn parse_u32not(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
 /// 32-bit value.
 ///
 /// VM cycles per mode:
-/// - u32shl: 46 cycles
+/// - u32shl: 47 cycles
 /// - u32shl.b: 4 cycles
 /// - u32shl.unsafe: 39 cycles
 pub fn parse_u32shl(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
@@ -477,7 +477,7 @@ pub fn parse_u32shl(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
 /// be shifted is asserted to be a 32-bit value.
 ///
 /// VM cycles per mode:
-/// - u32shr: 46 cycles
+/// - u32shr: 47 cycles
 /// - u32shr.b: 4 cycles
 /// - u32shr.unsafe: 44 cycles
 pub fn parse_u32shr(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
@@ -531,7 +531,7 @@ pub fn parse_u32shr(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
 /// between 0-31 and the value to be shifted is asserted to be a 32-bit value.
 ///
 /// VM cycles per mode:
-/// - u32rotl: 46 cycles
+/// - u32rotl: 47 cycles
 /// - u32rotl.b: 4 cycles
 /// - u32rotl.unsafe: 40 cycles
 pub fn parse_u32rotl(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
@@ -569,7 +569,7 @@ pub fn parse_u32rotl(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), As
 /// 0-31 and the value to be shifted is asserted to be a 32-bit value.
 ///
 /// VM cycles per mode:
-/// - u32rotr: 58 cycles
+/// - u32rotr: 59 cycles
 /// - u32rotr.b: 6 cycles
 /// - u32rotr.unsafe: 44 cycles
 pub fn parse_u32rotr(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {

--- a/miden/tests/integration/operations/field_ops.rs
+++ b/miden/tests/integration/operations/field_ops.rs
@@ -325,7 +325,14 @@ fn pow2_unsafe() {
 fn pow2_fail() {
     let asm_op = "pow2";
 
+    let mut value = rand_value::<u32>() as u64;
+    value += (u32::MAX as u64) + 1;
+
+    // --- random u32 values > 63 ------------------------------------------------------
     build_op_test!(asm_op, &[64]).expect_error(TestError::ExecutionError("FailedAssertion"));
+
+    // --- random u64 values > u32MAX  ------------------------------------------------
+    build_op_test!(asm_op, &[value]).expect_error(TestError::ExecutionError("NotU32Value"))
 }
 
 #[test]


### PR DESCRIPTION
This PR address a part of first part of #200.

- The pow2 safe mode doesn't check if the input value to which we want to raise 2 to is u32 or not. The PR addresses this.

- Add handling of failures test for cases when the input value is greater than u32 max. 