### PR TITLE
Add bitwise operations to the chiplets bus column

### DIFF
--- a/core/src/chiplets/bitwise.rs
+++ b/core/src/chiplets/bitwise.rs
@@ -16,12 +16,21 @@ pub const OP_CYCLE_LEN: usize = 8;
 
 /// Specifies a bitwise AND operation.
 pub const BITWISE_AND: Selectors = [Felt::ZERO, Felt::ZERO];
+/// Unique label for the bitwise AND operation. Computed as 1 more than the binary composition of
+/// the chiplet and operation selectors [1, 0, 0, 0].
+pub const BITWISE_AND_LABEL: Felt = Felt::new(2);
 
 /// Specifies a bitwise OR operation.
 pub const BITWISE_OR: Selectors = [Felt::ZERO, Felt::ONE];
+/// Unique label for the bitwise OR operation. Computed as 1 more than the binary composition of the
+/// chiplet and operation selectors [1, 0, 0, 1].
+pub const BITWISE_OR_LABEL: Felt = Felt::new(10);
 
 /// Specifies a bitwise XOR operation.
 pub const BITWISE_XOR: Selectors = [Felt::ONE, Felt::ZERO];
+/// Unique label for the bitwise XOR operation. Computed as 1 more than the binary composition of
+/// the chiplet and operation selectors [1, 0, 1, 0].
+pub const BITWISE_XOR_LABEL: Felt = Felt::new(6);
 
 // --- INPUT DECOMPOSITION ------------------------------------------------------------------------
 

--- a/core/src/chiplets/hasher.rs
+++ b/core/src/chiplets/hasher.rs
@@ -62,26 +62,44 @@ pub const TRACE_WIDTH: usize = NUM_SELECTORS + STATE_WIDTH + 2;
 /// executing linear hash computation. These selectors can also be used for a simple 2-to-1 hash
 /// computation.
 pub const LINEAR_HASH: Selectors = [Felt::ONE, Felt::ZERO, Felt::ZERO];
+/// Unique label for the linear hash operation. Computed as 1 more than the binary composition of
+/// the chiplet and operation selectors [0, 1, 0, 0].
+pub const LINEAR_HASH_LABEL: Felt = Felt::new(3);
 
 /// Specifies a start of Merkle path verification computation or absorption of a new path node
 /// into the hasher state.
 pub const MP_VERIFY: Selectors = [Felt::ONE, Felt::ZERO, Felt::ONE];
+/// Unique label for the merkle path verification operation. Computed as 1 more than the binary
+/// composition of the chiplet and operation selectors [0, 1, 0, 1].
+pub const MP_VERIFY_LABEL: Felt = Felt::new(11);
 
 /// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
 /// state for the "old" node value during Merkle root update computation.
 pub const MR_UPDATE_OLD: Selectors = [Felt::ONE, Felt::ONE, Felt::ZERO];
+/// Unique label for the merkle path update operation for an "old" node. Computed as 1 more than the
+/// binary composition of the chiplet and operation selectors [0, 1, 1, 0].
+pub const MR_UPDATE_OLD_LABEL: Felt = Felt::new(7);
 
 /// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
 /// state for the "new" node value during Merkle root update computation.
 pub const MR_UPDATE_NEW: Selectors = [Felt::ONE, Felt::ONE, Felt::ONE];
+/// Unique label for the merkle path update operation for a "new" node. Computed as 1 more than the
+/// binary composition of the chiplet and operation selectors [0, 1, 1, 1].
+pub const MR_UPDATE_NEW_LABEL: Felt = Felt::new(15);
 
 /// Specifies a completion of a computation such that only the hash result (values in h0, h1, h2
 /// h3) is returned.
 pub const RETURN_HASH: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ZERO];
+/// Unique label for specifying the return of a hash result. Computed as 1 more than the binary
+/// composition of the chiplet and operation selectors [0, 0, 0, 0].
+pub const RETURN_HASH_LABEL: Felt = Felt::new(1);
 
 /// Specifies a completion of a computation such that the entire hasher state (values in h0 through
 /// h11) is returned.
 pub const RETURN_STATE: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ONE];
