### PR TITLE
Implement RLP Decode for stdlib, add test

### DIFF
--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -46,6 +46,7 @@ structopt = { version = "0.3", default-features = false, optional = true }
 verifier = { package = "miden-verifier", path = "../verifier", version = "0.2", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.4", optional = true }
 vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
+rlp = "0.5.1"
 
 [dev-dependencies]
 blake3 = "1.3.1"

--- a/miden/tests/integration/stdlib/mod.rs
+++ b/miden/tests/integration/stdlib/mod.rs
@@ -2,4 +2,5 @@ use crate::build_test;
 
 mod crypto;
 mod math;
+mod str;
 mod sys;

--- a/miden/tests/integration/stdlib/str/mod.rs
+++ b/miden/tests/integration/stdlib/str/mod.rs
@@ -1,0 +1,3 @@
+use super::build_test;
+
+mod rlp;

--- a/miden/tests/integration/stdlib/str/rlp.rs
+++ b/miden/tests/integration/stdlib/str/rlp.rs
@@ -1,0 +1,150 @@
+use super::build_test;
+use rand_utils::rand_value;
+use rlp;
+
+struct FlagMemory {
+    flag: bool,
+    memory_address: Option<u32>,
+}
+
+// the decoding result should be stored on stack
+#[test]
+fn rlp_specific_value() {
+    let source = "
+    use.std::str::rlp
+
+    begin
+        exec.rlp::rlp_decode
+    end
+    ";
+    let origin_str = "results are stored on stack";
+    assert!(
+        origin_str.len() <= 34,
+        "the fixed-size convertion can only deal with string with lte 34 chars"
+    );
+    // flag - whether the decoding result should be stored into memory
+    let flag = false;
+    let flag_memory_on_stack = FlagMemory {
+        flag,
+        memory_address: None,
+    };
+    let rlp_encode_felt = comupute_rlp_encode_felt(origin_str, &flag_memory_on_stack);
+    let expected_result = compute_expected_result(origin_str, &flag_memory_on_stack);
+
+    build_test!(source, &[], &rlp_encode_felt, vec![]).expect_stack(&expected_result.0);
+}
+
+// the decoding result should be stored into memory
+#[test]
+fn rlp_specific_value_stored_into_memory() {
+    let source = "
+    use.std::str::rlp
+
+    begin
+        exec.rlp::rlp_decode
+    end
+    ";
+    let origin_str = "results are stored in memory";
+    assert!(
+        origin_str.len() <= 34,
+        "the fixed-size convertion can only deal with string with lte 34 chars"
+    );
+    // flag - whether the decoding result should be stored into memory
+    let flag = true;
+
+    // --- random u32 values ----------------------------------------------------------------------
+    let address = rand_value::<u64>() as u32;
+
+    let flag_memory_into_memory = FlagMemory {
+        flag,
+        memory_address: Some(address),
+    };
+    let rlp_encode_felt = comupute_rlp_encode_felt(origin_str, &flag_memory_into_memory);
+    let expected_result = compute_expected_result(origin_str, &flag_memory_into_memory);
+
+    build_test!(source, &[], &rlp_encode_felt, vec![]).expect_stack_and_memory(
+        &expected_result.0,
+        address as u64,
+        &expected_result.1,
+    );
+}
+
+// HELPER
+fn comupute_rlp_encode_felt(origin_string: &str, flag_memory: &FlagMemory) -> Vec<u64> {
+    // encoding the string into rlp code
+    let mut rlp_encode_felt: Vec<u64> = Vec::new();
+    let mut rlp_encode = rlp::encode(&origin_string).to_vec();
+
+    // if the length of string is not some multiple of 7, pad with 0s
+    for _i in 0..7 - (rlp_encode.len() % 7) {
+        rlp_encode.push(0);
+    }
+
+    // reverse, make the padding '0's leading '0's, little-endian
+    rlp_encode.reverse();
+    let mut single_rlp_felt: u64 = 0;
+    // combine every 7 rlp-element into a field element
+    for (i, &item) in rlp_encode.iter().enumerate() {
+        if i % 7 == 0 {
+            single_rlp_felt = item as u64;
+            continue;
+        }
+        single_rlp_felt = (single_rlp_felt as u64) * 256 + item as u64;
+        if i % 7 == 6 {
+            rlp_encode_felt.insert(0, single_rlp_felt);
+        }
+    }
+    // fixed-size, the input should be 5 field element
+    while rlp_encode_felt.len() < 5 {
+        rlp_encode_felt.push(0);
+    }
+    // flag == false -- the result should be on stack, should insert '0'
+    // flag == true -- the result should be stored into the memory address, should insert '1` at high-32-bit, and memory address at low-32-bit
+    if flag_memory.flag == false {
+        rlp_encode_felt.insert(0, 0);
+    } else {
+        rlp_encode_felt.insert(
+            0,
+            2_u64.pow(32) + flag_memory.memory_address.unwrap() as u64,
+        );
+    }
+    return rlp_encode_felt;
+}
+
+// HELPER
+fn compute_expected_result(origin_string: &str, flag_memory: &FlagMemory) -> (Vec<u64>, Vec<u64>) {
+    let mut expected_result: Vec<u64> = Vec::new();
+    let mut bytes = origin_string.as_bytes().to_vec();
+    // pad '0's in the end, and reverse it making them become leading '0's
+    for _i in 0..9 - (bytes.len() % 9) {
+        bytes.push(0);
+    }
+    bytes.reverse();
+
+    let mut ascii_felt: u64 = 0;
+    for (i, &item) in bytes.iter().enumerate() {
+        if i % 9 == 0 {
+            ascii_felt = item as u64;
+            continue;
+        }
+        ascii_felt = (ascii_felt as u64) * 128 + item as u64;
+        if i % 9 == 8 {
+            expected_result.insert(0, ascii_felt);
+        }
+    }
+    let mut decoding_result = expected_result.clone();
+    decoding_result.reverse();
+
+    // flag == false -- the result should be on stack
+    // flag == true -- the result should be stored into the memory address, should insert '1` at high-32-bit, and memory address at low-32-bit
+    if flag_memory.flag == false {
+        expected_result.insert(0, 0);
+    } else {
+        // the decoding result should be stored into memery
+        expected_result.clear();
+        expected_result.push(2_u64.pow(32) + flag_memory.memory_address.unwrap() as u64);
+    }
+    expected_result.insert(0, origin_string.len() as u64);
+
+    return (expected_result, decoding_result);
+}

--- a/stdlib/asm/str/rlp.masm
+++ b/stdlib/asm/str/rlp.masm
@@ -1,0 +1,128 @@
+# Total Number of VM Cycles: 638 #
+# This is used for 5 field-elements -> 4 field-elements RLP converting. #
+# Used to decode a RLP code which contains up to 34 chars, the decoding result is ASCII #
+# input: [a, b_0, b_1, b_2, b_3, b_4] #
+#   a: a_hi -- whether the decoding result will be put into memory #
+#      a_lo -- only if a_hi is '1', this is the memory address to put the decoding result in  #
+#   b_0 to b_4 are the RLP code #
+# output: a, b, (C)
+#   a: the number of chars in the RLP Code #
+#   b: b_hi -- whether the decoding result will be put into memory #
+#      b_lo -- only if b_hi is '1', this is the memory address to put the decoding result in  #
+#   C: the decoding result if not stored into memory. If the decoding result is stored into memory, C doesn't exist on stack. #
+
+export.rlp_decode.2
+    push.adv.1
+    pop.local.1                                                     #pop the first one into local[1]# 
+    # handle the first field element of RLP Code, which is unique to 2-5 field element.#
+    push.adv.1
+    u32split
+    swap
+    dup.0 push.255 u32and 
+    dup.0 push.162 lte assert                                       #make sure the string length is less than(or equal to) 34, otherwise error #
+    u32checked_sub.128 pop.local.0 u32shr.8                                    #local[0] should hold the first R-bytes, which represent the length of this string#
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 1st R-bytes, we need to make sure each char can be represent as ASCII#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 2nd R-bytes#
+    u32shr.8
+    movup.3
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 3rd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 4th R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 5rd R-bytes#
+    u32shr.8                                                        #the actuall 6rd R-bytes#
+    drop                                                            #the leading 0 should be discarded. #
+    dup.0 push.128 u32and not assert
+
+    # read the 2nd field element #
+    push.adv.1 u32split swap
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the 1nd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the 2nd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the 3nd R-bytes, now 9 ASCII have been read, we need to do one compression #
+
+    movdn.10 movup.3 movdn.10
+    repeat.8
+        mul.128 add
+    end
+    movdn.2 u32shr.8                                                    #the 4th R-bytes#
+    dup.0 push.128 u32and not assert
+    swap dup.0 dup.0 push.128 u32and not assert push.255 u32and swap    #the 5th R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 6th R-bytes#
+    u32shr.8                                                            #the 7th R-bytes#
+    dup.0 push.128 u32and not assert
+
+    # read the 3rd field element #
+    push.adv.1 u32split swap
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 1st R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 2rd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 3rd R-bytes#
+    u32shr.8                                                            #the 4th R-bytes#
+    dup.0 push.128 u32and not assert
+
+    movup.4
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 5th R-bytes,now 9 ASCII have been read, we need to do one compression #
+    movdn.10 
+    repeat.8
+         mul.128 add
+    end
+    swap movup.2
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 6th R-bytes#
+    u32shr.8                                                            #the 7th R-bytes#
+    dup.0 push.128 u32and not assert
+
+    # read the 4th field element #
+    push.adv.1 u32split swap
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 1st R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 2rd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 3rd R-bytes#
+    u32shr.8                                                            #the 4th R-bytes#
+    dup.0 push.128 u32and not assert
+    movup.4
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 5th R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 6th R-bytes#
+    u32shr.8                                                            #the 7th R-bytes, do one compression#
+    dup.0 push.128 u32and not assert 
+    repeat.8
+        mul.128 add 
+    end
+    movdn.2
+
+    # read the 5th field element #
+    push.adv.1 u32split swap
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 1st R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 2rd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 3rd R-bytes#
+    u32shr.8                                                           #the 4th R-bytes#
+    dup.0 push.128 u32and not assert
+    movup.4
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 5th R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 6th R-bytes#
+    u32shr.8                                                           #the 7th R-bytes#
+    dup.0 push.128 u32and not assert
+    push.0.0                                                           #add leading 0s make 9 items, do one compression #
+    repeat.8
+        mul.128 add
+    end
+    movdn.3 push.local.1 dup.0 movdn.5
+    u32split
+    if.true
+        popw.mem
+    else
+        drop
+        movup.4
+    end
+    push.local.0
+end

--- a/stdlib/docs/rlp_str.md
+++ b/stdlib/docs/rlp_str.md
@@ -1,0 +1,4 @@
+## std::str::rlp
+| Procedure | Description |
+| ----------- | ------------- |
+| rlp_decode.2 | This is used for 5 field-elements -> 4 field-elements RLP converting. Used to decode a RLP code which contains up to 34 chars, the decoding result is ASCII in the form of WORD <br /> <br /> Input: [a, b_0, b_1, b_2, b_3, b_4] <br /> a: `a_hi` -- whether the decoding result will be put into memory;<br />a: `a_lo` -- only if `a_hi` is '1', this is the memory address to put the decoding result in  <br />  b_0 to b_4 : are the RLP code.<br /><br />Output: a, b, (C)<br /> a: the number of chars in the RLP Code <br />   b: `b_hi` -- whether the decoding result will be put into memory;<br />b: `b_lo` -- only if `b_hi` is '1', this is the memory address to put the decoding result in  <br />  C: the decoding result if not stored into memory. If the decoding result is stored into memory, C doesn't exist on stack. |

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -4,7 +4,7 @@
 ///
 /// Entries in the array are tuples containing module namespace and module source code.
 #[rustfmt::skip]
-pub const MODULES: [(&str, &str); 6] = [
+pub const MODULES: [(&str, &str); 7] = [
 // ----- std::crypto::hashes::blake3 --------------------------------------------------------------
 ("std::crypto::hashes::blake3", "# Initializes four memory addresses, provided for storing initial 4x4 blake3 
 # state matrix ( i.e. 16 elements each of 32 -bit ), for computing blake3 2-to-1 hash
@@ -10466,6 +10466,135 @@ export.unchecked_rotr
     cswap
 end
 "),
+// ----- std::str::rlp ----------------------------------------------------------------------------
+("std::str::rlp", "# Total Number of VM Cycles: 638 #
+# This is used for 5 field-elements -> 4 field-elements RLP converting. #
+# Used to decode a RLP code which contains up to 34 chars, the decoding result is ASCII #
+# input: [a, b_0, b_1, b_2, b_3, b_4] #
+#   a: a_hi -- whether the decoding result will be put into memory #
+#      a_lo -- only if a_hi is '1', this is the memory address to put the decoding result in  #
+#   b_0 to b_4 are the RLP code #
+# output: a, b, (C)
+#   a: the number of chars in the RLP Code #
+#   b: b_hi -- whether the decoding result will be put into memory #
+#      b_lo -- only if b_hi is '1', this is the memory address to put the decoding result in  #
+#   C: the decoding result if not stored into memory. If the decoding result is stored into memory, C doesn't exist on stack. #
+
+export.rlp_decode.2
+    push.adv.1
+    pop.local.1                                                     #pop the first one into local[1]# 
+    # handle the first field element of RLP Code, which is unique to 2-5 field element.#
+    push.adv.1
+    u32split
+    swap
+    dup.0 push.255 u32and 
+    dup.0 push.162 lte assert                                       #make sure the string length is less than(or equal to) 34, otherwise error #
+    u32checked_sub.128 pop.local.0 u32shr.8                                    #local[0] should hold the first R-bytes, which represent the length of this string#
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 1st R-bytes, we need to make sure each char can be represent as ASCII#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 2nd R-bytes#
+    u32shr.8
+    movup.3
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 3rd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 4th R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the actuall 5rd R-bytes#
+    u32shr.8                                                        #the actuall 6rd R-bytes#
+    drop                                                            #the leading 0 should be discarded. #
+    dup.0 push.128 u32and not assert
+
+    # read the 2nd field element #
+    push.adv.1 u32split swap
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the 1nd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the 2nd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap     #the 3nd R-bytes, now 9 ASCII have been read, we need to do one compression #
+
+    movdn.10 movup.3 movdn.10
+    repeat.8
+        mul.128 add
+    end
+    movdn.2 u32shr.8                                                    #the 4th R-bytes#
+    dup.0 push.128 u32and not assert
+    swap dup.0 dup.0 push.128 u32and not assert push.255 u32and swap    #the 5th R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 6th R-bytes#
+    u32shr.8                                                            #the 7th R-bytes#
+    dup.0 push.128 u32and not assert
+
+    # read the 3rd field element #
+    push.adv.1 u32split swap
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 1st R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 2rd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 3rd R-bytes#
+    u32shr.8                                                            #the 4th R-bytes#
+    dup.0 push.128 u32and not assert
+
+    movup.4
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 5th R-bytes,now 9 ASCII have been read, we need to do one compression #
+    movdn.10 
+    repeat.8
+         mul.128 add
+    end
+    swap movup.2
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 6th R-bytes#
+    u32shr.8                                                            #the 7th R-bytes#
+    dup.0 push.128 u32and not assert
+
+    # read the 4th field element #
+    push.adv.1 u32split swap
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 1st R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 2rd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 3rd R-bytes#
+    u32shr.8                                                            #the 4th R-bytes#
+    dup.0 push.128 u32and not assert
+    movup.4
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 5th R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap         #the 6th R-bytes#
+    u32shr.8                                                            #the 7th R-bytes, do one compression#
+    dup.0 push.128 u32and not assert 
+    repeat.8
+        mul.128 add 
+    end
+    movdn.2
+
+    # read the 5th field element #
+    push.adv.1 u32split swap
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 1st R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 2rd R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 3rd R-bytes#
+    u32shr.8                                                           #the 4th R-bytes#
+    dup.0 push.128 u32and not assert
+    movup.4
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 5th R-bytes#
+    u32shr.8
+    dup.0 dup.0 push.128 u32and not assert push.255 u32and swap        #the 6th R-bytes#
+    u32shr.8                                                           #the 7th R-bytes#
+    dup.0 push.128 u32and not assert
+    push.0.0                                                           #add leading 0s make 9 items, do one compression #
+    repeat.8
+        mul.128 add
+    end
+    movdn.3 push.local.1 dup.0 movdn.5
+    u32split
+    if.true
+        popw.mem
+    else
+        drop
+        movup.4
+    end
+    push.local.0
+end"),
 // ----- std::sys ---------------------------------------------------------------------------------
 ("std::sys", "# Removes elements deep in the stack until the depth of the stack is exactly 16. The elements
 # are removed in such a way that the top 16 elements of the stack remain unchanged.


### PR DESCRIPTION
This PR adds RLP decoding procedure to the standard library, which should be used as `std::str` as mentioned in https://github.com/maticnetwork/miden/issues/295
This RLP decoding method deals with each RLP Code element, turning each one(8-bits) into ASCII(7-bits), and combining 9 ASCII into 1 field-element. The decoding result will have better performance when doing String operation. The RLP code is now set to a fixed length (**inputs**: 5 field elements; **outputs**: 4 field elements) and will expand to other forms later.
- Total Number of VM Cycles: 638 
- input: [a, b_0, b_1, b_2, b_3, b_4]  
  a:  `a_hi` -- whether the decoding result will be put into memory 
       `a_lo` -- only if a_hi is '1', this is the memory address to put the decoding result in  
  b_0 to b_4: are the field-element form of RLP code 
- output: a, b, (C)
   a: the number of chars in the RLP Code 
   b: `b_hi` -- whether the decoding result will be put into memory 
       `b_lo` -- only if b_hi is '1', this is the memory address to put the decoding result in  
   (C): the decoding result if not stored into memory. If the decoding result is stored into memory, C won't exist on stack. 