### PR TITLE
Add bitwise operations to the chiplets bus column

### DIFF
--- a/air/src/chiplets/bitwise/mod.rs
+++ b/air/src/chiplets/bitwise/mod.rs
@@ -4,7 +4,7 @@ use core::ops::Range;
 use vm_core::{
     bitwise::{
         BITWISE_A_COL_IDX, BITWISE_B_COL_IDX, BITWISE_NUM_DECOMP_BITS as NUM_DECOMP_BITS,
-        BITWISE_OUTPUT_COL_IDX, NUM_SELECTORS, OP_CYCLE_LEN,
+        BITWISE_OUTPUT_COL_IDX, BITWISE_PREV_OUTPUT_COL_IDX, NUM_SELECTORS, OP_CYCLE_LEN,
     },
     utils::range as create_range,
     Felt,
@@ -31,9 +31,9 @@ const A_COL_RANGE: Range<usize> = create_range(B_COL_IDX + 1, NUM_DECOMP_BITS);
 /// The index range for the bit decomposition of `b`.
 const B_COL_RANGE: Range<usize> = create_range(A_COL_RANGE.end, NUM_DECOMP_BITS);
 /// The index of the column containing the aggregated output value of the previous row.
-const OUTPUT_COL_PREV_IDX: usize = BITWISE_TRACE_OFFSET + BITWISE_OUTPUT_COL_IDX;
+const OUTPUT_COL_PREV_IDX: usize = BITWISE_TRACE_OFFSET + BITWISE_PREV_OUTPUT_COL_IDX;
 /// The index of the column containing the aggregated output value.
-const OUTPUT_COL_IDX: usize = OUTPUT_COL_PREV_IDX + 1;
+const OUTPUT_COL_IDX: usize = BITWISE_TRACE_OFFSET + BITWISE_OUTPUT_COL_IDX;
 
 // PERIODIC COLUMNS
 // ================================================================================================

--- a/core/src/chiplets/bitwise.rs
+++ b/core/src/chiplets/bitwise.rs
@@ -49,7 +49,11 @@ pub const BITWISE_B_COL_IDX: usize = BITWISE_A_COL_IDX + 1;
 
 /// The index of the column containing the aggregated output value within the bitwise execution
 /// trace.
-pub const BITWISE_OUTPUT_COL_IDX: usize = BITWISE_B_COL_IDX + 1 + 2 * BITWISE_NUM_DECOMP_BITS;
+pub const BITWISE_PREV_OUTPUT_COL_IDX: usize = BITWISE_B_COL_IDX + 1 + 2 * BITWISE_NUM_DECOMP_BITS;
+
+/// The index of the column containing the aggregated output value within the bitwise execution
+/// trace.
+pub const BITWISE_OUTPUT_COL_IDX: usize = BITWISE_PREV_OUTPUT_COL_IDX + 1;
 
 // TYPE ALIASES
 // ================================================================================================

--- a/core/src/chiplets/bitwise.rs
+++ b/core/src/chiplets/bitwise.rs
@@ -16,12 +16,21 @@ pub const OP_CYCLE_LEN: usize = 8;
 
 /// Specifies a bitwise AND operation.
 pub const BITWISE_AND: Selectors = [Felt::ZERO, Felt::ZERO];
+/// Unique id for the bitwise AND operation. Computed as 1 more than the binary composition of the
+/// chiplet and operation selectors [1, 0, 0, 0].
+pub const BITWISE_AND_OP_ID: Felt = Felt::new(2);
 
 /// Specifies a bitwise OR operation.
 pub const BITWISE_OR: Selectors = [Felt::ZERO, Felt::ONE];
+/// Unique id for the bitwise OR operation. Computed as 1 more than the binary composition of the
+/// chiplet and operation selectors [1, 0, 0, 1].
+pub const BITWISE_OR_OP_ID: Felt = Felt::new(10);
 
 /// Specifies a bitwise XOR operation.
 pub const BITWISE_XOR: Selectors = [Felt::ONE, Felt::ZERO];
+/// Unique id for the bitwise XOR operation. Computed as 1 more than the binary composition of the
+/// chiplet and operation selectors [1, 0, 1, 0].
+pub const BITWISE_XOR_OP_ID: Felt = Felt::new(6);
 
 // --- INPUT DECOMPOSITION ------------------------------------------------------------------------
 

--- a/core/src/chiplets/hasher.rs
+++ b/core/src/chiplets/hasher.rs
@@ -62,26 +62,44 @@ pub const TRACE_WIDTH: usize = NUM_SELECTORS + STATE_WIDTH + 2;
 /// executing linear hash computation. These selectors can also be used for a simple 2-to-1 hash
 /// computation.
 pub const LINEAR_HASH: Selectors = [Felt::ONE, Felt::ZERO, Felt::ZERO];
+/// Unique id for the linear hash operation. Computed as 1 more than the binary composition of the
+/// chiplet and operation selectors [0, 1, 0, 0].
+pub const LINEAR_HASH_OP_ID: Felt = Felt::new(3);
 
 /// Specifies a start of Merkle path verification computation or absorption of a new path node
 /// into the hasher state.
 pub const MP_VERIFY: Selectors = [Felt::ONE, Felt::ZERO, Felt::ONE];
+/// Unique id for the merkle path verification operation. Computed as 1 more than the binary
+/// composition of the chiplet and operation selectors [0, 1, 0, 1].
+pub const MP_VERIFY_OP_ID: Felt = Felt::new(11);
 
 /// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
 /// state for the "old" node value during Merkle root update computation.
 pub const MR_UPDATE_OLD: Selectors = [Felt::ONE, Felt::ONE, Felt::ZERO];
+/// Unique id for the merkle path update operation for an "old" node. Computed as 1 more than the
+/// binary composition of the chiplet and operation selectors [0, 1, 1, 0].
+pub const MR_UPDATE_OLD_OP_ID: Felt = Felt::new(7);
 
 /// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
 /// state for the "new" node value during Merkle root update computation.
 pub const MR_UPDATE_NEW: Selectors = [Felt::ONE, Felt::ONE, Felt::ONE];
+/// Unique id for the merkle path update operation for a "new" node. Computed as 1 more than the
+/// binary composition of the chiplet and operation selectors [0, 1, 1, 1].
+pub const MR_UPDATE_NEW_OP_ID: Felt = Felt::new(15);
 
 /// Specifies a completion of a computation such that only the hash result (values in h0, h1, h2
 /// h3) is returned.
 pub const RETURN_HASH: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ZERO];