+/// Unique label for specifying the return of the entire hasher state. Computed as 1 more than the
+/// binary composition of  the chiplet and operation selectors [0, 0, 0, 1]
+pub const RETURN_STATE_LABEL: Felt = Felt::new(9);
 
 // --- Column accessors in the auxiliary trace ----------------------------------------------------
 

--- a/core/src/chiplets/memory.rs
+++ b/core/src/chiplets/memory.rs
@@ -1,4 +1,4 @@
-use super::{create_range, Range, MEMORY_TRACE_OFFSET};
+use super::{create_range, Felt, Range, MEMORY_TRACE_OFFSET};
 
 // CONSTANTS
 // ================================================================================================
@@ -28,3 +28,9 @@ pub const D1_COL_IDX: usize = D0_COL_IDX + 1;
 /// Column for the inverse of the delta between two consecutive context IDs, addresses, or clock
 /// cycles, used to enforce that changes are correctly constrained.
 pub const D_INV_COL_IDX: usize = D1_COL_IDX + 1;
+
+// --- OPERATION SELECTOR -----------------------------------------------------------------------
+
+/// Unique label for memory operations. Computed as 1 more than the binary composition of the
+/// chiplet selectors [1, 1, 1].
+pub const MEMORY_LABEL: Felt = Felt::new(8);

--- a/processor/src/chiplets/bitwise/mod.rs
+++ b/processor/src/chiplets/bitwise/mod.rs
@@ -1,8 +1,11 @@
-use super::{ExecutionError, Felt, StarkField, TraceFragment, Vec};
+use super::{
+    ChipletsBus, ExecutionError, Felt, FieldElement, LookupTableRow, StarkField, TraceFragment,
+    Vec, BITWISE_AND_LABEL, BITWISE_OR_LABEL, BITWISE_XOR_LABEL,
+};
 use crate::utils::get_trace_len;
 use vm_core::chiplets::bitwise::{
-    BITWISE_AND, BITWISE_OR, BITWISE_XOR, NUM_SELECTORS, OUTPUT_COL_IDX, PREV_OUTPUT_COL_IDX,
-    TRACE_WIDTH,
+    A_COL_IDX, BITWISE_AND, BITWISE_OR, BITWISE_XOR, B_COL_IDX, NUM_SELECTORS, OP_CYCLE_LEN,
+    OUTPUT_COL_IDX, PREV_OUTPUT_COL_IDX, TRACE_WIDTH,
 };
 
 #[cfg(test)]
