### PR TITLE
refactor(proc): remove row index from the bitwise ops output

### DIFF
--- a/processor/src/chiplets/bitwise/mod.rs
+++ b/processor/src/chiplets/bitwise/mod.rs
@@ -78,14 +78,12 @@ impl Bitwise {
     // TRACE MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// Computes a bitwise AND of `a` and `b` and returns the result along with the index of the
-    /// result row, which is used for the lookup product column used for multiset checks. We assume
-    /// that `a` and `b` are 32-bit values. If that's not the case, the result of the computation is
-    /// undefined.
+    /// Computes a bitwise AND of `a` and `b` and returns the result. We assume that `a` and `b`
+    /// are 32-bit values. If that's not the case, the result of the computation is undefined.
     ///
     /// This also adds 8 rows to the internal execution trace table required for computing the
     /// operation.
-    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
+    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
         let a = assert_u32(a)?.as_int();
         let b = assert_u32(b)?.as_int();
         let mut result = 0u64;
@@ -112,20 +110,15 @@ impl Bitwise {
             self.trace[13].push(Felt::new(result));
         }
 
-        // Return the result row for calculating the lookup product.
-        let result_row = self.trace_len() - 1;
-
-        Ok((Felt::new(result), Felt::new(result_row as u64)))
+        Ok(Felt::new(result))
     }
 
-    /// Computes a bitwise OR of `a` and `b` and returns the result along with the index of the
-    /// result row, which is used for the lookup product column used for multiset checks. We assume
-    /// that `a` and `b` are 32-bit values. If that's not the case, the result of the computation is
-    /// undefined.
+    /// Computes a bitwise OR of `a` and `b` and returns the result. We assume that `a` and `b`
+    ///  are 32-bit values. If that's not the case, the result of the computation is undefined.
     ///
     /// This also adds 8 rows to the internal execution trace table required for computing the
     /// operation.
-    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
+    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
         let a = assert_u32(a)?.as_int();
         let b = assert_u32(b)?.as_int();
         let mut result = 0u64;
@@ -152,20 +145,15 @@ impl Bitwise {
             self.trace[13].push(Felt::new(result));
         }
 
-        // Return the result row for calculating the lookup product.
-        let result_row = self.trace_len() - 1;
-
-        Ok((Felt::new(result), Felt::new(result_row as u64)))
+        Ok(Felt::new(result))
     }
 
-    /// Computes a bitwise XOR of `a` and `b` and returns the result along with the index of the
-    /// result row, which is used for the lookup product column used for multiset checks. We assume
-    /// that `a` and `b` are 32-bit values. If that's not the case, the result of the computation is
-    /// undefined.
+    /// Computes a bitwise XOR of `a` and `b` and returns the result. We assume that `a` and `b`
+    /// are 32-bit values. If that's not the case, the result of the computation is undefined.
     ///
     /// This also adds 8 rows to the internal execution trace table required for computing the
     /// operation.
-    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
+    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
         let a = assert_u32(a)?.as_int();
         let b = assert_u32(b)?.as_int();
         let mut result = 0u64;
@@ -192,10 +180,7 @@ impl Bitwise {
             self.trace[13].push(Felt::new(result));
         }
 
-        // Return the result row for calculating the lookup product.
-        let result_row = self.trace_len() - 1;
-
-        Ok((Felt::new(result), Felt::new(result_row as u64)))
+        Ok(Felt::new(result))
     }
 
     // EXECUTION TRACE GENERATION

--- a/processor/src/chiplets/bitwise/tests.rs
+++ b/processor/src/chiplets/bitwise/tests.rs
@@ -2,7 +2,6 @@ use super::{
     Bitwise, Felt, StarkField, TraceFragment, BITWISE_AND, BITWISE_OR, BITWISE_XOR, TRACE_WIDTH,
 };
 use rand_utils::rand_value;
