### PR TITLE
Fix bitwise chiplet error & improve bitwise tests

### DIFF
--- a/air/src/chiplets/bitwise/mod.rs
+++ b/air/src/chiplets/bitwise/mod.rs
@@ -1,13 +1,9 @@
-use super::{EvaluationFrame, FieldElement, Vec, BITWISE_TRACE_OFFSET};
+use super::{EvaluationFrame, Felt, FieldElement, Vec};
 use crate::utils::{are_equal, binary_not, is_binary, is_zero, EvaluationResult};
-use core::ops::Range;
-use vm_core::{
-    bitwise::{
-        BITWISE_A_COL_IDX, BITWISE_B_COL_IDX, BITWISE_NUM_DECOMP_BITS as NUM_DECOMP_BITS,
-        BITWISE_OUTPUT_COL_IDX, NUM_SELECTORS, OP_CYCLE_LEN,
-    },
-    utils::range as create_range,
-    Felt,
+use vm_core::chiplets::{
+    bitwise::{NUM_DECOMP_BITS, NUM_SELECTORS, OP_CYCLE_LEN},
+    BITWISE_A_COL_IDX, BITWISE_A_COL_RANGE, BITWISE_B_COL_IDX, BITWISE_B_COL_RANGE,
+    BITWISE_OUTPUT_COL_IDX, BITWISE_PREV_OUTPUT_COL_IDX, BITWISE_SELECTOR_COL_RANGE,
 };
 use winter_air::TransitionConstraintDegree;
 
@@ -19,21 +15,6 @@ pub mod tests;
 
 /// The number of transition constraints on the bitwise chiplet.
 pub const NUM_CONSTRAINTS: usize = 19;
-
-/// The range of the selector columns in the trace.
-const SELECTOR_COL_RANGE: Range<usize> = create_range(BITWISE_TRACE_OFFSET, NUM_SELECTORS);
-/// The index of the column holding the aggregated value of input `a`.
-const A_COL_IDX: usize = BITWISE_TRACE_OFFSET + BITWISE_A_COL_IDX;
-/// The index of the column holding the aggregated value of input `b`.
-const B_COL_IDX: usize = BITWISE_TRACE_OFFSET + BITWISE_B_COL_IDX;
-/// The index range for the bit decomposition of `a`.
-const A_COL_RANGE: Range<usize> = create_range(B_COL_IDX + 1, NUM_DECOMP_BITS);
-/// The index range for the bit decomposition of `b`.
-const B_COL_RANGE: Range<usize> = create_range(A_COL_RANGE.end, NUM_DECOMP_BITS);
-/// The index of the column containing the aggregated output value of the previous row.
-const OUTPUT_COL_PREV_IDX: usize = BITWISE_TRACE_OFFSET + BITWISE_OUTPUT_COL_IDX;
-/// The index of the column containing the aggregated output value.
-const OUTPUT_COL_IDX: usize = OUTPUT_COL_PREV_IDX + 1;
 
 // PERIODIC COLUMNS
 // ================================================================================================
@@ -358,69 +339,69 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
 
     #[inline(always)]
     fn selector(&self, index: usize) -> E {
-        self.current()[SELECTOR_COL_RANGE.start + index]
+        self.current()[BITWISE_SELECTOR_COL_RANGE.start + index]
     }
     #[inline(always)]
     fn selector_next(&self, index: usize) -> E {
-        self.next()[SELECTOR_COL_RANGE.start + index]
+        self.next()[BITWISE_SELECTOR_COL_RANGE.start + index]
     }
     #[inline(always)]
     fn a(&self) -> E {
-        self.current()[A_COL_IDX]
+        self.current()[BITWISE_A_COL_IDX]
     }
     #[inline(always)]
     fn a_next(&self) -> E {
-        self.next()[A_COL_IDX]
+        self.next()[BITWISE_A_COL_IDX]
     }
     #[inline(always)]
     fn a_bit(&self, index: usize) -> E {
-        self.current()[A_COL_RANGE.start + index]
+        self.current()[BITWISE_A_COL_RANGE.start + index]
     }
     #[inline(always)]
     fn b(&self) -> E {
-        self.current()[B_COL_IDX]
+        self.current()[BITWISE_B_COL_IDX]
     }
     #[inline(always)]
     fn b_next(&self) -> E {
-        self.next()[B_COL_IDX]
+        self.next()[BITWISE_B_COL_IDX]
     }
     #[inline(always)]
     fn b_bit(&self, index: usize) -> E {
-        self.current()[B_COL_RANGE.start + index]
+        self.current()[BITWISE_B_COL_RANGE.start + index]
     }
     #[inline(always)]
     fn bit_decomp(&self) -> &[E] {
-        &self.current()[A_COL_RANGE.start..B_COL_RANGE.end]
+        &self.current()[BITWISE_A_COL_RANGE.start..BITWISE_B_COL_RANGE.end]
     }
     #[inline(always)]
     fn output_prev(&self) -> E {
-        self.current()[OUTPUT_COL_PREV_IDX]
+        self.current()[BITWISE_PREV_OUTPUT_COL_IDX]
     }
     #[inline(always)]
     fn output_prev_next(&self) -> E {
-        self.next()[OUTPUT_COL_PREV_IDX]
+        self.next()[BITWISE_PREV_OUTPUT_COL_IDX]
     }
     #[inline(always)]
     fn output(&self) -> E {
-        self.current()[OUTPUT_COL_IDX]
+        self.current()[BITWISE_OUTPUT_COL_IDX]
     }
 
     // --- Intermediate variables & helpers -------------------------------------------------------
     #[inline(always)]
     fn a_agg_bits(&self) -> E {
-        agg_bits(self.current(), A_COL_RANGE.start)
+        agg_bits(self.current(), BITWISE_A_COL_RANGE.start)
     }
     #[inline(always)]
     fn a_agg_bits_next(&self) -> E {
-        agg_bits(self.next(), A_COL_RANGE.start)
+        agg_bits(self.next(), BITWISE_A_COL_RANGE.start)
     }
     #[inline(always)]
     fn b_agg_bits(&self) -> E {
-        agg_bits(self.current(), B_COL_RANGE.start)
+        agg_bits(self.current(), BITWISE_B_COL_RANGE.start)
     }
     #[inline(always)]
     fn b_agg_bits_next(&self) -> E {
-        agg_bits(self.next(), B_COL_RANGE.start)
+        agg_bits(self.next(), BITWISE_B_COL_RANGE.start)
     }
 
     // --- Flags ----------------------------------------------------------------------------------

--- a/air/src/chiplets/mod.rs
+++ b/air/src/chiplets/mod.rs
@@ -1,9 +1,6 @@
 use super::{Assertion, EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree, Vec};
 use crate::utils::{are_equal, binary_not, is_binary};
-use vm_core::{
-    chiplets::{BITWISE_TRACE_OFFSET, HASHER_TRACE_OFFSET},
-    CHIPLETS_OFFSET,
-};
+use vm_core::{chiplets::HASHER_TRACE_OFFSET, CHIPLETS_OFFSET};
 
 mod bitwise;
 mod hasher;

--- a/core/src/chiplets/bitwise.rs
+++ b/core/src/chiplets/bitwise.rs
@@ -1,4 +1,4 @@
-use super::{Felt, FieldElement};
+use super::{create_range, Felt, FieldElement, Range};
 
 // CONSTANTS
 // ================================================================================================
@@ -26,21 +26,31 @@ pub const BITWISE_XOR: Selectors = [Felt::ONE, Felt::ZERO];
 // --- INPUT DECOMPOSITION ------------------------------------------------------------------------
 
 /// The number of bits decomposed per row per input parameter `a` or `b`.
-pub const BITWISE_NUM_DECOMP_BITS: usize = 4;
+pub const NUM_DECOMP_BITS: usize = 4;
 
-// --- COLUMN ACCESSORS ---------------------------------------------------------------------------
+// --- COLUMN ACCESSOR INDICES WITHIN THE CHIPLET -------------------------------------------------
 
-/// The index of the column holding the aggregated value of input `a` within the bitwise execution
-/// trace.
-pub const BITWISE_A_COL_IDX: usize = NUM_SELECTORS;
+/// The index of the column holding the aggregated value of input `a` within the bitwise chiplet
+/// execution trace.
+pub const A_COL_IDX: usize = NUM_SELECTORS;
 
-/// The index of the column holding the aggregated value of input `b` within the bitwise execution
-/// trace.
-pub const BITWISE_B_COL_IDX: usize = BITWISE_A_COL_IDX + 1;
+/// The index of the column holding the aggregated value of input `b` within the bitwise chiplet
+/// execution trace.
+pub const B_COL_IDX: usize = A_COL_IDX + 1;
 
-/// The index of the column containing the aggregated output value within the bitwise execution
-/// trace.
-pub const BITWISE_OUTPUT_COL_IDX: usize = BITWISE_B_COL_IDX + 1 + 2 * BITWISE_NUM_DECOMP_BITS;
+/// The index range for the bit decomposition of `a` within the bitwise chiplet's trace.
+pub const A_COL_RANGE: Range<usize> = create_range(B_COL_IDX + 1, NUM_DECOMP_BITS);
+
+/// The index range for the bit decomposition of `b` within the bitwise chiplet's trace.
+pub const B_COL_RANGE: Range<usize> = create_range(A_COL_RANGE.end, NUM_DECOMP_BITS);
+
+/// The index of the column containing the aggregated output value within the bitwise chiplet
+/// execution trace.
+pub const PREV_OUTPUT_COL_IDX: usize = B_COL_IDX + 1 + 2 * NUM_DECOMP_BITS;
+
+/// The index of the column containing the aggregated output value within the bitwise chiplet
+/// execution trace.
+pub const OUTPUT_COL_IDX: usize = PREV_OUTPUT_COL_IDX + 1;
 
 // TYPE ALIASES
 // ================================================================================================

--- a/core/src/chiplets/mod.rs
+++ b/core/src/chiplets/mod.rs
@@ -24,3 +24,28 @@ pub const HASHER_TRACE_OFFSET: usize = CHIPLETS_OFFSET + NUM_HASHER_SELECTORS;
 pub const BITWISE_TRACE_OFFSET: usize = CHIPLETS_OFFSET + NUM_BITWISE_SELECTORS;
 /// The first column of the memory chiplet.
 pub const MEMORY_TRACE_OFFSET: usize = CHIPLETS_OFFSET + NUM_MEMORY_SELECTORS;
+
+// --- GLOBALLY-INDEXED CHIPLET COLUMN ACCESSORS --------------------------------------------------
+
+/// The range within the main trace of the bitwise selector columns.
+pub const BITWISE_SELECTOR_COL_RANGE: Range<usize> =
+    create_range(BITWISE_TRACE_OFFSET, bitwise::NUM_SELECTORS);
+/// The index within the main trace of the bitwise column holding the aggregated value of input `a`.
+pub const BITWISE_A_COL_IDX: usize = BITWISE_TRACE_OFFSET + bitwise::A_COL_IDX;
+/// The index within the main trace of the bitwise column holding the aggregated value of input `b`.
+pub const BITWISE_B_COL_IDX: usize = BITWISE_TRACE_OFFSET + bitwise::B_COL_IDX;
+/// The index range within the main trace for the bit decomposition of `a` for bitwise operations.
+pub const BITWISE_A_COL_RANGE: Range<usize> = Range {
+    start: BITWISE_TRACE_OFFSET + bitwise::A_COL_RANGE.start,
+    end: BITWISE_TRACE_OFFSET + bitwise::A_COL_RANGE.end,
+};
+/// The index range within the main trace for the bit decomposition of `b` for bitwise operations.
+pub const BITWISE_B_COL_RANGE: Range<usize> = Range {
+    start: BITWISE_TRACE_OFFSET + bitwise::B_COL_RANGE.start,
+    end: BITWISE_TRACE_OFFSET + bitwise::B_COL_RANGE.end,
+};
+/// The index within the main trace of the bitwise column containing the aggregated output value of
+/// the previous row.
+pub const BITWISE_PREV_OUTPUT_COL_IDX: usize = BITWISE_TRACE_OFFSET + bitwise::PREV_OUTPUT_COL_IDX;
+/// The index within the main trace of the bitwise column containing the aggregated output value.
+pub const BITWISE_OUTPUT_COL_IDX: usize = BITWISE_TRACE_OFFSET + bitwise::OUTPUT_COL_IDX;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 use core::ops::Range;
 
 pub mod chiplets;
-pub use chiplets::{bitwise, hasher};
+pub use chiplets::hasher;
 pub mod decoder;
 pub mod errors;
 pub mod range;

--- a/processor/src/chiplets/bitwise/mod.rs
+++ b/processor/src/chiplets/bitwise/mod.rs
@@ -1,6 +1,9 @@
 use super::{ExecutionError, Felt, StarkField, TraceFragment, Vec};
 use crate::utils::get_trace_len;
-use vm_core::bitwise::{BITWISE_AND, BITWISE_OR, BITWISE_XOR, NUM_SELECTORS, TRACE_WIDTH};
+use vm_core::chiplets::bitwise::{
+    BITWISE_AND, BITWISE_OR, BITWISE_XOR, NUM_SELECTORS, OUTPUT_COL_IDX, PREV_OUTPUT_COL_IDX,
+    TRACE_WIDTH,
+};
 
 #[cfg(test)]
 mod tests;
@@ -91,8 +94,8 @@ impl Bitwise {
         // append 8 rows to the trace, each row computing bitwise AND in 4 bit limbs starting with
         // the most significant limb.
         for bit_offset in (0..32).step_by(4).rev() {
-            // append the previous row's result to the 13th column of the trace
-            self.trace[12].push(Felt::new(result));
+            // append the previous row's result to the column for previous output values
+            self.trace[PREV_OUTPUT_COL_IDX].push(Felt::new(result));
             // shift a and b so that the next 4-bit limb is in the least significant position
             let a = a >> bit_offset;
             let b = b >> bit_offset;
@@ -105,9 +108,9 @@ impl Bitwise {
             let result_4_bit = (a & b) & 0xF;
 
             // append the 4 bit result to the result accumulator, and save the current result into
-            // the 14th column of the trace.
+            // the output column in the trace.
             result = (result << 4) | result_4_bit;
-            self.trace[13].push(Felt::new(result));
+            self.trace[OUTPUT_COL_IDX].push(Felt::new(result));
         }
 
         Ok(Felt::new(result))
@@ -126,8 +129,8 @@ impl Bitwise {
         // append 8 rows to the trace, each row computing bitwise OR in 4 bit limbs starting with
         // the most significant limb.
         for bit_offset in (0..32).step_by(4).rev() {
-            // append the previous row's result to the 13th column of the trace
-            self.trace[12].push(Felt::new(result));
+            // append the previous row's result to the column for previous output values
+            self.trace[PREV_OUTPUT_COL_IDX].push(Felt::new(result));
             // shift a and b so that the next 4-bit limb is in the least significant position
             let a = a >> bit_offset;
             let b = b >> bit_offset;
@@ -140,9 +143,9 @@ impl Bitwise {
             let result_4_bit = (a | b) & 0xF;
 
             // append the 4 bit result to the result accumulator, and save the current result into
-            // the 14th column of the trace.
+            // the output column in the trace.
             result = (result << 4) | result_4_bit;
-            self.trace[13].push(Felt::new(result));
+            self.trace[OUTPUT_COL_IDX].push(Felt::new(result));
         }
 
         Ok(Felt::new(result))
@@ -161,8 +164,8 @@ impl Bitwise {
         // append 8 rows to the trace, each row computing bitwise XOR in 4 bit limbs starting with
         // the most significant limb.
         for bit_offset in (0..32).step_by(4).rev() {
-            // append the previous row's result to the 13th column of the trace
-            self.trace[12].push(Felt::new(result));
+            // append the previous row's result to the column for previous output values
+            self.trace[PREV_OUTPUT_COL_IDX].push(Felt::new(result));
             // shift a and b so that the next 4-bit limb is in the least significant position
             let a = a >> bit_offset;
             let b = b >> bit_offset;
@@ -175,9 +178,9 @@ impl Bitwise {
             let result_4_bit = (a ^ b) & 0xF;
 
             // append the 4 bit result to the result accumulator, and save the current result into
-            // the 14th column of the trace.
+            // the output column in the trace.
             result = (result << 4) | result_4_bit;
-            self.trace[13].push(Felt::new(result));
+            self.trace[OUTPUT_COL_IDX].push(Felt::new(result));
         }
 
         Ok(Felt::new(result))

--- a/processor/src/chiplets/bitwise/tests.rs
+++ b/processor/src/chiplets/bitwise/tests.rs
@@ -2,7 +2,10 @@ use super::{
     Bitwise, Felt, StarkField, TraceFragment, BITWISE_AND, BITWISE_OR, BITWISE_XOR, TRACE_WIDTH,
 };
 use rand_utils::rand_value;
-use vm_core::chiplets::bitwise::{A_COL_IDX, B_COL_IDX, OP_CYCLE_LEN, OUTPUT_COL_IDX};
+use vm_core::{
+    chiplets::bitwise::{A_COL_IDX, B_COL_IDX, OP_CYCLE_LEN, OUTPUT_COL_IDX, PREV_OUTPUT_COL_IDX},
+    ZERO,
+};
 
 #[test]
 fn bitwise_init() {
@@ -23,7 +26,7 @@ fn bitwise_and() {
     // --- check generated trace ----------------------------------------------
     let num_rows = OP_CYCLE_LEN;
     let mut trace = (0..TRACE_WIDTH)
-        .map(|_| vec![Felt::new(0); num_rows])
+        .map(|_| vec![ZERO; num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
 
@@ -41,7 +44,7 @@ fn bitwise_and() {
     check_decomposition(&trace, 0, a.as_int(), b.as_int());
 
     // make sure the result was re-composed correctly
-    let mut prev_result = Felt::new(0);
+    let mut prev_result = ZERO;
 
     for i in 0..OP_CYCLE_LEN {
         let c0 = binary_and(trace[4][i], trace[8][i]);
@@ -51,6 +54,8 @@ fn bitwise_and() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
+
+        assert_eq!(prev_result, trace[PREV_OUTPUT_COL_IDX][i]);
         assert_eq!(result, trace[OUTPUT_COL_IDX][i]);
 
         prev_result = result;
@@ -70,7 +75,7 @@ fn bitwise_or() {
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
     let mut trace = (0..TRACE_WIDTH)
-        .map(|_| vec![Felt::new(0); num_rows])
+        .map(|_| vec![ZERO; num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
 
@@ -88,7 +93,7 @@ fn bitwise_or() {
     check_decomposition(&trace, 0, a.as_int(), b.as_int());
 
     // make sure the result was re-composed correctly
-    let mut prev_result = Felt::new(0);
+    let mut prev_result = ZERO;
 
     for i in 0..OP_CYCLE_LEN {
         let c0 = binary_or(trace[4][i], trace[8][i]);
@@ -98,6 +103,8 @@ fn bitwise_or() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
+
+        assert_eq!(prev_result, trace[PREV_OUTPUT_COL_IDX][i]);
         assert_eq!(result, trace[OUTPUT_COL_IDX][i]);
 
         prev_result = result;
@@ -117,7 +124,7 @@ fn bitwise_xor() {
     // --- check generated trace ----------------------------------------------
     let num_rows = 8;
     let mut trace = (0..TRACE_WIDTH)
-        .map(|_| vec![Felt::new(0); num_rows])
+        .map(|_| vec![ZERO; num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
 
@@ -135,7 +142,7 @@ fn bitwise_xor() {
     check_decomposition(&trace, 0, a.as_int(), b.as_int());
 
     // make sure the result was re-composed correctly
-    let mut prev_result = Felt::new(0);
+    let mut prev_result = ZERO;
 
     for i in 0..8 {
         let c0 = binary_xor(trace[4][i], trace[8][i]);
@@ -145,6 +152,8 @@ fn bitwise_xor() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
+
+        assert_eq!(prev_result, trace[PREV_OUTPUT_COL_IDX][i]);
         assert_eq!(result, trace[OUTPUT_COL_IDX][i]);
 
         prev_result = result;
@@ -177,7 +186,7 @@ fn bitwise_multiple() {
     // --- check generated trace ----------------------------------------------
     let num_rows = 4 * OP_CYCLE_LEN;
     let mut trace = (0..TRACE_WIDTH)
-        .map(|_| vec![Felt::new(0); num_rows])
+        .map(|_| vec![ZERO; num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
 
@@ -197,7 +206,7 @@ fn bitwise_multiple() {
 
     // make sure the results was re-composed correctly
 
-    let mut prev_result = Felt::new(0);
+    let mut prev_result = ZERO;
     for i in 0..OP_CYCLE_LEN {
         let c0 = binary_and(trace[4][i], trace[8][i]);
         let c1 = binary_and(trace[5][i], trace[9][i]);
@@ -206,12 +215,14 @@ fn bitwise_multiple() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
+
+        assert_eq!(prev_result, trace[PREV_OUTPUT_COL_IDX][i]);
         assert_eq!(result, trace[OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
 
-    let mut prev_result = Felt::new(0);
+    let mut prev_result = ZERO;
     for i in OP_CYCLE_LEN..(2 * OP_CYCLE_LEN) {
         let c0 = binary_or(trace[4][i], trace[8][i]);
         let c1 = binary_or(trace[5][i], trace[9][i]);
@@ -220,12 +231,14 @@ fn bitwise_multiple() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
+
+        assert_eq!(prev_result, trace[PREV_OUTPUT_COL_IDX][i]);
         assert_eq!(result, trace[OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
 
-    let mut prev_result = Felt::new(0);
+    let mut prev_result = ZERO;
     for i in (2 * OP_CYCLE_LEN)..(3 * OP_CYCLE_LEN) {
         let c0 = binary_xor(trace[4][i], trace[8][i]);
         let c1 = binary_xor(trace[5][i], trace[9][i]);
@@ -234,12 +247,14 @@ fn bitwise_multiple() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
+
+        assert_eq!(prev_result, trace[PREV_OUTPUT_COL_IDX][i]);
         assert_eq!(result, trace[OUTPUT_COL_IDX][i]);
 
         prev_result = result;
     }
 
-    let mut prev_result = Felt::new(0);
+    let mut prev_result = ZERO;
     for i in (3 * OP_CYCLE_LEN)..(4 * OP_CYCLE_LEN) {
         let c0 = binary_and(trace[4][i], trace[8][i]);
         let c1 = binary_and(trace[5][i], trace[9][i]);
@@ -248,6 +263,8 @@ fn bitwise_multiple() {
 
         let result_4_bit = c0 + Felt::new(2) * c1 + Felt::new(4) * c2 + Felt::new(8) * c3;
         let result = prev_result * Felt::new(16) + result_4_bit;
+
+        assert_eq!(prev_result, trace[PREV_OUTPUT_COL_IDX][i]);
         assert_eq!(result, trace[OUTPUT_COL_IDX][i]);
 
         prev_result = result;

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -1,6 +1,6 @@
 use crate::{utils::get_trace_len, CodeBlock, ExecutionTrace, Operation, Process};
 use vm_core::{
-    bitwise::{BITWISE_OR, OP_CYCLE_LEN},
+    chiplets::bitwise::{BITWISE_OR, OP_CYCLE_LEN},
     hasher::{HASH_CYCLE_LEN, LINEAR_HASH, RETURN_STATE},
     Felt, FieldElement, ProgramInputs, CHIPLETS_RANGE, CHIPLETS_WIDTH,
 };


### PR DESCRIPTION
This PR addresses some issues with the modules related to the bitwise chiplet and its tests.

- fixes an error swapping the indices of prev_output and output columns
- minor refactor of consts for consistency (prefix name with `BITWISE_` when indexing globally)
- updates bitwise unit tests in the processor to use constants (this would have caught the error)
- refactors the air unit tests to simplify and reduce the code, now that the prev_output column has been added
- removes an unnecessary unit test from the air tests (irrelevant because output is now aggregated differently)
- adds verification of the previous column to the unit tests of the bitwise execution trace generation in the processor