@@ -189,11 +192,43 @@ impl Bitwise {
     // EXECUTION TRACE GENERATION
     // --------------------------------------------------------------------------------------------
 
-    /// Fills the provide trace fragment with trace data from this bitwise helper instance.
-    pub fn fill_trace(self, trace: &mut TraceFragment) {
+    /// Fills the provided trace fragment with trace data from this bitwise helper instance. Each
+    /// bitwise operation lookup is also sent to the chiplets bus, along with the cycle at which it
+    /// was provided, which is calculated as an offset from the first row of the Bitwise chiplet.
+    /// Lookup values come from the last row of each bitwise operation cycle which contains both the
+    /// aggregated input values and the output result.
+    pub fn fill_trace(
+        self,
+        trace: &mut TraceFragment,
+        bitwise_start_row: usize,
+        chiplets_bus: &mut ChipletsBus,
+    ) {
         // make sure fragment dimensions are consistent with the dimensions of this trace
         debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace lengths");
         debug_assert_eq!(TRACE_WIDTH, trace.width(), "inconsistent trace widths");
+
+        // provide the lookup data from the last row in each bitwise cycle
+        for row in ((OP_CYCLE_LEN - 1)..self.trace_len()).step_by(OP_CYCLE_LEN) {
+            let a = self.trace[A_COL_IDX][row];
+            let b = self.trace[B_COL_IDX][row];
+            let z = self.trace[OUTPUT_COL_IDX][row];
+
+            // get the operation label.
+            let op_selectors: Selectors = [self.trace[0][row], self.trace[1][row]];
+            let op_id = if op_selectors == BITWISE_AND {
+                BITWISE_AND_LABEL
+            } else if op_selectors == BITWISE_OR {
+                BITWISE_OR_LABEL
+            } else {
+                assert!(
+                    op_selectors == BITWISE_XOR,
+                    "Unrecognized operation selectors in Bitwise chiplet"
+                );
+                BITWISE_XOR_LABEL
+            };
+
+            chiplets_bus.provide_bitwise_operation(op_id, a, b, z, bitwise_start_row + row);
+        }
 
         // copy trace into the fragment column-by-column
         // TODO: this can be parallelized to copy columns in multiple threads
@@ -247,5 +282,33 @@ pub fn assert_u32(value: Felt) -> Result<Felt, ExecutionError> {
         Err(ExecutionError::NotU32Value(value))
     } else {
         Ok(value)
+    }
+}
+
+// BITWISE LOOKUPS
+// ================================================================================================
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct BitwiseLookup {
+    op_id: Felt,
+    a: Felt,
+    b: Felt,
+    z: Felt,
+}
+
+impl BitwiseLookup {
+    pub fn new(op_id: Felt, a: Felt, b: Felt, z: Felt) -> Self {
+        Self { op_id, a, b, z }
+    }
+}
+
+impl LookupTableRow for BitwiseLookup {
+    /// Reduces this row to a single field element in the field specified by E. This requires
+    /// at least 5 alpha values.
+    fn to_value<E: FieldElement<BaseField = Felt>>(&self, alphas: &[E]) -> E {
+        alphas[0]
+            + alphas[1].mul_base(self.op_id)
+            + alphas[2].mul_base(self.a)
+            + alphas[3].mul_base(self.b)
+            + alphas[4].mul_base(self.z)
     }
 }

--- a/processor/src/chiplets/bitwise/mod.rs
+++ b/processor/src/chiplets/bitwise/mod.rs
@@ -215,7 +215,7 @@ impl Bitwise {
 
             // get the operation label.
             let op_selectors: Selectors = [self.trace[0][row], self.trace[1][row]];
-            let op_id = if op_selectors == BITWISE_AND {
+            let label = if op_selectors == BITWISE_AND {
                 BITWISE_AND_LABEL
             } else if op_selectors == BITWISE_OR {
                 BITWISE_OR_LABEL
@@ -227,7 +227,8 @@ impl Bitwise {
                 BITWISE_XOR_LABEL
             };
 
-            chiplets_bus.provide_bitwise_operation(op_id, a, b, z, bitwise_start_row + row);
+            let lookup = BitwiseLookup::new(label, a, b, z);
+            chiplets_bus.provide_bitwise_operation(lookup, bitwise_start_row + row);
         }
 
         // copy trace into the fragment column-by-column

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -296,13 +296,8 @@ impl Memory {
                 trace.set(i, 13, delta.inv());
 
                 // provide the memory access data to the chiplets bus.
-                chiplets_bus.provide_memory_operation(
-                    addr,
-                    clk,
-                    prev_value,
-                    value,
-                    memory_start_row + i,
-                );
+                let memory_lookup = MemoryLookup::new(addr, clk.as_int(), prev_value, value);
+                chiplets_bus.provide_memory_operation(memory_lookup, memory_start_row + i);
 
                 // update values for the next iteration of the loop
                 prev_addr = addr;

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -8,6 +8,7 @@ use super::{
     BTreeMap, ChipletsBus, Felt, FieldElement, RangeInclusive, StarkField, TraceFragment, Vec,
     Word, ONE, ZERO,
 };
+use vm_core::chiplets::memory::MEMORY_LABEL;
 
 #[cfg(test)]
 mod tests;
@@ -355,27 +356,28 @@ impl MemoryLookup {
 
 impl LookupTableRow for MemoryLookup {
     /// Reduces this row to a single field element in the field specified by E. This requires
-    /// at least 12 alpha values.
+    /// at least 13 alpha values.
     fn to_value<E: FieldElement<BaseField = Felt>>(&self, alphas: &[E]) -> E {
         let old_word_value = self
             .old_word
             .iter()
             .enumerate()
             .fold(E::ZERO, |acc, (j, element)| {
-                acc + alphas[j + 4].mul_base(*element)
+                acc + alphas[j + 5].mul_base(*element)
             });
         let new_word_value = self
             .new_word
             .iter()
             .enumerate()
             .fold(E::ZERO, |acc, (j, element)| {
-                acc + alphas[j + 8].mul_base(*element)
+                acc + alphas[j + 9].mul_base(*element)
             });
 
         alphas[0]
-            + alphas[1].mul_base(self.ctx)
-            + alphas[2].mul_base(self.addr)
-            + alphas[3].mul_base(Felt::new(self.clk))
+            + alphas[1].mul_base(MEMORY_LABEL)
+            + alphas[2].mul_base(self.ctx)
+            + alphas[3].mul_base(self.addr)
+            + alphas[4].mul_base(Felt::new(self.clk))
             + old_word_value
             + new_word_value
     }

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -163,8 +163,9 @@ impl Chiplets {
     /// computation is undefined.
     pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
         let result = self.bitwise.u32and(a, b)?;
-        self.bus
-            .request_bitwise_operation(BITWISE_AND_LABEL, a, b, result, self.clk);
+
+        let bitwise_lookup = BitwiseLookup::new(BITWISE_AND_LABEL, a, b, result);
+        self.bus.request_bitwise_operation(bitwise_lookup, self.clk);
 
         Ok(result)
     }
@@ -174,8 +175,9 @@ impl Chiplets {
     /// computation is undefined.
     pub fn u32or(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
         let result = self.bitwise.u32or(a, b)?;
-        self.bus
-            .request_bitwise_operation(BITWISE_OR_LABEL, a, b, result, self.clk);
+
+        let bitwise_lookup = BitwiseLookup::new(BITWISE_OR_LABEL, a, b, result);
+        self.bus.request_bitwise_operation(bitwise_lookup, self.clk);
 
         Ok(result)
     }
@@ -185,8 +187,9 @@ impl Chiplets {
     /// computation is undefined.
     pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
         let result = self.bitwise.u32xor(a, b)?;
-        self.bus
-            .request_bitwise_operation(BITWISE_XOR_LABEL, a, b, result, self.clk);
+
+        let bitwise_lookup = BitwiseLookup::new(BITWISE_XOR_LABEL, a, b, result);
+        self.bus.request_bitwise_operation(bitwise_lookup, self.clk);
 
         Ok(result)
     }
@@ -203,8 +206,8 @@ impl Chiplets {
         let value = self.memory.read(addr);
 
         // send the memory read request to the bus
-        self.bus
-            .request_memory_operation(addr, self.clk, value, value);
+        let memory_lookup = MemoryLookup::new(addr, self.clk as u64, value, value);
+        self.bus.request_memory_operation(memory_lookup, self.clk);
 
         value
     }
@@ -218,8 +221,8 @@ impl Chiplets {
         self.memory.write(addr, word);
 
         // send the memory write request to the bus
-        self.bus
-            .request_memory_operation(addr, self.clk, old_word, word);
+        let memory_lookup = MemoryLookup::new(addr, self.clk as u64, old_word, word);
+        self.bus.request_memory_operation(memory_lookup, self.clk);
 
         old_word
     }
@@ -230,8 +233,8 @@ impl Chiplets {
         self.memory.write(addr, word);
 
         // send the memory write request to the bus
-        self.bus
-            .request_memory_operation(addr, self.clk, old_word, word);
+        let memory_lookup = MemoryLookup::new(addr, self.clk as u64, old_word, word);
+        self.bus.request_memory_operation(memory_lookup, self.clk);
 
         old_word
     }

--- a/processor/src/trace/tests/chiplets.rs
+++ b/processor/src/trace/tests/chiplets.rs
@@ -3,12 +3,147 @@ use super::{
     build_trace_from_ops, rand_array, ExecutionTrace, Felt, FieldElement, Operation, Word, ONE,
     ZERO,
 };
+use rand_utils::rand_value;
 use vm_core::{
-    chiplets::memory::{
-        ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, NUM_ELEMENTS, U_COL_RANGE, V_COL_RANGE,
+    chiplets::{
+        bitwise::{
+            Selectors, BITWISE_AND, BITWISE_AND_LABEL, BITWISE_OR, BITWISE_OR_LABEL, BITWISE_XOR,
+            BITWISE_XOR_LABEL, OP_CYCLE_LEN,
+        },
+        hasher::HASH_CYCLE_LEN,
+        memory::{
+            ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, MEMORY_LABEL, NUM_ELEMENTS, U_COL_RANGE,
+            V_COL_RANGE,
+        },
+        BITWISE_A_COL_IDX, BITWISE_B_COL_IDX, BITWISE_OUTPUT_COL_IDX, BITWISE_TRACE_OFFSET,
     },
     AUX_TRACE_RAND_ELEMENTS, CHIPLETS_AUX_TRACE_OFFSET,
 };
+
+/// Tests the generation of the `b_aux` bus column when only bitwise lookups are included. It
+/// ensures that trace generation is correct when all of the following are true.
+///
+/// - All possible bitwise operations are called by the stack.
+/// - Some requests from the Stack and responses from the Bitwise chiplet occur at the same cycle.
+#[test]
+#[allow(clippy::needless_range_loop)]
+fn b_aux_trace_bitwise() {
+    let a = rand_value::<u32>();
+    let b = rand_value::<u32>();
+    let stack = [a as u64, b as u64];
+    let operations = vec![
+        Operation::U32and,
+        Operation::Push(Felt::from(a)),
+        Operation::Push(Felt::from(b)),
+        Operation::U32or,
+        // Add 8 padding operations so that U32xor is requested by the stack in the same cycle when
+        // U32and is provided by the Bitwise chiplet.
+        Operation::Pad,
+        Operation::Pad,
+        Operation::Pad,
+        Operation::Pad,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Push(Felt::from(a)),
+        Operation::Push(Felt::from(b)),
+        Operation::U32xor,
+        // Drop 4 values to empty the stack's overflow table.
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+    ];
+    let mut trace = build_trace_from_ops(operations, &stack);
+
+    let rand_elements = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
+    let aux_columns = trace.build_aux_segment(&[], &rand_elements).unwrap();
+    let b_aux = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
+
+    assert_eq!(trace.length(), b_aux.len());
+    assert_eq!(ONE, b_aux[0]);
+    assert_eq!(ONE, b_aux[1]);
+
+    // The first bitwise request from the stack is sent when the `U32and` operation is executed at
+    // cycle 1, so the request is included in the next row. (The trace begins by executing `span`).
+    let value = build_expected_bitwise(
+        &rand_elements,
+        BITWISE_AND_LABEL,
+        Felt::from(a),
+        Felt::from(b),
+        Felt::from(a & b),
+    );
+    let mut expected = value.inv();
+    assert_eq!(expected, b_aux[2]);
+
+    // Nothing changes during user operations with no requests to the Chiplets.
+    for row in 3..5 {
+        assert_eq!(expected, b_aux[row]);
+    }
+
+    // The second bitwise request from the stack is sent when the `U32or` operation is executed at
+    // cycle 4, so the request is included in the next row.
+    let value = build_expected_bitwise(
+        &rand_elements,
+        BITWISE_OR_LABEL,
+        Felt::from(a),
+        Felt::from(b),
+        Felt::from(a | b),
+    );
+    expected *= value.inv();
+    assert_eq!(expected, b_aux[5]);
+
+    // Nothing changes during user operations with no requests to the Chiplets.
+    for row in 6..16 {
+        assert_eq!(expected, b_aux[row]);
+    }
+
+    // Bitwise responses will be provided during the bitwise segment of the Chiplets trace,
+    // which starts after the hash for the span block. Responses are provided at the last row of the
+    // Bitwise chiplet's operation cycle.
+    let response_1_row = HASH_CYCLE_LEN + OP_CYCLE_LEN;
+    let response_2_row = response_1_row + OP_CYCLE_LEN;
+    let response_3_row = response_2_row + OP_CYCLE_LEN;
+
+    // At cycle 15, `U32xor` is requested by the stack and `U32and` is provided by the bitwise
+    // chiplet.
+    let value = build_expected_bitwise(
+        &rand_elements,
+        BITWISE_XOR_LABEL,
+        Felt::from(a),
+        Felt::from(b),
+        Felt::from(a ^ b),
+    );
+    expected *= value.inv();
+    expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_1_row - 1);
+    assert_eq!(expected, b_aux[response_1_row]);
+
+    // Nothing changes until the next time the Bitwise chiplet responds.
+    for row in response_1_row..response_2_row {
+        assert_eq!(expected, b_aux[row]);
+    }
+
+    // At the end of the next bitwise cycle, the response for `U32or` is provided by the Bitwise
+    // chiplet.
+    expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_2_row - 1);
+    assert_eq!(expected, b_aux[response_2_row]);
+
+    // Nothing changes until the next time the Bitwise chiplet responds.
+    for row in response_2_row..response_3_row {
+        assert_eq!(expected, b_aux[row]);
+    }
+
+    // At the end of the next bitwise cycle, the response for `U32or` is provided by the Bitwise
+    // chiplet.
+    expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_3_row - 1);
+    assert_eq!(expected, b_aux[response_3_row]);
+
+    // The value in b_aux should be ONE now and for the rest of the trace.
+    for row in response_3_row..trace.length() - NUM_RAND_ROWS {
+        assert_eq!(ONE, b_aux[row]);
+    }
+}
 
 /// Tests the generation of the `b_aux` bus column when only memory lookups are included. It ensures
 /// that trace generation is correct when all of the following are true.
@@ -105,6 +240,32 @@ fn b_aux_trace_mem() {
 // TEST HELPERS
 // ================================================================================================
 
+fn build_expected_bitwise(alphas: &[Felt], op_id: Felt, a: Felt, b: Felt, result: Felt) -> Felt {
+    alphas[0] + alphas[1] * op_id + alphas[2] * a + alphas[3] * b + alphas[4] * result
+}
+
+fn build_expected_bitwise_from_trace(trace: &ExecutionTrace, alphas: &[Felt], row: usize) -> Felt {
+    let s0 = trace.main_trace.get_column(BITWISE_TRACE_OFFSET)[row];
+    let s1 = trace.main_trace.get_column(BITWISE_TRACE_OFFSET + 1)[row];
+    let selectors: Selectors = [s0, s1];
+
+    let op_id = if selectors == BITWISE_AND {
+        BITWISE_AND_LABEL
+    } else if selectors == BITWISE_OR {
+        BITWISE_OR_LABEL
+    } else if selectors == BITWISE_XOR {
+        BITWISE_XOR_LABEL
+    } else {
+        panic!("Execution trace contains an invalid bitwise operation.")
+    };
+
+    let a = trace.main_trace.get_column(BITWISE_A_COL_IDX)[row];
+    let b = trace.main_trace.get_column(BITWISE_B_COL_IDX)[row];
+    let output = trace.main_trace.get_column(BITWISE_OUTPUT_COL_IDX)[row];
+
+    build_expected_bitwise(alphas, op_id, a, b, output)
+}
+
 fn build_expected_memory(
     alphas: &[Felt],
     ctx: Felt,
@@ -117,14 +278,15 @@ fn build_expected_memory(
     let mut new_word_value = ZERO;
 
     for i in 0..NUM_ELEMENTS {
-        old_word_value += alphas[i + 4] * old_word[i];
-        new_word_value += alphas[i + 8] * new_word[i];
+        old_word_value += alphas[i + 5] * old_word[i];
+        new_word_value += alphas[i + 9] * new_word[i];
     }
 
     alphas[0]
-        + alphas[1] * ctx
-        + alphas[2] * addr
-        + alphas[3] * clk
+        + alphas[1] * MEMORY_LABEL
+        + alphas[2] * ctx
+        + alphas[3] * addr
+        + alphas[4] * clk
         + old_word_value
         + new_word_value
 }


### PR DESCRIPTION
This PR adds bitwise operations to the chiplets bus.

- [x] Adds bitwise operation request/response handling in the Chiplets module
- [x] Adds operation ids for all chiplet operations (hasher, bitwise, memory) and updates memory lookups with the hasher id
- [x] adds testing of bitwise chiplet responses to the bitwise unit tests
- [x] adds a unit test for bitwise lookups to the chiplets bus aux column unit tests