### PR TITLE
U32 div, mod and divmod operations refactoring

### DIFF
--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -88,8 +88,14 @@ fn parse_op_token(
 
         "u32unchecked_madd" => u32_ops::parse_u32madd(span_ops, op, U32OpMode::Unchecked),
 
-        "u32div" => u32_ops::parse_u32div(span_ops, op),
-        "u32mod" => u32_ops::parse_u32mod(span_ops, op),
+        "u32checked_div" => u32_ops::parse_u32div(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_div" => u32_ops::parse_u32div(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_mod" => u32_ops::parse_u32mod(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_mod" => u32_ops::parse_u32mod(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_divmod" => u32_ops::parse_u32divmod(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_divmod" => u32_ops::parse_u32divmod(span_ops, op, U32OpMode::Unchecked),
 
         "u32and" => u32_ops::parse_u32and(span_ops, op),
         "u32or" => u32_ops::parse_u32or(span_ops, op),

--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -83,7 +83,7 @@ fn u32checked_add_b_fail() {
     test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32.
-    test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);
+    test_param_out_of_bounds("u32checked_add", U32_BOUND);
 
     // should fail if a + b >= 2^32.
     let a = u32::MAX;
@@ -362,7 +362,7 @@ fn u32checked_sub_b_fail() {
     test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32.
-    test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);
+    test_param_out_of_bounds("u32checked_sub", U32_BOUND);
 
     // should fail if a < b.
     let a = 1_u64;
@@ -568,7 +568,7 @@ fn u32checked_mul_b_fail() {
     test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32.
-    test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);
+    test_param_out_of_bounds("u32checked_mul", U32_BOUND);
 
     // should fail if a * b >= 2^32.
     let a = u32::MAX as u64;
@@ -720,39 +720,15 @@ fn u32unchecked_madd() {
 }
 
 #[test]
-// issue: https://github.com/maticnetwork/miden/issues/94
-fn u32div() {
-    let asm_op = "u32div";
+fn u32checked_div() {
+    let asm_op = "u32checked_div";
 
-    // --- simple cases ---------------------------------------------------------------------------
-    let test = build_op_test!(asm_op, &[0, 1]);
-    test.expect_stack(&[0]);
-
-    // division with no remainder
-    let test = build_op_test!(asm_op, &[2, 1]);
-    test.expect_stack(&[2]);
-
-    // division with remainder
-    let test = build_op_test!(asm_op, &[1, 2]);
-    test.expect_stack(&[0]);
-
-    // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() as u32;
-    let expected = a / b;
-    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
-    test.expect_stack(&[expected as u64]);
-
-    // --- test that the rest of the stack isn't affected -----------------------------------------
-    let c = rand_value::<u64>();
-
-    let test = build_op_test!(asm_op, &[c, a as u64, b as u64]);
-    test.expect_stack(&[expected as u64, c]);
+    test_div(asm_op);
 }
 
 #[test]
-fn u32div_fail() {
-    let asm_op = "u32div";
+fn u32checked_div_fail() {
+    let asm_op = "u32checked_div";
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
@@ -768,9 +744,8 @@ fn u32div_fail() {
 }
 
 #[test]
-// issue: https://github.com/maticnetwork/miden/issues/94
-fn u32div_b() {
-    let build_asm_op = |param: u32| format!("u32div.{}", param);
+fn u32checked_div_b() {
+    let build_asm_op = |param: u32| format!("u32checked_div.{}", param);
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1).as_str(), &[0]);
@@ -785,31 +760,33 @@ fn u32div_b() {
     test.expect_stack(&[0]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() as u32;
-    let expected = a / b;
+    let a = rand_value::<u32>();
+    let mut b = rand_value::<u32>();
+    if b == 0 {
+        // ensure we're not using a failure case.
+        b += 1;
+    }
+    let expected = (a / b) as u64;
 
     let test = build_op_test!(build_asm_op(b).as_str(), &[a as u64]);
-    test.expect_stack(&[expected as u64]);
+    test.expect_stack(&[expected]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
     let c = rand_value::<u64>();
-
     let test = build_op_test!(build_asm_op(b).as_str(), &[c, a as u64]);
     test.expect_stack(&[expected as u64, c]);
 }
 
 #[test]
-// issue: https://github.com/maticnetwork/miden/issues/94
-fn u32div_b_fail() {
-    let build_asm_op = |param: u64| format!("u32div.{}", param);
+fn u32checked_div_b_fail() {
+    let build_asm_op = |param: u64| format!("u32checked_div.{}", param);
 
     // should fail during execution if a >= 2^32.
     let test = build_op_test!(build_asm_op(1).as_str(), &[U32_BOUND]);
     test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32.
-    test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);
+    test_param_out_of_bounds("u32checked_div", U32_BOUND);
 
     // should fail during compilation if b = 0.
     let test = build_op_test!(build_asm_op(0).as_str());
@@ -817,46 +794,19 @@ fn u32div_b_fail() {
 }
 
 #[test]
-fn u32div_full() {
-    let asm_op = "u32div.full";
+fn u32unchecked_div() {
+    let asm_op = "u32unchecked_div";
 
-    // should push the quotient c = a / b onto the stack.
-    // should push the remainder d = a % b onto the stack.
-    test_div_full(asm_op);
-}
-
-#[test]
-fn u32div_full_fail() {
-    let asm_op = "u32div.full";
-
-    // should fail if a >= 2^32.
-    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    test.expect_error(TestError::ExecutionError("NotU32Value"));
-
-    // should fail if b >= 2^32.
-    let test = build_op_test!(asm_op, &[1, U32_BOUND]);
-    test.expect_error(TestError::ExecutionError("NotU32Value"));
-
-    // should fail if b == 0.
-    let test = build_op_test!(asm_op, &[1, 0]);
-    test.expect_error(TestError::ExecutionError("DivideByZero"));
-}
-
-#[test]
-fn u32div_unsafe() {
-    let asm_op = "u32div.unsafe";
-
-    // should push c = (a * b) % 2^32 onto the stack.
     // should push d = (a * b) / 2^32 onto the stack.
-    test_div_full(asm_op);
+    test_div(asm_op);
 
     // should not fail when inputs are out of bounds.
     test_unsafe_execution(asm_op, 2);
 }
 
 #[test]
-fn u32div_unsafe_fail() {
-    let asm_op = "u32div.unsafe";
+fn u32unchecked_div_fail() {
+    let asm_op = "u32unchecked_div";
 
     // should fail if b == 0.
     let test = build_op_test!(asm_op, &[1, 0]);
@@ -864,16 +814,15 @@ fn u32div_unsafe_fail() {
 }
 
 #[test]
-fn u32mod() {
-    let asm_op = "u32mod";
+fn u32checked_mod() {
+    let asm_op = "u32checked_mod";
 
-    // should pop b, a off the stack and push the result of a % b onto the stack.
     test_mod(asm_op);
 }
 
 #[test]
-fn u32mod_fail() {
-    let asm_op = "u32mod";
+fn u32checked_mod_fail() {
+    let asm_op = "u32checked_mod";
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
@@ -889,8 +838,8 @@ fn u32mod_fail() {
 }
 
 #[test]
-fn u32mod_b() {
-    let build_asm_op = |param: u32| format!("u32mod.{}", param);
+fn u32checked_mod_b() {
+    let build_asm_op = |param: u32| format!("u32checked_mod.{}", param);
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(5).as_str(), &[10]);
@@ -903,8 +852,8 @@ fn u32mod_b() {
     test.expect_stack(&[5]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let mut b = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
+    let mut b = rand_value::<u32>();
     if b == 0 {
         // ensure we're not using a failure case.
         b += 1;
@@ -922,15 +871,15 @@ fn u32mod_b() {
 }
 
 #[test]
-fn u32mod_b_fail() {
-    let build_asm_op = |param: u64| format!("u32mod.{}", param);
+fn u32checked_mod_b_fail() {
+    let build_asm_op = |param: u64| format!("u32checked_mod.{}", param);
 
     // should fail during execution if a >= 2^32.
     let test = build_op_test!(build_asm_op(1).as_str(), &[U32_BOUND]);
     test.expect_error(TestError::ExecutionError("NotU32Value"));
 
     // should fail during compilation if b >= 2^32.
-    test_param_out_of_bounds(build_asm_op(U32_BOUND).as_str(), U32_BOUND);
+    test_param_out_of_bounds("u32checked_mod", U32_BOUND);
 
     // should fail during compilation if b = 0.
     let test = build_op_test!(build_asm_op(0).as_str());
@@ -938,10 +887,9 @@ fn u32mod_b_fail() {
 }
 
 #[test]
-fn u32mod_unsafe() {
-    let asm_op = "u32mod.unsafe";
+fn u32unchecked_mod() {
+    let asm_op = "u32unchecked_mod";
 
-    // should pop b, a off the stack and push the result of a % b onto the stack.
     test_mod(asm_op);
 
     // should not fail when inputs are out of bounds.
@@ -949,10 +897,105 @@ fn u32mod_unsafe() {
 }
 
 #[test]
-fn u32mod_unsafe_fail() {
-    let asm_op = "u32mod.unsafe";
+fn u32unchecked_mod_fail() {
+    let asm_op = "u32unchecked_mod";
 
     // should fail if b == 0
+    let test = build_op_test!(asm_op, &[1, 0]);
+    test.expect_error(TestError::ExecutionError("DivideByZero"));
+}
+
+#[test]
+fn u32checked_divmod() {
+    let asm_op = "u32checked_divmod";
+
+    test_divmod(asm_op);
+}
+
+#[test]
+fn u32checked_divmod_fail() {
+    let asm_op = "u32checked_divmod";
+
+    // should fail if a >= 2^32
+    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
+
+    // should fail if b >= 2^32
+    let test = build_op_test!(asm_op, &[1, U32_BOUND]);
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
+
+    // should fail if b == 0
+    let test = build_op_test!(asm_op, &[1, 0]);
+    test.expect_error(TestError::ExecutionError("DivideByZero"));
+}
+
+#[test]
+fn u32checked_divmod_b() {
+    let build_asm_op = |param: u32| format!("u32checked_divmod.{}", param);
+
+    // --- simple cases ---------------------------------------------------------------------------
+    let test = build_op_test!(build_asm_op(1).as_str(), &[0]);
+    test.expect_stack(&[0, 0]);
+
+    // division with no remainder
+    let test = build_op_test!(build_asm_op(1).as_str(), &[2]);
+    test.expect_stack(&[0, 2]);
+
+    // division with remainder
+    let test = build_op_test!(build_asm_op(2).as_str(), &[1]);
+    test.expect_stack(&[1, 0]);
+    let test = build_op_test!(build_asm_op(2).as_str(), &[3]);
+    test.expect_stack(&[1, 1]);
+
+    // --- random u32 values ----------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let mut b = rand_value::<u32>();
+    if b == 0 {
+        // ensure we're not using a failure case.
+        b += 1;
+    }
+    let quot = (a / b) as u64;
+    let rem = (a % b) as u64;
+    let test = build_op_test!(build_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[rem, quot]);
+
+    // --- test that the rest of the stack isn't affected -----------------------------------------
+    let e = rand_value::<u64>();
+    let test = build_op_test!(build_asm_op(b).as_str(), &[e, a as u64]);
+    test.expect_stack(&[rem, quot, e]);
+}
+
+#[test]
+fn u32checked_divmod_b_fail() {
+    let build_asm_op = |param: u64| format!("u32checked_divmod.{}", param);
+
+    // should fail during execution if a >= 2^32.
+    let test = build_op_test!(build_asm_op(1).as_str(), &[U32_BOUND]);
+    test.expect_error(TestError::ExecutionError("NotU32Value"));
+
+    // should fail during compilation if b >= 2^32.
+    test_param_out_of_bounds("u32checked_divmod", U32_BOUND);
+
+    // should fail during compilation if b = 0.
+    let test = build_op_test!(build_asm_op(0).as_str());
+    test.expect_error(TestError::AssemblyError("parameter"));
+}
+
+#[test]
+fn u32unchecked_divmod() {
+    let asm_op = "u32unchecked_divmod";
+
+    test_divmod(asm_op);
+
+    // should not fail when inputs are out of bounds.
+    test_unsafe_execution(asm_op, 2);
+}
+
+#[test]
+fn u32unchecked_divmod_fail() {
+    let asm_op = "u32unchecked_divmod";
+
+    // should fail if b == 0.
     let test = build_op_test!(asm_op, &[1, 0]);
     test.expect_error(TestError::ExecutionError("DivideByZero"));
 }
@@ -1090,41 +1133,33 @@ proptest! {
     }
 
     #[test]
-    // issue: https://github.com/maticnetwork/miden/issues/94
     fn u32div_proptest(a in any::<u32>(), b in 1..u32::MAX) {
-        let asm_op = "u32div";
+        let asm_op = "u32checked_div";
 
-        let expected = a / b;
+        let expected = (a / b) as u64;
 
         // b provided via the stack.
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
-        test.prop_expect_stack(&[expected as u64])?;
+        test.prop_expect_stack(&[expected])?;
 
         // b provided as a parameter.
         let asm_op = format!("{}.{}", asm_op, b);
         let test = build_op_test!(&asm_op, &[a as u64]);
+        test.prop_expect_stack(&[expected])?;
+
+        // unchecked version should produce the same result for valid values.
+        let asm_op = "u32unchecked_div";
+        let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
 
-    }
-
-    #[test]
-    fn u32div_full_proptest(a in any::<u32>(), b in 1..u32::MAX) {
-        let asm_op = "u32div";
-
-        let quot = (a / b) as u64;
-        let rem = (a % b) as u64;
-
-        // full and unsafe should produce the same result for valid values.
-        let test = build_op_test!(format!("{}.full", asm_op).as_str(), &[a as u64, b as u64]);
-        test.prop_expect_stack(&[rem, quot])?;
-
-        let test = build_op_test!(format!("{}.unsafe", asm_op).as_str(), &[a as u64, b as u64]);
-        test.prop_expect_stack(&[rem, quot])?;
+        let asm_op = format!("{}.{}", asm_op, b);
+        let test = build_op_test!(&asm_op, &[a as u64]);
+        test.prop_expect_stack(&[expected as u64])?;
     }
 
     #[test]
     fn u32mod_proptest(a in any::<u32>(), b in 1..u32::MAX) {
-        let base_op = "u32mod";
+        let base_op = "u32checked_mod";
 
         let expected = a % b;
 
@@ -1137,44 +1172,78 @@ proptest! {
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[expected as u64])?;
 
-        // safe and unsafe should produce the same result for valid values.
-        let asm_op = format!("{}.unsafe", base_op);
+        // unchecked version should produce the same result for valid values.
+        let asm_op = "u32unchecked_mod";
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
+
+        let asm_op = format!("{}.{}", asm_op, b);
+        let test = build_op_test!(&asm_op, &[a as u64]);
+        test.prop_expect_stack(&[expected as u64])?;
+    }
+
+    #[test]
+    fn u32divmod_proptest(a in any::<u32>(), b in 1..u32::MAX) {
+        let asm_op = "u32checked_divmod";
+
+        let quot = (a / b) as u64;
+        let rem = (a % b) as u64;
+
+        // b provided via the stack.
+        let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+        test.prop_expect_stack(&[rem, quot])?;
+
+        // b provided as a parameter.
+        let asm_op = format!("{}.{}", asm_op, b);
+        let test = build_op_test!(&asm_op, &[a as u64]);
+        test.prop_expect_stack(&[rem, quot])?;
+
+        // unchecked version should produce the same result for valid values.
+        let asm_op = "u32unchecked_divmod";
+        let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
+        test.prop_expect_stack(&[rem, quot])?;
+
+        let asm_op = format!("{}.{}", asm_op, b);
+        let test = build_op_test!(&asm_op, &[a as u64]);
+        test.prop_expect_stack(&[rem, quot])?;
     }
 }
 
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// This helper function tests division with remainder for two u32 inputs for a number of simple
+/// This helper function tests division without remainder for two u32 inputs for a number of simple
 /// cases as well as for random values. It checks that the floor of a / b is pushed to the
-/// stack, along with the remainder a % b. Finally, it ensures that the rest of the stack was
-/// unaffected.
-fn test_div_full(asm_op: &str) {
+/// stack. Finally, it ensures that the rest of the stack was unaffected.
+fn test_div(asm_op: &str) {
     // --- simple cases ---------------------------------------------------------------------------
-    // division with no remainder
-    let test = build_op_test!(asm_op, &[2, 1]);
-    test.expect_stack(&[0, 2]);
+    let test = build_op_test!(asm_op, &[0, 1]);
+    test.expect_stack(&[0]);
 
-    // division with remainder
+    let test = build_op_test!(asm_op, &[2, 1]);
+    test.expect_stack(&[2]);
+
     let test = build_op_test!(asm_op, &[1, 2]);
-    test.expect_stack(&[1, 0]);
+    test.expect_stack(&[0]);
+
     let test = build_op_test!(asm_op, &[3, 2]);
-    test.expect_stack(&[1, 1]);
+    test.expect_stack(&[1]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
+    let mut b = rand_value::<u32>();
+    if b == 0 {
+        // ensure we're not using a failure case.
+        b += 1;
+    }
     let quot = (a / b) as u64;
-    let rem = (a % b) as u64;
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
-    test.expect_stack(&[rem, quot]);
+    test.expect_stack(&[quot]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
     let e = rand_value::<u64>();
     let test = build_op_test!(asm_op, &[e, a as u64, b as u64]);
-    test.expect_stack(&[rem, quot, e]);
+    test.expect_stack(&[quot, e]);
 }
 
 /// This helper function tests the modulus operation for two u32 inputs for a number of simple
@@ -1192,8 +1261,8 @@ fn test_mod(asm_op: &str) {
     test.expect_stack(&[5]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let mut b = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
+    let mut b = rand_value::<u32>();
     if b == 0 {
         // ensure we're not using a failure case.
         b += 1;
@@ -1206,4 +1275,41 @@ fn test_mod(asm_op: &str) {
     let c = rand_value::<u64>();
     let test = build_op_test!(asm_op, &[c, a as u64, b as u64]);
     test.expect_stack(&[expected as u64, c]);
+}
+
+/// This helper function tests division with remainder for two u32 inputs for a number of simple
+/// cases as well as for random values. It checks that the floor of a / b is pushed to the
+/// stack, along with the remainder a % b. Finally, it ensures that the rest of the stack was
+/// unaffected.
+fn test_divmod(asm_op: &str) {
+    // --- simple cases ---------------------------------------------------------------------------
+    let test = build_op_test!(asm_op, &[0, 1]);
+    test.expect_stack(&[0, 0]);
+
+    // division with no remainder
+    let test = build_op_test!(asm_op, &[2, 1]);
+    test.expect_stack(&[0, 2]);
+
+    // division with remainder
+    let test = build_op_test!(asm_op, &[1, 2]);
+    test.expect_stack(&[1, 0]);
+    let test = build_op_test!(asm_op, &[3, 2]);
+    test.expect_stack(&[1, 1]);
+
+    // --- random u32 values ----------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let mut b = rand_value::<u32>();
+    if b == 0 {
+        // ensure we're not using a failure case.
+        b += 1;
+    }
+    let quot = (a / b) as u64;
+    let rem = (a % b) as u64;
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[rem, quot]);
+
+    // --- test that the rest of the stack isn't affected -----------------------------------------
+    let e = rand_value::<u64>();
+    let test = build_op_test!(asm_op, &[e, a as u64, b as u64]);
+    test.expect_stack(&[rem, quot, e]);
 }

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -652,7 +652,7 @@ export.unchecked_shr
     add
     movup.2
     swap
-    u32div.unsafe
+    u32unchecked_divmod
     movup.3
     movup.3
     dup
@@ -662,7 +662,7 @@ export.unchecked_shr
     movdn.4
     dup
     movdn.4
-    u32div.unsafe
+    u32unchecked_divmod
     drop
     push.4294967296
     dup.5

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -10554,7 +10554,7 @@ export.unchecked_shr
     add
     movup.2
     swap
-    u32div.unsafe
+    u32unchecked_divmod
     movup.3
     movup.3
     dup
@@ -10564,7 +10564,7 @@ export.unchecked_shr
     movdn.4
     dup
     movdn.4
-    u32div.unsafe
+    u32unchecked_divmod
     drop
     push.4294967296
     dup.5


### PR DESCRIPTION
Refactoring of the `u32div` and `u32mod` operations to match stdlib underscoring style.