### PR TITLE
Remove `EQW` vm  instruction

### DIFF
--- a/assembly/src/parsers/crypto_ops.rs
+++ b/assembly/src/parsers/crypto_ops.rs
@@ -121,7 +121,7 @@ pub fn parse_mtree(
 /// - node V, 4 elements
 /// - root of the tree, 4 elements
 ///
-/// This operation takes 24 VM cycles.
+/// This operation takes 38 VM cycles.
 fn mtree_get(span_ops: &mut Vec<Operation>, decorators: &mut DecoratorList) {
     // stack: [d, i, R, ...]
     // inject the node value we're looking for at the head of the advice tape
@@ -237,10 +237,27 @@ fn mtree_cwm(span_ops: &mut Vec<Operation>, decorators: &mut DecoratorList) {
 /// - root of a Merkle tree, 4 elements
 /// - root of a Merkle tree, 4 elements
 ///
-/// This operation takes 6 VM cycles.
+/// This operation takes 20 VM cycles.
 fn validate_and_drop_root(span_ops: &mut Vec<Operation>) {
     // verify the provided root and the computed root are equal
-    span_ops.push(Operation::Eqw);
+    span_ops.push(Operation::Dup7);
+    span_ops.push(Operation::Dup4);
+    span_ops.push(Operation::Eq);
+
+    span_ops.push(Operation::Dup7);
+    span_ops.push(Operation::Dup4);
+    span_ops.push(Operation::Eq);
+    span_ops.push(Operation::And);
+
+    span_ops.push(Operation::Dup6);
+    span_ops.push(Operation::Dup3);
+    span_ops.push(Operation::Eq);
+    span_ops.push(Operation::And);
+
+    span_ops.push(Operation::Dup5);
+    span_ops.push(Operation::Dup2);
+    span_ops.push(Operation::Eq);
+    span_ops.push(Operation::And);
     span_ops.push(Operation::Assert);
 
     // drop one of the duplicate roots
@@ -324,7 +341,7 @@ fn prep_stack_for_mrupdate(span_ops: &mut Vec<Operation>, decorators: &mut Decor
 /// - old Merkle tree root, 4 elements
 /// - new Merkle tree root, 4 elements
 ///
-/// This operation takes 10 VM cycles.
+/// This operation takes 24 VM cycles.
 fn validate_root_after_mrupdate(span_ops: &mut Vec<Operation>) {
     // drop d, i => [R_computed, R_new, R, ...]
     span_ops.push(Operation::Drop);

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -93,10 +93,6 @@ pub enum Operation {
     /// the stack, otherwise pushes 0 onto the stack.
     Eqz,
 
-    /// Compares the first word (four elements) with the second word on the stack, if the words are
-    /// equal, pushes 1 onto the stack, otherwise pushes 0 onto the stack.
-    Eqw,
-
     // ----- u32 operations -----------------------------------------------------------------------
     /// Pops an element off the stack, splits it into upper and lower 32-bit values, and pushes
     /// these values back onto the stack.
@@ -377,7 +373,6 @@ impl Operation {
 
             Self::Eq => 0b0100_1001,
             Self::Eqz => 5,
-            Self::Eqw => 6,
 
             Self::Add => 0b0100_1000,
             Self::Neg => 7,
@@ -524,7 +519,6 @@ impl fmt::Display for Operation {
 
             Self::Eq => write!(f, "eq"),
             Self::Eqz => write!(f, "eqz"),
-            Self::Eqw => write!(f, "eqw"),
 
             // ----- u32 operations ---------------------------------------------------------------
             Self::U32assert2 => write!(f, "u32assert2"),

--- a/miden/tests/integration/operations/field_ops.rs
+++ b/miden/tests/integration/operations/field_ops.rs
@@ -485,31 +485,6 @@ fn eq() {
 }
 
 #[test]
-fn eqw() {
-    let asm_op = "eqw";
-
-    // --- test when top two words are equal ------------------------------------------------------
-    let values = vec![5, 4, 3, 2, 5, 4, 3, 2];
-    let mut expected = values.clone();
-    // push the result
-    expected.push(1);
-    // put it in stack order
-    expected.reverse();
-    let test = build_op_test!(asm_op, &values);
-    test.expect_stack(&expected);
-
-    // --- test when top two words are not equal --------------------------------------------------
-    let values = vec![8, 7, 6, 5, 4, 3, 2, 1];
-    let mut expected = values.clone();
-    // push the result
-    expected.push(0);
-    // put it in stack order
-    expected.reverse();
-    let test = build_op_test!(asm_op, &values);
-    test.expect_stack(&expected);
-}
-
-#[test]
 fn lt() {
     // Results in 1 if a < b for a starting stack of [b, a, ...] and 0 otherwise
     test_felt_comparison_op("lt", 1, 0, 0);
@@ -665,36 +640,6 @@ proptest! {
 
         let test = build_op_test!(asm_op, &[a,b]);
         test.prop_expect_stack(&[expected_result])?;
-    }
-
-    #[test]
-    fn eqw_proptest(w1 in prop_randw(), w2 in prop_randw()) {
-        // test the eqw assembly operation with randomized inputs
-        let asm_op = "eqw";
-
-        // 2 words (8 values) for comparison and 1 for the result
-        let mut values = vec![0; 2 * WORD_LEN + 1];
-
-        // check the inputs for equality in the field
-        let mut inputs_equal = true;
-        for (i, (a, b)) in w1.iter().zip(w2.iter()).enumerate() {
-            // if any of the values are unequal in the field, then the words will be unequal
-            if *a % Felt::MODULUS != *b % Felt::MODULUS {
-                inputs_equal = false;
-            }
-            // add the values to the vector
-            values[i] = *a;
-            values[i + WORD_LEN] = *b;
-        }
-
-        let test = build_op_test!(asm_op, &values);
-
-        // add the expected result to get the expected state
-        let expected_result = if inputs_equal { 1 } else { 0 };
-        values.push(expected_result);
-        values.reverse();
-
-        test.prop_expect_stack(&values)?;
     }
 
     #[test]

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -434,12 +434,4 @@ mod tests {
         }
         expected
     }
-
-    fn build_expected_from_ints(values: &[u64]) -> [Felt; 16] {
-        let mut expected = [Felt::ZERO; 16];
-        for (&value, result) in values.iter().zip(expected.iter_mut()) {
-            *result = Felt::new(value);
-        }
-        expected
-    }
 }

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -139,28 +139,6 @@ impl Process {
         self.stack.copy_state(1);
         Ok(())
     }
-
-    /// Compares the first word (four elements) with the second word on the stack, if the words are
-    /// equal, pushes ONE onto the stack, otherwise pushes ZERO onto the stack.
-    pub(super) fn op_eqw(&mut self) -> Result<(), ExecutionError> {
-        let b3 = self.stack.get(0);
-        let b2 = self.stack.get(1);
-        let b1 = self.stack.get(2);
-        let b0 = self.stack.get(3);
-
-        let a3 = self.stack.get(4);
-        let a2 = self.stack.get(5);
-        let a1 = self.stack.get(6);
-        let a0 = self.stack.get(7);
-
-        if a0 == b0 && a1 == b1 && a2 == b2 && a3 == b3 {
-            self.stack.set(0, Felt::ONE);
-        } else {
-            self.stack.set(0, Felt::ZERO);
-        }
-        self.stack.shift_right(0);
-        Ok(())
-    }
 }
 
 // TESTS
@@ -434,31 +412,6 @@ mod tests {
 
         process.execute_op(Operation::Eqz).unwrap();
         let expected = build_expected(&[Felt::ZERO, Felt::new(3)]);
-        assert_eq!(expected, process.stack.trace_state());
-    }
-
-    #[test]
-    fn op_eqw() {
-        // --- test when top two words are equal ------------------------------
-        let mut process = Process::new_dummy();
-        let mut values = vec![1, 2, 3, 4, 5, 2, 3, 4, 5];
-        init_stack_with(&mut process, &values);
-
-        process.execute_op(Operation::Eqw).unwrap();
-        values.reverse();
-        values.insert(0, 1);
-        let expected = build_expected_from_ints(&values);
-        assert_eq!(expected, process.stack.trace_state());
-
-        // --- test when top two words are not equal --------------------------
-        let mut process = Process::new_dummy();
-        let mut values = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
-        init_stack_with(&mut process, &values);
-
-        process.execute_op(Operation::Eqw).unwrap();
-        values.reverse();
-        values.insert(0, 0);
-        let expected = build_expected_from_ints(&values);
         assert_eq!(expected, process.stack.trace_state());
     }
 

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -47,7 +47,6 @@ impl Process {
 
             Operation::Eq => self.op_eq()?,
             Operation::Eqz => self.op_eqz()?,
-            Operation::Eqw => self.op_eqw()?,
 
             // ----- u32 operations ---------------------------------------------------------------
             Operation::U32split => self.op_u32split()?,

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -222,7 +222,7 @@ impl Stack {
         }
     }
 
-    /// Copies stack values starting a the specified position at the current clock cycle to
+    /// Copies stack values starting at the specified position at the current clock cycle to
     /// position + 1 at the next clock cycle
     ///
     /// If stack depth grows beyond 16 items, the additional item is pushed into the overflow table.


### PR DESCRIPTION
This PR addresses https://github.com/maticnetwork/miden/issues/320.

- Removed `EQW` instruction from the VM.
- Emulated `EQW` operation using other VM instruction in the assembly.
- Updated the docs/cycle count of the impacted operations.