+/// Unique id for specifying the return of a hash result. Computed as 1 more than the binary
+/// composition of the chiplet and operation selectors [0, 0, 0, 0].
+pub const RETURN_HASH_OP_ID: Felt = Felt::new(1);
 
 /// Specifies a completion of a computation such that the entire hasher state (values in h0 through
 /// h11) is returned.
 pub const RETURN_STATE: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ONE];
+/// Unique id for specifying the return of the entire hasher state. Computed as 1 more than the
+/// binary composition of  the chiplet and operation selectors [0, 0, 0, 1]
+pub const RETURN_STATE_OP_ID: Felt = Felt::new(9);
 
 // --- Column accessors in the auxiliary trace ----------------------------------------------------
 

--- a/core/src/chiplets/memory.rs
+++ b/core/src/chiplets/memory.rs
@@ -1,4 +1,4 @@
-use super::{create_range, Range, MEMORY_TRACE_OFFSET};
+use super::{create_range, Felt, Range, MEMORY_TRACE_OFFSET};
 
 // CONSTANTS
 // ================================================================================================
@@ -28,3 +28,9 @@ pub const D1_COL_IDX: usize = D0_COL_IDX + 1;
 /// Column for the inverse of the delta between two consecutive context IDs, addresses, or clock
 /// cycles, used to enforce that changes are correctly constrained.
 pub const D_INV_COL_IDX: usize = D1_COL_IDX + 1;
+
+// --- OPERATION SELECTOR -----------------------------------------------------------------------
+
+/// Unique id for memory operations. Computed as 1 more than the binary composition of the
+/// chiplet selectors [1, 1, 1].
+pub const MEMORY_OP_ID: Felt = Felt::new(8);

--- a/processor/src/chiplets/bitwise/tests.rs
+++ b/processor/src/chiplets/bitwise/tests.rs
@@ -1,7 +1,11 @@
 use super::{
-    Bitwise, Felt, StarkField, TraceFragment, BITWISE_AND, BITWISE_OR, BITWISE_XOR, TRACE_WIDTH,
+    super::{ChipletsLookup, ChipletsLookupRow},
+    Bitwise, BitwiseLookup, ChipletsBus, Felt, StarkField, TraceFragment, BITWISE_AND,
+    BITWISE_AND_OP_ID, BITWISE_OR, BITWISE_OR_OP_ID, BITWISE_XOR, BITWISE_XOR_OP_ID, OP_CYCLE_LEN,
+    TRACE_WIDTH,
 };
 use rand_utils::rand_value;
