### PR TITLE
Bitwise and comparison ops refactoring

### DIFF
--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -96,23 +96,45 @@ fn parse_op_token(
         "u32checked_divmod" => u32_ops::parse_u32divmod(span_ops, op, U32OpMode::Checked),
         "u32unchecked_divmod" => u32_ops::parse_u32divmod(span_ops, op, U32OpMode::Unchecked),
 
-        "u32and" => u32_ops::parse_u32and(span_ops, op),
-        "u32or" => u32_ops::parse_u32or(span_ops, op),
-        "u32xor" => u32_ops::parse_u32xor(span_ops, op),
-        "u32not" => u32_ops::parse_u32not(span_ops, op),
-        "u32shr" => u32_ops::parse_u32shr(span_ops, op),
-        "u32shl" => u32_ops::parse_u32shl(span_ops, op),
-        "u32rotr" => u32_ops::parse_u32rotr(span_ops, op),
-        "u32rotl" => u32_ops::parse_u32rotl(span_ops, op),
+        "u32checked_and" => u32_ops::parse_u32and(span_ops, op),
+        "u32checked_or" => u32_ops::parse_u32or(span_ops, op),
+        "u32checked_xor" => u32_ops::parse_u32xor(span_ops, op),
+        "u32checked_not" => u32_ops::parse_u32not(span_ops, op),
 
-        "u32eq" => u32_ops::parse_u32eq(span_ops, op),
-        "u32neq" => u32_ops::parse_u32neq(span_ops, op),
-        "u32lt" => u32_ops::parse_u32lt(span_ops, op),
-        "u32lte" => u32_ops::parse_u32lte(span_ops, op),
-        "u32gt" => u32_ops::parse_u32gt(span_ops, op),
-        "u32gte" => u32_ops::parse_u32gte(span_ops, op),
-        "u32min" => u32_ops::parse_u32min(span_ops, op),
-        "u32max" => u32_ops::parse_u32max(span_ops, op),
+        "u32checked_shr" => u32_ops::parse_u32shr(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_shr" => u32_ops::parse_u32shr(span_ops, op, U32OpMode::Unchecked),
+        "u32overflowing_shr" => u32_ops::parse_u32shr(span_ops, op, U32OpMode::Overflowing),
+
+        "u32checked_shl" => u32_ops::parse_u32shl(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_shl" => u32_ops::parse_u32shl(span_ops, op, U32OpMode::Unchecked),
+        "u32overflowing_shl" => u32_ops::parse_u32shl(span_ops, op, U32OpMode::Overflowing),
+
+        "u32checked_rotr" => u32_ops::parse_u32rotr(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_rotr" => u32_ops::parse_u32rotr(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_rotl" => u32_ops::parse_u32rotl(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_rotl" => u32_ops::parse_u32rotl(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_eq" => u32_ops::parse_u32eq(span_ops, op),
+        "u32checked_neq" => u32_ops::parse_u32neq(span_ops, op),
+
+        "u32checked_lt" => u32_ops::parse_u32lt(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_lt" => u32_ops::parse_u32lt(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_lte" => u32_ops::parse_u32lte(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_lte" => u32_ops::parse_u32lte(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_gt" => u32_ops::parse_u32gt(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_gt" => u32_ops::parse_u32gt(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_gte" => u32_ops::parse_u32gte(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_gte" => u32_ops::parse_u32gte(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_min" => u32_ops::parse_u32min(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_min" => u32_ops::parse_u32min(span_ops, op, U32OpMode::Unchecked),
+
+        "u32checked_max" => u32_ops::parse_u32max(span_ops, op, U32OpMode::Checked),
+        "u32unchecked_max" => u32_ops::parse_u32max(span_ops, op, U32OpMode::Unchecked),
 
         // ----- stack manipulation ---------------------------------------------------------------
         "drop" => stack_ops::parse_drop(span_ops, op),

--- a/miden/tests/integration/air/chiplets/bitwise.rs
+++ b/miden/tests/integration/air/chiplets/bitwise.rs
@@ -4,7 +4,7 @@ use crate::{build_op_test, build_test};
 fn bitwise_and() {
     // Test all bit input combinations: (1, 1), (1, 0), (0, 0). Then test larger numbers.
     // the last drop at the end is added to make sure stack overflow table is empty at the end
-    let asm_op = "u32and push.0 u32and push.0 u32and push.65535 push.137 u32and drop";
+    let asm_op = "u32checked_and push.0 u32checked_and push.0 u32checked_and push.65535 push.137 u32checked_and drop";
     let pub_inputs = vec![1, 1];
 
     build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
@@ -14,7 +14,7 @@ fn bitwise_and() {
 fn bitwise_or() {
     // Test all bit input combinations: (1, 1), (1, 0), (0, 0). Then test larger numbers.
     // the last drop at the end is added to make sure stack overflow table is empty at the end
-    let asm_op = "u32or push.0 u32or not push.0 u32or push.65535 push.137 u32or drop";
+    let asm_op = "u32checked_or push.0 u32checked_or not push.0 u32checked_or push.65535 push.137 u32checked_or drop";
     let pub_inputs = vec![1, 1];
 
     build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
@@ -24,7 +24,7 @@ fn bitwise_or() {
 fn bitwise_xor() {
     // Test all bit input combinations: (1, 1), (0, 0), (1, 0). Then test larger numbers
     // the last drop at the end is added to make sure stack overflow table is empty at the end
-    let asm_op = "u32xor push.0 u32xor push.1 u32xor push.65535 push.137 u32xor drop";
+    let asm_op = "u32checked_xor push.0 u32checked_xor push.1 u32checked_xor push.65535 push.137 u32checked_xor drop";
     let pub_inputs = vec![1, 1];
 
     build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
@@ -56,7 +56,8 @@ fn pow2() {
 
 #[test]
 fn all_operations() {
-    let source = "begin u32and push.0 u32or push.0 u32xor push.9 pow2 drop end";
+    let source =
+        "begin u32checked_and push.0 u32checked_or push.0 u32checked_xor push.9 pow2 drop end";
     let pub_inputs = vec![1, 1];
 
     build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);

--- a/miden/tests/integration/air/chiplets/mod.rs
+++ b/miden/tests/integration/air/chiplets/mod.rs
@@ -9,11 +9,11 @@ mod memory;
 fn chiplets() {
     // Test a program that uses all of the chiplets.
     let source = "begin
-        rpperm                  # hasher operation
-        push.5 push.10 u32or    # bitwise operation
-        pow2                    # power of two operation
-        push.mem                # memory operation
-        drop                    # make sure the stack overflow table is empty
+        rpperm                          # hasher operation
+        push.5 push.10 u32checked_or    # bitwise operation
+        pow2                            # power of two operation
+        push.mem                        # memory operation
+        drop                            # make sure the stack overflow table is empty
     end";
     let pub_inputs = rand_vector::<u64>(8);
 

--- a/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -8,8 +8,8 @@ use rand_utils::rand_value;
 // ================================================================================================
 
 #[test]
-fn u32and() {
-    let asm_op = "u32and";
+fn u32checked_and() {
+    let asm_op = "u32checked_and";
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[1, 1]);
@@ -25,24 +25,23 @@ fn u32and() {
     test.expect_stack(&[0]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>();
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[(a & b) as u64]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
-    let c = rand_value::<u64>() as u32;
-    let d = rand_value::<u64>() as u32;
+    let c = rand_value::<u32>();
+    let d = rand_value::<u32>();
 
     let test = build_op_test!(asm_op, &[c as u64, d as u64, a as u64, b as u64]);
     test.expect_stack(&[(a & b) as u64, d as u64, c as u64]);
 }
 
 #[test]
-// issue: https://github.com/maticnetwork/miden/issues/74
-fn u32and_fail() {
-    let asm_op = "u32and";
+fn u32checked_and_fail() {
+    let asm_op = "u32checked_and";
 
     let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
     test.expect_error(TestError::ExecutionError("NotU32Value"));
@@ -52,8 +51,8 @@ fn u32and_fail() {
 }
 
 #[test]
-fn u32or() {
-    let asm_op = "u32or";
+fn u32checked_or() {
+    let asm_op = "u32checked_or";
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[1, 1]);
@@ -69,24 +68,23 @@ fn u32or() {
     test.expect_stack(&[0]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>();
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[(a | b) as u64]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
-    let c = rand_value::<u64>() as u32;
-    let d = rand_value::<u64>() as u32;
+    let c = rand_value::<u32>();
+    let d = rand_value::<u32>();
 
     let test = build_op_test!(asm_op, &[c as u64, d as u64, a as u64, b as u64]);
     test.expect_stack(&[(a | b) as u64, d as u64, c as u64]);
 }
 
 #[test]
-// issue: https://github.com/maticnetwork/miden/issues/74
-fn u32or_fail() {
-    let asm_op = "u32or";
+fn u32checked_or_fail() {
+    let asm_op = "u32checked_or";
 
     let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
     test.expect_error(TestError::ExecutionError("NotU32Value"));
@@ -96,8 +94,8 @@ fn u32or_fail() {
 }
 
 #[test]
-fn u32xor() {
-    let asm_op = "u32xor";
+fn u32checked_xor() {
+    let asm_op = "u32checked_xor";
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[1, 1]);
@@ -113,23 +111,22 @@ fn u32xor() {
     test.expect_stack(&[0]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>();
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[(a ^ b) as u64]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
-    let c = rand_value::<u64>() as u32;
-    let d = rand_value::<u64>() as u32;
+    let c = rand_value::<u32>();
+    let d = rand_value::<u32>();
     let test = build_op_test!(asm_op, &[c as u64, d as u64, a as u64, b as u64]);
     test.expect_stack(&[(a ^ b) as u64, d as u64, c as u64]);
 }
 
 #[test]
-// issue: https://github.com/maticnetwork/miden/issues/74
-fn u32xor_fail() {
-    let asm_op = "u32xor";
+fn u32checked_xor_fail() {
+    let asm_op = "u32checked_xor";
 
     let test = build_op_test!(asm_op, &[U32_BOUND, 0]);
     test.expect_error(TestError::ExecutionError("NotU32Value"));
@@ -139,8 +136,8 @@ fn u32xor_fail() {
 }
 
 #[test]
-fn u32not() {
-    let asm_op = "u32not";
+fn u32checked_not() {
+    let asm_op = "u32checked_not";
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[U32_BOUND - 1]);
@@ -150,28 +147,28 @@ fn u32not() {
     test.expect_stack(&[U32_BOUND - 1]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
 
     let test = build_op_test!(asm_op, &[a as u64]);
     test.expect_stack(&[!a as u64]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
-    let b = rand_value::<u64>() as u32;
+    let b = rand_value::<u32>();
 
     let test = build_op_test!(asm_op, &[b as u64, a as u64]);
     test.expect_stack(&[!a as u64, b as u64]);
 }
 
 #[test]
-fn u32not_fail() {
-    let asm_op = "u32not";
+fn u32checked_not_fail() {
+    let asm_op = "u32checked_not";
     test_input_out_of_bounds(asm_op);
 }
 
 #[test]
-fn u32shl() {
+fn u32checked_shl() {
     // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
-    let asm_op = "u32shl";
+    let asm_op = "u32checked_shl";
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u32;
@@ -187,23 +184,23 @@ fn u32shl() {
     test.expect_stack(&[a.wrapping_shl(b) as u64]);
 
     // --- test b = 0 -----------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.wrapping_shl(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.wrapping_shl(b) as u64]);
 }
 
 #[test]
-fn u32shl_fail() {
-    let asm_op = "u32shl";
+fn u32checked_shl_fail() {
+    let asm_op = "u32checked_shl";
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
@@ -216,9 +213,9 @@ fn u32shl_fail() {
 }
 
 #[test]
-fn u32shl_b() {
+fn u32checked_shl_b() {
     // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
-    let op_base = "u32shl";
+    let op_base = "u32checked_shl";
     let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
 
     // --- test simple case -----------------------------------------------------------------------
@@ -235,32 +232,108 @@ fn u32shl_b() {
     test.expect_stack(&[a.wrapping_shl(b) as u64]);
 
     // --- test b = 0 -----------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.wrapping_shl(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.wrapping_shl(b) as u64]);
 }
 
 #[test]
-fn u32shl_b_fail() {
-    let op_base = "u32shl";
+fn u32checked_shl_b_fail() {
+    let op_base = "u32checked_shl";
 
     test_input_out_of_bounds(format!("{}.{}", op_base, 1).as_str());
     test_param_out_of_bounds(op_base, 32);
 }
 
 #[test]
-fn u32shl_unsafe() {
+fn u32unchecked_shl() {
     // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
-    let asm_op = "u32shl.unsafe";
+    let asm_op = "u32unchecked_shl";
+
+    // --- test simple case -----------------------------------------------------------------------
+    let a = 1_u32;
+    let b = 1_u32;
+    let test = build_op_test!(asm_op, &[5, a as u64, b as u64]);
+    test.expect_stack(&[2, 5]);
+
+    // --- test max values of a and b -------------------------------------------------------------
+    let a = (U32_BOUND - 1) as u32;
+    let b = 31;
+
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[a.wrapping_shl(b) as u64]);
+
+    // --- test b = 0 -----------------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = 0;
+
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[a.wrapping_shl(b) as u64]);
+
+    // --- test random values ---------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
+
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[a.wrapping_shl(b) as u64]);
+
+    // --- test out of bounds input (should not fail) --------------------------------------------
+    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
+    assert!(test.execute().is_ok());
+}
+
+#[test]
+fn u32unchecked_shl_b() {
+    // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
+    let op_base = "u32unchecked_shl";
+    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+
+    // --- test simple case -----------------------------------------------------------------------
+    let a = 1_u32;
+    let b = 1_u32;
+    let test = build_op_test!(get_asm_op(b).as_str(), &[5, a as u64]);
+    test.expect_stack(&[2, 5]);
+
+    // --- test max values of a and b -------------------------------------------------------------
+    let a = (U32_BOUND - 1) as u32;
+    let b = 31;
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shl(b) as u64]);
+
+    // --- test b = 0 -----------------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = 0;
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shl(b) as u64]);
+
+    // --- test random values ---------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shl(b) as u64]);
+
+    // --- test out of bounds input (should not fail) --------------------------------------------
+    let b = 1;
+    let test = build_op_test!(get_asm_op(b).as_str(), &[U32_BOUND]);
+    assert!(test.execute().is_ok());
+}
+
+#[test]
+fn u32overflowing_shl() {
+    // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
+    let asm_op = "u32overflowing_shl";
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u32;
@@ -278,15 +351,15 @@ fn u32shl_unsafe() {
     test.expect_stack(&[d as u64, c as u64]);
 
     // --- test b = 0 -----------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[0, a as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
     let c = a.wrapping_shl(b);
     let d = if b == 0 { 0 } else { a.wrapping_shr(32 - b) };
 
@@ -299,9 +372,52 @@ fn u32shl_unsafe() {
 }
 
 #[test]
-fn u32shr() {
+fn u32overflowing_shl_b() {
+    // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
+    let op_base = "u32overflowing_shl";
+    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+
+    // --- test simple case -----------------------------------------------------------------------
+    let a = 1_u32;
+    let b = 1_u32;
+    let test = build_op_test!(get_asm_op(b).as_str(), &[5, a as u64]);
+    test.expect_stack(&[0, 2, 5]);
+
+    // --- test max values of a and b -------------------------------------------------------------
+    let a = (U32_BOUND - 1) as u32;
+    let b = 31;
+    let c = a.wrapping_shl(b);
+    let d = a.wrapping_shr(32 - b);
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[d as u64, c as u64]);
+
+    // --- test b = 0 -----------------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = 0;
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[0, a as u64]);
+
+    // --- test random values ---------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
+    let c = a.wrapping_shl(b);
+    let d = if b == 0 { 0 } else { a.wrapping_shr(32 - b) };
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[d as u64, c as u64]);
+
+    // --- test out of bounds input (should not fail) --------------------------------------------
+    let b = 1;
+    let test = build_op_test!(get_asm_op(b).as_str(), &[U32_BOUND]);
+    assert!(test.execute().is_ok());
+}
+
+#[test]
+fn u32checked_shr() {
     // right shift: pops a from the stack and pushes a / 2^b for a provided value b
-    let asm_op = "u32shr";
+    let asm_op = "u32checked_shr";
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 4_u32;
@@ -317,23 +433,23 @@ fn u32shr() {
     test.expect_stack(&[a.wrapping_shr(b) as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.wrapping_shr(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.wrapping_shr(b) as u64]);
 }
 
 #[test]
-fn u32shr_fail() {
-    let asm_op = "u32shr";
+fn u32checked_shr_fail() {
+    let asm_op = "u32checked_shr";
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
@@ -345,9 +461,9 @@ fn u32shr_fail() {
 }
 
 #[test]
-fn u32shr_b() {
+fn u32checked_shr_b() {
     // right shift: pops a from the stack and pushes a / 2^b for a provided value b
-    let op_base = "u32shr";
+    let op_base = "u32checked_shr";
     let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
 
     // --- test simple case -----------------------------------------------------------------------
@@ -364,32 +480,108 @@ fn u32shr_b() {
     test.expect_stack(&[a.wrapping_shr(b) as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.wrapping_shr(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.wrapping_shr(b) as u64]);
 }
 
 #[test]
-fn u32shr_b_fail() {
-    let op_base = "u32shr";
+fn u32checked_shr_b_fail() {
+    let op_base = "u32checked_shr";
 
     test_input_out_of_bounds(format!("{}.{}", op_base, 1).as_str());
     test_param_out_of_bounds(op_base, 32);
 }
 
 #[test]
-fn u32shr_unsafe() {
+fn u32unchecked_shr() {
     // right shift: pops a from the stack and pushes a / 2^b for a provided value b
-    let asm_op = "u32shr.unsafe";
+    let asm_op = "u32unchecked_shr";
+
+    // --- test simple case -----------------------------------------------------------------------
+    let a = 4_u32;
+    let b = 2_u32;
+    let test = build_op_test!(asm_op, &[5, a as u64, b as u64]);
+    test.expect_stack(&[1, 5]);
+
+    // --- test max values of a and b -------------------------------------------------------------
+    let a = (U32_BOUND - 1) as u32;
+    let b = 31;
+
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[a.wrapping_shr(b) as u64]);
+
+    // --- test b = 0 ---------------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = 0;
+
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[a.wrapping_shr(b) as u64]);
+
+    // --- test random values ---------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
+
+    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
+    test.expect_stack(&[a.wrapping_shr(b) as u64]);
+
+    // --- test out of bounds inputs (should not fail) --------------------------------------------
+    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
+    assert!(test.execute().is_ok());
+}
+
+#[test]
+fn u32unchecked_shr_b() {
+    // right shift: pops a from the stack and pushes a / 2^b for a provided value b
+    let op_base = "u32unchecked_shr";
+    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+
+    // --- test simple case -----------------------------------------------------------------------
+    let a = 4_u32;
+    let b = 2_u32;
+    let test = build_op_test!(get_asm_op(b).as_str(), &[5, a as u64]);
+    test.expect_stack(&[1, 5]);
+
+    // --- test max values of a and b -------------------------------------------------------------
+    let a = (U32_BOUND - 1) as u32;
+    let b = 31;
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shr(b) as u64]);
+
+    // --- test b = 0 ---------------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = 0;
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shr(b) as u64]);
+
+    // --- test random values ---------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[a.wrapping_shr(b) as u64]);
+
+    // --- test out of bounds inputs (should not fail) --------------------------------------------
+    let b = 1;
+    let test = build_op_test!(get_asm_op(b).as_str(), &[U32_BOUND]);
+    assert!(test.execute().is_ok());
+}
+
+#[test]
+fn u32overflowing_shr() {
+    // right shift: pops a from the stack and pushes a / 2^b for a provided value b
+    let asm_op = "u32overflowing_shr";
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 4_u32;
@@ -407,15 +599,15 @@ fn u32shr_unsafe() {
     test.expect_stack(&[d as u64, c as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[0, a as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
     let c = a.wrapping_shr(b);
     let d = if b == 0 { 0 } else { a.wrapping_shl(32 - b) };
 
@@ -428,9 +620,52 @@ fn u32shr_unsafe() {
 }
 
 #[test]
-fn u32rotl() {
+fn u32overflowing_shr_b() {
+    // right shift: pops a from the stack and pushes a / 2^b for a provided value b
+    let op_base = "u32overflowing_shr";
+    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+
+    // --- test simple case -----------------------------------------------------------------------
+    let a = 4_u32;
+    let b = 2_u32;
+    let test = build_op_test!(get_asm_op(b).as_str(), &[5, a as u64]);
+    test.expect_stack(&[0, 1, 5]);
+
+    // --- test max values of a and b -------------------------------------------------------------
+    let a = (U32_BOUND - 1) as u32;
+    let b = 31;
+    let c = a.wrapping_shr(b);
+    let d = a.wrapping_shl(32 - b);
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[d as u64, c as u64]);
+
+    // --- test b = 0 ---------------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = 0;
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[0, a as u64]);
+
+    // --- test random values ---------------------------------------------------------------------
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
+    let c = a.wrapping_shr(b);
+    let d = if b == 0 { 0 } else { a.wrapping_shl(32 - b) };
+
+    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
+    test.expect_stack(&[d as u64, c as u64]);
+
+    // --- test out of bounds inputs (should not fail) --------------------------------------------
+    let b = 1;
+    let test = build_op_test!(get_asm_op(b).as_str(), &[U32_BOUND]);
+    assert!(test.execute().is_ok());
+}
+
+#[test]
+fn u32checked_rotl() {
     // Computes c by rotating a 32-bit representation of a to the left by b bits.
-    let asm_op = "u32rotl";
+    let asm_op = "u32checked_rotl";
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u32;
@@ -457,24 +692,24 @@ fn u32rotl() {
     test.expect_stack(&[a as u64]);
 
     // --- test b = 0 -----------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_left(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_left(b) as u64]);
 }
 
 #[test]
-fn u32rotl_b() {
+fn u32checked_rotl_b() {
     // Computes c by rotating a 32-bit representation of a to the left by b bits.
-    let op_base = "u32rotl";
+    let op_base = "u32checked_rotl";
     let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
 
     // --- test simple case -----------------------------------------------------------------------
@@ -502,32 +737,32 @@ fn u32rotl_b() {
     test.expect_stack(&[a as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.rotate_left(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.rotate_left(b) as u64]);
 }
 
 #[test]
-fn u32rotl_fail_b() {
-    let op_base = "u32rotl";
+fn u32checked_rotl_fail_b() {
+    let op_base = "u32checked_rotl";
 
     test_input_out_of_bounds(format!("{}.{}", op_base, 1).as_str());
     test_param_out_of_bounds(op_base, 32);
 }
 
 #[test]
-fn u32rotl_unsafe() {
+fn u32unchecked_rotl() {
     // Computes c by rotating a 32-bit representation of a to the left by b bits.
-    let asm_op = "u32rotl.unsafe";
+    let asm_op = "u32unchecked_rotl";
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u32;
@@ -554,15 +789,15 @@ fn u32rotl_unsafe() {
     test.expect_stack(&[a as u64]);
 
     // --- test b = 0 -----------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_left(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_left(b) as u64]);
@@ -573,9 +808,9 @@ fn u32rotl_unsafe() {
 }
 
 #[test]
-fn u32rotr() {
+fn u32checked_rotr() {
     // Computes c by rotating a 32-bit representation of a to the right by b bits.
-    let asm_op = "u32rotr";
+    let asm_op = "u32checked_rotr";
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 2_u32;
@@ -602,23 +837,23 @@ fn u32rotr() {
     test.expect_stack(&[a as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_right(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_right(b) as u64]);
 }
 
 #[test]
-fn u32rotr_fail() {
-    let asm_op = "u32rotr";
+fn u32checked_rotr_fail() {
+    let asm_op = "u32checked_rotr";
 
     // should fail if a >= 2^32
     let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
@@ -630,9 +865,9 @@ fn u32rotr_fail() {
 }
 
 #[test]
-fn u32rotr_b() {
+fn u32checked_rotr_b() {
     // Computes c by rotating a 32-bit representation of a to the right by b bits.
-    let op_base = "u32rotr";
+    let op_base = "u32checked_rotr";
     let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
 
     // --- test simple case -----------------------------------------------------------------------
@@ -660,32 +895,32 @@ fn u32rotr_b() {
     test.expect_stack(&[a as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.rotate_right(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.rotate_right(b) as u64]);
 }
 
 #[test]
-fn u32rotr_b_fail() {
-    let op_base = "u32rotr";
+fn u32checked_rotr_b_fail() {
+    let op_base = "u32checked_rotr";
 
     test_input_out_of_bounds(format!("{}.{}", op_base, 1).as_str());
     test_param_out_of_bounds(op_base, 32);
 }
 
 #[test]
-fn u32rotr_unsafe() {
+fn u32unchecked_rotr() {
     // Computes c by rotating a 32-bit representation of a to the right by b bits.
-    let asm_op = "u32rotr.unsafe";
+    let asm_op = "u32unchecked_rotr";
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 2_u32;
@@ -712,15 +947,15 @@ fn u32rotr_unsafe() {
     test.expect_stack(&[a as u64]);
 
     // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
     let b = 0;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_right(b) as u64]);
 
     // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = (rand_value::<u64>() % 32) as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>() % 32;
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_right(b) as u64]);
@@ -735,8 +970,8 @@ fn u32rotr_unsafe() {
 
 proptest! {
     #[test]
-    fn u32and_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_opcode = "u32and";
+    fn u32checked_and_proptest(a in any::<u32>(), b in any::<u32>()) {
+        let asm_opcode = "u32checked_and";
         let values = [a as u64, b as u64];
         // should result in bitwise AND
         let expected = (a & b) as u64;
@@ -746,8 +981,8 @@ proptest! {
     }
 
     #[test]
-    fn u32or_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_opcode = "u32or";
+    fn u32checked_or_proptest(a in any::<u32>(), b in any::<u32>()) {
+        let asm_opcode = "u32checked_or";
         let values = [a as u64, b as u64];
         // should result in bitwise OR
         let expected = (a | b) as u64;
@@ -757,8 +992,8 @@ proptest! {
     }
 
     #[test]
-    fn u32xor_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_opcode = "u32xor";
+    fn u32checked_xor_proptest(a in any::<u32>(), b in any::<u32>()) {
+        let asm_opcode = "u32checked_xor";
         let values = [a as u64, b as u64];
         // should result in bitwise XOR
         let expected = (a ^ b) as u64;
@@ -768,8 +1003,8 @@ proptest! {
     }
 
     #[test]
-    fn u32not_proptest(value in any::<u32>()) {
-        let asm_opcode = "u32not";
+    fn u32checked_not_proptest(value in any::<u32>()) {
+        let asm_opcode = "u32checked_not";
 
         // should result in bitwise NOT
         let test = build_op_test!(asm_opcode, &[value as u64]);
@@ -777,72 +1012,116 @@ proptest! {
     }
 
     #[test]
-    fn u32shl_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32shl";
+    fn u32checked_shl_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = "u32checked_shl";
 
         // should execute left shift
-        let expected =  a << b;
+        let expected = a << b;
         let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
     }
 
     #[test]
-    fn u32shl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = format!("u32shl.{}", b);
+    fn u32checked_shl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = format!("u32checked_shl.{}", b);
 
         // should execute left shift
-        let expected =  a << b;
+        let expected = a << b;
         let test = build_op_test!(asm_opcode, &[a as u64]);
         test.prop_expect_stack(&[expected as u64])?;
     }
 
     #[test]
-    fn u32shl_unsafe_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32shl.unsafe";
+    fn u32unchecked_shl_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = "u32unchecked_shl";
 
         // should execute left shift
-        let c =  a.wrapping_shl(b);
+        let c = a.wrapping_shl(b);
+        let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
+        test.prop_expect_stack(&[c as u64])?;
+    }
+
+    #[test]
+    fn u32unchecked_shl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = format!("u32unchecked_shl.{}", b);
+
+        // should execute left shift
+        let c = a.wrapping_shl(b);
+        let test = build_op_test!(asm_opcode, &[a as u64]);
+        test.prop_expect_stack(&[c as u64])?;
+    }
+
+    #[test]
+    fn u32overflowing_shl_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = "u32overflowing_shl";
+
+        // should execute left shift
+        let c = a.wrapping_shl(b);
         // and leave the result that was shifted off
-        let d = if b==0 { 0} else { a.wrapping_shr(32-b) };
+        let d = if b == 0 { 0 } else { a.wrapping_shr(32 - b) };
         let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
         test.prop_expect_stack(&[d as u64, c as u64])?;
     }
 
     #[test]
-    fn u32shr_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32shr";
+    fn u32overflowing_shl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = format!("u32overflowing_shl.{}", b);
+
+        // should execute left shift
+        let c = a.wrapping_shl(b);
+        // and leave the result that was shifted off
+        let d = if b == 0 { 0 } else { a.wrapping_shr(32 - b) };
+        let test = build_op_test!(asm_opcode, &[a as u64]);
+        test.prop_expect_stack(&[d as u64, c as u64])?;
+    }
+
+    #[test]
+    fn u32checked_shr_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = "u32checked_shr";
 
         // should execute right shift
-        let expected =  a >> b;
+        let expected = a >> b;
         let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
     }
 
     #[test]
-    fn u32shr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = format!("u32shr.{}", b);
+    fn u32checked_shr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = format!("u32checked_shr.{}", b);
 
         // should execute right shift
-        let expected =  a >> b;
+        let expected = a >> b;
         let test = build_op_test!(asm_opcode, &[a as u64]);
         test.prop_expect_stack(&[expected as u64])?;
     }
 
     #[test]
-    fn u32shr_unsafe_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32shr.unsafe";
+    fn u32overflowing_shr_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = "u32overflowing_shr";
 
         // should execute right shift
-        let c =  a.wrapping_shr(b);
+        let c = a.wrapping_shr(b);
         // and leave the result that was shifted off
-        let d = if b==0 { 0} else { a.wrapping_shl(32-b) };
+        let d = if b == 0 { 0 } else { a.wrapping_shl(32 - b) };
         let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
         test.prop_expect_stack(&[d as u64, c as u64])?;
     }
 
     #[test]
-    fn u32rotl_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32rotl";
+    fn u32overflowing_shr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = format!("u32overflowing_shr.{}", b);
+
+        // should execute right shift
+        let c = a.wrapping_shr(b);
+        // and leave the result that was shifted off
+        let d = if b == 0 { 0 } else { a.wrapping_shl(32 - b) };
+        let test = build_op_test!(asm_opcode, &[a as u64]);
+        test.prop_expect_stack(&[d as u64, c as u64])?;
+    }
+
+    #[test]
+    fn u32checked_rotl_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = "u32checked_rotl";
 
         // should execute left bit rotation
         let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
@@ -850,8 +1129,8 @@ proptest! {
     }
 
     #[test]
-    fn u32rotl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let op_base = "u32rotl";
+    fn u32checked_rotl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let op_base = "u32checked_rotl";
         let asm_opcode = format!("{}.{}", op_base, b);
 
         // should execute left bit rotation
@@ -860,8 +1139,8 @@ proptest! {
     }
 
     #[test]
-    fn u32rotl_unsafe_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32rotl.unsafe";
+    fn u32unchecked_rotl_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = "u32unchecked_rotl";
 
         // should execute left bit rotation
         let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
@@ -869,8 +1148,18 @@ proptest! {
     }
 
     #[test]
-    fn u32rotr_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32rotr";
+    fn u32unchecked_rotl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let op_base = "u32unchecked_rotl";
+        let asm_opcode = format!("{}.{}", op_base, b);
+
+        // should execute left bit rotation
+        let test = build_op_test!(asm_opcode, &[a as u64]);
+        test.prop_expect_stack(&[a.rotate_left(b) as u64])?;
+    }
+
+    #[test]
+    fn u32checked_rotr_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = "u32checked_rotr";
 
         // should execute right bit rotation
         let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
@@ -878,8 +1167,8 @@ proptest! {
     }
 
     #[test]
-    fn u32rotr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let op_base = "u32rotr";
+    fn u32checked_rotr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let op_base = "u32checked_rotr";
         let asm_opcode = format!("{}.{}", op_base, b);
 
         // should execute right bit rotation
@@ -888,11 +1177,21 @@ proptest! {
     }
 
     #[test]
-    fn u32rotr_unsafe_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32rotr.unsafe";
+    fn u32unchecked_rotr_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let asm_opcode = "u32unchecked_rotr";
 
         // should execute right bit rotation
         let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
+        test.prop_expect_stack(&[a.rotate_right(b) as u64])?;
+    }
+
+    #[test]
+    fn u32unchecked_rotr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
+        let op_base = "u32unchecked_rotr";
+        let asm_opcode = format!("{}.{}", op_base, b);
+
+        // should execute right bit rotation
+        let test = build_op_test!(asm_opcode, &[a as u64]);
         test.prop_expect_stack(&[a.rotate_right(b) as u64])?;
     }
 }

--- a/miden/tests/integration/operations/u32_ops/comparison_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/comparison_ops.rs
@@ -11,8 +11,8 @@ use rand_utils::rand_value;
 // ================================================================================================
 
 #[test]
-fn u32eq() {
-    let asm_op = "u32eq";
+fn u32checked_eq() {
+    let asm_op = "u32checked_eq";
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[1, 1]);
@@ -43,15 +43,15 @@ fn u32eq() {
 
 #[test]
 fn u32eq_fail() {
-    let asm_op = "u32eq";
+    let asm_op = "u32checked_eq";
 
     // should fail if either one of 2 inputs is out of bounds
     test_inputs_out_of_bounds(asm_op, 2);
 }
 
 #[test]
-fn u32eq_b() {
-    let build_asm_op = |param: u32| format!("u32eq.{}", param);
+fn u32checked_eq_b() {
+    let build_asm_op = |param: u32| format!("u32checked_eq.{}", param);
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1).as_str(), &[1]);
@@ -81,8 +81,8 @@ fn u32eq_b() {
 }
 
 #[test]
-fn u32eq_b_fail() {
-    let asm_op = "u32eq";
+fn u32checked_eq_b_fail() {
+    let asm_op = "u32checked_eq";
 
     // should fail when b is out of bounds and provided as a parameter
     test_param_out_of_bounds(asm_op, U32_BOUND);
@@ -94,8 +94,8 @@ fn u32eq_b_fail() {
 }
 
 #[test]
-fn u32neq() {
-    let asm_op = "u32neq";
+fn u32checked_neq() {
+    let asm_op = "u32checked_neq";
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[1, 1]);
@@ -125,16 +125,16 @@ fn u32neq() {
 }
 
 #[test]
-fn u32neq_fail() {
-    let asm_op = "u32neq";
+fn u32checked_neq_fail() {
+    let asm_op = "u32checked_neq";
 
     // should fail if either one of 2 inputs is out of bounds
     test_inputs_out_of_bounds(asm_op, 2);
 }
 
 #[test]
-fn u32neq_b() {
-    let build_asm_op = |param: u32| format!("u32neq.{}", param);
+fn u32checked_neq_b() {
+    let build_asm_op = |param: u32| format!("u32checked_neq.{}", param);
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1).as_str(), &[1]);
@@ -164,8 +164,8 @@ fn u32neq_b() {
 }
 
 #[test]
-fn u32neq_b_fail() {
-    let asm_op = "u32neq";
+fn u32checked_neq_b_fail() {
+    let asm_op = "u32checked_neq";
 
     // should fail when b is out of bounds and provided as a parameter
     test_param_out_of_bounds(asm_op, U32_BOUND);
@@ -177,24 +177,24 @@ fn u32neq_b_fail() {
 }
 
 #[test]
-fn u32lt() {
-    let asm_op = "u32lt";
+fn u32checked_lt() {
+    let asm_op = "u32checked_lt";
 
     // should push 1 to the stack when a < b and 0 otherwise
     test_comparison_op(asm_op, 1, 0, 0);
 }
 
 #[test]
-fn u32lt_fail() {
-    let asm_op = "u32lt";
+fn u32checked_lt_fail() {
+    let asm_op = "u32checked_lt";
 
     // should fail if either one of 2 inputs is out of bounds
     test_inputs_out_of_bounds(asm_op, 2);
 }
 
 #[test]
-fn u32lt_unsafe() {
-    let asm_op = "u32lt.unsafe";
+fn u32unchecked_lt() {
+    let asm_op = "u32unchecked_lt";
 
     // should push 1 to the stack when a < b and 0 otherwise
     test_comparison_op(asm_op, 1, 0, 0);
@@ -204,24 +204,24 @@ fn u32lt_unsafe() {
 }
 
 #[test]
-fn u32lte() {
-    let asm_op = "u32lte";
+fn u32checked_lte() {
+    let asm_op = "u32checked_lte";
 
     // should push 1 to the stack when a <= b and 0 otherwise
     test_comparison_op(asm_op, 1, 1, 0);
 }
 
 #[test]
-fn u32lte_fail() {
-    let asm_op = "u32lte";
+fn u32checked_lte_fail() {
+    let asm_op = "u32checked_lte";
 
     // should fail if either one of 2 inputs is out of bounds
     test_inputs_out_of_bounds(asm_op, 2);
 }
 
 #[test]
-fn u32lte_unsafe() {
-    let asm_op = "u32lte.unsafe";
+fn u32unchecked_lte() {
+    let asm_op = "u32unchecked_lte";
 
     // should push 1 to the stack when a <= b and 0 otherwise
     test_comparison_op(asm_op, 1, 1, 0);
@@ -231,24 +231,24 @@ fn u32lte_unsafe() {
 }
 
 #[test]
-fn u32gt() {
-    let asm_op = "u32gt";
+fn u32checked_gt() {
+    let asm_op = "u32checked_gt";
 
     // should push 1 to the stack when a > b and 0 otherwise
     test_comparison_op(asm_op, 0, 0, 1);
 }
 
 #[test]
-fn u32gt_fail() {
-    let asm_op = "u32gt";
+fn u32checked_gt_fail() {
+    let asm_op = "u32checked_gt";
 
     // should fail if either one of 2 inputs is out of bounds
     test_inputs_out_of_bounds(asm_op, 2);
 }
 
 #[test]
-fn u32gt_unsafe() {
-    let asm_op = "u32gt.unsafe";
+fn u32unchecked_gt() {
+    let asm_op = "u32unchecked_gt";
 
     // should push 1 to the stack when a > b and 0 otherwise
     test_comparison_op(asm_op, 0, 0, 1);
@@ -258,24 +258,24 @@ fn u32gt_unsafe() {
 }
 
 #[test]
-fn u32gte() {
-    let asm_op = "u32gte";
+fn u32checked_gte() {
+    let asm_op = "u32checked_gte";
 
     // should push 1 to the stack when a >= b and 0 otherwise
     test_comparison_op(asm_op, 0, 1, 1);
 }
 
 #[test]
-fn u32gte_fail() {
-    let asm_op = "u32gte";
+fn u32checked_gte_fail() {
+    let asm_op = "u32checked_gte";
 
     // should fail if either one of 2 inputs is out of bounds
     test_inputs_out_of_bounds(asm_op, 2);
 }
 
 #[test]
-fn u32gte_unsafe() {
-    let asm_op = "u32gte.unsafe";
+fn u32unchecked_gte() {
+    let asm_op = "u32unchecked_gte";
 
     // should push 1 to the stack when a >= b and 0 otherwise
     test_comparison_op(asm_op, 0, 1, 1);
@@ -285,24 +285,24 @@ fn u32gte_unsafe() {
 }
 
 #[test]
-fn u32min() {
-    let asm_op = "u32min";
+fn u32checked_min() {
+    let asm_op = "u32checked_min";
 
     // should put the minimum of the 2 inputs on the stack
     test_min(asm_op);
 }
 
 #[test]
-fn u32min_fail() {
-    let asm_op = "u32min";
+fn u32checked_min_fail() {
+    let asm_op = "u32checked_min";
 
     // should fail if either one of 2 inputs is out of bounds
     test_inputs_out_of_bounds(asm_op, 2);
 }
 
 #[test]
-fn u32min_unsafe() {
-    let asm_op = "u32min.unsafe";
+fn u32unchecked_min() {
+    let asm_op = "u32unchecked_min";
 
     // should put the minimum of the 2 inputs on the stack
     test_min(asm_op);
@@ -312,24 +312,24 @@ fn u32min_unsafe() {
 }
 
 #[test]
-fn u32max() {
-    let asm_op = "u32max";
+fn u32checked_max() {
+    let asm_op = "u32checked_max";
 
     // should put the maximum of the 2 inputs on the stack
     test_max(asm_op);
 }
 
 #[test]
-fn u32max_fail() {
-    let asm_op = "u32max";
+fn u32checked_max_fail() {
+    let asm_op = "u32checked_max";
 
     // should fail if either one of 2 inputs is out of bounds
     test_inputs_out_of_bounds(asm_op, 2);
 }
 
 #[test]
-fn u32max_unsafe() {
-    let asm_op = "u32max.unsafe";
+fn u32unchecked_max() {
+    let asm_op = "u32unchecked_max";
 
     // should put the maximum of the 2 inputs on the stack
     test_max(asm_op);
@@ -343,8 +343,8 @@ fn u32max_unsafe() {
 
 proptest! {
     #[test]
-    fn u32eq_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_op = "u32eq";
+    fn u32checked_eq_proptest(a in any::<u32>(), b in any::<u32>()) {
+        let asm_op = "u32checked_eq";
         let values = [b as u64, a as u64];
 
         // should test for equality
@@ -360,8 +360,8 @@ proptest! {
     }
 
     #[test]
-    fn u32neq_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_op = "u32neq";
+    fn u32checked_neq_proptest(a in any::<u32>(), b in any::<u32>()) {
+        let asm_op = "u32checked_neq";
         let values = [b as u64, a as u64];
 
         // should test for inequality
@@ -378,7 +378,7 @@ proptest! {
 
     #[test]
     fn u32lt_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_op = "u32lt";
+        let asm_op = "u32checked_lt";
         let expected = match a.cmp(&b) {
             Ordering::Less => 1,
             Ordering::Equal => 0,
@@ -389,14 +389,14 @@ proptest! {
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
 
-        let asm_op = format!("{}.unsafe", asm_op);
+        let asm_op = "u32unchecked_lt";
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
     }
 
     #[test]
     fn u32lte_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_op = "u32lte";
+        let asm_op = "u32checked_lte";
         let expected = match a.cmp(&b) {
             Ordering::Less => 1,
             Ordering::Equal => 1,
@@ -407,14 +407,14 @@ proptest! {
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
 
-        let asm_op = format!("{}.unsafe", asm_op);
+        let asm_op = "u32unchecked_lte";
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
     }
 
     #[test]
     fn u32gt_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_op = "u32gt";
+        let asm_op = "u32checked_gt";
         let expected = match a.cmp(&b) {
             Ordering::Less => 0,
             Ordering::Equal => 0,
@@ -425,14 +425,14 @@ proptest! {
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
 
-        let asm_op = format!("{}.unsafe", asm_op);
+        let asm_op = "u32unchecked_gt";
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
     }
 
     #[test]
     fn u32gte_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_op = "u32gte";
+        let asm_op = "u32checked_gte";
         let expected = match a.cmp(&b) {
             Ordering::Less => 0,
             Ordering::Equal => 1,
@@ -443,35 +443,35 @@ proptest! {
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
 
-        let asm_op = format!("{}.unsafe", asm_op);
+        let asm_op = "u32unchecked_gte";
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
     }
 
     #[test]
     fn u32min_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_op = "u32min";
+        let asm_op = "u32checked_min";
         let expected = if a < b { a } else { b };
 
         // safe and unsafe should produce the same result for valid values
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
 
-        let asm_op = format!("{}.unsafe", asm_op);
+        let asm_op = "u32unchecked_min";
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
     }
 
     #[test]
     fn u32max_proptest(a in any::<u32>(), b in any::<u32>()) {
-        let asm_op = "u32max";
+        let asm_op = "u32checked_max";
         let expected = if a > b { a } else { b };
 
         // safe and unsafe should produce the same result for valid values
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
 
-        let asm_op = format!("{}.unsafe", asm_op);
+        let asm_op = "u32unchecked_max";
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
     }
@@ -532,8 +532,8 @@ fn test_min(asm_op: &str) {
     test.expect_stack(&[0]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>();
     let expected = match a.cmp(&b) {
         Ordering::Less => a,
         Ordering::Equal => b,
@@ -567,8 +567,8 @@ fn test_max(asm_op: &str) {
     test.expect_stack(&[1]);
 
     // --- random u32 values ----------------------------------------------------------------------
-    let a = rand_value::<u64>() as u32;
-    let b = rand_value::<u64>() as u32;
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>();
     let expected = match a.cmp(&b) {
         Ordering::Less => b,
         Ordering::Equal => b,

--- a/stdlib/asm/crypto/hashes/blake3.masm
+++ b/stdlib/asm/crypto/hashes/blake3.masm
@@ -83,41 +83,41 @@ end
 # that's because it doesn't dictate what output of 2-to-1 hash will be.
 proc.finalize
     movup.8
-    u32xor
+    u32checked_xor
 
     swap
     movup.8
-    u32xor
+    u32checked_xor
     swap
 
     movup.2
     movup.8
-    u32xor
+    u32checked_xor
     movdn.2
 
     movup.3
     movup.8
-    u32xor
+    u32checked_xor
     movdn.3
 
     movup.4
     movup.8
-    u32xor
+    u32checked_xor
     movdn.4
 
     movup.5
     movup.8
-    u32xor
+    u32checked_xor
     movdn.5
 
     movup.6
     movup.8
-    u32xor
+    u32checked_xor
     movdn.6
 
     movup.7
     movup.8
-    u32xor
+    u32checked_xor
     movdn.7
 end
 
@@ -186,25 +186,25 @@ proc.columnar_mixing.1
     pushw.mem
 
     dup.4
-    u32xor
-    u32rotr.16
-
+    u32checked_xor
+    u32checked_rotr.16
+    
     swap
     dup.5
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     swap
 
     movup.2
     dup.6
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     movdn.2
 
     movup.3
     dup.7
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     movdn.3
 
     movup.12
@@ -231,25 +231,25 @@ proc.columnar_mixing.1
     movupw.3
 
     dup.4
-    u32xor
-    u32rotr.12
-
+    u32checked_xor
+    u32checked_rotr.12
+    
     swap
     dup.5
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     swap
 
     movup.2
     dup.6
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     movdn.2
 
     movup.3
     dup.7
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     movdn.3
 
     movupw.3
@@ -285,25 +285,25 @@ proc.columnar_mixing.1
     movupw.3
 
     dup.4
-    u32xor
-    u32rotr.8
-
+    u32checked_xor
+    u32checked_rotr.8
+    
     swap
     dup.5
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     swap
 
     movup.2
     dup.6
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     movdn.2
 
     movup.3
     dup.7
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     movdn.3
 
     movupw.3
@@ -329,25 +329,25 @@ proc.columnar_mixing.1
     movupw.3
 
     dup.4
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
 
     swap
     dup.5
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     swap
 
     movup.2
     dup.6
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     movdn.2
 
     movup.3
     dup.7
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     movdn.3
 
     movupw.3
@@ -419,24 +419,24 @@ proc.diagonal_mixing.1
 
     movup.3
     dup.4
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     movdn.3
 
     dup.5
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
 
     swap
     dup.6
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     swap
 
     movup.2
     dup.7
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     movdn.2
 
     movup.12
@@ -464,25 +464,25 @@ proc.diagonal_mixing.1
 
     swap
     dup.6
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     swap
 
     movup.2
     dup.7
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     movdn.2
 
     movup.3
     dup.4
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     movdn.3
 
     dup.5
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
 
     movupw.3
     pushw.local.0
@@ -518,24 +518,24 @@ proc.diagonal_mixing.1
 
     movup.3
     dup.4
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     movdn.3
 
     dup.5
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
 
     swap
     dup.6
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     swap
 
     movup.2
     dup.7
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     movdn.2
 
     movupw.3
@@ -562,25 +562,25 @@ proc.diagonal_mixing.1
 
     swap
     dup.6
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     swap
 
     movup.2
     dup.7
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     movdn.2
 
     movup.3
     dup.4
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     movdn.3
 
     dup.5
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
 
     movupw.3
 end

--- a/stdlib/asm/crypto/hashes/keccak256.masm
+++ b/stdlib/asm/crypto/hashes/keccak256.masm
@@ -9,20 +9,20 @@ end
 # given four elements of from each of a, b sets, following procedure computes a[i] ^ b[i] ∀ i = [0, 3]
 proc.xor_4_elements
     movup.7
-    u32xor
+    u32checked_xor
 
     swap
 
     movup.6
-    u32xor
+    u32checked_xor
 
     movup.2
     movup.5
-    u32xor
+    u32checked_xor
 
     movup.4
     movup.4
-    u32xor
+    u32checked_xor
 end
 
 # keccak-p[b, n_r] | b = 1600, n_r = 24, permutation's θ function, which is
@@ -56,7 +56,7 @@ proc.theta.7
     swap
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
     drop
@@ -76,8 +76,8 @@ proc.theta.7
     swap
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
     drop
@@ -91,7 +91,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     # stack = [c_0]
     # -----
@@ -116,7 +116,7 @@ proc.theta.7
     drop
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
     drop
@@ -138,8 +138,8 @@ proc.theta.7
     drop
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
     drop
@@ -155,7 +155,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     # stack = [c_1, c_0]
     # -----
@@ -183,7 +183,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
 
@@ -200,7 +200,7 @@ proc.theta.7
     swap
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -225,8 +225,8 @@ proc.theta.7
     swap
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_2, c_1, c_0]
     # -----
@@ -255,7 +255,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
 
@@ -271,7 +271,7 @@ proc.theta.7
     drop
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -296,8 +296,8 @@ proc.theta.7
     drop
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_3, c_2, c_1, c_0]
     # -----
@@ -325,7 +325,7 @@ proc.theta.7
     swap
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
 
@@ -341,7 +341,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -366,8 +366,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -395,7 +395,7 @@ proc.theta.7
     drop
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
 
@@ -412,7 +412,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -437,8 +437,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_5, c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -482,8 +482,8 @@ proc.theta.7
     swap
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -507,8 +507,8 @@ proc.theta.7
     swap
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_6, c_5, c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -551,8 +551,8 @@ proc.theta.7
     drop
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -576,8 +576,8 @@ proc.theta.7
     drop
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_7, c_6, c_5, c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -620,8 +620,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -638,7 +638,7 @@ proc.theta.7
     swap
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.3
 
@@ -654,7 +654,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     # stack = [c_8, c_7, c_6, c_5, c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -698,8 +698,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -730,8 +730,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     push.0.0
 
@@ -761,14 +761,14 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
     movup.2
     swap
 
-    u32rotl.1
-    u32xor
+    u32checked_rotl.1
+    u32checked_xor
 
     # stack = [d0, d1]
 
@@ -785,12 +785,12 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
-    u32rotl.1
+    u32checked_rotl.1
     movup.2
-    u32xor
+    u32checked_xor
 
     # stack = [d2, d3, d0, d1]
 
@@ -808,12 +808,12 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
-    u32rotl.1
+    u32checked_rotl.1
     movup.2
-    u32xor
+    u32checked_xor
 
     # stack = [d4, d5, d0, d1, d2, d3]
 
@@ -830,12 +830,12 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
-    u32rotl.1
+    u32checked_rotl.1
     movup.2
-    u32xor
+    u32checked_xor
 
     # stack = [d6, d7, d4, d5, d0, d1, d2, d3]
 
@@ -855,12 +855,12 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
-    u32rotl.1
+    u32checked_rotl.1
     movup.2
-    u32xor
+    u32checked_xor
 
     # stack = [d8, d9, d4, d5, d6, d7, d0, d1, d2, d3]
 
@@ -1088,7 +1088,7 @@ proc.rho.4
     pushw.mem
     exec.rev_4_elements
 
-    u32rotl.1
+    u32checked_rotl.1
     swap
 
     exec.rev_4_elements
@@ -1098,16 +1098,16 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.31
+    u32checked_rotl.31
     swap
-    u32rotl.31
+    u32checked_rotl.31
     swap
 
     exec.rev_4_elements
 
-    u32rotl.14
+    u32checked_rotl.14
     swap
-    u32rotl.14
+    u32checked_rotl.14
     swap
 
     exec.rev_4_elements
@@ -1117,15 +1117,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.13
+    u32checked_rotl.13
     swap
-    u32rotl.14
+    u32checked_rotl.14
 
     exec.rev_4_elements
 
-    u32rotl.18
+    u32checked_rotl.18
     swap
-    u32rotl.18
+    u32checked_rotl.18
     swap
 
     exec.rev_4_elements
@@ -1135,16 +1135,16 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.22
+    u32checked_rotl.22
     swap
-    u32rotl.22
+    u32checked_rotl.22
     swap
 
     exec.rev_4_elements
 
-    u32rotl.3
+    u32checked_rotl.3
     swap
-    u32rotl.3
+    u32checked_rotl.3
     swap
 
     exec.rev_4_elements
@@ -1157,15 +1157,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.27
+    u32checked_rotl.27
     swap
-    u32rotl.28
+    u32checked_rotl.28
 
     exec.rev_4_elements
 
-    u32rotl.10
+    u32checked_rotl.10
     swap
-    u32rotl.10
+    u32checked_rotl.10
     swap
 
     exec.rev_4_elements
@@ -1175,15 +1175,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.1
+    u32checked_rotl.1
     swap
-    u32rotl.2
+    u32checked_rotl.2
 
     exec.rev_4_elements
 
-    u32rotl.5
+    u32checked_rotl.5
     swap
-    u32rotl.5
+    u32checked_rotl.5
     swap
 
     exec.rev_4_elements
@@ -1193,15 +1193,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.21
+    u32checked_rotl.21
     swap
-    u32rotl.22
+    u32checked_rotl.22
 
     exec.rev_4_elements
 
-    u32rotl.13
+    u32checked_rotl.13
     swap
-    u32rotl.12
+    u32checked_rotl.12
 
     exec.rev_4_elements
 
@@ -1210,15 +1210,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.19
+    u32checked_rotl.19
     swap
-    u32rotl.20
+    u32checked_rotl.20
 
     exec.rev_4_elements
 
-    u32rotl.21
+    u32checked_rotl.21
     swap
-    u32rotl.20
+    u32checked_rotl.20
 
     exec.rev_4_elements
 
@@ -1230,15 +1230,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.22
+    u32checked_rotl.22
     swap
-    u32rotl.23
+    u32checked_rotl.23
 
     exec.rev_4_elements
 
-    u32rotl.8
+    u32checked_rotl.8
     swap
-    u32rotl.7
+    u32checked_rotl.7
 
     exec.rev_4_elements
 
@@ -1247,15 +1247,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.10
+    u32checked_rotl.10
     swap
-    u32rotl.11
+    u32checked_rotl.11
 
     exec.rev_4_elements
 
-    u32rotl.4
+    u32checked_rotl.4
     swap
-    u32rotl.4
+    u32checked_rotl.4
     swap
 
     exec.rev_4_elements
@@ -1265,16 +1265,16 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.9
+    u32checked_rotl.9
     swap
-    u32rotl.9
+    u32checked_rotl.9
     swap
 
     exec.rev_4_elements
 
-    u32rotl.1
+    u32checked_rotl.1
     swap
-    u32rotl.1
+    u32checked_rotl.1
     swap
 
     exec.rev_4_elements
@@ -1284,15 +1284,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.30
+    u32checked_rotl.30
     swap
-    u32rotl.31
+    u32checked_rotl.31
 
     exec.rev_4_elements
 
-    u32rotl.28
+    u32checked_rotl.28
     swap
-    u32rotl.28
+    u32checked_rotl.28
     swap
 
     exec.rev_4_elements
@@ -1311,9 +1311,9 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.7
+    u32checked_rotl.7
     swap
-    u32rotl.7
+    u32checked_rotl.7
     swap
 
     movup.4
@@ -1760,17 +1760,17 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.0
@@ -1783,17 +1783,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     swap
@@ -1823,17 +1823,17 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     pushw.local.0
 
@@ -1850,9 +1850,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
 
     movup.2
     pushw.mem
@@ -1863,11 +1863,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     swap
     exec.rev_4_elements
@@ -1883,17 +1883,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     push.0.0
     exec.rev_4_elements
@@ -1946,17 +1946,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     swap
     push.0.0
@@ -1988,17 +1988,17 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     pushw.local.1
 
@@ -2009,17 +2009,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     popw.local.5 # write to c[2..6]
@@ -2036,9 +2036,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     pushw.local.0
@@ -2054,11 +2054,11 @@ proc.chi.7
     drop
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     pushw.local.0
 
@@ -2070,9 +2070,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
@@ -2085,11 +2085,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     exec.rev_4_elements
@@ -2151,9 +2151,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
@@ -2166,11 +2166,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.1
@@ -2182,17 +2182,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     popw.local.4 # write to c[0..4]
@@ -2207,9 +2207,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
@@ -2222,11 +2222,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.1
@@ -2242,9 +2242,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
 
     pushw.local.1
 
@@ -2262,11 +2262,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     exec.rev_4_elements
@@ -2282,17 +2282,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     push.0.0
     exec.rev_4_elements
@@ -2345,17 +2345,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     push.0.0
@@ -2372,9 +2372,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     dup.2
@@ -2387,27 +2387,27 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     movup.2
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     popw.local.5 # write to c[2..6]
@@ -2425,9 +2425,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     pushw.local.1
@@ -2442,11 +2442,11 @@ proc.chi.7
     drop
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     pushw.local.1
 
@@ -2459,9 +2459,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     pushw.local.2
@@ -2479,11 +2479,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     exec.rev_4_elements
@@ -2547,9 +2547,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
@@ -2562,11 +2562,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.2
@@ -2577,17 +2577,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     popw.local.4 # write to c[0..4]
@@ -2603,9 +2603,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     pushw.local.3
@@ -2623,11 +2623,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.3
@@ -2644,9 +2644,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
 
     pushw.local.2
 
@@ -2663,11 +2663,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     exec.rev_4_elements
@@ -2682,17 +2682,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     push.0.0
 
@@ -2753,7 +2753,7 @@ proc.iota_round_1
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     movup.4
     popw.mem # write to state[0..2]
@@ -2769,7 +2769,7 @@ proc.iota_round_2
     swap
 
     push.137
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2787,7 +2787,7 @@ proc.iota_round_3
     swap
 
     push.2147483787
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2805,7 +2805,7 @@ proc.iota_round_4
     swap
 
     push.2147516544
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2821,12 +2821,12 @@ proc.iota_round_5
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.139
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2842,12 +2842,12 @@ proc.iota_round_6
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.32768
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2863,12 +2863,12 @@ proc.iota_round_7
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147516552
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2884,12 +2884,12 @@ proc.iota_round_8
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147483778
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2907,7 +2907,7 @@ proc.iota_round_9
     swap
 
     push.11
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2925,7 +2925,7 @@ proc.iota_round_10
     swap
 
     push.10
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2941,12 +2941,12 @@ proc.iota_round_11
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.32898
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2964,7 +2964,7 @@ proc.iota_round_12
     swap
 
     push.32771
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -2980,12 +2980,12 @@ proc.iota_round_13
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.32907
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3001,12 +3001,12 @@ proc.iota_round_14
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147483659
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3022,12 +3022,12 @@ proc.iota_round_15
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147483786
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3043,12 +3043,12 @@ proc.iota_round_16
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147483777
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3066,7 +3066,7 @@ proc.iota_round_17
     swap
 
     push.2147483777
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3084,7 +3084,7 @@ proc.iota_round_18
     swap
 
     push.2147483656
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3102,7 +3102,7 @@ proc.iota_round_19
     swap
 
     push.131
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3120,7 +3120,7 @@ proc.iota_round_20
     swap
 
     push.2147516419
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3136,12 +3136,12 @@ proc.iota_round_21
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147516552
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3159,7 +3159,7 @@ proc.iota_round_22
     swap
 
     push.2147483784
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3175,12 +3175,12 @@ proc.iota_round_23
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.32768
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3198,7 +3198,7 @@ proc.iota_round_24
     swap
 
     push.2147516546
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3685,693 +3685,693 @@ export.to_bit_interleaved
     dup.1
 
     push.1
-    u32and
+    u32checked_and
 
     dup.2
-    u32shr.1
+    u32checked_shr.1
     push.1
-    u32and
+    u32checked_and
 
     swap
 
     dup.3
 
-    u32shr.2
+    u32checked_shr.2
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.1
-    u32or
+    u32checked_shl.1
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.3
+    u32checked_shr.3
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.1
-    u32or
+    u32checked_shl.1
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.4
+    u32checked_shr.4
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.2
-    u32or
+    u32checked_shl.2
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.5
+    u32checked_shr.5
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.2
-    u32or
+    u32checked_shl.2
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.6
+    u32checked_shr.6
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.3
-    u32or
+    u32checked_shl.3
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.7
+    u32checked_shr.7
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.3
-    u32or
+    u32checked_shl.3
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.8
+    u32checked_shr.8
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.4
-    u32or
+    u32checked_shl.4
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.9
+    u32checked_shr.9
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.4
-    u32or
+    u32checked_shl.4
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.10
+    u32checked_shr.10
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.5
-    u32or
+    u32checked_shl.5
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.11
+    u32checked_shr.11
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.5
-    u32or
+    u32checked_shl.5
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.12
+    u32checked_shr.12
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.6
-    u32or
+    u32checked_shl.6
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.13
+    u32checked_shr.13
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.6
-    u32or
+    u32checked_shl.6
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.14
+    u32checked_shr.14
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.7
-    u32or
+    u32checked_shl.7
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.15
+    u32checked_shr.15
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.7
-    u32or
+    u32checked_shl.7
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.16
+    u32checked_shr.16
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.8
-    u32or
+    u32checked_shl.8
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.17
+    u32checked_shr.17
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.8
-    u32or
+    u32checked_shl.8
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.18
+    u32checked_shr.18
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.9
-    u32or
+    u32checked_shl.9
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.19
+    u32checked_shr.19
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.9
-    u32or
+    u32checked_shl.9
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.20
+    u32checked_shr.20
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.10
-    u32or
+    u32checked_shl.10
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.21
+    u32checked_shr.21
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.10
-    u32or
+    u32checked_shl.10
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.22
+    u32checked_shr.22
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.11
-    u32or
+    u32checked_shl.11
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.23
+    u32checked_shr.23
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.11
-    u32or
+    u32checked_shl.11
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.24
+    u32checked_shr.24
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.12
-    u32or
+    u32checked_shl.12
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.25
+    u32checked_shr.25
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.12
-    u32or
+    u32checked_shl.12
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.26
+    u32checked_shr.26
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.13
-    u32or
+    u32checked_shl.13
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.27
+    u32checked_shr.27
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.13
-    u32or
+    u32checked_shl.13
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.28
+    u32checked_shr.28
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.14
-    u32or
+    u32checked_shl.14
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.29
+    u32checked_shr.29
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.14
-    u32or
+    u32checked_shl.14
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.30
+    u32checked_shr.30
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.15
-    u32or
+    u32checked_shl.15
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.31
+    u32checked_shr.31
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.15
-    u32or
+    u32checked_shl.15
+    u32checked_or
 
     swap
 
     dup.2
 
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.16
-    u32or
-
-    swap
-
-    dup.2
-
-    u32shr.1
-    push.1
-    u32and
-
-    u32shl.16
-    u32or
+    u32checked_shl.16
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.2
+    u32checked_shr.1
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.17
-    u32or
+    u32checked_shl.16
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.3
+    u32checked_shr.2
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.17
-    u32or
+    u32checked_shl.17
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.4
+    u32checked_shr.3
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.18
-    u32or
+    u32checked_shl.17
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.5
+    u32checked_shr.4
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.18
-    u32or
+    u32checked_shl.18
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.6
+    u32checked_shr.5
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.19
-    u32or
+    u32checked_shl.18
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.7
+    u32checked_shr.6
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.19
-    u32or
+    u32checked_shl.19
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.8
+    u32checked_shr.7
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.20
-    u32or
+    u32checked_shl.19
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.9
+    u32checked_shr.8
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.20
-    u32or
+    u32checked_shl.20
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.10
+    u32checked_shr.9
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.21
-    u32or
+    u32checked_shl.20
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.11
+    u32checked_shr.10
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.21
-    u32or
+    u32checked_shl.21
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.12
+    u32checked_shr.11
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.22
-    u32or
+    u32checked_shl.21
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.13
+    u32checked_shr.12
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.22
-    u32or
+    u32checked_shl.22
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.14
+    u32checked_shr.13
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.23
-    u32or
+    u32checked_shl.22
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.15
+    u32checked_shr.14
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.23
-    u32or
+    u32checked_shl.23
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.16
+    u32checked_shr.15
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.24
-    u32or
+    u32checked_shl.23
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.17
+    u32checked_shr.16
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.24
-    u32or
+    u32checked_shl.24
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.18
+    u32checked_shr.17
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.25
-    u32or
+    u32checked_shl.24
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.19
+    u32checked_shr.18
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.25
-    u32or
+    u32checked_shl.25
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.20
+    u32checked_shr.19
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.26
-    u32or
+    u32checked_shl.25
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.21
+    u32checked_shr.20
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.26
-    u32or
+    u32checked_shl.26
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.22
+    u32checked_shr.21
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.27
-    u32or
+    u32checked_shl.26
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.23
+    u32checked_shr.22
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.27
-    u32or
+    u32checked_shl.27
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.24
+    u32checked_shr.23
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.28
-    u32or
+    u32checked_shl.27
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.25
+    u32checked_shr.24
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.28
-    u32or
+    u32checked_shl.28
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.26
+    u32checked_shr.25
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.29
-    u32or
+    u32checked_shl.28
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.27
+    u32checked_shr.26
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.29
-    u32or
+    u32checked_shl.29
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.28
+    u32checked_shr.27
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.30
-    u32or
+    u32checked_shl.29
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.29
+    u32checked_shr.28
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.30
-    u32or
+    u32checked_shl.30
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.30
+    u32checked_shr.29
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.31
-    u32or
+    u32checked_shl.30
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.31
+    u32checked_shr.30
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.31
-    u32or
+    u32checked_shl.31
+    u32checked_or
+
+    swap
+
+    dup.2
+
+    u32checked_shr.31
+    push.1
+    u32checked_and
+
+    u32checked_shl.31
+    u32checked_or
 
     swap
 end
@@ -4392,570 +4392,570 @@ export.from_bit_interleaved
     dup
 
     push.1
-    u32and
+    u32checked_and
 
     dup.2
 
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.1
-    u32or
+    u32checked_shl.1
+    u32checked_or
 
     dup.1
 
-    u32shr.1
+    u32checked_shr.1
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.2
-    u32or
+    u32checked_shl.2
+    u32checked_or
 
     dup.2
 
-    u32shr.1
+    u32checked_shr.1
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.3
-    u32or
+    u32checked_shl.3
+    u32checked_or
 
     dup.1
 
-    u32shr.2
+    u32checked_shr.2
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.4
-    u32or
+    u32checked_shl.4
+    u32checked_or
 
     dup.2
 
-    u32shr.2
+    u32checked_shr.2
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.5
-    u32or
+    u32checked_shl.5
+    u32checked_or
 
     dup.1
 
-    u32shr.3
+    u32checked_shr.3
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.6
-    u32or
+    u32checked_shl.6
+    u32checked_or
 
     dup.2
 
-    u32shr.3
+    u32checked_shr.3
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.7
-    u32or
+    u32checked_shl.7
+    u32checked_or
 
     dup.1
 
-    u32shr.4
+    u32checked_shr.4
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.8
-    u32or
+    u32checked_shl.8
+    u32checked_or
 
     dup.2
 
-    u32shr.4
+    u32checked_shr.4
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.9
-    u32or
+    u32checked_shl.9
+    u32checked_or
 
     dup.1
 
-    u32shr.5
+    u32checked_shr.5
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.10
-    u32or
+    u32checked_shl.10
+    u32checked_or
 
     dup.2
 
-    u32shr.5
+    u32checked_shr.5
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.11
-    u32or
+    u32checked_shl.11
+    u32checked_or
 
     dup.1
 
-    u32shr.6
+    u32checked_shr.6
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.12
-    u32or
+    u32checked_shl.12
+    u32checked_or
 
     dup.2
 
-    u32shr.6
+    u32checked_shr.6
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.13
-    u32or
+    u32checked_shl.13
+    u32checked_or
 
     dup.1
 
-    u32shr.7
+    u32checked_shr.7
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.14
-    u32or
+    u32checked_shl.14
+    u32checked_or
 
     dup.2
 
-    u32shr.7
+    u32checked_shr.7
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.15
-    u32or
+    u32checked_shl.15
+    u32checked_or
 
     dup.1
 
-    u32shr.8
+    u32checked_shr.8
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.16
-    u32or
+    u32checked_shl.16
+    u32checked_or
 
     dup.2
 
-    u32shr.8
+    u32checked_shr.8
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.17
-    u32or
+    u32checked_shl.17
+    u32checked_or
 
     dup.1
 
-    u32shr.9
+    u32checked_shr.9
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.18
-    u32or
+    u32checked_shl.18
+    u32checked_or
 
     dup.2
 
-    u32shr.9
+    u32checked_shr.9
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.19
-    u32or
+    u32checked_shl.19
+    u32checked_or
 
     dup.1
 
-    u32shr.10
+    u32checked_shr.10
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.20
-    u32or
+    u32checked_shl.20
+    u32checked_or
 
     dup.2
 
-    u32shr.10
+    u32checked_shr.10
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.21
-    u32or
+    u32checked_shl.21
+    u32checked_or
 
     dup.1
 
-    u32shr.11
+    u32checked_shr.11
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.22
-    u32or
+    u32checked_shl.22
+    u32checked_or
 
     dup.2
 
-    u32shr.11
+    u32checked_shr.11
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.23
-    u32or
+    u32checked_shl.23
+    u32checked_or
 
     dup.1
 
-    u32shr.12
+    u32checked_shr.12
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.24
-    u32or
+    u32checked_shl.24
+    u32checked_or
 
     dup.2
 
-    u32shr.12
+    u32checked_shr.12
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.25
-    u32or
+    u32checked_shl.25
+    u32checked_or
 
     dup.1
 
-    u32shr.13
+    u32checked_shr.13
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.26
-    u32or
+    u32checked_shl.26
+    u32checked_or
 
     dup.2
 
-    u32shr.13
+    u32checked_shr.13
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.27
-    u32or
+    u32checked_shl.27
+    u32checked_or
 
     dup.1
 
-    u32shr.14
+    u32checked_shr.14
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.28
-    u32or
+    u32checked_shl.28
+    u32checked_or
 
     dup.2
 
-    u32shr.14
+    u32checked_shr.14
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.29
-    u32or
+    u32checked_shl.29
+    u32checked_or
 
     dup.1
 
-    u32shr.15
+    u32checked_shr.15
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.30
-    u32or
+    u32checked_shl.30
+    u32checked_or
 
     dup.2
 
-    u32shr.15
+    u32checked_shr.15
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.31
-    u32or
+    u32checked_shl.31
+    u32checked_or
 
     dup.1
 
-    u32shr.16
+    u32checked_shr.16
     push.1
-    u32and
+    u32checked_and
 
     dup.3
 
-    u32shr.16
+    u32checked_shr.16
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.1
-    u32or
+    u32checked_shl.1
+    u32checked_or
 
     dup.2
 
-    u32shr.17
+    u32checked_shr.17
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.2
-    u32or
+    u32checked_shl.2
+    u32checked_or
 
     dup.3
 
-    u32shr.17
+    u32checked_shr.17
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.3
-    u32or
+    u32checked_shl.3
+    u32checked_or
 
     dup.2
 
-    u32shr.18
+    u32checked_shr.18
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.4
-    u32or
+    u32checked_shl.4
+    u32checked_or
 
     dup.3
 
-    u32shr.18
+    u32checked_shr.18
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.5
-    u32or
+    u32checked_shl.5
+    u32checked_or
 
     dup.2
 
-    u32shr.19
+    u32checked_shr.19
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.6
-    u32or
+    u32checked_shl.6
+    u32checked_or
 
     dup.3
 
-    u32shr.19
+    u32checked_shr.19
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.7
-    u32or
+    u32checked_shl.7
+    u32checked_or
 
     dup.2
 
-    u32shr.20
+    u32checked_shr.20
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.8
-    u32or
+    u32checked_shl.8
+    u32checked_or
 
     dup.3
 
-    u32shr.20
+    u32checked_shr.20
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.9
-    u32or
+    u32checked_shl.9
+    u32checked_or
 
     dup.2
 
-    u32shr.21
+    u32checked_shr.21
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.10
-    u32or
+    u32checked_shl.10
+    u32checked_or
 
     dup.3
 
-    u32shr.21
+    u32checked_shr.21
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.11
-    u32or
+    u32checked_shl.11
+    u32checked_or
 
     dup.2
 
-    u32shr.22
+    u32checked_shr.22
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.12
-    u32or
+    u32checked_shl.12
+    u32checked_or
 
     dup.3
 
-    u32shr.22
+    u32checked_shr.22
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.13
-    u32or
+    u32checked_shl.13
+    u32checked_or
 
     dup.2
 
-    u32shr.23
+    u32checked_shr.23
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.14
-    u32or
+    u32checked_shl.14
+    u32checked_or
 
     dup.3
 
-    u32shr.23
+    u32checked_shr.23
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.15
-    u32or
+    u32checked_shl.15
+    u32checked_or
 
     dup.2
 
-    u32shr.24
+    u32checked_shr.24
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.16
-    u32or
+    u32checked_shl.16
+    u32checked_or
 
     dup.3
 
-    u32shr.24
+    u32checked_shr.24
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.17
-    u32or
+    u32checked_shl.17
+    u32checked_or
 
     dup.2
 
-    u32shr.25
+    u32checked_shr.25
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.18
-    u32or
+    u32checked_shl.18
+    u32checked_or
 
     dup.3
 
-    u32shr.25
+    u32checked_shr.25
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.19
-    u32or
+    u32checked_shl.19
+    u32checked_or
 
     dup.2
 
-    u32shr.26
+    u32checked_shr.26
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.20
-    u32or
+    u32checked_shl.20
+    u32checked_or
 
     dup.3
 
-    u32shr.26
+    u32checked_shr.26
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.21
-    u32or
+    u32checked_shl.21
+    u32checked_or
 
     dup.2
 
-    u32shr.27
+    u32checked_shr.27
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.22
-    u32or
+    u32checked_shl.22
+    u32checked_or
 
     dup.3
 
-    u32shr.27
+    u32checked_shr.27
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.23
-    u32or
+    u32checked_shl.23
+    u32checked_or
 
     dup.2
 
-    u32shr.28
+    u32checked_shr.28
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.24
-    u32or
+    u32checked_shl.24
+    u32checked_or
 
     dup.3
 
-    u32shr.28
+    u32checked_shr.28
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.25
-    u32or
+    u32checked_shl.25
+    u32checked_or
 
     dup.2
 
-    u32shr.29
+    u32checked_shr.29
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.26
-    u32or
+    u32checked_shl.26
+    u32checked_or
 
     dup.3
 
-    u32shr.29
+    u32checked_shr.29
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.27
-    u32or
+    u32checked_shl.27
+    u32checked_or
 
     dup.2
 
-    u32shr.30
+    u32checked_shr.30
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.28
-    u32or
+    u32checked_shl.28
+    u32checked_or
 
     dup.3
 
-    u32shr.30
+    u32checked_shr.30
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.29
-    u32or
+    u32checked_shl.29
+    u32checked_or
 
     dup.2
 
-    u32shr.31
+    u32checked_shr.31
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.30
-    u32or
+    u32checked_shl.30
+    u32checked_or
 
     dup.3
 
-    u32shr.31
+    u32checked_shr.31
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.31
-    u32or
+    u32checked_shl.31
+    u32checked_or
 end
 
 # given 64 -bytes input ( in terms of sixteen u32 elements on stack top ) to 2-to-1

--- a/stdlib/asm/crypto/hashes/sha256.masm
+++ b/stdlib/asm/crypto/hashes/sha256.masm
@@ -1,106 +1,106 @@
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L73-L79
 proc.small_sigma_0
     dup
-    u32rotr.7
+    u32checked_rotr.7
 
     swap
 
     dup
-    u32rotr.18
+    u32checked_rotr.18
 
     swap
 
-    u32shr.3
+    u32checked_shr.3
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L81-L87
 proc.small_sigma_1
     dup
-    u32rotr.17
+    u32checked_rotr.17
 
     swap
 
     dup
-    u32rotr.19
+    u32checked_rotr.19
 
     swap
 
-    u32shr.10
+    u32checked_shr.10
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L57-L63
 proc.cap_sigma_0
     dup
-    u32rotr.2
+    u32checked_rotr.2
 
     swap
 
     dup
-    u32rotr.13
+    u32checked_rotr.13
 
     swap
 
-    u32rotr.22
+    u32checked_rotr.22
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L65-L71
 proc.cap_sigma_1
     dup
-    u32rotr.6
+    u32checked_rotr.6
 
     swap
 
     dup
-    u32rotr.11
+    u32checked_rotr.11
 
     swap
 
-    u32rotr.25
+    u32checked_rotr.25
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L37-L45
 proc.ch
     swap
     dup.1
-    u32and
+    u32checked_and
 
     swap
-    u32not
+    u32checked_not
 
     movup.2
-    u32and
+    u32checked_and
 
-    u32xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L47-L55
 proc.maj
     dup.1
     dup.1
-    u32and
+    u32checked_and
 
     swap
     dup.3
-    u32and
+    u32checked_and
 
     movup.2
     movup.3
-    u32and
+    u32checked_and
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # assume top 4 elements of stack are [3, 2, 1, 0, ...], then after execution of this function, stack should look like [0, 1, 2, 3, ...]

--- a/stdlib/asm/math/u256.masm
+++ b/stdlib/asm/math/u256.masm
@@ -93,87 +93,87 @@ export.and
     swapw.3
     movup.3
     movup.7
-    u32and
+    u32checked_and
     movup.3
     movup.6
-    u32and
+    u32checked_and
     movup.3
     movup.5
-    u32and
+    u32checked_and
     movup.3
     movup.4
-    u32and
+    u32checked_and
     swapw.2
     movup.3
     movup.7
-    u32and
+    u32checked_and
     movup.3
     movup.6
-    u32and
+    u32checked_and
     movup.3
     movup.5
-    u32and
+    u32checked_and
     movup.3
     movup.4
-    u32and
+    u32checked_and
 end
 
 export.or
     swapw.3
     movup.3
     movup.7
-    u32or
+    u32checked_or
     movup.3
     movup.6
-    u32or
+    u32checked_or
     movup.3
     movup.5
-    u32or
+    u32checked_or
     movup.3
     movup.4
-    u32or
+    u32checked_or
     swapw.2
     movup.3
     movup.7
-    u32or
+    u32checked_or
     movup.3
     movup.6
-    u32or
+    u32checked_or
     movup.3
     movup.5
-    u32or
+    u32checked_or
     movup.3
     movup.4
-    u32or
+    u32checked_or
 end
 
 export.xor
     swapw.3
     movup.3
     movup.7
-    u32xor
+    u32checked_xor
     movup.3
     movup.6
-    u32xor
+    u32checked_xor
     movup.3
     movup.5
-    u32xor
+    u32checked_xor
     movup.3
     movup.4
-    u32xor
+    u32checked_xor
     swapw.2
     movup.3
     movup.7
-    u32xor
+    u32checked_xor
     movup.3
     movup.6
-    u32xor
+    u32checked_xor
     movup.3
     movup.5
-    u32xor
+    u32checked_xor
     movup.3
     movup.4
-    u32xor
+    u32checked_xor
 end
 
 export.iszero_unsafe

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -158,7 +158,7 @@ end
 export.checked_mul
     exec.u32assert4
     exec.overflowing_mul
-    u32or
+    u32checked_or
     eq.0
     assert
 end
@@ -264,10 +264,10 @@ end
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise.
 export.unchecked_eq
     movup.2
-    u32eq
+    u32checked_eq
     swap
     movup.2
-    u32eq
+    u32checked_eq
     and
 end
 
@@ -286,10 +286,10 @@ end
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a != b, and 0 otherwise.
 export.unchecked_neq
     movup.2
-    u32neq
+    u32checked_neq
     swap
     movup.2
-    u32neq
+    u32checked_neq
     or
 end
 
@@ -593,10 +593,10 @@ end
 export.checked_and
     swap
     movup.3
-    u32and
+    u32checked_and
     swap
     movup.2
-    u32and
+    u32checked_and
 end
 
 # Performs bitwise OR of two unsigned 64 bit integers.
@@ -606,10 +606,10 @@ end
 export.checked_or
     swap
     movup.3
-    u32or
+    u32checked_or
     swap
     movup.2
-    u32or
+    u32checked_or
 end
 
 # Performs bitwise XOR of two unsigned 64 bit integers.
@@ -619,10 +619,10 @@ end
 export.checked_xor
     swap
     movup.3
-    u32xor
+    u32checked_xor
     swap
     movup.2
-    u32xor
+    u32checked_xor
 end
 
 # Performs left shift of one unsigned 64-bit integer using the pow2 operation.
@@ -738,7 +738,7 @@ export.unchecked_rotl
 
     # Shift the low limb.
     push.31
-    u32and
+    u32checked_and
     pow2.unsafe
     dup
     movup.3
@@ -775,7 +775,7 @@ export.unchecked_rotr
 
     # Shift the low limb left by 32-b.
     push.31
-    u32and
+    u32checked_and
     push.32
     swap
     u32overflowing_sub

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -91,41 +91,41 @@ end
 # that's because it doesn't dictate what output of 2-to-1 hash will be.
 proc.finalize
     movup.8
-    u32xor
+    u32checked_xor
 
     swap
     movup.8
-    u32xor
+    u32checked_xor
     swap
 
     movup.2
     movup.8
-    u32xor
+    u32checked_xor
     movdn.2
 
     movup.3
     movup.8
-    u32xor
+    u32checked_xor
     movdn.3
 
     movup.4
     movup.8
-    u32xor
+    u32checked_xor
     movdn.4
 
     movup.5
     movup.8
-    u32xor
+    u32checked_xor
     movdn.5
 
     movup.6
     movup.8
-    u32xor
+    u32checked_xor
     movdn.6
 
     movup.7
     movup.8
-    u32xor
+    u32checked_xor
     movdn.7
 end
 
@@ -194,25 +194,25 @@ proc.columnar_mixing.1
     pushw.mem
 
     dup.4
-    u32xor
-    u32rotr.16
-
+    u32checked_xor
+    u32checked_rotr.16
+    
     swap
     dup.5
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     swap
 
     movup.2
     dup.6
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     movdn.2
 
     movup.3
     dup.7
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     movdn.3
 
     movup.12
@@ -239,25 +239,25 @@ proc.columnar_mixing.1
     movupw.3
 
     dup.4
-    u32xor
-    u32rotr.12
-
+    u32checked_xor
+    u32checked_rotr.12
+    
     swap
     dup.5
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     swap
 
     movup.2
     dup.6
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     movdn.2
 
     movup.3
     dup.7
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     movdn.3
 
     movupw.3
@@ -293,25 +293,25 @@ proc.columnar_mixing.1
     movupw.3
 
     dup.4
-    u32xor
-    u32rotr.8
-
+    u32checked_xor
+    u32checked_rotr.8
+    
     swap
     dup.5
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     swap
 
     movup.2
     dup.6
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     movdn.2
 
     movup.3
     dup.7
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     movdn.3
 
     movupw.3
@@ -337,25 +337,25 @@ proc.columnar_mixing.1
     movupw.3
 
     dup.4
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
 
     swap
     dup.5
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     swap
 
     movup.2
     dup.6
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     movdn.2
 
     movup.3
     dup.7
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     movdn.3
 
     movupw.3
@@ -427,24 +427,24 @@ proc.diagonal_mixing.1
 
     movup.3
     dup.4
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     movdn.3
 
     dup.5
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
 
     swap
     dup.6
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     swap
 
     movup.2
     dup.7
-    u32xor
-    u32rotr.16
+    u32checked_xor
+    u32checked_rotr.16
     movdn.2
 
     movup.12
@@ -472,25 +472,25 @@ proc.diagonal_mixing.1
 
     swap
     dup.6
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     swap
 
     movup.2
     dup.7
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     movdn.2
 
     movup.3
     dup.4
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
     movdn.3
 
     dup.5
-    u32xor
-    u32rotr.12
+    u32checked_xor
+    u32checked_rotr.12
 
     movupw.3
     pushw.local.0
@@ -526,24 +526,24 @@ proc.diagonal_mixing.1
 
     movup.3
     dup.4
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     movdn.3
 
     dup.5
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
 
     swap
     dup.6
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     swap
 
     movup.2
     dup.7
-    u32xor
-    u32rotr.8
+    u32checked_xor
+    u32checked_rotr.8
     movdn.2
 
     movupw.3
@@ -570,25 +570,25 @@ proc.diagonal_mixing.1
 
     swap
     dup.6
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     swap
 
     movup.2
     dup.7
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     movdn.2
 
     movup.3
     dup.4
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
     movdn.3
 
     dup.5
-    u32xor
-    u32rotr.7
+    u32checked_xor
+    u32checked_rotr.7
 
     movupw.3
 end
@@ -743,20 +743,20 @@ end
 # given four elements of from each of a, b sets, following procedure computes a[i] ^ b[i] ∀ i = [0, 3]
 proc.xor_4_elements
     movup.7
-    u32xor
+    u32checked_xor
 
     swap
 
     movup.6
-    u32xor
+    u32checked_xor
 
     movup.2
     movup.5
-    u32xor
+    u32checked_xor
 
     movup.4
     movup.4
-    u32xor
+    u32checked_xor
 end
 
 # keccak-p[b, n_r] | b = 1600, n_r = 24, permutation's θ function, which is
@@ -790,7 +790,7 @@ proc.theta.7
     swap
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
     drop
@@ -810,8 +810,8 @@ proc.theta.7
     swap
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
     drop
@@ -825,7 +825,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     # stack = [c_0]
     # -----
@@ -850,7 +850,7 @@ proc.theta.7
     drop
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
     drop
@@ -872,8 +872,8 @@ proc.theta.7
     drop
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
     drop
@@ -889,7 +889,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     # stack = [c_1, c_0]
     # -----
@@ -917,7 +917,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
 
@@ -934,7 +934,7 @@ proc.theta.7
     swap
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -959,8 +959,8 @@ proc.theta.7
     swap
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_2, c_1, c_0]
     # -----
@@ -989,7 +989,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
 
@@ -1005,7 +1005,7 @@ proc.theta.7
     drop
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -1030,8 +1030,8 @@ proc.theta.7
     drop
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_3, c_2, c_1, c_0]
     # -----
@@ -1059,7 +1059,7 @@ proc.theta.7
     swap
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
 
@@ -1075,7 +1075,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -1100,8 +1100,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -1129,7 +1129,7 @@ proc.theta.7
     drop
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.1
 
@@ -1146,7 +1146,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -1171,8 +1171,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_5, c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -1216,8 +1216,8 @@ proc.theta.7
     swap
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -1241,8 +1241,8 @@ proc.theta.7
     swap
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_6, c_5, c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -1285,8 +1285,8 @@ proc.theta.7
     drop
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -1310,8 +1310,8 @@ proc.theta.7
     drop
     drop
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     # stack = [c_7, c_6, c_5, c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -1354,8 +1354,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -1372,7 +1372,7 @@ proc.theta.7
     swap
     drop
 
-    u32xor
+    u32checked_xor
 
     pushw.local.3
 
@@ -1388,7 +1388,7 @@ proc.theta.7
         drop
     end
 
-    u32xor
+    u32checked_xor
 
     # stack = [c_8, c_7, c_6, c_5, c_4, c_3, c_2, c_1, c_0]
     # -----
@@ -1432,8 +1432,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     pushw.local.2
 
@@ -1464,8 +1464,8 @@ proc.theta.7
         drop
     end
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 
     push.0.0
 
@@ -1495,14 +1495,14 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
     movup.2
     swap
 
-    u32rotl.1
-    u32xor
+    u32checked_rotl.1
+    u32checked_xor
 
     # stack = [d0, d1]
 
@@ -1519,12 +1519,12 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
-    u32rotl.1
+    u32checked_rotl.1
     movup.2
-    u32xor
+    u32checked_xor
 
     # stack = [d2, d3, d0, d1]
 
@@ -1542,12 +1542,12 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
-    u32rotl.1
+    u32checked_rotl.1
     movup.2
-    u32xor
+    u32checked_xor
 
     # stack = [d4, d5, d0, d1, d2, d3]
 
@@ -1564,12 +1564,12 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
-    u32rotl.1
+    u32checked_rotl.1
     movup.2
-    u32xor
+    u32checked_xor
 
     # stack = [d6, d7, d4, d5, d0, d1, d2, d3]
 
@@ -1589,12 +1589,12 @@ proc.theta.7
     drop
 
     movup.3
-    u32xor
+    u32checked_xor
 
     swap
-    u32rotl.1
+    u32checked_rotl.1
     movup.2
-    u32xor
+    u32checked_xor
 
     # stack = [d8, d9, d4, d5, d6, d7, d0, d1, d2, d3]
 
@@ -1822,7 +1822,7 @@ proc.rho.4
     pushw.mem
     exec.rev_4_elements
 
-    u32rotl.1
+    u32checked_rotl.1
     swap
 
     exec.rev_4_elements
@@ -1832,16 +1832,16 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.31
+    u32checked_rotl.31
     swap
-    u32rotl.31
+    u32checked_rotl.31
     swap
 
     exec.rev_4_elements
 
-    u32rotl.14
+    u32checked_rotl.14
     swap
-    u32rotl.14
+    u32checked_rotl.14
     swap
 
     exec.rev_4_elements
@@ -1851,15 +1851,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.13
+    u32checked_rotl.13
     swap
-    u32rotl.14
+    u32checked_rotl.14
 
     exec.rev_4_elements
 
-    u32rotl.18
+    u32checked_rotl.18
     swap
-    u32rotl.18
+    u32checked_rotl.18
     swap
 
     exec.rev_4_elements
@@ -1869,16 +1869,16 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.22
+    u32checked_rotl.22
     swap
-    u32rotl.22
+    u32checked_rotl.22
     swap
 
     exec.rev_4_elements
 
-    u32rotl.3
+    u32checked_rotl.3
     swap
-    u32rotl.3
+    u32checked_rotl.3
     swap
 
     exec.rev_4_elements
@@ -1891,15 +1891,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.27
+    u32checked_rotl.27
     swap
-    u32rotl.28
+    u32checked_rotl.28
 
     exec.rev_4_elements
 
-    u32rotl.10
+    u32checked_rotl.10
     swap
-    u32rotl.10
+    u32checked_rotl.10
     swap
 
     exec.rev_4_elements
@@ -1909,15 +1909,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.1
+    u32checked_rotl.1
     swap
-    u32rotl.2
+    u32checked_rotl.2
 
     exec.rev_4_elements
 
-    u32rotl.5
+    u32checked_rotl.5
     swap
-    u32rotl.5
+    u32checked_rotl.5
     swap
 
     exec.rev_4_elements
@@ -1927,15 +1927,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.21
+    u32checked_rotl.21
     swap
-    u32rotl.22
+    u32checked_rotl.22
 
     exec.rev_4_elements
 
-    u32rotl.13
+    u32checked_rotl.13
     swap
-    u32rotl.12
+    u32checked_rotl.12
 
     exec.rev_4_elements
 
@@ -1944,15 +1944,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.19
+    u32checked_rotl.19
     swap
-    u32rotl.20
+    u32checked_rotl.20
 
     exec.rev_4_elements
 
-    u32rotl.21
+    u32checked_rotl.21
     swap
-    u32rotl.20
+    u32checked_rotl.20
 
     exec.rev_4_elements
 
@@ -1964,15 +1964,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.22
+    u32checked_rotl.22
     swap
-    u32rotl.23
+    u32checked_rotl.23
 
     exec.rev_4_elements
 
-    u32rotl.8
+    u32checked_rotl.8
     swap
-    u32rotl.7
+    u32checked_rotl.7
 
     exec.rev_4_elements
 
@@ -1981,15 +1981,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.10
+    u32checked_rotl.10
     swap
-    u32rotl.11
+    u32checked_rotl.11
 
     exec.rev_4_elements
 
-    u32rotl.4
+    u32checked_rotl.4
     swap
-    u32rotl.4
+    u32checked_rotl.4
     swap
 
     exec.rev_4_elements
@@ -1999,16 +1999,16 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.9
+    u32checked_rotl.9
     swap
-    u32rotl.9
+    u32checked_rotl.9
     swap
 
     exec.rev_4_elements
 
-    u32rotl.1
+    u32checked_rotl.1
     swap
-    u32rotl.1
+    u32checked_rotl.1
     swap
 
     exec.rev_4_elements
@@ -2018,15 +2018,15 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.30
+    u32checked_rotl.30
     swap
-    u32rotl.31
+    u32checked_rotl.31
 
     exec.rev_4_elements
 
-    u32rotl.28
+    u32checked_rotl.28
     swap
-    u32rotl.28
+    u32checked_rotl.28
     swap
 
     exec.rev_4_elements
@@ -2045,9 +2045,9 @@ proc.rho.4
 
     pushw.mem
 
-    u32rotl.7
+    u32checked_rotl.7
     swap
-    u32rotl.7
+    u32checked_rotl.7
     swap
 
     movup.4
@@ -2494,17 +2494,17 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.0
@@ -2517,17 +2517,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     swap
@@ -2557,17 +2557,17 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     pushw.local.0
 
@@ -2584,9 +2584,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
 
     movup.2
     pushw.mem
@@ -2597,11 +2597,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     swap
     exec.rev_4_elements
@@ -2617,17 +2617,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     push.0.0
     exec.rev_4_elements
@@ -2680,17 +2680,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     swap
     push.0.0
@@ -2722,17 +2722,17 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     pushw.local.1
 
@@ -2743,17 +2743,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     popw.local.5 # write to c[2..6]
@@ -2770,9 +2770,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     pushw.local.0
@@ -2788,11 +2788,11 @@ proc.chi.7
     drop
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     pushw.local.0
 
@@ -2804,9 +2804,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
@@ -2819,11 +2819,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     exec.rev_4_elements
@@ -2885,9 +2885,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
@@ -2900,11 +2900,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.1
@@ -2916,17 +2916,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     popw.local.4 # write to c[0..4]
@@ -2941,9 +2941,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
@@ -2956,11 +2956,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.1
@@ -2976,9 +2976,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
 
     pushw.local.1
 
@@ -2996,11 +2996,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     exec.rev_4_elements
@@ -3016,17 +3016,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     push.0.0
     exec.rev_4_elements
@@ -3079,17 +3079,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     push.0.0
@@ -3106,9 +3106,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     dup.2
@@ -3121,27 +3121,27 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     movup.2
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     popw.local.5 # write to c[2..6]
@@ -3159,9 +3159,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     pushw.local.1
@@ -3176,11 +3176,11 @@ proc.chi.7
     drop
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     pushw.local.1
 
@@ -3193,9 +3193,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     pushw.local.2
@@ -3213,11 +3213,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     exec.rev_4_elements
@@ -3281,9 +3281,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
@@ -3296,11 +3296,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.2
@@ -3311,17 +3311,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     exec.rev_4_elements
     popw.local.4 # write to c[0..4]
@@ -3337,9 +3337,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     pushw.local.3
@@ -3357,11 +3357,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     pushw.local.3
@@ -3378,9 +3378,9 @@ proc.chi.7
     drop
     drop
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
 
     pushw.local.2
 
@@ -3397,11 +3397,11 @@ proc.chi.7
     drop
 
     movup.3
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
     swap
 
     exec.rev_4_elements
@@ -3416,17 +3416,17 @@ proc.chi.7
 
     pushw.mem
 
-    u32not
+    u32checked_not
     swap
-    u32not
+    u32checked_not
     swap
 
     movup.2
-    u32and
+    u32checked_and
 
     swap
     movup.2
-    u32and
+    u32checked_and
 
     push.0.0
 
@@ -3487,7 +3487,7 @@ proc.iota_round_1
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     movup.4
     popw.mem # write to state[0..2]
@@ -3503,7 +3503,7 @@ proc.iota_round_2
     swap
 
     push.137
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3521,7 +3521,7 @@ proc.iota_round_3
     swap
 
     push.2147483787
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3539,7 +3539,7 @@ proc.iota_round_4
     swap
 
     push.2147516544
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3555,12 +3555,12 @@ proc.iota_round_5
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.139
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3576,12 +3576,12 @@ proc.iota_round_6
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.32768
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3597,12 +3597,12 @@ proc.iota_round_7
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147516552
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3618,12 +3618,12 @@ proc.iota_round_8
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147483778
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3641,7 +3641,7 @@ proc.iota_round_9
     swap
 
     push.11
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3659,7 +3659,7 @@ proc.iota_round_10
     swap
 
     push.10
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3675,12 +3675,12 @@ proc.iota_round_11
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.32898
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3698,7 +3698,7 @@ proc.iota_round_12
     swap
 
     push.32771
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3714,12 +3714,12 @@ proc.iota_round_13
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.32907
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3735,12 +3735,12 @@ proc.iota_round_14
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147483659
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3756,12 +3756,12 @@ proc.iota_round_15
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147483786
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3777,12 +3777,12 @@ proc.iota_round_16
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147483777
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3800,7 +3800,7 @@ proc.iota_round_17
     swap
 
     push.2147483777
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3818,7 +3818,7 @@ proc.iota_round_18
     swap
 
     push.2147483656
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3836,7 +3836,7 @@ proc.iota_round_19
     swap
 
     push.131
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3854,7 +3854,7 @@ proc.iota_round_20
     swap
 
     push.2147516419
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3870,12 +3870,12 @@ proc.iota_round_21
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.2147516552
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3893,7 +3893,7 @@ proc.iota_round_22
     swap
 
     push.2147483784
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3909,12 +3909,12 @@ proc.iota_round_23
     pushw.mem
 
     push.1
-    u32xor
+    u32checked_xor
 
     swap
 
     push.32768
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -3932,7 +3932,7 @@ proc.iota_round_24
     swap
 
     push.2147516546
-    u32xor
+    u32checked_xor
 
     swap
 
@@ -4419,693 +4419,693 @@ export.to_bit_interleaved
     dup.1
 
     push.1
-    u32and
+    u32checked_and
 
     dup.2
-    u32shr.1
+    u32checked_shr.1
     push.1
-    u32and
+    u32checked_and
 
     swap
 
     dup.3
 
-    u32shr.2
+    u32checked_shr.2
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.1
-    u32or
+    u32checked_shl.1
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.3
+    u32checked_shr.3
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.1
-    u32or
+    u32checked_shl.1
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.4
+    u32checked_shr.4
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.2
-    u32or
+    u32checked_shl.2
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.5
+    u32checked_shr.5
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.2
-    u32or
+    u32checked_shl.2
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.6
+    u32checked_shr.6
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.3
-    u32or
+    u32checked_shl.3
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.7
+    u32checked_shr.7
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.3
-    u32or
+    u32checked_shl.3
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.8
+    u32checked_shr.8
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.4
-    u32or
+    u32checked_shl.4
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.9
+    u32checked_shr.9
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.4
-    u32or
+    u32checked_shl.4
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.10
+    u32checked_shr.10
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.5
-    u32or
+    u32checked_shl.5
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.11
+    u32checked_shr.11
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.5
-    u32or
+    u32checked_shl.5
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.12
+    u32checked_shr.12
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.6
-    u32or
+    u32checked_shl.6
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.13
+    u32checked_shr.13
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.6
-    u32or
+    u32checked_shl.6
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.14
+    u32checked_shr.14
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.7
-    u32or
+    u32checked_shl.7
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.15
+    u32checked_shr.15
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.7
-    u32or
+    u32checked_shl.7
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.16
+    u32checked_shr.16
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.8
-    u32or
+    u32checked_shl.8
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.17
+    u32checked_shr.17
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.8
-    u32or
+    u32checked_shl.8
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.18
+    u32checked_shr.18
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.9
-    u32or
+    u32checked_shl.9
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.19
+    u32checked_shr.19
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.9
-    u32or
+    u32checked_shl.9
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.20
+    u32checked_shr.20
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.10
-    u32or
+    u32checked_shl.10
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.21
+    u32checked_shr.21
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.10
-    u32or
+    u32checked_shl.10
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.22
+    u32checked_shr.22
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.11
-    u32or
+    u32checked_shl.11
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.23
+    u32checked_shr.23
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.11
-    u32or
+    u32checked_shl.11
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.24
+    u32checked_shr.24
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.12
-    u32or
+    u32checked_shl.12
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.25
+    u32checked_shr.25
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.12
-    u32or
+    u32checked_shl.12
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.26
+    u32checked_shr.26
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.13
-    u32or
+    u32checked_shl.13
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.27
+    u32checked_shr.27
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.13
-    u32or
+    u32checked_shl.13
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.28
+    u32checked_shr.28
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.14
-    u32or
+    u32checked_shl.14
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.29
+    u32checked_shr.29
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.14
-    u32or
+    u32checked_shl.14
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.30
+    u32checked_shr.30
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.15
-    u32or
+    u32checked_shl.15
+    u32checked_or
 
     swap
 
     dup.3
 
-    u32shr.31
+    u32checked_shr.31
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.15
-    u32or
+    u32checked_shl.15
+    u32checked_or
 
     swap
 
     dup.2
 
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.16
-    u32or
-
-    swap
-
-    dup.2
-
-    u32shr.1
-    push.1
-    u32and
-
-    u32shl.16
-    u32or
+    u32checked_shl.16
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.2
+    u32checked_shr.1
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.17
-    u32or
+    u32checked_shl.16
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.3
+    u32checked_shr.2
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.17
-    u32or
+    u32checked_shl.17
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.4
+    u32checked_shr.3
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.18
-    u32or
+    u32checked_shl.17
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.5
+    u32checked_shr.4
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.18
-    u32or
+    u32checked_shl.18
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.6
+    u32checked_shr.5
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.19
-    u32or
+    u32checked_shl.18
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.7
+    u32checked_shr.6
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.19
-    u32or
+    u32checked_shl.19
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.8
+    u32checked_shr.7
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.20
-    u32or
+    u32checked_shl.19
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.9
+    u32checked_shr.8
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.20
-    u32or
+    u32checked_shl.20
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.10
+    u32checked_shr.9
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.21
-    u32or
+    u32checked_shl.20
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.11
+    u32checked_shr.10
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.21
-    u32or
+    u32checked_shl.21
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.12
+    u32checked_shr.11
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.22
-    u32or
+    u32checked_shl.21
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.13
+    u32checked_shr.12
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.22
-    u32or
+    u32checked_shl.22
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.14
+    u32checked_shr.13
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.23
-    u32or
+    u32checked_shl.22
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.15
+    u32checked_shr.14
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.23
-    u32or
+    u32checked_shl.23
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.16
+    u32checked_shr.15
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.24
-    u32or
+    u32checked_shl.23
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.17
+    u32checked_shr.16
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.24
-    u32or
+    u32checked_shl.24
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.18
+    u32checked_shr.17
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.25
-    u32or
+    u32checked_shl.24
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.19
+    u32checked_shr.18
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.25
-    u32or
+    u32checked_shl.25
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.20
+    u32checked_shr.19
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.26
-    u32or
+    u32checked_shl.25
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.21
+    u32checked_shr.20
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.26
-    u32or
+    u32checked_shl.26
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.22
+    u32checked_shr.21
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.27
-    u32or
+    u32checked_shl.26
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.23
+    u32checked_shr.22
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.27
-    u32or
+    u32checked_shl.27
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.24
+    u32checked_shr.23
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.28
-    u32or
+    u32checked_shl.27
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.25
+    u32checked_shr.24
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.28
-    u32or
+    u32checked_shl.28
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.26
+    u32checked_shr.25
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.29
-    u32or
+    u32checked_shl.28
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.27
+    u32checked_shr.26
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.29
-    u32or
+    u32checked_shl.29
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.28
+    u32checked_shr.27
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.30
-    u32or
+    u32checked_shl.29
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.29
+    u32checked_shr.28
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.30
-    u32or
+    u32checked_shl.30
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.30
+    u32checked_shr.29
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.31
-    u32or
+    u32checked_shl.30
+    u32checked_or
 
     swap
 
     dup.2
 
-    u32shr.31
+    u32checked_shr.30
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.31
-    u32or
+    u32checked_shl.31
+    u32checked_or
+
+    swap
+
+    dup.2
+
+    u32checked_shr.31
+    push.1
+    u32checked_and
+
+    u32checked_shl.31
+    u32checked_or
 
     swap
 end
@@ -5126,570 +5126,570 @@ export.from_bit_interleaved
     dup
 
     push.1
-    u32and
+    u32checked_and
 
     dup.2
 
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.1
-    u32or
+    u32checked_shl.1
+    u32checked_or
 
     dup.1
 
-    u32shr.1
+    u32checked_shr.1
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.2
-    u32or
+    u32checked_shl.2
+    u32checked_or
 
     dup.2
 
-    u32shr.1
+    u32checked_shr.1
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.3
-    u32or
+    u32checked_shl.3
+    u32checked_or
 
     dup.1
 
-    u32shr.2
+    u32checked_shr.2
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.4
-    u32or
+    u32checked_shl.4
+    u32checked_or
 
     dup.2
 
-    u32shr.2
+    u32checked_shr.2
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.5
-    u32or
+    u32checked_shl.5
+    u32checked_or
 
     dup.1
 
-    u32shr.3
+    u32checked_shr.3
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.6
-    u32or
+    u32checked_shl.6
+    u32checked_or
 
     dup.2
 
-    u32shr.3
+    u32checked_shr.3
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.7
-    u32or
+    u32checked_shl.7
+    u32checked_or
 
     dup.1
 
-    u32shr.4
+    u32checked_shr.4
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.8
-    u32or
+    u32checked_shl.8
+    u32checked_or
 
     dup.2
 
-    u32shr.4
+    u32checked_shr.4
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.9
-    u32or
+    u32checked_shl.9
+    u32checked_or
 
     dup.1
 
-    u32shr.5
+    u32checked_shr.5
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.10
-    u32or
+    u32checked_shl.10
+    u32checked_or
 
     dup.2
 
-    u32shr.5
+    u32checked_shr.5
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.11
-    u32or
+    u32checked_shl.11
+    u32checked_or
 
     dup.1
 
-    u32shr.6
+    u32checked_shr.6
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.12
-    u32or
+    u32checked_shl.12
+    u32checked_or
 
     dup.2
 
-    u32shr.6
+    u32checked_shr.6
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.13
-    u32or
+    u32checked_shl.13
+    u32checked_or
 
     dup.1
 
-    u32shr.7
+    u32checked_shr.7
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.14
-    u32or
+    u32checked_shl.14
+    u32checked_or
 
     dup.2
 
-    u32shr.7
+    u32checked_shr.7
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.15
-    u32or
+    u32checked_shl.15
+    u32checked_or
 
     dup.1
 
-    u32shr.8
+    u32checked_shr.8
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.16
-    u32or
+    u32checked_shl.16
+    u32checked_or
 
     dup.2
 
-    u32shr.8
+    u32checked_shr.8
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.17
-    u32or
+    u32checked_shl.17
+    u32checked_or
 
     dup.1
 
-    u32shr.9
+    u32checked_shr.9
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.18
-    u32or
+    u32checked_shl.18
+    u32checked_or
 
     dup.2
 
-    u32shr.9
+    u32checked_shr.9
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.19
-    u32or
+    u32checked_shl.19
+    u32checked_or
 
     dup.1
 
-    u32shr.10
+    u32checked_shr.10
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.20
-    u32or
+    u32checked_shl.20
+    u32checked_or
 
     dup.2
 
-    u32shr.10
+    u32checked_shr.10
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.21
-    u32or
+    u32checked_shl.21
+    u32checked_or
 
     dup.1
 
-    u32shr.11
+    u32checked_shr.11
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.22
-    u32or
+    u32checked_shl.22
+    u32checked_or
 
     dup.2
 
-    u32shr.11
+    u32checked_shr.11
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.23
-    u32or
+    u32checked_shl.23
+    u32checked_or
 
     dup.1
 
-    u32shr.12
+    u32checked_shr.12
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.24
-    u32or
+    u32checked_shl.24
+    u32checked_or
 
     dup.2
 
-    u32shr.12
+    u32checked_shr.12
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.25
-    u32or
+    u32checked_shl.25
+    u32checked_or
 
     dup.1
 
-    u32shr.13
+    u32checked_shr.13
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.26
-    u32or
+    u32checked_shl.26
+    u32checked_or
 
     dup.2
 
-    u32shr.13
+    u32checked_shr.13
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.27
-    u32or
+    u32checked_shl.27
+    u32checked_or
 
     dup.1
 
-    u32shr.14
+    u32checked_shr.14
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.28
-    u32or
+    u32checked_shl.28
+    u32checked_or
 
     dup.2
 
-    u32shr.14
+    u32checked_shr.14
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.29
-    u32or
+    u32checked_shl.29
+    u32checked_or
 
     dup.1
 
-    u32shr.15
+    u32checked_shr.15
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.30
-    u32or
+    u32checked_shl.30
+    u32checked_or
 
     dup.2
 
-    u32shr.15
+    u32checked_shr.15
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.31
-    u32or
+    u32checked_shl.31
+    u32checked_or
 
     dup.1
 
-    u32shr.16
+    u32checked_shr.16
     push.1
-    u32and
+    u32checked_and
 
     dup.3
 
-    u32shr.16
+    u32checked_shr.16
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.1
-    u32or
+    u32checked_shl.1
+    u32checked_or
 
     dup.2
 
-    u32shr.17
+    u32checked_shr.17
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.2
-    u32or
+    u32checked_shl.2
+    u32checked_or
 
     dup.3
 
-    u32shr.17
+    u32checked_shr.17
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.3
-    u32or
+    u32checked_shl.3
+    u32checked_or
 
     dup.2
 
-    u32shr.18
+    u32checked_shr.18
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.4
-    u32or
+    u32checked_shl.4
+    u32checked_or
 
     dup.3
 
-    u32shr.18
+    u32checked_shr.18
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.5
-    u32or
+    u32checked_shl.5
+    u32checked_or
 
     dup.2
 
-    u32shr.19
+    u32checked_shr.19
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.6
-    u32or
+    u32checked_shl.6
+    u32checked_or
 
     dup.3
 
-    u32shr.19
+    u32checked_shr.19
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.7
-    u32or
+    u32checked_shl.7
+    u32checked_or
 
     dup.2
 
-    u32shr.20
+    u32checked_shr.20
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.8
-    u32or
+    u32checked_shl.8
+    u32checked_or
 
     dup.3
 
-    u32shr.20
+    u32checked_shr.20
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.9
-    u32or
+    u32checked_shl.9
+    u32checked_or
 
     dup.2
 
-    u32shr.21
+    u32checked_shr.21
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.10
-    u32or
+    u32checked_shl.10
+    u32checked_or
 
     dup.3
 
-    u32shr.21
+    u32checked_shr.21
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.11
-    u32or
+    u32checked_shl.11
+    u32checked_or
 
     dup.2
 
-    u32shr.22
+    u32checked_shr.22
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.12
-    u32or
+    u32checked_shl.12
+    u32checked_or
 
     dup.3
 
-    u32shr.22
+    u32checked_shr.22
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.13
-    u32or
+    u32checked_shl.13
+    u32checked_or
 
     dup.2
 
-    u32shr.23
+    u32checked_shr.23
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.14
-    u32or
+    u32checked_shl.14
+    u32checked_or
 
     dup.3
 
-    u32shr.23
+    u32checked_shr.23
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.15
-    u32or
+    u32checked_shl.15
+    u32checked_or
 
     dup.2
 
-    u32shr.24
+    u32checked_shr.24
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.16
-    u32or
+    u32checked_shl.16
+    u32checked_or
 
     dup.3
 
-    u32shr.24
+    u32checked_shr.24
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.17
-    u32or
+    u32checked_shl.17
+    u32checked_or
 
     dup.2
 
-    u32shr.25
+    u32checked_shr.25
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.18
-    u32or
+    u32checked_shl.18
+    u32checked_or
 
     dup.3
 
-    u32shr.25
+    u32checked_shr.25
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.19
-    u32or
+    u32checked_shl.19
+    u32checked_or
 
     dup.2
 
-    u32shr.26
+    u32checked_shr.26
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.20
-    u32or
+    u32checked_shl.20
+    u32checked_or
 
     dup.3
 
-    u32shr.26
+    u32checked_shr.26
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.21
-    u32or
+    u32checked_shl.21
+    u32checked_or
 
     dup.2
 
-    u32shr.27
+    u32checked_shr.27
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.22
-    u32or
+    u32checked_shl.22
+    u32checked_or
 
     dup.3
 
-    u32shr.27
+    u32checked_shr.27
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.23
-    u32or
+    u32checked_shl.23
+    u32checked_or
 
     dup.2
 
-    u32shr.28
+    u32checked_shr.28
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.24
-    u32or
+    u32checked_shl.24
+    u32checked_or
 
     dup.3
 
-    u32shr.28
+    u32checked_shr.28
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.25
-    u32or
+    u32checked_shl.25
+    u32checked_or
 
     dup.2
 
-    u32shr.29
+    u32checked_shr.29
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.26
-    u32or
+    u32checked_shl.26
+    u32checked_or
 
     dup.3
 
-    u32shr.29
+    u32checked_shr.29
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.27
-    u32or
+    u32checked_shl.27
+    u32checked_or
 
     dup.2
 
-    u32shr.30
+    u32checked_shr.30
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.28
-    u32or
+    u32checked_shl.28
+    u32checked_or
 
     dup.3
 
-    u32shr.30
+    u32checked_shr.30
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.29
-    u32or
+    u32checked_shl.29
+    u32checked_or
 
     dup.2
 
-    u32shr.31
+    u32checked_shr.31
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.30
-    u32or
+    u32checked_shl.30
+    u32checked_or
 
     dup.3
 
-    u32shr.31
+    u32checked_shr.31
     push.1
-    u32and
+    u32checked_and
 
-    u32shl.31
-    u32or
+    u32checked_shl.31
+    u32checked_or
 end
 
 # given 64 -bytes input ( in terms of sixteen u32 elements on stack top ) to 2-to-1
@@ -6027,106 +6027,106 @@ end
 ("std::crypto::hashes::sha256", "# SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L73-L79
 proc.small_sigma_0
     dup
-    u32rotr.7
+    u32checked_rotr.7
 
     swap
 
     dup
-    u32rotr.18
+    u32checked_rotr.18
 
     swap
 
-    u32shr.3
+    u32checked_shr.3
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L81-L87
 proc.small_sigma_1
     dup
-    u32rotr.17
+    u32checked_rotr.17
 
     swap
 
     dup
-    u32rotr.19
+    u32checked_rotr.19
 
     swap
 
-    u32shr.10
+    u32checked_shr.10
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L57-L63
 proc.cap_sigma_0
     dup
-    u32rotr.2
+    u32checked_rotr.2
 
     swap
 
     dup
-    u32rotr.13
+    u32checked_rotr.13
 
     swap
 
-    u32rotr.22
+    u32checked_rotr.22
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L65-L71
 proc.cap_sigma_1
     dup
-    u32rotr.6
+    u32checked_rotr.6
 
     swap
 
     dup
-    u32rotr.11
+    u32checked_rotr.11
 
     swap
 
-    u32rotr.25
+    u32checked_rotr.25
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L37-L45
 proc.ch
     swap
     dup.1
-    u32and
+    u32checked_and
 
     swap
-    u32not
+    u32checked_not
 
     movup.2
-    u32and
+    u32checked_and
 
-    u32xor
+    u32checked_xor
 end
 
 # SHA256 function; see https://github.com/itzmeanjan/merklize-sha/blob/8a2c006a2ffe1e6e8e36b375bc5a570385e9f0f2/include/sha2.hpp#L47-L55
 proc.maj
     dup.1
     dup.1
-    u32and
+    u32checked_and
 
     swap
     dup.3
-    u32and
+    u32checked_and
 
     movup.2
     movup.3
-    u32and
+    u32checked_and
 
-    u32xor
-    u32xor
+    u32checked_xor
+    u32checked_xor
 end
 
 # assume top 4 elements of stack are [3, 2, 1, 0, ...], then after execution of this function, stack should look like [0, 1, 2, 3, ...]
@@ -9217,87 +9217,87 @@ export.and
     swapw.3
     movup.3
     movup.7
-    u32and
+    u32checked_and
     movup.3
     movup.6
-    u32and
+    u32checked_and
     movup.3
     movup.5
-    u32and
+    u32checked_and
     movup.3
     movup.4
-    u32and
+    u32checked_and
     swapw.2
     movup.3
     movup.7
-    u32and
+    u32checked_and
     movup.3
     movup.6
-    u32and
+    u32checked_and
     movup.3
     movup.5
-    u32and
+    u32checked_and
     movup.3
     movup.4
-    u32and
+    u32checked_and
 end
 
 export.or
     swapw.3
     movup.3
     movup.7
-    u32or
+    u32checked_or
     movup.3
     movup.6
-    u32or
+    u32checked_or
     movup.3
     movup.5
-    u32or
+    u32checked_or
     movup.3
     movup.4
-    u32or
+    u32checked_or
     swapw.2
     movup.3
     movup.7
-    u32or
+    u32checked_or
     movup.3
     movup.6
-    u32or
+    u32checked_or
     movup.3
     movup.5
-    u32or
+    u32checked_or
     movup.3
     movup.4
-    u32or
+    u32checked_or
 end
 
 export.xor
     swapw.3
     movup.3
     movup.7
-    u32xor
+    u32checked_xor
     movup.3
     movup.6
-    u32xor
+    u32checked_xor
     movup.3
     movup.5
-    u32xor
+    u32checked_xor
     movup.3
     movup.4
-    u32xor
+    u32checked_xor
     swapw.2
     movup.3
     movup.7
-    u32xor
+    u32checked_xor
     movup.3
     movup.6
-    u32xor
+    u32checked_xor
     movup.3
     movup.5
-    u32xor
+    u32checked_xor
     movup.3
     movup.4
-    u32xor
+    u32checked_xor
 end
 
 export.iszero_unsafe
@@ -9823,7 +9823,7 @@ end
 export.checked_mul
     exec.u32assert4
     exec.overflowing_mul
-    u32or
+    u32checked_or
     eq.0
     assert
 end
@@ -9929,10 +9929,10 @@ end
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise.
 export.unchecked_eq
     movup.2
-    u32eq
+    u32checked_eq
     swap
     movup.2
-    u32eq
+    u32checked_eq
     and
 end
 
@@ -9951,10 +9951,10 @@ end
 # [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a != b, and 0 otherwise.
 export.unchecked_neq
     movup.2
-    u32neq
+    u32checked_neq
     swap
     movup.2
-    u32neq
+    u32checked_neq
     or
 end
 
@@ -10258,10 +10258,10 @@ end
 export.checked_and
     swap
     movup.3
-    u32and
+    u32checked_and
     swap
     movup.2
-    u32and
+    u32checked_and
 end
 
 # Performs bitwise OR of two unsigned 64 bit integers.
@@ -10271,10 +10271,10 @@ end
 export.checked_or
     swap
     movup.3
-    u32or
+    u32checked_or
     swap
     movup.2
-    u32or
+    u32checked_or
 end
 
 # Performs bitwise XOR of two unsigned 64 bit integers.
@@ -10284,10 +10284,10 @@ end
 export.checked_xor
     swap
     movup.3
-    u32xor
+    u32checked_xor
     swap
     movup.2
-    u32xor
+    u32checked_xor
 end
 
 # Performs left shift of one unsigned 64-bit integer using the pow2 operation.
@@ -10403,7 +10403,7 @@ export.unchecked_rotl
 
     # Shift the low limb.
     push.31
-    u32and
+    u32checked_and
     pow2.unsafe
     dup
     movup.3
@@ -10440,7 +10440,7 @@ export.unchecked_rotr
 
     # Shift the low limb left by 32-b.
     push.31
-    u32and
+    u32checked_and
     push.32
     swap
     u32overflowing_sub


### PR DESCRIPTION
Refactoring of the 
- `u32and`
- `u32or`
- `u32xor`
- `u32not`
- `u32shl`
- `u32shr`
- `u32rotl`
- `u32rotr`
- `u32lt`
- `u32lte`
- `u32gt`
- `u32gte`
- `u32min`
- `u32max`
operations to match stdlib underscoring style.