-use vm_core::bitwise::OP_CYCLE_LEN;
 
 #[test]
 fn bitwise_init() {
@@ -17,10 +16,8 @@ fn bitwise_and() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let (result, row_idx) = bitwise.u32and(a, b).unwrap();
-    let expected_row = OP_CYCLE_LEN - 1;
+    let result = bitwise.u32and(a, b).unwrap();
     assert_eq!(a.as_int() & b.as_int(), result.as_int());
-    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
@@ -66,10 +63,8 @@ fn bitwise_or() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let (result, row_idx) = bitwise.u32or(a, b).unwrap();
-    let expected_row = OP_CYCLE_LEN - 1;
+    let result = bitwise.u32or(a, b).unwrap();
     assert_eq!(a.as_int() | b.as_int(), result.as_int());
-    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
@@ -115,10 +110,8 @@ fn bitwise_xor() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let (result, row_idx) = bitwise.u32xor(a, b).unwrap();
-    let expected_row = OP_CYCLE_LEN - 1;
+    let result = bitwise.u32xor(a, b).unwrap();
     assert_eq!(a.as_int() ^ b.as_int(), result.as_int());
-    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
@@ -165,28 +158,20 @@ fn bitwise_multiple() {
     let b = [rand_u32(), rand_u32(), rand_u32(), rand_u32()];
 
     // first operation: AND
-    let (result0, row_idx) = bitwise.u32and(a[0], b[0]).unwrap();
-    let mut expected_row = OP_CYCLE_LEN - 1;
+    let result0 = bitwise.u32and(a[0], b[0]).unwrap();
     assert_eq!(a[0].as_int() & b[0].as_int(), result0.as_int());
-    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // second operation: OR
-    let (result1, row_idx) = bitwise.u32or(a[1], b[1]).unwrap();
-    expected_row += OP_CYCLE_LEN;
+    let result1 = bitwise.u32or(a[1], b[1]).unwrap();
     assert_eq!(a[1].as_int() | b[1].as_int(), result1.as_int());
-    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // third operation: XOR
-    let (result2, row_idx) = bitwise.u32xor(a[2], b[2]).unwrap();
-    expected_row += OP_CYCLE_LEN;
+    let result2 = bitwise.u32xor(a[2], b[2]).unwrap();
     assert_eq!(a[2].as_int() ^ b[2].as_int(), result2.as_int());
-    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // fourth operation: AND
-    let (result3, row_idx) = bitwise.u32and(a[3], b[3]).unwrap();
-    expected_row += OP_CYCLE_LEN;
+    let result3 = bitwise.u32and(a[3], b[3]).unwrap();
     assert_eq!(a[3].as_int() & b[3].as_int(), result3.as_int());
-    assert_eq!(row_idx, Felt::new(expected_row as u64));
 
     // --- check generated trace ----------------------------------------------
     let num_rows = 32;

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -155,27 +155,24 @@ impl Chiplets {
     // BITWISE CHIPLET ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Requests a bitwise AND of `a` and `b` from the Bitwise chiplet. Returns the result along
-    /// with the index of the  result row, which is used for the lookup product column used for
-    /// multiset checks. We assume that `a` and `b` are 32-bit values. If that's not the case, the
-    /// result of the computation is undefined.
-    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
+    /// Requests a bitwise AND of `a` and `b` from the Bitwise chiplet and returns the result.
+    /// We assume that `a` and `b` are 32-bit values. If that's not the case, the result of the
+    /// computation is undefined.
+    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
         self.bitwise.u32and(a, b)
     }
 
-    /// Requests a bitwise OR of `a` and `b` from the Bitwise chiplet. Returns the result along with
-    /// the index of the result row, which is used for the lookup product column used for multiset
-    /// checks. We assume that `a` and `b` are 32-bit values. If that's not the case, the result of
-    /// the computation is undefined.
-    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
+    /// Requests a bitwise OR of `a` and `b` from the Bitwise chiplet and returns the result.
+    /// We assume that `a` and `b` are 32-bit values. If that's not the case, the result of the
+    /// computation is undefined.
+    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
         self.bitwise.u32or(a, b)
     }
 
-    /// Requests a bitwise XOR of `a` and `b` from the Bitwise chiplet and returns the result along
-    /// with the index of the result row, which is used for the lookup product column used for
-    /// multiset checks. We assume that `a` and `b` are 32-bit values. If that's not the case, the
-    /// result of the computation is undefined.
-    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<(Felt, Felt), ExecutionError> {
+    /// Requests a bitwise XOR of `a` and `b` from the Bitwise chiplet and returns the result.
+    /// We assume that `a` and `b` are 32-bit values. If that's not the case, the result of the
+    /// computation is undefined.
+    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
         self.bitwise.u32xor(a, b)
     }
 

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -869,24 +869,6 @@ fn loop_block_repeat() {
 // HELPER REGISTERS TESTS
 // ================================================================================================
 #[test]
-fn set_user_op_helpers_one() {
-    // --- user operation with 1 helper value -----------------------------------------------------
-    let ops = vec![Operation::U32and, Operation::U32and];
-    let program = CodeBlock::new_span(ops);
-    let (trace, _, _) = build_trace(&[2, 6, 1], &program);
-
-    // Check the hasher state of the final user operation which was executed.
-    let hasher_state = get_hasher_state(&trace, 2);
-
-    // h0 holds the number of ops left in the group, which is 0. h1 holds the parent addr, which is
-    // ZERO. h2 holds one helper value, which is the lookup row in the bitwise trace. everything
-    // else is unused.
-    let expected = build_expected_hasher_state(&[ZERO, ZERO, Felt::new(15)]);
-
-    assert_eq!(expected, hasher_state);
-}
-
-#[test]
 fn set_user_op_helpers_many() {
     // --- user operation with 4 helper values ----------------------------------------------------
     let program = CodeBlock::new_span(vec![Operation::U32div]);

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -168,12 +168,10 @@ impl Process {
     pub(super) fn op_u32and(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
-        let (result, row_idx) = self.chiplets.u32and(a, b)?;
+        let result = self.chiplets.u32and(a, b)?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);
-        self.decoder
-            .set_user_op_helpers(Operation::U32and, &[row_idx]);
 
         Ok(())
     }
@@ -183,12 +181,10 @@ impl Process {
     pub(super) fn op_u32or(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
-        let (result, row_idx) = self.chiplets.u32or(a, b)?;
+        let result = self.chiplets.u32or(a, b)?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);
-        self.decoder
-            .set_user_op_helpers(Operation::U32or, &[row_idx]);
 
         Ok(())
     }
@@ -198,12 +194,10 @@ impl Process {
     pub(super) fn op_u32xor(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
-        let (result, row_idx) = self.chiplets.u32xor(a, b)?;
+        let result = self.chiplets.u32xor(a, b)?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);
-        self.decoder
-            .set_user_op_helpers(Operation::U32xor, &[row_idx]);
 
         Ok(())
     }


### PR DESCRIPTION
This PR removes the row index from the output of bitwise operations in the bitwise chiplet. We have inputs (a and b) and output (z) at the same row in the execution trace and might not require the row index anymore. 

-  remove row index as it is not needed in multiset check
-  remove bitwise single helper test from decoder unit tests (we can have this test back when #308 gets merged as it will also have one helper register).  