+use vm_core::bitwise::BITWISE_OUTPUT_COL_IDX;
 
 #[test]
 fn bitwise_init() {
@@ -20,21 +24,15 @@ fn bitwise_and() {
     assert_eq!(a.as_int() & b.as_int(), result.as_int());
 
     // --- check generated trace ----------------------------------------------
-    let num_rows = 8;
-    let mut trace = (0..TRACE_WIDTH)
-        .map(|_| vec![Felt::new(0); num_rows])
-        .collect::<Vec<_>>();
-    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
-
-    bitwise.fill_trace(&mut fragment);
+    let (trace, chiplets_bus) = build_trace(bitwise, OP_CYCLE_LEN);
 
     // make sure the selector values specify bitwise AND at each step in the trace
-    for row in 0..8 {
+    for row in 0..OP_CYCLE_LEN {
         assert_eq!([trace[0][row], trace[1][row]], BITWISE_AND);
     }
 
     // make sure result and result from the trace are the same
-    assert_eq!(result, trace[13][7]);
+    assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][OP_CYCLE_LEN - 1]);
 
     // make sure values a and b were decomposed correctly
     check_decomposition(&trace, 0, a.as_int(), b.as_int());
@@ -50,10 +48,15 @@ fn bitwise_and() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
-        assert_eq!(result, trace[13][i]);
+        assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
+
+    // make sure the lookup was sent to the bus correctly
+    let bitwise_lookup =
+        BitwiseLookup::new(BITWISE_AND_OP_ID, a, b, Felt::new(a.as_int() & b.as_int()));
+    verify_bus(&chiplets_bus, 0, OP_CYCLE_LEN - 1, &bitwise_lookup);
 }
 
 #[test]
@@ -67,21 +70,15 @@ fn bitwise_or() {
     assert_eq!(a.as_int() | b.as_int(), result.as_int());
 
     // --- check generated trace ----------------------------------------------
-    let num_rows = 8;
-    let mut trace = (0..TRACE_WIDTH)
-        .map(|_| vec![Felt::new(0); num_rows])
-        .collect::<Vec<_>>();
-    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
-
-    bitwise.fill_trace(&mut fragment);
+    let (trace, chiplets_bus) = build_trace(bitwise, OP_CYCLE_LEN);
 
     // make sure the selector values specify bitwise OR at each step in the trace
-    for row in 0..8 {
+    for row in 0..OP_CYCLE_LEN {
         assert_eq!([trace[0][row], trace[1][row]], BITWISE_OR);
     }
 
     // make sure result and result from the trace are the same
-    assert_eq!(result, trace[13][7]);
+    assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][OP_CYCLE_LEN - 1]);
 
     // make sure values a and b were decomposed correctly
     check_decomposition(&trace, 0, a.as_int(), b.as_int());
@@ -97,10 +94,15 @@ fn bitwise_or() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
-        assert_eq!(result, trace[13][i]);
+        assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
+
+    // make sure the lookup was sent to the bus correctly
+    let bitwise_lookup =
+        BitwiseLookup::new(BITWISE_OR_OP_ID, a, b, Felt::new(a.as_int() | b.as_int()));
+    verify_bus(&chiplets_bus, 0, OP_CYCLE_LEN - 1, &bitwise_lookup);
 }
 
 #[test]
@@ -114,21 +116,15 @@ fn bitwise_xor() {
     assert_eq!(a.as_int() ^ b.as_int(), result.as_int());
 
     // --- check generated trace ----------------------------------------------
-    let num_rows = 8;
-    let mut trace = (0..TRACE_WIDTH)
-        .map(|_| vec![Felt::new(0); num_rows])
-        .collect::<Vec<_>>();
-    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
-
-    bitwise.fill_trace(&mut fragment);
+    let (trace, chiplets_bus) = build_trace(bitwise, OP_CYCLE_LEN);
 
     // make sure the selector values specify bitwise XOR at each step in the trace
-    for row in 0..8 {
+    for row in 0..OP_CYCLE_LEN {
         assert_eq!([trace[0][row], trace[1][row]], BITWISE_XOR);
     }
 
     // make sure result and result from the trace are the same
-    assert_eq!(result, trace[13][7]);
+    assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][OP_CYCLE_LEN - 1]);
 
     // make sure values a and b were decomposed correctly
     check_decomposition(&trace, 0, a.as_int(), b.as_int());
