### PR TITLE
Update u32 operation docs

### DIFF
--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -75,7 +75,7 @@ fn parse_op_token(
         "u32wrapping_add" => u32_ops::parse_u32add(span_ops, op, U32OpMode::Wrapping),
         "u32overflowing_add" => u32_ops::parse_u32add(span_ops, op, U32OpMode::Overflowing),
 
-        "u32unchecked_add3" => u32_ops::parse_u32add3(span_ops, op, U32OpMode::Unchecked),
+        "u32overflowing_add3" => u32_ops::parse_u32add3(span_ops, op, U32OpMode::Overflowing),
 
         "u32checked_sub" => u32_ops::parse_u32sub(span_ops, op, U32OpMode::Checked),
         "u32wrapping_sub" => u32_ops::parse_u32sub(span_ops, op, U32OpMode::Wrapping),
@@ -85,7 +85,7 @@ fn parse_op_token(
         "u32wrapping_mul" => u32_ops::parse_u32mul(span_ops, op, U32OpMode::Wrapping),
         "u32overflowing_mul" => u32_ops::parse_u32mul(span_ops, op, U32OpMode::Overflowing),
 
-        "u32unchecked_madd" => u32_ops::parse_u32madd(span_ops, op, U32OpMode::Unchecked),
+        "u32overflowing_madd" => u32_ops::parse_u32madd(span_ops, op, U32OpMode::Overflowing),
 
         "u32checked_div" => u32_ops::parse_u32div(span_ops, op, U32OpMode::Checked),
         "u32unchecked_div" => u32_ops::parse_u32div(span_ops, op, U32OpMode::Unchecked),
@@ -103,11 +103,9 @@ fn parse_op_token(
 
         "u32checked_shr" => u32_ops::parse_u32shr(span_ops, op, U32OpMode::Checked),
         "u32unchecked_shr" => u32_ops::parse_u32shr(span_ops, op, U32OpMode::Unchecked),
-        "u32overflowing_shr" => u32_ops::parse_u32shr(span_ops, op, U32OpMode::Overflowing),
 
         "u32checked_shl" => u32_ops::parse_u32shl(span_ops, op, U32OpMode::Checked),
         "u32unchecked_shl" => u32_ops::parse_u32shl(span_ops, op, U32OpMode::Unchecked),
-        "u32overflowing_shl" => u32_ops::parse_u32shl(span_ops, op, U32OpMode::Overflowing),
 
         "u32checked_rotr" => u32_ops::parse_u32rotr(span_ops, op, U32OpMode::Checked),
         "u32unchecked_rotr" => u32_ops::parse_u32rotr(span_ops, op, U32OpMode::Unchecked),

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -48,7 +48,9 @@ fn parse_op_token(
         "div" => field_ops::parse_div(span_ops, op),
         "neg" => field_ops::parse_neg(span_ops, op),
         "inv" => field_ops::parse_inv(span_ops, op),
-        "pow2" => field_ops::parse_pow2(span_ops, op),
+
+        "checked_pow2" => field_ops::parse_pow2(span_ops, op, true),
+        "unchecked_pow2" => field_ops::parse_pow2(span_ops, op, false),
 
         "not" => field_ops::parse_not(span_ops, op),
         "and" => field_ops::parse_and(span_ops, op),

--- a/assembly/src/parsers/u32_ops.rs
+++ b/assembly/src/parsers/u32_ops.rs
@@ -98,7 +98,7 @@ pub fn parse_u32assert(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), 
     Ok(())
 }
 
-/// Translates u32assert assembly instruction to VM operations.
+/// Translates u32assertw assembly instruction to VM operations.
 ///
 /// Implemented by executing `U32ASSERT2` on each pair of elements in the word.
 /// Total of 6 VM cycles.
@@ -158,7 +158,7 @@ pub fn parse_u32split(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), A
 // ARITHMETIC OPERATIONS
 // ================================================================================================
 
-/// Translates u32add assembly instruction to VM operations.
+/// Translates u32add assembly instructions to VM operations.
 ///
 /// The base operation is `U32ADD`, but depending on the mode, additional operations may be
 /// inserted. Please refer to the docs of `handle_arithmetic_operation` for more details.
@@ -180,7 +180,7 @@ pub fn parse_u32add(
     handle_arithmetic_operation(span_ops, op, Operation::U32add, op_mode)
 }
 
-/// Translates u32unchecked_add3 assembly instruction directly to `U32ADD3` operation.
+/// Translates u32overflowing_add3 assembly instruction directly to `U32ADD3` operation.
 ///
 /// This operation takes 1 VM cycle.
 pub fn parse_u32add3(
@@ -191,7 +191,7 @@ pub fn parse_u32add3(
     match op.num_parts() {
         0 => return Err(AssemblyError::missing_param(op)),
         1 => {
-            if op_mode != U32OpMode::Unchecked {
+            if op_mode != U32OpMode::Overflowing {
                 return Err(AssemblyError::invalid_op(op));
             }
         }
@@ -203,7 +203,7 @@ pub fn parse_u32add3(
     Ok(())
 }
 
-/// Translates u32sub assembly instruction to VM operations.
+/// Translates u32sub assembly instructions to VM operations.
 ///
 /// The base operation is `U32SUB`, but depending on the mode, additional operations may be
 /// inserted. Please refer to the docs of `handle_arithmetic_operation` for more details.
@@ -225,7 +225,7 @@ pub fn parse_u32sub(
     handle_arithmetic_operation(span_ops, op, Operation::U32sub, op_mode)
 }
 
-/// Translates u32mul assembly instruction to VM operations.
+/// Translates u32mul assembly instructions to VM operations.
 ///
 /// The base operation is `U32MUL`, but depending on the mode, additional operations may be
 /// inserted. Please refer to the docs of `handle_arithmetic_operation` for more details.
@@ -247,7 +247,7 @@ pub fn parse_u32mul(
     handle_arithmetic_operation(span_ops, op, Operation::U32mul, op_mode)
 }
 
-/// Translates u32unchecked_madd assembly instruction directly to `U32MADD` operation.
+/// Translates u32overflowing_madd assembly instruction directly to `U32MADD` operation.
 ///
 /// This operation takes 1 VM cycle.
 pub fn parse_u32madd(
@@ -258,7 +258,7 @@ pub fn parse_u32madd(
     match op.num_parts() {
         0 => return Err(AssemblyError::missing_param(op)),
         1 => {
-            if op_mode != U32OpMode::Unchecked {
+            if op_mode != U32OpMode::Overflowing {
                 return Err(AssemblyError::invalid_op(op));
             }
         }
@@ -270,7 +270,7 @@ pub fn parse_u32madd(
     Ok(())
 }
 
-/// Translates u32div assembly instruction to VM operations.
+/// Translates u32div assembly instructions to VM operations.
 ///
 /// VM cycles per mode:
 /// - u32checked_div: 3 cycles
@@ -293,7 +293,7 @@ pub fn parse_u32div(
     Ok(())
 }
 
-/// Translates u32mod assembly instruction to VM operations.
+/// Translates u32mod assembly instructions to VM operations.
 ///
 /// VM cycles per mode:
 /// - u32checked_mod: 4 cycles
@@ -317,7 +317,7 @@ pub fn parse_u32mod(
     Ok(())
 }
 
-/// Translates u32divmod assembly instruction to VM operations.
+/// Translates u32divmod assembly instructions to VM operations.
 ///
 /// VM cycles per mode:
 /// - u32checked_divmod: 2 cycles
@@ -341,7 +341,7 @@ pub fn parse_u32divmod(
 // BITWISE OPERATIONS
 // ================================================================================================
 
-/// Translates u32and assembly instruction to VM operation.
+/// Translates u32checked_and assembly instruction to VM operation.
 ///
 /// Implemented as: `U32AND` (1 VM cycle).
 ///
@@ -357,7 +357,7 @@ pub fn parse_u32and(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
     Ok(())
 }
 
-/// Translates u32or assembly instruction to VM operation `U32OR`.
+/// Translates u32checked_or assembly instruction to VM operation `U32OR`.
 ///
 /// Implemented as: `U32OR` (1 VM cycle).
 ///
@@ -373,7 +373,7 @@ pub fn parse_u32or(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Asse
     Ok(())
 }
 
-/// Translates u32xor assembly instruction to VM operation `U32XOR`.
+/// Translates u32checked_xor assembly instruction to VM operation `U32XOR`.
 ///
 /// Implemented as: `U32XOR` (1 VM cycle).
 ///
@@ -389,7 +389,7 @@ pub fn parse_u32xor(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
     Ok(())
 }
 
-/// Translates u32not assembly instruction to VM operations.
+/// Translates u32checked_not assembly instruction to VM operations.
 ///
 /// The operation is implemented as `PUSH(2^32 - 1) U32ASSERT2 SWAP U32SUB DROP`,
 /// total to 5 cycles.
@@ -415,11 +415,11 @@ pub fn parse_u32not(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
     Ok(())
 }
 
-/// Translates u32shl assembly instruction to VM operations.
+/// Translates u32shl assembly instructions to VM operations.
 ///
 /// The operation is implemented by putting a power of 2 on the stack, then multiplying it with
 /// the value to be shifted and splitting the result. Depending on the mode, other instructions may
-/// be added, and the return value may or may not include an overflow result. For safe variations,
+/// be added, and the return value may or may not include an overflow result. For checked variants,
 /// the shift value is asserted to be between 0-31 and the value to be shifted is asserted to be a
 /// 32-bit value.
 ///
@@ -428,29 +428,21 @@ pub fn parse_u32not(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
 /// - u32checked_shl.b: 4 cycles
 /// - u32unchecked_shl: 40 cycles
 /// - u32unchecked_shl.b: 3 cycles
-/// - u32overflowing_shl: 39 cycles
-/// - u32overflowing_shl.b: 2 cycles
 pub fn parse_u32shl(
     span_ops: &mut Vec<Operation>,
     op: &Token,
     op_mode: U32OpMode,
 ) -> Result<(), AssemblyError> {
-    let drop_remainder = match op.num_parts() {
+    match op.num_parts() {
         0 => return Err(AssemblyError::invalid_op(op)),
         1 => match op_mode {
             U32OpMode::Checked => {
                 // Assume the dynamic shift value b is on top of the stack.
                 aggregate_power_2(span_ops, false);
                 span_ops.push(Operation::U32assert2);
-                true
             }
             U32OpMode::Unchecked => {
                 aggregate_power_2(span_ops, true);
-                true
-            }
-            U32OpMode::Overflowing => {
-                aggregate_power_2(span_ops, true);
-                false
             }
             _ => return Err(AssemblyError::invalid_op(op)),
         },
@@ -459,47 +451,35 @@ pub fn parse_u32shl(
                 let x = parse_u32_param(op, 1, 0, 31)?;
                 span_ops.push(Operation::Push(Felt::new(2u64.pow(x))));
                 span_ops.push(Operation::U32assert2);
-                true
             }
             U32OpMode::Unchecked => {
                 let x = parse_u32_param(op, 1, 0, u32::MAX)?;
                 span_ops.push(Operation::Push(Felt::new(2u64.pow(x))));
-                true
-            }
-            U32OpMode::Overflowing => {
-                let x = parse_u32_param(op, 1, 0, u32::MAX)?;
-                span_ops.push(Operation::Push(Felt::new(2u64.pow(x))));
-                false
             }
             _ => return Err(AssemblyError::invalid_op(op)),
         },
         _ => return Err(AssemblyError::extra_param(op)),
-    };
+    }
 
     span_ops.push(Operation::U32mul);
-
-    if drop_remainder {
-        span_ops.push(Operation::Drop);
-    }
+    span_ops.push(Operation::Drop);
 
     Ok(())
 }
 
-/// Translates u32shr assembly instruction to VM operations.
+/// Translates u32shr assembly instructions to VM operations.
 ///
-/// The safe modes of the operation are implemented by putting a power of 2 on the stack, then
-/// dividing the value to be shifted by it and returning the quotient. For unsafe mode, a left shift
-/// is implemented via multiplication and both the shifted value and the overflow shift are
-/// returned. For safe variations, the shift value is asserted to be between 0-31 and the value to
-/// be shifted is asserted to be a 32-bit value.
+/// The operation is implemented by putting a power of 2 on the stack, then dividing the value to
+/// be shifted by it and returning the quotient. Depending on the mode, other instructions may
+/// be added, and the return value may or may not include an overflow result. For checked variants,
+/// the shift value is asserted to be between 0-31 and the value to be shifted is asserted to be a
+/// 32-bit value.
 ///
 /// VM cycles per mode:
 /// - u32checked_shr: 47 cycles
 /// - u32checked_shr.b: 4 cycles
 /// - u32unchecked_shr: 40 cycles
 /// - u32unchecked_shr.b: 3 cycles
-/// - u32overflowing_shr: 44 cycles
-/// - u32overflowing_shr.b: 3 cycles
 pub fn parse_u32shr(
     span_ops: &mut Vec<Operation>,
     op: &Token,
@@ -516,19 +496,6 @@ pub fn parse_u32shr(
             U32OpMode::Unchecked => {
                 aggregate_power_2(span_ops, true);
             }
-            U32OpMode::Overflowing => {
-                // Use multiplication to shift left so the right-shifted result and the overflow
-                // shift can both be returned.
-                span_ops.push(Operation::Push(Felt::new(32)));
-                span_ops.push(Operation::Swap);
-                span_ops.push(Operation::U32sub);
-                span_ops.push(Operation::Drop);
-                aggregate_power_2(span_ops, true);
-                span_ops.push(Operation::U32mul);
-                span_ops.push(Operation::Swap);
-
-                return Ok(());
-            }
             _ => return Err(AssemblyError::invalid_op(op)),
         },
         2 => match op_mode {
@@ -540,14 +507,6 @@ pub fn parse_u32shr(
             U32OpMode::Unchecked => {
                 let x = parse_u32_param(op, 1, 0, u32::MAX)?;
                 span_ops.push(Operation::Push(Felt::new(2u64.pow(x))));
-            }
-            U32OpMode::Overflowing => {
-                let x = 32 - parse_u32_param(op, 1, 0, u32::MAX)?;
-                span_ops.push(Operation::Push(Felt::new(2u64.pow(x))));
-                span_ops.push(Operation::U32mul);
-                span_ops.push(Operation::Swap);
-
-                return Ok(());
             }
             _ => return Err(AssemblyError::invalid_op(op)),
         },
@@ -563,12 +522,12 @@ pub fn parse_u32shr(
     Ok(())
 }
 
-/// Translates u32rotl assembly instruction to VM operations.
+/// Translates u32rotl assembly instructions to VM operations.
 ///
 /// The base operation is implemented by putting a power of 2 on the stack, then multiplying the
 /// value to be shifted by it and adding the overflow limb to the shifted limb. Depending on the
-/// mode, other instructions may be added. For safe variations, the shift value is asserted to be
-/// between 0-31 and the value to be shifted is asserted to be a 32-bit value.
+/// mode, other instructions may be added. For the checked variants, the shift value is asserted
+/// to be between 0-31 and the value to be shifted is asserted to be a 32-bit value.
 ///
 /// VM cycles per mode:
 /// - u32checked_rotl: 47 cycles
@@ -614,12 +573,12 @@ pub fn parse_u32rotl(
     Ok(())
 }
 
-/// Translates u32rotr assembly instruction to VM operations.
+/// Translates u32rotr assembly instructions to VM operations.
 ///
-/// The base operation is implemented by multiplying the value to be shifted by 2^(32-b), where b is
-/// the shift amount, then adding the overflow limb to the shifted limb. Depending on the mode,
-/// other instructions may be added. For safe variations, the shift value is asserted to be between
-/// 0-31 and the value to be shifted is asserted to be a 32-bit value.
+/// The base operation is implemented by multiplying the value to be shifted by 2^(32-b), where b
+/// is the shift amount, then adding the overflow limb to the shifted limb. Depending on the mode,
+/// other instructions may be added. For the checked variants, the shift value is asserted to be
+/// between 0-31 and the value to be shifted is asserted to be a 32-bit value.
 ///
 /// VM cycles per mode:
 /// - u32checked_rotr: 59 cycles
@@ -716,8 +675,8 @@ pub fn parse_u32eq(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Asse
 /// equality.
 ///
 /// VM cycles per mode:
-/// u32checked_neq: 3 cycles
-/// u32checked_neq.b: 4 cycles
+/// - u32checked_neq: 3 cycles
+/// - u32checked_neq.b: 4 cycles
 pub fn parse_u32neq(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
     match op.num_parts() {
         0 => return Err(AssemblyError::missing_param(op)),
@@ -732,14 +691,14 @@ pub fn parse_u32neq(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), Ass
     Ok(())
 }
 
-/// Translates u32lt assembly instruction to VM operations.
+/// Translates u32lt assembly instructions to VM operations.
 ///
 /// Specifically we test the first two numbers to be u32, then perform a `U32SUB EQZ NOT` to check
 /// the underflow flag.
 ///
 /// VM cycles per mode:
-/// u32lt: 6 cycles
-/// u32lt.unsafe: 5 cycles
+/// - u32checked_lt: 6 cycles
+/// - u32unchecked_lt 5 cycles
 pub fn parse_u32lt(
     span_ops: &mut Vec<Operation>,
     op: &Token,
@@ -751,14 +710,14 @@ pub fn parse_u32lt(
     Ok(())
 }
 
-/// Translates u32lte assembly instruction to VM operations.
+/// Translates u32lte assembly instructions to VM operations.
 ///
 /// Specifically we test the first two numbers to be u32, then perform a gt check and flip the
 /// results.
 ///
 /// VM cycles per mode:
-/// u32lte: 8 cycles
-/// u32lte.unsafe: 7 cycles
+/// - u32checked_lte: 8 cycles
+/// - u32unchecked_lte: 7 cycles
 pub fn parse_u32lte(
     span_ops: &mut Vec<Operation>,
     op: &Token,
@@ -776,14 +735,14 @@ pub fn parse_u32lte(
     Ok(())
 }
 
-/// Translates u32gt assembly instruction to VM operations.
+/// Translates u32gt assembly instructions to VM operations.
 ///
 /// Specifically we test the first two numbers to be u32, then perform a lt check with the
 /// numbers swapped.
 ///
 /// VM cycles per mode:
-/// u32gt: 7 cycles
-/// u32gt.unsafe: 6 cycles
+/// - u32checked_gt: 7 cycles
+/// - u32unchecked_gt: 6 cycles
 pub fn parse_u32gt(
     span_ops: &mut Vec<Operation>,
     op: &Token,
@@ -799,14 +758,14 @@ pub fn parse_u32gt(
     Ok(())
 }
 
-/// Translates u32gte assembly instruction to VM operations.
+/// Translates u32gte assembly instructions to VM operations.
 ///
 /// Specifically we test the first two numbers to be u32, then compute a lt check and flip the
 /// results.
 ///
 /// VM cycles per mode:
-/// u32gte: 7 cycles
-/// u32gte.unsafe: 6 cycles
+/// - u32checked_gte: 7 cycles
+/// - u32unchecked_gte: 6 cycles
 pub fn parse_u32gte(
     span_ops: &mut Vec<Operation>,
     op: &Token,
@@ -822,7 +781,7 @@ pub fn parse_u32gte(
     Ok(())
 }
 
-/// Translates u32min assembly instruction to VM operations.
+/// Translates u32min assembly instructions to VM operations.
 ///
 /// Specifically, we test the first two numbers to be u32 (U32SPLIT NOT ASSERT), subtract the top
 /// value from the second to the top value (U32SUB), check the underflow flag (EQZ), and perform a
@@ -830,24 +789,23 @@ pub fn parse_u32gte(
 /// to keep the min.
 ///
 /// VM cycles per mode:
-/// u32min: 9 cycles
-/// u32min.unsafe: 8 cycles
+/// - u32checked_min: 9 cycles
+/// - u32unchecked_min: 8 cycles
 pub fn parse_u32min(
     span_ops: &mut Vec<Operation>,
     op: &Token,
     op_mode: U32OpMode,
 ) -> Result<(), AssemblyError> {
-    let unchecked_mode = match op.num_parts() {
+    match op.num_parts() {
         0 => return Err(AssemblyError::missing_param(op)),
         1 => match op_mode {
-            U32OpMode::Checked => false,
-            U32OpMode::Unchecked => true,
+            U32OpMode::Checked | U32OpMode::Unchecked => (),
             _ => return Err(AssemblyError::invalid_op(op)),
         },
         _ => return Err(AssemblyError::extra_param(op)),
-    };
+    }
 
-    compute_max_and_min(span_ops, unchecked_mode);
+    compute_max_and_min(span_ops, op_mode);
 
     // Drop the max and keep the min
     span_ops.push(Operation::Drop);
@@ -855,7 +813,7 @@ pub fn parse_u32min(
     Ok(())
 }
 
-/// Translates u32max assembly instruction to VM operations.
+/// Translates u32max assembly instructions to VM operations.
 ///
 /// Specifically, we test the first two values to be u32 (U32SPLIT NOT ASSERT), subtract the top
 /// value from the second to the top value (U32SUB), check the underflow flag (EQZ), and perform
@@ -863,24 +821,23 @@ pub fn parse_u32min(
 /// element to keep the max.
 ///
 /// VM cycles per mode:
-/// u32max: 10 cycles
-/// u32max.unsafe: 9 cycles
+/// - u32checked_max: 10 cycles
+/// - u32unchecked_max: 9 cycles
 pub fn parse_u32max(
     span_ops: &mut Vec<Operation>,
     op: &Token,
     op_mode: U32OpMode,
 ) -> Result<(), AssemblyError> {
-    let unchecked_mode = match op.num_parts() {
+    match op.num_parts() {
         0 => return Err(AssemblyError::missing_param(op)),
         1 => match op_mode {
-            U32OpMode::Checked => false,
-            U32OpMode::Unchecked => true,
+            U32OpMode::Checked | U32OpMode::Unchecked => (),
             _ => return Err(AssemblyError::invalid_op(op)),
         },
         _ => return Err(AssemblyError::extra_param(op)),
-    };
+    }
 
-    compute_max_and_min(span_ops, unchecked_mode);
+    compute_max_and_min(span_ops, op_mode);
 
     // Drop the min and keep the max
     span_ops.push(Operation::Swap);
@@ -971,11 +928,11 @@ fn push_int_param(
 /// and max between them.
 ///
 /// The maximum number will be at the top of the stack and minimum will be at the 2nd index.
-fn compute_max_and_min(span_ops: &mut Vec<Operation>, unsafe_mode: bool) {
+fn compute_max_and_min(span_ops: &mut Vec<Operation>, op_mode: U32OpMode) {
     // Copy top two elements of the stack.
     span_ops.push(Operation::Dup1);
     span_ops.push(Operation::Dup1);
-    if !unsafe_mode {
+    if op_mode == U32OpMode::Checked {
         span_ops.push(Operation::U32assert2);
     }
 
@@ -1001,7 +958,7 @@ fn compute_lt(span_ops: &mut Vec<Operation>) {
     span_ops.push(Operation::Not);
 }
 
-/// Handles u32 assertion and unsafe mode for any u32 operation.
+/// Handles u32 assertion and unchecked mode for any u32 operation.
 fn handle_u32_and_unchecked_mode(
     span_ops: &mut Vec<Operation>,
     op: &Token,

--- a/docs/src/user_docs/assembly/field_operations.md
+++ b/docs/src/user_docs/assembly/field_operations.md
@@ -22,7 +22,8 @@ For instructions where one or more operands can be provided as immediate paramet
 | div <br> div.*b* | [b, a, ...] | [c, ...]      | $c \leftarrow (a \cdot b^{-1}) \mod p$ <br> Fails if $b = 0$ |
 | neg              | [a, ...]    | [b, ...]      | $b \leftarrow -a \mod p$               |
 | inv              | [a, ...]    | [b, ...]      | $b \leftarrow a^{-1} \mod p$ <br> Fails if $a = 0$ |
-| pow2             | [a, ...]    | [b, ...]      | $b \leftarrow 2^a$ <br> Fails if $a > 63$ |
+| checked_pow2     | [a, ...]    | [b, ...]      | $b \leftarrow 2^a$ <br> Fails if $a > 63$ |
+| unchecked_pow2   | [a, ...]    | [b, ...]      | $b \leftarrow 2^a$ <br> Undefined if $a > 63$ |
 | not              | [a, ...]    | [b, ...]      | $b \leftarrow 1 - a$ <br> Fails if $a > 1$ |
 | and              | [b, a, ...] | [c, ...]      | $c \leftarrow a \cdot b$ <br> Fails if $max(a, b) > 1$ |
 | or               | [b, a, ...] | [c, ...]      | $c \leftarrow a + b - a \cdot b$ <br> Fails if $max(a, b) > 1$ |

--- a/docs/src/user_docs/assembly/u32_operations.md
+++ b/docs/src/user_docs/assembly/u32_operations.md
@@ -1,11 +1,11 @@
 ## u32 operations
 Miden assembly provides a set of instructions which can perform operations on regular 32-bit integers. These instructions are described in the tables below.
 
-Many instructions have *safe* and *unsafe* versions. The safe versions ensure that input values are 32-bit integers, and fail if that's not the case. The *unsafe* versions do not perform these checks, and thus, should be used only if the inputs are known to be 32-bit integers. Supplying inputs which are greater than or equal to $2^{32}$ to *unsafe* operations results in undefined behavior.
+Most instructions have _checked_ variants. These variants ensure that input values are 32-bit integers, and fail if that's not the case. All other variants do not perform these checks, and thus, should be used only if the inputs are known to be 32-bit integers. Supplying inputs which are greater than or equal to $2^{32}$ to unchecked operations results in undefined behavior.
 
-The primary benefit of using *unsafe* operations is performance: they can frequently be executed $2$ or $3$ times faster than their safe counterparts. In general, vast majority of the *unsafe* operations listed below can be executed in a single VM cycle.
+The primary benefit of using unchecked operations is performance: they can frequently be executed $2$ or $3$ times faster than their checked counterparts. In general, vast majority of the unchecked operations listed below can be executed in a single VM cycle.
 
-For instructions where one or more operands can be provided as immediate parameters (e.g., `u32add` and `u32add.b`), we provide stack transition diagrams only for the non-immediate version. For the immediate version, it can be assumed that the operand with the specified name is not present on the stack.
+For instructions where one or more operands can be provided as immediate parameters (e.g., `u32checked_add` and `u32checked_add.b`), we provide stack transition diagrams only for the non-immediate version. For the immediate version, it can be assumed that the operand with the specified name is not present on the stack.
 
 ### Conversions and tests
 

--- a/docs/src/user_docs/assembly/u32_operations.md
+++ b/docs/src/user_docs/assembly/u32_operations.md
@@ -21,55 +21,58 @@ For instructions where one or more operands can be provided as immediate paramet
 
 ### Arithmetic operations
 
-| Instruction    | Stack_input    | Stack_output  | Notes                                      |
+| Instruction    | Stack input    | Stack output  | Notes                                      |
 | -------------- | -------------- | ------------- | ------------------------------------------ |
-| u32add <br> u32add.*b* | [b, a, ...] | [c, ...] | $c \leftarrow a + b$ <br> Fails if $max(a, b, c) \ge 2^{32}$ |
-| u32add.full    | [b, a, ...]    | [d, c, ...]   | $c \leftarrow (a + b) \mod 2^{32}$ <br> $d \leftarrow \begin{cases} 1, & \text{if}\ (a + b) \ge 2^{32} \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
-| u32add.unsafe  | [b, a, ...]    | [d, c, ...]   | $c \leftarrow (a + b) \mod 2^{32}$, <br> $d \leftarrow \begin{cases} 1, & \text{if}\ (a + b) \ge 2^{32} \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
-| u32add3        | [c, b, a, ...] | [e, d, ...]   | $d \leftarrow (a + b + c) \mod 2^{32}$, <br> $e \leftarrow \lfloor (a + b + c) / 2^{32}\rfloor$ <br> Fails if $max(a, b, c) \ge 2^{32}$ |
-| u32add3.unsafe | [c, b, a, ...] | [e, d, ...]   | $d \leftarrow (a + b + c) \mod 2^{32}$, <br> $e \leftarrow \lfloor (a + b + c) / 2^{32}\rfloor$ <br> Undefined if $max(a, b, c) \ge 2^{32}$ <br> |
-| u32sub <br> u32sub.*b* | [b, a, ...] | [c, ...] | $c \leftarrow (a - b)$ <br> Fails if $max(a, b) \ge 2^{32}$ or $a < b$ |
-| u32sub.full    | [b, a, ...]    | [d, c, ...]   | $c \leftarrow (a - b) \mod 2^{32}$ <br> $d \leftarrow \begin{cases} 1, & \text{if}\ a < b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
-| u32sub.unsafe  | [b, a, ...]    | [d, c, ...]   | $c \leftarrow (a - b) \mod 2^{32}$ <br> $d \leftarrow \begin{cases} 1, & \text{if}\ a < b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
-| u32mul <br> u32mul.*b* | [b, a, ...] | [c, ...] | $c \leftarrow a \cdot b$ <br> Fails if $max(a, b, c) \ge 2^{32}$ |
-| u32mul.full    | [b, a, ...]    | [d, c, ...]   | $c \leftarrow (a \cdot b) \mod 2^{32}$ <br> $d \leftarrow \lfloor(a \cdot b) / 2^{32}\rfloor$ <br> Fails if $max(a, b) \ge 2^{32}$ |
-| u32mul.unsafe  | [b, a, ...]    | [d, c, ...]   | $c \leftarrow (a \cdot b) \mod 2^{32}$ <br> $d \leftarrow \lfloor(a \cdot b) / 2^{32}\rfloor$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
-| u32madd         | [b, a, c, ...] | [e, d, ...]   | $d \leftarrow (a \cdot b + c) \mod 2^{32}$ <br> $e \leftarrow \lfloor(a \cdot b + c) / 2^{32}\rfloor$ <br> Fails if $max(a, b, c) \ge 2^{32}$ |
-| u32madd.unsafe  | [b, a, c, ...] | [e, d, ...]   | $d \leftarrow (a \cdot b + c) \mod 2^{32}$ <br> $e \leftarrow \lfloor(a \cdot b + c) / 2^{32}\rfloor$ <br> Undefined if $max(a, b, c) \ge 2^{32}$ |
-| u32div <br> u32div.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \lfloor a / b\rfloor$ <br> Fails if $max(a, b) \ge 2^{32}$ or $b = 0$ |
-| u32div.full    | [b, a, ...]    | [d, c, ...]   | $c \leftarrow \lfloor a / b\rfloor$ <br> $d \leftarrow a \mod b$ <br> Fails if $max(a, b) \ge 2^{32}$ or $b = 0$ |
-| u32div.unsafe  | [b, a, ...]    | [d, c, ...]   | $c \leftarrow \lfloor a / b\rfloor$ <br> $d \leftarrow a \mod b$ <br> Fails if $b = 0$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
-| u32mod <br> u32mod.*b* | [b, a, ...] | [c, ...] | $c \leftarrow a \mod b$ <br> Fails if $max(a, b) \ge 2^{32}$ or $b = 0$ |
-| u32mod.unsafe  | [b, a, ...]    | [c, ...]      | $c \leftarrow a \mod b$ <br> Fails if $b = 0$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32checked_add <br> u32checked_add.*b* | [b, a, ...] | [c, ...] | $c \leftarrow a + b$ <br> Fails if $max(a, b, c) \ge 2^{32}$ |
+| u32overflowing_add <br> u32overflowing_add.*b* | [b, a, ...] | [d, c, ...] | $c \leftarrow (a + b) \mod 2^{32}$ <br> $d \leftarrow \begin{cases} 1, & \text{if}\ (a + b) \ge 2^{32} \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32wrapping_add <br> u32wrapping_add.*b* | [b, a, ...] | [c, ...] |  $c \leftarrow (a + b) \mod 2^{32}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32overflowing_add3 | [c, b, a, ...] | [e, d, ...]   | $d \leftarrow (a + b + c) \mod 2^{32}$, <br> $e \leftarrow \lfloor (a + b + c) / 2^{32}\rfloor$ <br> Undefined if $max(a, b, c) \ge 2^{32}$ <br> |
+| u32checked_sub <br> u32checked_sub.*b* | [b, a, ...] | [c, ...] | $c \leftarrow (a - b)$ <br> Fails if $max(a, b) \ge 2^{32}$ or $a < b$ |
+| u32overflowing_sub <br> u32overflowing_sub.*b* | [b, a, ...] | [d, c, ...] | $c \leftarrow (a - b) \mod 2^{32}$ <br> $d \leftarrow \begin{cases} 1, & \text{if}\ a < b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32wrapping_sub <br> u32wrapping_sub.*b* | [b, a, ...] | [c, ...] | $c \leftarrow (a - b) \mod 2^{32}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32checked_mul <br> u32checked_mul.*b* | [b, a, ...] | [c, ...] | $c \leftarrow a \cdot b$ <br> Fails if $max(a, b, c) \ge 2^{32}$ |
+| u32overflowing_mul <br> u32overflowing_mul.*b* | [b, a, ...] | [d, c, ...] | $c \leftarrow (a \cdot b) \mod 2^{32}$ <br> $d \leftarrow \lfloor(a \cdot b) / 2^{32}\rfloor$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32wrapping_mul <br> u32wrapping_mul.*b* | [b, a, ...] | [c, ...] | $c \leftarrow (a \cdot b) \mod 2^{32}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32overflowing_madd | [b, a, c, ...] | [e, d, ...] | $d \leftarrow (a \cdot b + c) \mod 2^{32}$ <br> $e \leftarrow \lfloor(a \cdot b + c) / 2^{32}\rfloor$ <br> Undefined if $max(a, b, c) \ge 2^{32}$ |
+| u32checked_div <br> u32checked_div.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \lfloor a / b\rfloor$ <br> Fails if $max(a, b) \ge 2^{32}$ or $b = 0$ |
+| u32unchecked_div <br> u32unchecked_div.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \lfloor a / b\rfloor$ <br> Fails if $b = 0$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32checked_mod <br> u32checked_mod.*b* | [b, a, ...] | [c, ...] | $c \leftarrow a \mod b$ <br> Fails if $max(a, b) \ge 2^{32}$ or $b = 0$ |
+| u32unchecked_mod <br> u32unchecked_mod.*b* | [b, a, ...] | [c, ...] | $c \leftarrow a \mod b$ <br> Fails if $b = 0$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32checked_divmod <br> u32checked_divmod.*b* | [b, a, ...] | [d, c, ...] | $c \leftarrow \lfloor a / b\rfloor$ <br> $d \leftarrow a \mod b$ <br> Fails if $max(a, b) \ge 2^{32}$ or $b = 0$ |
+| u32unchecked_divmod <br> u32unchecked_divmod.*b* | [b, a, ...] | [d, c, ...] | $c \leftarrow \lfloor a / b\rfloor$ <br> $d \leftarrow a \mod b$ <br> Fails if $b = 0$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
 
 ### Bitwise operations
 
-| Instruction    | Stack_input    | Stack_output  | Notes                                      |
+| Instruction    | Stack input    | Stack output  | Notes                                      |
 | -------------- | -------------- | ------------- | ------------------------------------------ |
-| u32and         | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `AND` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$ |
-| u32or          | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `OR` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$ |
-| u32xor         | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `XOR` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$ |
-| u32not         | [a, ...]       | [b, ...]      | Computes $b$ as a bitwise `NOT` of binary representation of $a$. <br> Fails if $a \ge 2^{32}$ |
-| u32shl <br> u32shl.*b* | [b, a, ...] | [c, ...] | $c \leftarrow (a \cdot 2^b) \mod 2^{32}$ <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
-| u32shr <br> u32shr.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \lfloor a/2^b \rfloor$ <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
-| u32rotl <br> u32rotl.*b* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the left by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
-| u32rotr <br> u32rotr.*b* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the right by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32checked_and | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `AND` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$ |
+| u32checked_or  | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `OR` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$ |
+| u32checked_xor | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `XOR` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$ |
+| u32checked_not | [a, ...]       | [b, ...]      | Computes $b$ as a bitwise `NOT` of binary representation of $a$. <br> Fails if $a \ge 2^{32}$ |
+| u32checked_shl <br> u32checked_shl.*b*         | [b, a, ...] | [c, ...]    | $c \leftarrow (a \cdot 2^b) \mod 2^{32}$ <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32unchecked_shl <br> u32unchecked_shl.*b*     | [b, a, ...] | [c, ...]    | $c \leftarrow (a \cdot 2^b) \mod 2^{32}$ <br> Undefined if $a \ge 2^{32}$ or $b > 31$ |
+| u32checked_shr <br> u32checked_shr.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \lfloor a/2^b \rfloor$ <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32unchecked_shr <br> u32unchecked_shr.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \lfloor a/2^b \rfloor$ <br> Undefined if $a \ge 2^{32}$ or $b > 31$ |
+| u32checked_rotl <br> u32checked_rotl.*b* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the left by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32unchecked_rotl <br> u32unchecked_rotl.*b* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the left by $b$ bits. <br> Undefined if $a \ge 2^{32}$ or $b > 31$ |
+| u32checked_rotr <br> u32checked_rotr.*b* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the right by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32unchecked_rotr <br> u32unchecked_rotr.*b* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the right by $b$ bits. <br> Undefined if $a \ge 2^{32}$ or $b > 31$ |
 
 ### Comparison operations
 
-| Instruction    | Stack_input  | Stack_output    | Notes                                      |
-| -------------- | ------------ | --------------- | ------------------------------------------ |
-| u32.eq <br> u32.eq.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \begin{cases} 1, & \text{if}\ a=b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ <br> Note: unsafe version is not provided because it is equivalent to simple `eq`. |
-| u32.neq <br> u32.neq.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \begin{cases} 1, & \text{if}\ a \ne b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ <br> Note: unsafe version is not provided because it is equivalent to simple `neq`. |
-| u32lt          | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a < b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
-| u32lt.unsafe   | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a < b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
-| u32lte         | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a \le b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
-| u32lte.unsafe  | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a \le b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
-| u32gt          | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a > b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
-| u32gt.unsafe   | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a > b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
-| u32gte         | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a \ge b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
-| u32gte.unsafe  | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a \ge b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
-| u32min         | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} a, & \text{if}\ a < b \\ b, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
-| u32min.unsafe  | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} a, & \text{if}\ a < b \\ b, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
-| u32max         | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} a, & \text{if}\ a > b \\ b, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
-| u32max.unsafe  | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} a, & \text{if}\ a > b \\ b, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| Instruction     | Stack input  | Stack output    | Notes                                      |
+| --------------- | ------------ | --------------- | ------------------------------------------ |
+| u32checked_eq <br> u32checked_eq.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \begin{cases} 1, & \text{if}\ a=b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ <br> Note: unchecked version is not provided because it is equivalent to simple `eq`. |
+| u32checked_neq <br> u32checked_neq.*b* | [b, a, ...] | [c, ...] | $c \leftarrow \begin{cases} 1, & \text{if}\ a \ne b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ <br> Note: unchecked version is not provided because it is equivalent to simple `neq`. |
+| u32checked_lt   | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a < b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
+| u32unchecked_lt | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a < b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32checked_lte  | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a \le b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
+| u32unchecked_lte | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a \le b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32checked_gt    | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a > b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
+| u32unchecked_gt  | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a > b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32checked_gte   | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a \ge b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
+| u32unchecked_gte | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} 1, & \text{if}\ a \ge b \\ 0, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32checked_min   | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} a, & \text{if}\ a < b \\ b, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
+| u32unchecked_min | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} a, & \text{if}\ a < b \\ b, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |
+| u32checked_max   | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} a, & \text{if}\ a > b \\ b, & \text{otherwise}\ \end{cases}$ <br> Fails if $max(a, b) \ge 2^{32}$ |
+| u32unchecked_max | [b, a, ...] | [c, ...]         | $c \leftarrow \begin{cases} a, & \text{if}\ a > b \\ b, & \text{otherwise}\ \end{cases}$ <br> Undefined if $max(a, b) \ge 2^{32}$ |

--- a/miden/tests/integration/air/chiplets/bitwise.rs
+++ b/miden/tests/integration/air/chiplets/bitwise.rs
@@ -31,33 +31,8 @@ fn bitwise_xor() {
 }
 
 #[test]
-fn pow2() {
-    // Test powers of two significant to the construction: each power decomposed in the first row
-    // of the pow2 trace; the first element of a  middle row; and the maximum exponent value.
-    // the drop's at the end are added to make sure stack overflow table is empty at the end
-    let source = "begin
-        push.0 pow2
-        push.1 pow2
-        push.2 pow2
-        push.3 pow2
-        push.4 pow2
-        push.5 pow2
-        push.6 pow2
-        push.7 pow2
-        push.8 pow2
-        push.9 pow2
-        push.63 pow2
-        drop drop drop drop drop drop drop drop drop drop drop
-    end";
-    let pub_inputs = vec![];
-
-    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
-}
-
-#[test]
 fn all_operations() {
-    let source =
-        "begin u32checked_and push.0 u32checked_or push.0 u32checked_xor push.9 pow2 drop end";
+    let source = "begin u32checked_and push.0 u32checked_or push.0 u32checked_xor end";
     let pub_inputs = vec![1, 1];
 
     build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);

--- a/miden/tests/integration/air/chiplets/mod.rs
+++ b/miden/tests/integration/air/chiplets/mod.rs
@@ -11,7 +11,6 @@ fn chiplets() {
     let source = "begin
         rpperm                          # hasher operation
         push.5 push.10 u32checked_or    # bitwise operation
-        pow2                            # power of two operation
         push.mem                        # memory operation
         drop                            # make sure the stack overflow table is empty
     end";

--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -1,4 +1,6 @@
-use super::{build_op_test, test_param_out_of_bounds, test_unsafe_execution, TestError, U32_BOUND};
+use super::{
+    build_op_test, test_param_out_of_bounds, test_unchecked_execution, TestError, U32_BOUND,
+};
 use proptest::prelude::*;
 use rand_utils::rand_value;
 
@@ -199,7 +201,7 @@ fn u32overflowing_add() {
     test.expect_stack(&[d, c as u64, e]);
 
     // should not fail when inputs are out of bounds.
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -479,7 +481,7 @@ fn u32overflowing_sub() {
     test.expect_stack(&[d, c as u64, e]);
 
     // should not fail when inputs are out of bounds.
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -675,7 +677,7 @@ fn u32overflowing_mul() {
     test.expect_stack(&[d, c as u64, e]);
 
     // should not fail when inputs are out of bounds.
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -716,7 +718,7 @@ fn u32overflowing_madd() {
     test.expect_stack(&[e, d, f]);
 
     // should not fail when inputs are out of bounds.
-    test_unsafe_execution(asm_op, 3);
+    test_unchecked_execution(asm_op, 3);
 }
 
 #[test]
@@ -801,7 +803,7 @@ fn u32unchecked_div() {
     test_div(asm_op);
 
     // should not fail when inputs are out of bounds.
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -893,7 +895,7 @@ fn u32unchecked_mod() {
     test_mod(asm_op);
 
     // should not fail when inputs are out of bounds.
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -988,7 +990,7 @@ fn u32unchecked_divmod() {
     test_divmod(asm_op);
 
     // should not fail when inputs are out of bounds.
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]

--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -203,8 +203,8 @@ fn u32overflowing_add() {
 }
 
 #[test]
-fn u32unchecked_add3() {
-    let asm_op = "u32unchecked_add3";
+fn u32overflowing_add3() {
+    let asm_op = "u32overflowing_add3";
 
     // --- test correct execution -----------------------------------------------------------------
     // --- (a + b + c) < 2^32 where c = 0 ---------------------------------------------------------
@@ -679,8 +679,8 @@ fn u32overflowing_mul() {
 }
 
 #[test]
-fn u32unchecked_madd() {
-    let asm_op = "u32unchecked_madd";
+fn u32overflowing_madd() {
+    let asm_op = "u32overflowing_madd";
 
     // --- no overflow ----------------------------------------------------------------------------
     // d = a * b + c and e should be unset, since there was no arithmetic overflow.
@@ -1035,8 +1035,8 @@ proptest! {
     }
 
     #[test]
-    fn u32unchecked_add3_proptest(a in any::<u32>(), b in any::<u32>(), c in any::<u32>()) {
-        let asm_op = "u32unchecked_add3";
+    fn u32overflowing_add3_proptest(a in any::<u32>(), b in any::<u32>(), c in any::<u32>()) {
+        let asm_op = "u32overflowing_add3";
 
         let sum: u64 = u64::from(a) + u64::from(b) + u64::from(c);
         let lo = (sum as u32) as u64;
@@ -1121,8 +1121,8 @@ proptest! {
     }
 
     #[test]
-    fn u32unchecked_madd_proptest(a in any::<u32>(), b in any::<u32>(), c in any::<u32>()) {
-        let asm_op = "u32unchecked_madd";
+    fn u32overflowing_madd_proptest(a in any::<u32>(), b in any::<u32>(), c in any::<u32>()) {
+        let asm_op = "u32overflowing_madd";
 
         let madd = a as u64 * b as u64 + c as u64;
         let d = madd % U32_BOUND;

--- a/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -331,90 +331,6 @@ fn u32unchecked_shl_b() {
 }
 
 #[test]
-fn u32overflowing_shl() {
-    // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
-    let asm_op = "u32overflowing_shl";
-
-    // --- test simple case -----------------------------------------------------------------------
-    let a = 1_u32;
-    let b = 1_u32;
-    let test = build_op_test!(asm_op, &[5, a as u64, b as u64]);
-    test.expect_stack(&[0, 2, 5]);
-
-    // --- test max values of a and b -------------------------------------------------------------
-    let a = (U32_BOUND - 1) as u32;
-    let b = 31;
-    let c = a.wrapping_shl(b);
-    let d = a.wrapping_shr(32 - b);
-
-    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
-    test.expect_stack(&[d as u64, c as u64]);
-
-    // --- test b = 0 -----------------------------------------------------------------------------
-    let a = rand_value::<u32>();
-    let b = 0;
-
-    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
-    test.expect_stack(&[0, a as u64]);
-
-    // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u32>();
-    let b = rand_value::<u32>() % 32;
-    let c = a.wrapping_shl(b);
-    let d = if b == 0 { 0 } else { a.wrapping_shr(32 - b) };
-
-    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
-    test.expect_stack(&[d as u64, c as u64]);
-
-    // --- test out of bounds input (should not fail) --------------------------------------------
-    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    assert!(test.execute().is_ok());
-}
-
-#[test]
-fn u32overflowing_shl_b() {
-    // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
-    let op_base = "u32overflowing_shl";
-    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
-
-    // --- test simple case -----------------------------------------------------------------------
-    let a = 1_u32;
-    let b = 1_u32;
-    let test = build_op_test!(get_asm_op(b).as_str(), &[5, a as u64]);
-    test.expect_stack(&[0, 2, 5]);
-
-    // --- test max values of a and b -------------------------------------------------------------
-    let a = (U32_BOUND - 1) as u32;
-    let b = 31;
-    let c = a.wrapping_shl(b);
-    let d = a.wrapping_shr(32 - b);
-
-    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
-    test.expect_stack(&[d as u64, c as u64]);
-
-    // --- test b = 0 -----------------------------------------------------------------------------
-    let a = rand_value::<u32>();
-    let b = 0;
-
-    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
-    test.expect_stack(&[0, a as u64]);
-
-    // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u32>();
-    let b = rand_value::<u32>() % 32;
-    let c = a.wrapping_shl(b);
-    let d = if b == 0 { 0 } else { a.wrapping_shr(32 - b) };
-
-    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
-    test.expect_stack(&[d as u64, c as u64]);
-
-    // --- test out of bounds input (should not fail) --------------------------------------------
-    let b = 1;
-    let test = build_op_test!(get_asm_op(b).as_str(), &[U32_BOUND]);
-    assert!(test.execute().is_ok());
-}
-
-#[test]
 fn u32checked_shr() {
     // right shift: pops a from the stack and pushes a / 2^b for a provided value b
     let asm_op = "u32checked_shr";
@@ -571,90 +487,6 @@ fn u32unchecked_shr_b() {
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.wrapping_shr(b) as u64]);
-
-    // --- test out of bounds inputs (should not fail) --------------------------------------------
-    let b = 1;
-    let test = build_op_test!(get_asm_op(b).as_str(), &[U32_BOUND]);
-    assert!(test.execute().is_ok());
-}
-
-#[test]
-fn u32overflowing_shr() {
-    // right shift: pops a from the stack and pushes a / 2^b for a provided value b
-    let asm_op = "u32overflowing_shr";
-
-    // --- test simple case -----------------------------------------------------------------------
-    let a = 4_u32;
-    let b = 2_u32;
-    let test = build_op_test!(asm_op, &[5, a as u64, b as u64]);
-    test.expect_stack(&[0, 1, 5]);
-
-    // --- test max values of a and b -------------------------------------------------------------
-    let a = (U32_BOUND - 1) as u32;
-    let b = 31;
-    let c = a.wrapping_shr(b);
-    let d = a.wrapping_shl(32 - b);
-
-    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
-    test.expect_stack(&[d as u64, c as u64]);
-
-    // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u32>();
-    let b = 0;
-
-    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
-    test.expect_stack(&[0, a as u64]);
-
-    // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u32>();
-    let b = rand_value::<u32>() % 32;
-    let c = a.wrapping_shr(b);
-    let d = if b == 0 { 0 } else { a.wrapping_shl(32 - b) };
-
-    let test = build_op_test!(asm_op, &[a as u64, b as u64]);
-    test.expect_stack(&[d as u64, c as u64]);
-
-    // --- test out of bounds inputs (should not fail) --------------------------------------------
-    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    assert!(test.execute().is_ok());
-}
-
-#[test]
-fn u32overflowing_shr_b() {
-    // right shift: pops a from the stack and pushes a / 2^b for a provided value b
-    let op_base = "u32overflowing_shr";
-    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
-
-    // --- test simple case -----------------------------------------------------------------------
-    let a = 4_u32;
-    let b = 2_u32;
-    let test = build_op_test!(get_asm_op(b).as_str(), &[5, a as u64]);
-    test.expect_stack(&[0, 1, 5]);
-
-    // --- test max values of a and b -------------------------------------------------------------
-    let a = (U32_BOUND - 1) as u32;
-    let b = 31;
-    let c = a.wrapping_shr(b);
-    let d = a.wrapping_shl(32 - b);
-
-    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
-    test.expect_stack(&[d as u64, c as u64]);
-
-    // --- test b = 0 ---------------------------------------------------------------------------
-    let a = rand_value::<u32>();
-    let b = 0;
-
-    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
-    test.expect_stack(&[0, a as u64]);
-
-    // --- test random values ---------------------------------------------------------------------
-    let a = rand_value::<u32>();
-    let b = rand_value::<u32>() % 32;
-    let c = a.wrapping_shr(b);
-    let d = if b == 0 { 0 } else { a.wrapping_shl(32 - b) };
-
-    let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
-    test.expect_stack(&[d as u64, c as u64]);
 
     // --- test out of bounds inputs (should not fail) --------------------------------------------
     let b = 1;
@@ -1052,30 +884,6 @@ proptest! {
     }
 
     #[test]
-    fn u32overflowing_shl_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32overflowing_shl";
-
-        // should execute left shift
-        let c = a.wrapping_shl(b);
-        // and leave the result that was shifted off
-        let d = if b == 0 { 0 } else { a.wrapping_shr(32 - b) };
-        let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
-        test.prop_expect_stack(&[d as u64, c as u64])?;
-    }
-
-    #[test]
-    fn u32overflowing_shl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = format!("u32overflowing_shl.{}", b);
-
-        // should execute left shift
-        let c = a.wrapping_shl(b);
-        // and leave the result that was shifted off
-        let d = if b == 0 { 0 } else { a.wrapping_shr(32 - b) };
-        let test = build_op_test!(asm_opcode, &[a as u64]);
-        test.prop_expect_stack(&[d as u64, c as u64])?;
-    }
-
-    #[test]
     fn u32checked_shr_proptest(a in any::<u32>(), b in 0_u32..32) {
         let asm_opcode = "u32checked_shr";
 
@@ -1093,30 +901,6 @@ proptest! {
         let expected = a >> b;
         let test = build_op_test!(asm_opcode, &[a as u64]);
         test.prop_expect_stack(&[expected as u64])?;
-    }
-
-    #[test]
-    fn u32overflowing_shr_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = "u32overflowing_shr";
-
-        // should execute right shift
-        let c = a.wrapping_shr(b);
-        // and leave the result that was shifted off
-        let d = if b == 0 { 0 } else { a.wrapping_shl(32 - b) };
-        let test = build_op_test!(asm_opcode, &[a as u64, b as u64]);
-        test.prop_expect_stack(&[d as u64, c as u64])?;
-    }
-
-    #[test]
-    fn u32overflowing_shr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = format!("u32overflowing_shr.{}", b);
-
-        // should execute right shift
-        let c = a.wrapping_shr(b);
-        // and leave the result that was shifted off
-        let d = if b == 0 { 0 } else { a.wrapping_shl(32 - b) };
-        let test = build_op_test!(asm_opcode, &[a as u64]);
-        test.prop_expect_stack(&[d as u64, c as u64])?;
     }
 
     #[test]

--- a/miden/tests/integration/operations/u32_ops/comparison_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/comparison_ops.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 use super::{
-    build_op_test, test_inputs_out_of_bounds, test_param_out_of_bounds, test_unsafe_execution,
+    build_op_test, test_inputs_out_of_bounds, test_param_out_of_bounds, test_unchecked_execution,
     TestError, U32_BOUND,
 };
 use proptest::prelude::*;
@@ -200,7 +200,7 @@ fn u32unchecked_lt() {
     test_comparison_op(asm_op, 1, 0, 0);
 
     // should not fail when inputs are out of bounds
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -227,7 +227,7 @@ fn u32unchecked_lte() {
     test_comparison_op(asm_op, 1, 1, 0);
 
     // should not fail when inputs are out of bounds
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -254,7 +254,7 @@ fn u32unchecked_gt() {
     test_comparison_op(asm_op, 0, 0, 1);
 
     // should not fail when inputs are out of bounds
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -281,7 +281,7 @@ fn u32unchecked_gte() {
     test_comparison_op(asm_op, 0, 1, 1);
 
     // should not fail when inputs are out of bounds
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -308,7 +308,7 @@ fn u32unchecked_min() {
     test_min(asm_op);
 
     // should not fail when inputs are out of bounds
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -335,7 +335,7 @@ fn u32unchecked_max() {
     test_max(asm_op);
 
     // should not fail when inputs are out of bounds
-    test_unsafe_execution(asm_op, 2);
+    test_unchecked_execution(asm_op, 2);
 }
 
 // U32 OPERATIONS TESTS - RANDOMIZED - COMPARISON OPERATIONS
@@ -385,7 +385,7 @@ proptest! {
             Ordering::Greater => 0,
         };
 
-        // safe and unsafe should produce the same result for valid values
+        // checked and unchecked should produce the same result for valid values
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
 
@@ -403,7 +403,7 @@ proptest! {
             Ordering::Greater => 0,
         };
 
-        // safe and unsafe should produce the same result for valid values
+        // checked and unchecked should produce the same result for valid values
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
 
@@ -421,7 +421,7 @@ proptest! {
             Ordering::Greater => 1,
         };
 
-        // safe and unsafe should produce the same result for valid values
+        // checked and unchecked should produce the same result for valid values
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
 
@@ -439,7 +439,7 @@ proptest! {
             Ordering::Greater => 1,
         };
 
-        // safe and unsafe should produce the same result for valid values
+        // checked and unchecked should produce the same result for valid values
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected])?;
 
@@ -453,7 +453,7 @@ proptest! {
         let asm_op = "u32checked_min";
         let expected = if a < b { a } else { b };
 
-        // safe and unsafe should produce the same result for valid values
+        // checked and unchecked should produce the same result for valid values
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
 
@@ -467,7 +467,7 @@ proptest! {
         let asm_op = "u32checked_max";
         let expected = if a > b { a } else { b };
 
-        // safe and unsafe should produce the same result for valid values
+        // checked and unchecked should produce the same result for valid values
         let test = build_op_test!(asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
 
@@ -515,8 +515,8 @@ fn test_comparison_op(asm_op: &str, expected_lt: u64, expected_eq: u64, expected
     test.expect_stack(&[expected, c]);
 }
 
-/// Tests a u32min assembly operation (u32min or u32min.unsafe) against a number of cases to ensure
-/// that the operation puts the minimum of 2 input values on the stack.
+/// Tests a u32min assembly operation (u32checked_min or u32unchecked_min) against a number of
+/// cases to ensure that the operation puts the minimum of 2 input values on the stack.
 fn test_min(asm_op: &str) {
     // --- simple cases ---------------------------------------------------------------------------
     // a < b should put a on the stack
@@ -550,8 +550,8 @@ fn test_min(asm_op: &str) {
     test.expect_stack(&[expected as u64, c]);
 }
 
-/// Tests a u32max assembly operation (u32max or u32max.unsafe) against a number of cases to ensure
-/// that the operation puts the maximum of 2 input values on the stack.
+/// Tests a u32max assembly operation (u32checked_max or u32unchecked_max) against a number of
+/// cases to ensure that the operation puts the maximum of 2 input values on the stack.
 fn test_max(asm_op: &str) {
     // --- simple cases ---------------------------------------------------------------------------
     // a < b should put b on the stack

--- a/miden/tests/integration/operations/u32_ops/mod.rs
+++ b/miden/tests/integration/operations/u32_ops/mod.rs
@@ -45,7 +45,7 @@ pub fn test_param_out_of_bounds(asm_op_base: &str, gt_max_value: u64) {
 
 /// This helper function tests that when the given u32 assembly instruction is executed on
 /// out-of-bounds inputs it does not fail. Each input is tested independently.
-pub fn test_unsafe_execution(asm_op: &str, input_count: usize) {
+pub fn test_unchecked_execution(asm_op: &str, input_count: usize) {
     let values = vec![1_u64; input_count];
 
     for i in 0..input_count {

--- a/stdlib/asm/crypto/hashes/blake3.masm
+++ b/stdlib/asm/crypto/hashes/blake3.masm
@@ -158,27 +158,27 @@ proc.columnar_mixing.1
 
     movup.8
     dup.5
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 
     swap
     movup.8
     dup.6
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     swap
 
     movup.2
     dup.6
     movup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.2
 
     movup.3
     dup.7
     movup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.3
 
@@ -258,27 +258,27 @@ proc.columnar_mixing.1
 
     movup.4
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 
     swap
     movup.4
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     swap
 
     movup.2
     movup.4
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.2
 
     movup.3
     movup.4
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.3
 
@@ -390,27 +390,27 @@ proc.diagonal_mixing.1
 
     movup.8
     dup.6
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 
     swap
     movup.8
     dup.7
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     swap
 
     movup.2
     movup.8
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.2
 
     movup.3
     movup.8
     dup.5
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.3
 
@@ -490,27 +490,27 @@ proc.diagonal_mixing.1
 
     movup.4
     dup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 
     swap
     movup.4
     dup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     swap
 
     movup.2
     movup.4
     dup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.2
 
     movup.3
     movup.4
     dup.5
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.3
 

--- a/stdlib/asm/math/u256.masm
+++ b/stdlib/asm/math/u256.masm
@@ -5,28 +5,28 @@ export.add_unsafe
     u32overflowing_add
     movup.4
     movup.7
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.6
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.5
-    u32unchecked_add3
+    u32overflowing_add3
     movdn.12
     swapw.2
     movup.12
     movup.4
     movup.8
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.7
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.6
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.5
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 end
 
@@ -203,7 +203,7 @@ end
 
 proc.mulstep
     movdn.2
-    u32unchecked_madd
+    u32overflowing_madd
     movdn.2
     u32overflowing_add
     movup.2

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -632,7 +632,7 @@ end
 # [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64.
 # This takes 50 cycles.
 export.unchecked_shl
-    pow2.unsafe
+    unchecked_pow2
     u32split
     exec.wrapping_mul
 end
@@ -645,7 +645,7 @@ end
 # [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a >> b.
 # This takes 66 cycles.
 export.unchecked_shr
-    pow2.unsafe
+    unchecked_pow2
     u32split
 
     dup.1
@@ -685,7 +685,7 @@ end
 # which d contains the bits shifted out.
 # This takes 57 cycles.
 export.overflowing_shl
-    pow2.unsafe
+    unchecked_pow2
     u32split
     exec.overflowing_mul
 end
@@ -739,7 +739,7 @@ export.unchecked_rotl
     # Shift the low limb.
     push.31
     u32checked_and
-    pow2.unsafe
+    unchecked_pow2
     dup
     movup.3
     u32overflowing_mul
@@ -780,7 +780,7 @@ export.unchecked_rotr
     swap
     u32overflowing_sub
     drop
-    pow2.unsafe
+    unchecked_pow2
     dup
     movup.3
     u32overflowing_mul

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -25,7 +25,7 @@ export.overflowing_add
     u32overflowing_add
     movup.3
     movup.3
-    u32unchecked_add3
+    u32overflowing_add3
 end
 
 # Performs addition of two unsigned 64 bit integers discarding the overflow.
@@ -117,11 +117,11 @@ export.wrapping_mul
     u32overflowing_mul
     movup.4
     movup.4
-    u32unchecked_madd
+    u32overflowing_madd
     drop
     movup.3
     movup.3
-    u32unchecked_madd
+    u32overflowing_madd
     drop
 end
 
@@ -136,14 +136,14 @@ export.overflowing_mul
     u32overflowing_mul
     dup.4
     movup.4
-    u32unchecked_madd
+    u32overflowing_madd
     swap
     movup.5
     dup.4
-    u32unchecked_madd
+    u32overflowing_madd
     movup.5
     movup.5
-    u32unchecked_madd
+    u32overflowing_madd
     movup.3
     movup.2
     u32overflowing_add
@@ -396,12 +396,12 @@ export.unchecked_div
     u32overflowing_mul
     dup.4
     dup.4
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.5
     dup.3
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.4
@@ -427,7 +427,7 @@ export.unchecked_div
     u32overflowing_add
     movup.3
     movup.3
-    u32unchecked_add3
+    u32overflowing_add3
     eq.0
     assert
 
@@ -465,12 +465,12 @@ export.unchecked_mod
     u32overflowing_mul
     dup.4
     movup.4
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.4
     dup.3
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.3
@@ -496,7 +496,7 @@ export.unchecked_mod
     u32overflowing_add
     movup.4
     dup.3
-    u32unchecked_add3
+    u32overflowing_add3
     eq.0
     assert
 
@@ -534,12 +534,12 @@ export.unchecked_divmod
     u32overflowing_mul
     dup.4
     dup.4
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.5
     dup.3
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.4
@@ -565,7 +565,7 @@ export.unchecked_divmod
     u32overflowing_add
     movup.4
     dup.3
-    u32unchecked_add3
+    u32overflowing_add3
     eq.0
     assert
 
@@ -747,7 +747,7 @@ export.unchecked_rotl
     # Shift the high limb.
     movup.3
     movup.3
-    u32unchecked_madd
+    u32overflowing_madd
 
     # Carry the overflow shift to the low bits.
     movup.2
@@ -788,7 +788,7 @@ export.unchecked_rotr
     # Shift the high limb left by 32-b.
     movup.3
     movup.3
-    u32unchecked_madd
+    u32overflowing_madd
 
     # Carry the overflow shift to the low bits.
     movup.2

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -10297,7 +10297,7 @@ end
 # [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64.
 # This takes 50 cycles.
 export.unchecked_shl
-    pow2.unsafe
+    unchecked_pow2
     u32split
     exec.wrapping_mul
 end
@@ -10310,7 +10310,7 @@ end
 # [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a >> b.
 # This takes 66 cycles.
 export.unchecked_shr
-    pow2.unsafe
+    unchecked_pow2
     u32split
 
     dup.1
@@ -10350,7 +10350,7 @@ end
 # which d contains the bits shifted out.
 # This takes 57 cycles.
 export.overflowing_shl
-    pow2.unsafe
+    unchecked_pow2
     u32split
     exec.overflowing_mul
 end
@@ -10404,7 +10404,7 @@ export.unchecked_rotl
     # Shift the low limb.
     push.31
     u32checked_and
-    pow2.unsafe
+    unchecked_pow2
     dup
     movup.3
     u32overflowing_mul
@@ -10445,7 +10445,7 @@ export.unchecked_rotr
     swap
     u32overflowing_sub
     drop
-    pow2.unsafe
+    unchecked_pow2
     dup
     movup.3
     u32overflowing_mul

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -166,27 +166,27 @@ proc.columnar_mixing.1
 
     movup.8
     dup.5
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 
     swap
     movup.8
     dup.6
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     swap
 
     movup.2
     dup.6
     movup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.2
 
     movup.3
     dup.7
     movup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.3
 
@@ -266,27 +266,27 @@ proc.columnar_mixing.1
 
     movup.4
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 
     swap
     movup.4
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     swap
 
     movup.2
     movup.4
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.2
 
     movup.3
     movup.4
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.3
 
@@ -398,27 +398,27 @@ proc.diagonal_mixing.1
 
     movup.8
     dup.6
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 
     swap
     movup.8
     dup.7
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     swap
 
     movup.2
     movup.8
     dup.8
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.2
 
     movup.3
     movup.8
     dup.5
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.3
 
@@ -498,27 +498,27 @@ proc.diagonal_mixing.1
 
     movup.4
     dup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 
     swap
     movup.4
     dup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     swap
 
     movup.2
     movup.4
     dup.9
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.2
 
     movup.3
     movup.4
     dup.5
-    u32unchecked_add3
+    u32overflowing_add3
     drop
     movdn.3
 
@@ -9129,28 +9129,28 @@ end
     u32overflowing_add
     movup.4
     movup.7
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.6
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.5
-    u32unchecked_add3
+    u32overflowing_add3
     movdn.12
     swapw.2
     movup.12
     movup.4
     movup.8
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.7
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.6
-    u32unchecked_add3
+    u32overflowing_add3
     movup.4
     movup.5
-    u32unchecked_add3
+    u32overflowing_add3
     drop
 end
 
@@ -9327,7 +9327,7 @@ end
 
 proc.mulstep
     movdn.2
-    u32unchecked_madd
+    u32overflowing_madd
     movdn.2
     u32overflowing_add
     movup.2
@@ -9690,7 +9690,7 @@ export.overflowing_add
     u32overflowing_add
     movup.3
     movup.3
-    u32unchecked_add3
+    u32overflowing_add3
 end
 
 # Performs addition of two unsigned 64 bit integers discarding the overflow.
@@ -9782,11 +9782,11 @@ export.wrapping_mul
     u32overflowing_mul
     movup.4
     movup.4
-    u32unchecked_madd
+    u32overflowing_madd
     drop
     movup.3
     movup.3
-    u32unchecked_madd
+    u32overflowing_madd
     drop
 end
 
@@ -9801,14 +9801,14 @@ export.overflowing_mul
     u32overflowing_mul
     dup.4
     movup.4
-    u32unchecked_madd
+    u32overflowing_madd
     swap
     movup.5
     dup.4
-    u32unchecked_madd
+    u32overflowing_madd
     movup.5
     movup.5
-    u32unchecked_madd
+    u32overflowing_madd
     movup.3
     movup.2
     u32overflowing_add
@@ -10061,12 +10061,12 @@ export.unchecked_div
     u32overflowing_mul
     dup.4
     dup.4
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.5
     dup.3
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.4
@@ -10092,7 +10092,7 @@ export.unchecked_div
     u32overflowing_add
     movup.3
     movup.3
-    u32unchecked_add3
+    u32overflowing_add3
     eq.0
     assert
 
@@ -10130,12 +10130,12 @@ export.unchecked_mod
     u32overflowing_mul
     dup.4
     movup.4
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.4
     dup.3
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.3
@@ -10161,7 +10161,7 @@ export.unchecked_mod
     u32overflowing_add
     movup.4
     dup.3
-    u32unchecked_add3
+    u32overflowing_add3
     eq.0
     assert
 
@@ -10199,12 +10199,12 @@ export.unchecked_divmod
     u32overflowing_mul
     dup.4
     dup.4
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.5
     dup.3
-    u32unchecked_madd
+    u32overflowing_madd
     eq.0
     assert
     dup.4
@@ -10230,7 +10230,7 @@ export.unchecked_divmod
     u32overflowing_add
     movup.4
     dup.3
-    u32unchecked_add3
+    u32overflowing_add3
     eq.0
     assert
 
@@ -10412,7 +10412,7 @@ export.unchecked_rotl
     # Shift the high limb.
     movup.3
     movup.3
-    u32unchecked_madd
+    u32overflowing_madd
 
     # Carry the overflow shift to the low bits.
     movup.2
@@ -10453,7 +10453,7 @@ export.unchecked_rotr
     # Shift the high limb left by 32-b.
     movup.3
     movup.3
-    u32unchecked_madd
+    u32overflowing_madd
 
     # Carry the overflow shift to the low bits.
     movup.2


### PR DESCRIPTION
This PR updated assembly documentation for u32 operation. It also includes four small refactorings:

* Renamed `u32unchecked_add3` to `u32overflowing_add3`.
* Renamed `u32unchecked_madd` to `u32overflowing_madd`.
* Removed `u32overflowing_shl` and `u32overflowing_shr` procedures.
* Refactored `pow2` instruction to have two variants: `checked_pow2` and `unchecked_pow2`.