@@ -144,10 +140,15 @@ fn bitwise_xor() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
-        assert_eq!(result, trace[13][i]);
+        assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
+
+    // make sure the lookup was sent to the bus correctly
+    let bitwise_lookup =
+        BitwiseLookup::new(BITWISE_XOR_OP_ID, a, b, Felt::new(a.as_int() ^ b.as_int()));
+    verify_bus(&chiplets_bus, 0, OP_CYCLE_LEN - 1, &bitwise_lookup);
 }
 
 #[test]
@@ -174,30 +175,24 @@ fn bitwise_multiple() {
     assert_eq!(a[3].as_int() & b[3].as_int(), result3.as_int());
 
     // --- check generated trace ----------------------------------------------
-    let num_rows = 32;
-    let mut trace = (0..TRACE_WIDTH)
-        .map(|_| vec![Felt::new(0); num_rows])
-        .collect::<Vec<_>>();
-    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
-
-    bitwise.fill_trace(&mut fragment);
+    let (trace, chiplets_bus) = build_trace(bitwise, OP_CYCLE_LEN * 4);
 
     // make sure results and results from the trace are the same
-    assert_eq!(result0, trace[13][7]);
-    assert_eq!(result1, trace[13][15]);
-    assert_eq!(result2, trace[13][23]);
-    assert_eq!(result3, trace[13][31]);
+    assert_eq!(result0, trace[BITWISE_OUTPUT_COL_IDX][OP_CYCLE_LEN - 1]);
+    assert_eq!(result1, trace[BITWISE_OUTPUT_COL_IDX][2 * OP_CYCLE_LEN - 1]);
+    assert_eq!(result2, trace[BITWISE_OUTPUT_COL_IDX][3 * OP_CYCLE_LEN - 1]);
+    assert_eq!(result3, trace[BITWISE_OUTPUT_COL_IDX][4 * OP_CYCLE_LEN - 1]);
 
     // make sure input values were decomposed correctly
     check_decomposition(&trace, 0, a[0].as_int(), b[0].as_int());
-    check_decomposition(&trace, 8, a[1].as_int(), b[1].as_int());
-    check_decomposition(&trace, 16, a[2].as_int(), b[2].as_int());
-    check_decomposition(&trace, 24, a[3].as_int(), b[3].as_int());
+    check_decomposition(&trace, OP_CYCLE_LEN, a[1].as_int(), b[1].as_int());
+    check_decomposition(&trace, 2 * OP_CYCLE_LEN, a[2].as_int(), b[2].as_int());
+    check_decomposition(&trace, 3 * OP_CYCLE_LEN, a[3].as_int(), b[3].as_int());
 
     // make sure the results was re-composed correctly
 
     let mut prev_result = Felt::new(0);
-    for i in 0..8 {
+    for i in 0..OP_CYCLE_LEN {
         let c0 = binary_and(trace[4][i], trace[8][i]);
         let c1 = binary_and(trace[5][i], trace[9][i]);
         let c2 = binary_and(trace[6][i], trace[10][i]);
@@ -205,13 +200,13 @@ fn bitwise_multiple() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
-        assert_eq!(result, trace[13][i]);
+        assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
 
     let mut prev_result = Felt::new(0);
-    for i in 8..16 {
+    for i in OP_CYCLE_LEN..(2 * OP_CYCLE_LEN) {
         let c0 = binary_or(trace[4][i], trace[8][i]);
         let c1 = binary_or(trace[5][i], trace[9][i]);
         let c2 = binary_or(trace[6][i], trace[10][i]);
@@ -219,13 +214,13 @@ fn bitwise_multiple() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
-        assert_eq!(result, trace[13][i]);
+        assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
 
     let mut prev_result = Felt::new(0);
-    for i in 16..24 {
+    for i in (2 * OP_CYCLE_LEN)..(3 * OP_CYCLE_LEN) {
         let c0 = binary_xor(trace[4][i], trace[8][i]);
         let c1 = binary_xor(trace[5][i], trace[9][i]);
         let c2 = binary_xor(trace[6][i], trace[10][i]);
@@ -233,13 +228,13 @@ fn bitwise_multiple() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
-        assert_eq!(result, trace[13][i]);
+        assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
 
     let mut prev_result = Felt::new(0);
-    for i in 24..32 {
+    for i in (3 * OP_CYCLE_LEN)..(4 * OP_CYCLE_LEN) {
         let c0 = binary_and(trace[4][i], trace[8][i]);
         let c1 = binary_and(trace[5][i], trace[9][i]);
         let c2 = binary_and(trace[6][i], trace[10][i]);
@@ -247,14 +242,59 @@ fn bitwise_multiple() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
-        assert_eq!(result, trace[13][i]);
+        assert_eq!(result, trace[BITWISE_OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
+
+    // make sure the lookups were sent to the bus correctly
+    let bitwise_lookup = BitwiseLookup::new(
+        BITWISE_AND_OP_ID,
+        a[0],
+        b[0],
+        Felt::new(a[0].as_int() & b[0].as_int()),
+    );
+    verify_bus(&chiplets_bus, 0, OP_CYCLE_LEN - 1, &bitwise_lookup);
+
+    let bitwise_lookup = BitwiseLookup::new(
+        BITWISE_OR_OP_ID,
+        a[1],
+        b[1],
+        Felt::new(a[1].as_int() | b[1].as_int()),
+    );
+    verify_bus(&chiplets_bus, 1, OP_CYCLE_LEN * 2 - 1, &bitwise_lookup);
+
+    let bitwise_lookup = BitwiseLookup::new(
+        BITWISE_XOR_OP_ID,
+        a[2],
+        b[2],
+        Felt::new(a[2].as_int() ^ b[2].as_int()),
+    );
+    verify_bus(&chiplets_bus, 2, OP_CYCLE_LEN * 3 - 1, &bitwise_lookup);
+
+    let bitwise_lookup = BitwiseLookup::new(
+        BITWISE_AND_OP_ID,
+        a[3],
+        b[3],
+        Felt::new(a[3].as_int() & b[3].as_int()),
+    );
+    verify_bus(&chiplets_bus, 3, OP_CYCLE_LEN * 4 - 1, &bitwise_lookup);
 }
 
 // HELPER FUNCTIONS
 // ================================================================================================
+
+/// Builds a trace of the specified length and fills it with data from the provided Bitwise instance.
+fn build_trace(bitwise: Bitwise, num_rows: usize) -> (Vec<Vec<Felt>>, ChipletsBus) {
+    let mut chiplets_bus = ChipletsBus::default();
+    let mut trace = (0..TRACE_WIDTH)
+        .map(|_| vec![Felt::new(0); num_rows])
+        .collect::<Vec<_>>();
+    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
+    bitwise.fill_trace(&mut fragment, 0, &mut chiplets_bus);
+
+    (trace, chiplets_bus)
+}
 
 fn check_decomposition(trace: &[Vec<Felt>], start: usize, a: u64, b: u64) {
     let mut bit_offset = 28;
@@ -295,4 +335,22 @@ fn binary_xor(a: Felt, b: Felt) -> Felt {
 fn rand_u32() -> Felt {
     let value = rand_value::<u64>() as u32 as u64;
     Felt::new(value)
+}
+
+/// Verifies that the chiplet bus received the specified BitwiseLookup response at `cycle` which was
+/// added to the list of responses at `index`.
+fn verify_bus(
+    chiplets_bus: &ChipletsBus,
+    index: usize,
+    cycle: usize,
+    bitwise_lookup: &BitwiseLookup,
+) {
+    let expected_lookup = ChipletsLookupRow::Bitwise(*bitwise_lookup);
+    let expected_hint = ChipletsLookup::Response(index);
+
+    let lookup = chiplets_bus.get_response_row(index);
+    let hint = chiplets_bus.get_lookup_hint(cycle).unwrap();
+
+    assert_eq!(expected_lookup, lookup);
+    assert_eq!(&expected_hint, hint);
 }

--- a/processor/src/chiplets/bus/mod.rs
+++ b/processor/src/chiplets/bus/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    BTreeMap, ChipletsLookup, ChipletsLookupRow, Felt, FieldElement, MemoryLookup, StarkField, Vec,
-    Word,
+    BTreeMap, BitwiseLookup, ChipletsLookup, ChipletsLookupRow, Felt, FieldElement, MemoryLookup,
+    StarkField, Vec, Word,
 };
 
 mod aux_trace;
@@ -32,6 +32,35 @@ impl ChipletsBus {
     // LOOKUP MUTATORS
     // --------------------------------------------------------------------------------------------
 
+    /// Requests a lookup at the specified cycle.
+    pub fn request_operation(&mut self, cycle: usize) {
+        // all requests are sent from the stack before responses are provided (during Chiplets trace
+        // finalization). requests are guaranteed not to share cycles with other requests, since
+        // only one operation will be executed at a time.
+        let request_idx = self.request_rows.len();
+        self.lookup_hints
+            .insert(cycle, ChipletsLookup::Request(request_idx));
+    }
+
+    /// Provides lookup data at the specified cycle, which is the row of the AuxTable execution
+    /// trace that contains this lookup row.
+    pub fn provide_operation(&mut self, response_cycle: usize) {
+        // results are guaranteed not to share cycles with other results, but they might share
+        // a cycle with a request which has already been sent.
+        let response_idx = self.response_rows.len();
+        self.lookup_hints
+            .entry(response_cycle)
+            .and_modify(|lookup| {
+                if let ChipletsLookup::Request(request_idx) = *lookup {
+                    *lookup = ChipletsLookup::RequestAndResponse((request_idx, response_idx));
+                }
+            })
+            .or_insert_with(|| ChipletsLookup::Response(response_idx));
+    }
+
+    // MEMORY LOOKUPS
+    // --------------------------------------------------------------------------------------------
+
     /// Requests a memory access with the specified data. When `old_word` and `new_word` are the
     /// same, this is a read request. When they are different, it's a write request. The memory
     /// value is requested at cycle `clk`. This is expected to be called by operation executors.
@@ -42,12 +71,7 @@ impl ChipletsBus {
         old_word: Word,
         new_word: Word,
     ) {
-        // all requests are sent from the stack before responses are provided (during Chiplets trace
-        // finalization). requests are guaranteed not to share cycles with other requests, since
-        // only one operation will be executed at a time.
-        let request_idx = self.request_rows.len();
-        self.lookup_hints
-            .insert(clk, ChipletsLookup::Request(request_idx));
+        self.request_operation(clk);
 
         let memory_lookup = MemoryLookup::new(addr, clk as u64, old_word, new_word);
         self.request_rows
@@ -66,21 +90,49 @@ impl ChipletsBus {
         new_word: Word,
         response_cycle: usize,
     ) {
-        // results are guaranteed not to share cycles with other results, but they might share
-        // a cycle with a request which has already been sent.
-        let response_idx = self.response_rows.len();
-        self.lookup_hints
-            .entry(response_cycle)
-            .and_modify(|lookup| {
-                if let ChipletsLookup::Request(request_idx) = *lookup {
-                    *lookup = ChipletsLookup::RequestAndResponse((request_idx, response_idx));
-                }
-            })
-            .or_insert_with(|| ChipletsLookup::Response(response_idx));
+        self.provide_operation(response_cycle);
 
         let memory_lookup = MemoryLookup::new(addr, clk.as_int(), old_word, new_word);
         self.response_rows
             .push(ChipletsLookupRow::Memory(memory_lookup));
+    }
+
+    // BITWISE LOOKUPS
+    // --------------------------------------------------------------------------------------------
+
+    /// Requests a bitwise lookup with the specified data. This is expected to be called by
+    /// operation executors.
+    pub fn request_bitwise_operation(
+        &mut self,
+        op_id: Felt,
+        a: Felt,
+        b: Felt,
+        z: Felt,
+        cycle: usize,
+    ) {
+        self.request_operation(cycle);
+
+        let bitwise_lookup = BitwiseLookup::new(op_id, a, b, z);
+        self.request_rows
+            .push(ChipletsLookupRow::Bitwise(bitwise_lookup));
+    }
+
+    /// Provides the data of a bitwise operation contained in the [Bitwise] table. The bitwise value
+    /// is provided at cycle `response_cycle`, which is the row of the execution trace that contains
+    /// this Bitwise row.
+    pub fn provide_bitwise_operation(
+        &mut self,
+        op_id: Felt,
+        a: Felt,
+        b: Felt,
+        z: Felt,
+        cycle: usize,
+    ) {
+        self.provide_operation(cycle);
+
+        let bitwise_lookup = BitwiseLookup::new(op_id, a, b, z);
+        self.response_rows
+            .push(ChipletsLookupRow::Bitwise(bitwise_lookup));
     }
 
     // AUX TRACE BUILDER GENERATION

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -8,6 +8,7 @@ use super::{
     BTreeMap, ChipletsBus, Felt, FieldElement, RangeInclusive, StarkField, TraceFragment, Vec,
     Word, ONE, ZERO,
 };
+use vm_core::chiplets::memory::MEMORY_OP_ID;
 
 #[cfg(test)]
 mod tests;
@@ -362,20 +363,21 @@ impl LookupTableRow for MemoryLookup {
             .iter()
             .enumerate()
             .fold(E::ZERO, |acc, (j, element)| {
-                acc + alphas[j + 4].mul_base(*element)
+                acc + alphas[j + 5].mul_base(*element)
             });
         let new_word_value = self
             .new_word
             .iter()
             .enumerate()
             .fold(E::ZERO, |acc, (j, element)| {
-                acc + alphas[j + 8].mul_base(*element)
+                acc + alphas[j + 9].mul_base(*element)
             });
 
         alphas[0]
-            + alphas[1].mul_base(self.ctx)
-            + alphas[2].mul_base(self.addr)
-            + alphas[3].mul_base(Felt::new(self.clk))
+            + alphas[1].mul_base(MEMORY_OP_ID)
+            + alphas[2].mul_base(self.ctx)
+            + alphas[3].mul_base(self.addr)
+            + alphas[4].mul_base(Felt::new(self.clk))
             + old_word_value
             + new_word_value
     }

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -4,10 +4,13 @@ use super::{
 };
 use crate::{trace::LookupTableRow, ExecutionError};
 use core::ops::RangeInclusive;
-use vm_core::code_blocks::OpBatch;
+use vm_core::{
+    chiplets::bitwise::{BITWISE_AND_OP_ID, BITWISE_OR_OP_ID, BITWISE_XOR_OP_ID},
+    code_blocks::OpBatch,
+};
 
 mod bitwise;
-use bitwise::Bitwise;
+use bitwise::{Bitwise, BitwiseLookup};
 
 mod hasher;
 pub use hasher::{AuxTraceBuilder as HasherAuxTraceBuilder, SiblingTableRow};
@@ -158,22 +161,34 @@ impl Chiplets {
     /// Requests a bitwise AND of `a` and `b` from the Bitwise chiplet and returns the result.
     /// We assume that `a` and `b` are 32-bit values. If that's not the case, the result of the
     /// computation is undefined.
-    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
-        self.bitwise.u32and(a, b)
+    pub fn u32and(&mut self, a: Felt, b: Felt, clk: usize) -> Result<Felt, ExecutionError> {
+        let result = self.bitwise.u32and(a, b)?;
+        self.bus
+            .request_bitwise_operation(BITWISE_AND_OP_ID, a, b, result, clk);
+
+        Ok(result)
     }
 
     /// Requests a bitwise OR of `a` and `b` from the Bitwise chiplet and returns the result.
     /// We assume that `a` and `b` are 32-bit values. If that's not the case, the result of the
     /// computation is undefined.
-    pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
-        self.bitwise.u32or(a, b)
+    pub fn u32or(&mut self, a: Felt, b: Felt, clk: usize) -> Result<Felt, ExecutionError> {
+        let result = self.bitwise.u32or(a, b)?;
+        self.bus
+            .request_bitwise_operation(BITWISE_OR_OP_ID, a, b, result, clk);
+
+        Ok(result)
     }
 
     /// Requests a bitwise XOR of `a` and `b` from the Bitwise chiplet and returns the result.
     /// We assume that `a` and `b` are 32-bit values. If that's not the case, the result of the
     /// computation is undefined.
-    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
-        self.bitwise.u32xor(a, b)
+    pub fn u32xor(&mut self, a: Felt, b: Felt, clk: usize) -> Result<Felt, ExecutionError> {
+        let result = self.bitwise.u32xor(a, b)?;
+        self.bus
+            .request_bitwise_operation(BITWISE_XOR_OP_ID, a, b, result, clk);
+
+        Ok(result)
     }
 
     // MEMORY CHIPLET ACCESSORS
@@ -304,7 +319,8 @@ impl Chiplets {
         trace: &mut [Vec<Felt>; CHIPLETS_WIDTH],
         trace_len: usize,
     ) -> (HasherAuxTraceBuilder, AuxTraceBuilder) {
-        // get the row where the memory segment begins before destructuring.
+        // get the rows where chiplets begin before destructuring.
+        let bitwise_start = self.hasher.trace_len();
         let memory_start = self.memory_start();
         let Chiplets {
             clk: _,
@@ -387,7 +403,7 @@ impl Chiplets {
         // fill the fragments with the execution trace from each chiplet
         // TODO: this can be parallelized to fill the traces in multiple threads
         let hasher_aux_builder = hasher.fill_trace(&mut hasher_fragment);
-        bitwise.fill_trace(&mut bitwise_fragment);
+        bitwise.fill_trace(&mut bitwise_fragment, bitwise_start, &mut bus);
         memory.fill_trace(&mut memory_fragment, memory_start, &mut bus);
 
         (hasher_aux_builder, bus.into_aux_builder())
@@ -408,7 +424,7 @@ pub(super) enum ChipletsLookup {
 #[allow(dead_code)]
 pub(super) enum ChipletsLookupRow {
     Hasher(HasherLookupRow),
-    Bitwise(BitwiseLookupRow),
+    Bitwise(BitwiseLookup),
     Memory(MemoryLookup),
 }
 
@@ -430,21 +446,6 @@ impl LookupTableRow for ChipletsLookupRow {
 pub(super) struct HasherLookupRow {}
 
 impl LookupTableRow for HasherLookupRow {
-    /// Reduces this row to a single field element in the field specified by E. This requires
-    /// at least 12 alpha values.
-    fn to_value<E: FieldElement<BaseField = Felt>>(&self, _alphas: &[E]) -> E {
-        unimplemented!()
-    }
-}
-
-// BITWISE PROCESSOR LOOKUPS
-// ================================================================================================
-
-#[allow(dead_code)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(super) struct BitwiseLookupRow {}
-
-impl LookupTableRow for BitwiseLookupRow {
     /// Reduces this row to a single field element in the field specified by E. This requires
     /// at least 12 alpha values.
     fn to_value<E: FieldElement<BaseField = Felt>>(&self, _alphas: &[E]) -> E {

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -168,7 +168,7 @@ impl Process {
     pub(super) fn op_u32and(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
-        let result = self.chiplets.u32and(a, b)?;
+        let result = self.chiplets.u32and(a, b, self.system.clk())?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);
@@ -181,7 +181,7 @@ impl Process {
     pub(super) fn op_u32or(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
-        let result = self.chiplets.u32or(a, b)?;
+        let result = self.chiplets.u32or(a, b, self.system.clk())?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);
@@ -194,7 +194,7 @@ impl Process {
     pub(super) fn op_u32xor(&mut self) -> Result<(), ExecutionError> {
         let b = self.stack.get(0);
         let a = self.stack.get(1);
-        let result = self.chiplets.u32xor(a, b)?;
+        let result = self.chiplets.u32xor(a, b, self.system.clk())?;
 
         self.stack.set(0, result);
         self.stack.shift_left(2);

--- a/processor/src/trace/tests/chiplets.rs
+++ b/processor/src/trace/tests/chiplets.rs
@@ -5,7 +5,8 @@ use super::{
 };
 use vm_core::{
     chiplets::memory::{
-        ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, NUM_ELEMENTS, U_COL_RANGE, V_COL_RANGE,
+        ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, MEMORY_OP_ID, NUM_ELEMENTS, U_COL_RANGE,
+        V_COL_RANGE,
     },
     AUX_TRACE_RAND_ELEMENTS, CHIPLETS_AUX_TRACE_OFFSET,
 };
@@ -117,14 +118,15 @@ fn build_expected_memory(
     let mut new_word_value = ZERO;
 
     for i in 0..NUM_ELEMENTS {
-        old_word_value += alphas[i + 4] * old_word[i];
-        new_word_value += alphas[i + 8] * new_word[i];
+        old_word_value += alphas[i + 5] * old_word[i];
+        new_word_value += alphas[i + 9] * new_word[i];
     }
 
     alphas[0]
-        + alphas[1] * ctx
-        + alphas[2] * addr
-        + alphas[3] * clk
+        + alphas[1] * MEMORY_OP_ID
+        + alphas[2] * ctx
+        + alphas[3] * addr
+        + alphas[4] * clk
         + old_word_value
         + new_word_value
 }


### PR DESCRIPTION
This PR adds bitwise operations to the chiplets bus.

- [x] Adds bitwise operation request/response handling in the Chiplets module
- [x] Adds operation ids for all chiplet operations (hasher, bitwise, memory) and updates memory lookups with the hasher id
- [x] fixes indexing of the bitwse output column and updates tests to use the bitwise constants
- [x] adds bitwise chiplet responses to the bitwise unit tests
- [ ] add bitwise lookup unit test