### PR TITLE
Assign real opcodes to all operations

### DIFF
--- a/core/src/decoder/mod.rs
+++ b/core/src/decoder/mod.rs
@@ -19,7 +19,7 @@ pub const OP_BITS_RANGE: Range<usize> = range(OP_BITS_OFFSET, NUM_OP_BITS);
 // TODO: probably rename "hasher state" to something like "shared columns".
 
 /// Index at which hasher state columns start in the decoder trace.
-pub const HASHER_STATE_OFFSET: usize = OP_BITS_OFFSET + NUM_OP_BITS;
+pub const HASHER_STATE_OFFSET: usize = OP_BITS_RANGE.end;
 
 /// Number of hasher columns in the decoder trace.
 pub const NUM_HASHER_COLUMNS: usize = 8;
@@ -35,7 +35,7 @@ pub const USER_OP_HELPERS_OFFSET: usize = HASHER_STATE_OFFSET + 2;
 pub const HASHER_STATE_RANGE: Range<usize> = range(HASHER_STATE_OFFSET, NUM_HASHER_COLUMNS);
 
 /// Index of the in_span column in the decoder trace.
-pub const IN_SPAN_COL_IDX: usize = HASHER_STATE_OFFSET + NUM_HASHER_COLUMNS;
+pub const IN_SPAN_COL_IDX: usize = HASHER_STATE_RANGE.end;
 
 /// Index of the operation group count column in the decoder trace.
 pub const GROUP_COUNT_COL_IDX: usize = IN_SPAN_COL_IDX + 1;
@@ -63,6 +63,9 @@ pub const OP_BATCH_2_GROUPS: [Felt; NUM_OP_BATCH_FLAGS] = [ZERO, ZERO, ONE];
 
 /// Operation batch consists of 1 operation group.
 pub const OP_BATCH_1_GROUPS: [Felt; NUM_OP_BATCH_FLAGS] = [ZERO, ONE, ONE];
+
+// Index of the op bits extra column in the decoder trace.
+pub const OP_BIT_EXTRA_COL_IDX: usize = OP_BATCH_FLAGS_RANGE.end;
 
 // --- Column accessors in the auxiliary columns --------------------------------------------------
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -57,8 +57,8 @@ pub const NUM_STACK_HELPER_COLS: usize = 3;
 // MAIN TRACE LAYOUT
 // ------------------------------------------------------------------------------------------------
 
-//      system          decoder           stack      range checks    chiplets
-//    (2 columns)     (22 columns)    (19 columns)    (4 columns)     (18 columns)
+//      system          decoder           stack      range checks       chiplets
+//    (2 columns)     (23 columns)    (19 columns)    (4 columns)     (18 columns)
 // ├───────────────┴───────────────┴───────────────┴───────────────┴─────────────────┤
 
 pub const SYS_TRACE_OFFSET: usize = 0;
@@ -70,7 +70,7 @@ pub const FMP_COL_IDX: usize = SYS_TRACE_OFFSET + 1;
 
 // decoder trace
 pub const DECODER_TRACE_OFFSET: usize = SYS_TRACE_OFFSET + SYS_TRACE_WIDTH;
-pub const DECODER_TRACE_WIDTH: usize = 22;
+pub const DECODER_TRACE_WIDTH: usize = 23;
 pub const DECODER_TRACE_RANGE: Range<usize> = range(DECODER_TRACE_OFFSET, DECODER_TRACE_WIDTH);
 
 // Stack trace
@@ -97,8 +97,8 @@ pub const TRACE_WIDTH: usize = CHIPLETS_OFFSET + CHIPLETS_WIDTH;
 // AUXILIARY COLUMNS LAYOUT
 // ------------------------------------------------------------------------------------------------
 
-//      decoder         stack       range checks      hasher      chiplets
-//    (3 columns)     (1 column)     (3 columns)    (1 column)       (1 column)
+//      decoder         stack       range checks      hasher         chiplets
+//    (3 columns)     (1 column)     (3 columns)    (1 column)      (1 column)
 // ├───────────────┴──────────────┴──────────────┴───────────────┴───────────────┤
 
 // Decoder auxiliary columns

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -355,109 +355,112 @@ impl Operation {
     /// Returns the opcode of this operation.
     ///
     /// Opcode patterns have the following meanings:
-    /// - 1001xxx: operations that result in a stack left shift from index 2, but do not require
-    ///   range checks. These are the left shifting u32 and field ops without range checks.
-    /// - 1000xxx: operations that consume four range checks.
-    ///   - 100010x: an operation that consumes four range checks and shifts the stack left.
-    ///   - 1000110: an operation that consumes four range checks and shifts the stack right.
+    /// - 00xxxxx operations do not shift the stack; constraint degree can be up to 2.
+    /// - 010xxxx operations shift the stack the left; constraint degree can be up to 2.
+    /// - 011xxxx operations shift the stack to the right; constraint degree can be up to 2.
+    /// - 100xxx-: operations consume 4 range checks; constraint degree can be up to 3. These are
+    ///   used to encode most u32 operations.
+    /// - 101xxx-: operations where constraint degree can be up to 3. These include control flow
+    ///   operations and some other operations requiring high degree constraints.
+    /// - 11xxx--: operations where constraint degree can be up to 5. These include control flow
+    ///   operations and some other operations requiring very high degree constraints.
+    #[rustfmt::skip]
     pub fn op_code(&self) -> u8 {
         match self {
-            Self::Noop => 0,
-            Self::Assert => 1,
+            Self::Noop      => 0b0000_0000,
+            Self::Eqz       => 0b0000_0001,
+            Self::Neg       => 0b0000_0010,
+            Self::Inv       => 0b0000_0011,
+            Self::Incr      => 0b0000_0100,
+            Self::Not       => 0b0000_0101,
+            Self::FmpAdd    => 0b0000_0110,
+            Self::MLoad     => 0b0000_0111,
+            Self::Swap      => 0b0000_1000,
+            // <empty>      => 0b0000_1001,
+            Self::MovUp2    => 0b0000_1010,
+            Self::MovDn2    => 0b0000_1011,
+            Self::MovUp3    => 0b0000_1100,
+            Self::MovDn3    => 0b0000_1101,
+            Self::ReadW     => 0b0000_1110,
+            // <empty>      => 0b0000_1111
 
-            Self::FmpAdd => 2,
-            Self::FmpUpdate => 3,
+            Self::MovUp4    => 0b0001_0000,
+            Self::MovDn4    => 0b0001_0001,
+            Self::MovUp5    => 0b0001_0010,
+            Self::MovDn5    => 0b0001_0011,
+            Self::MovUp6    => 0b0001_0100,
+            Self::MovDn6    => 0b0001_0101,
+            Self::MovUp7    => 0b0001_0110,
+            Self::MovDn7    => 0b0001_0111,
+            Self::SwapW     => 0b0001_1000,
+            // <empty>      => 0b0001_1001
+            Self::MovUp8    => 0b0001_1010,
+            Self::MovDn8    => 0b0001_1011,
+            Self::SwapW2    => 0b0001_1100,
+            Self::SwapW3    => 0b0001_1101,
+            Self::SwapDW    => 0b0001_1110,
+            // <empty>      => 0b0001_1111
 
-            Self::Push(_) => 4,
+            Self::Assert    => 0b0010_0000,
+            Self::Eq        => 0b0010_0001,
+            Self::Add       => 0b0010_0010,
+            Self::Mul       => 0b0010_0011,
+            Self::And       => 0b0010_0100,
+            Self::Or        => 0b0010_0101,
+            Self::U32and    => 0b0010_0110,
+            Self::U32or     => 0b0010_0111,
+            Self::U32xor    => 0b0010_1000,
+            Self::Drop      => 0b0010_1001,
+            Self::CSwap     => 0b0010_1010,
+            Self::CSwapW    => 0b0010_1011,
+            Self::MLoadW    => 0b0010_1100,
+            Self::MStore    => 0b0010_1101,
+            Self::MStoreW   => 0b0010_1110,
+            Self::FmpUpdate => 0b0010_1111,
 
-            Self::Eq => 0b0100_1001,
-            Self::Eqz => 5,
+            Self::Pad       => 0b0011_0000,
+            Self::Dup0      => 0b0011_0001,
+            Self::Dup1      => 0b0011_0010,
+            Self::Dup2      => 0b0011_0011,
+            Self::Dup3      => 0b0011_0100,
+            Self::Dup4      => 0b0011_0101,
+            Self::Dup5      => 0b0011_0110,
+            Self::Dup6      => 0b0011_0111,
+            Self::Dup7      => 0b0011_1000,
+            Self::Dup9      => 0b0011_1001,
+            Self::Dup11     => 0b0011_1010,
+            Self::Dup13     => 0b0011_1011,
+            Self::Dup15     => 0b0011_1100,
+            Self::Read      => 0b0011_1101,
+            Self::SDepth    => 0b0011_1110,
+            // <empty>      => 0b0011_1111
 
-            Self::Add => 0b0100_1000,
-            Self::Neg => 7,
-            Self::Mul => 0b0100_1010,
-            Self::Inv => 8,
-            Self::Incr => 9,
-            Self::And => 0b0100_1011,
-            Self::Or => 0b0100_1100,
-            Self::Not => 11,
+            Self::U32add    => 0b0100_0000,
+            Self::U32sub    => 0b0100_0010,
+            Self::U32mul    => 0b0100_0100,
+            Self::U32div    => 0b0100_0110,
+            Self::U32split  => 0b0100_1000,
+            Self::U32assert2 => 0b0100_1010,
+            Self::U32add3   => 0b0100_1100,
+            Self::U32madd   => 0b0100_1110,
 
-            Self::Pad => 12,
-            Self::Drop => 13,
+            Self::RpPerm    => 0b0101_0000,
+            Self::MpVerify  => 0b0101_0010,
+            // <empty>      => 0b0101_0100
+            // <empty>      => 0b0101_0110
+            Self::Span      => 0b0101_1000,
+            Self::Join      => 0b0101_1010,
+            Self::Split     => 0b0101_1100,
+            Self::Loop      => 0b0101_1110,
 
-            Self::Dup0 => 14,
-            Self::Dup1 => 15,
-            Self::Dup2 => 16,
-            Self::Dup3 => 17,
-            Self::Dup4 => 18,
-            Self::Dup5 => 19,
-            Self::Dup6 => 20,
-            Self::Dup7 => 21,
-            Self::Dup9 => 22,
-            Self::Dup11 => 23,
-            Self::Dup13 => 24,
-            Self::Dup15 => 25,
-
-            Self::Swap => 26,
-            Self::SwapW => 27,
-            Self::SwapW2 => 28,
-            Self::SwapW3 => 29,
-            Self::SwapDW => 30,
-
-            Self::MovUp2 => 31,
-            Self::MovUp3 => 32,
-            Self::MovUp4 => 33,
-            Self::MovUp5 => 34,
-            Self::MovUp6 => 35,
-            Self::MovUp7 => 36,
-            Self::MovUp8 => 37,
-
-            Self::MovDn2 => 40,
-            Self::MovDn3 => 41,
-            Self::MovDn4 => 42,
-            Self::MovDn5 => 43,
-            Self::MovDn6 => 44,
-            Self::MovDn7 => 45,
-            Self::MovDn8 => 46,
-
-            Self::CSwap => 50,
-            Self::CSwapW => 51,
-
-            Self::U32add => 0b0100_0000,
-            Self::U32sub => 0b0100_0001,
-            Self::U32mul => 0b0100_0010,
-            Self::U32div => 0b0100_0011,
-            Self::U32add3 => 0b0100_0100,
-            Self::U32madd => 0b0100_0101,
-            Self::U32split => 0b0100_0110,
-            Self::U32assert2 => 0b0100_0111,
-
-            Self::U32and => 0b0100_1101,
-            Self::U32or => 0b0100_1110,
-            Self::U32xor => 0b0100_1111,
-
-            Self::MLoadW => 52,
-            Self::MStoreW => 53,
-
-            Self::Read => 54,
-            Self::ReadW => 55,
-
-            Self::SDepth => 56,
-
-            Self::RpPerm => 57,
-            Self::MpVerify => 58,
-            Self::MrUpdate(_) => 59,
-
-            Self::End => 60,
-            Self::Join => 61,
-            Self::Split => 62,
-            Self::Loop => 63,
-            Self::Repeat => 80,
-            Self::Respan => 81,
-            Self::Span => 82,
-            Self::Halt => 83,
-            Self::MLoad => 84,
-            Self::MStore => 85,
+            Self::MrUpdate(_) => 0b0110_0000,
+            Self::Push(_)   => 0b0110_0100,
+            // <empty>      => 0b0110_1000
+            // <empty>      => 0b0110_1100
+            Self::End       => 0b0111_0000,
+            Self::Repeat    => 0b0111_0100,
+            Self::Respan    => 0b0111_1000,
+            Self::Halt      => 0b0111_1100,
         }
     }
 

--- a/docs/src/design/chiplets/hasher.md
+++ b/docs/src/design/chiplets/hasher.md
@@ -239,7 +239,7 @@ When describing AIR constraints, we adopt the following notation: for column $x$
 As mentioned above, row address $r$ starts at $1$, and is incremented by $1$ with every row. The first condition can be enforced with a boundary constraint which specifies $r=1$ at the first row. The second condition can be enforced via the following transition constraint:
 
 >$$
-r' - r - 1 = 0  \text{ | degree } = 1
+r' - r - 1 = 0  \text{ | degree} = 1
 $$
 
 This constraint should not be applied to the very last row of the hasher execution trace, since we do not want to enforce a value that would conflict with the first row of a subsequent chiplet in the Chiplets module. Therefore we can create a special virtual flag for this constraint using the $aux\_s_0$ selector column from the [Chiplets](main.md) module that selects for the hash chiplet.
@@ -393,7 +393,7 @@ $$
 v_{res} = v_h + v_b
 $$
 
-Using the above values, we can describe constraints for updating column $p_0$ as follows.
+Using the above values, we can describe the constraints for updating column $p_0$ as follows.
 
 >$$
 p_0' = p_0 \cdot ((f_{bp} + f_{sout}) \cdot v_{all} + (f_{mp} + f_{mv} + f_{mu}) \cdot v_{leaf} + f_{abp} \cdot v_{abp} + f_{hout} \cdot v_{res} + \\

--- a/docs/src/design/decoder/constraints.md
+++ b/docs/src/design/decoder/constraints.md
@@ -253,8 +253,8 @@ Adding and removing entries to/from the block hash table is accomplished as foll
 To simplify constraint descriptions, we define values representing left and right children of a block as follows:
 
 $$
-ch_1 = \alpha_0 + \alpha_1 \cdot a' + \sum_{i=0}^3(a_{i+2} \cdot h_i) \text{ | degree } = 1 \\
-ch_2 = \alpha_0 + \alpha_1 \cdot a' + \sum_{i=0}^3(a_{i+2} \cdot h_{i+4}) \text{ | degree } = 1
+ch_1 = \alpha_0 + \alpha_1 \cdot a' + \sum_{i=0}^3(a_{i+2} \cdot h_i) \text{ | degree} = 1 \\
+ch_2 = \alpha_0 + \alpha_1 \cdot a' + \sum_{i=0}^3(a_{i+2} \cdot h_{i+4}) \text{ | degree} = 1
 $$
 
 Graphically, this looks like so:
@@ -264,7 +264,7 @@ Graphically, this looks like so:
 In a similar manner, we define a value representing the result of hash computation as follows:
 
 $$
-bh = \alpha_0 + \alpha_1 \cdot a + \sum_{i=0}^3(\alpha_{i+2} \cdot h_i) + \alpha_7 \cdot h_4 \text{ | degree } = 1
+bh = \alpha_0 + \alpha_1 \cdot a + \sum_{i=0}^3(\alpha_{i+2} \cdot h_i) + \alpha_7 \cdot h_4 \text{ | degree} = 1
 $$
 
 Note that in the above we use $a$ (block address from the current row) rather than $a'$ (block address from the next row) as we did for for values of $ch_1$ and $ch_2$. Also, note that we are not adding a flag indicating whether the block is the first child of a join block (i.e., $\alpha_6$ term is missing). It will be added later on.
@@ -382,7 +382,7 @@ $$
 \Delta gc = gc - gc'
 $$
 
-Using this variable, we can describe constraints against the $gc$ column as follows:
+Using this variable, we can describe the constraints against the $gc$ column as follows:
 
 Inside a *span* block, group count can either stay the same or decrease by one:
 
@@ -463,7 +463,7 @@ ng = \Delta gc - f_{push} \\
 \Delta ox = ox' - ox
 $$
 
-The value of $ng$ is set to $1$ when we are about to start executing a new operation group (i.e., group count is decremented but we did not execute a `PUSH` operation). Using these variables, we can describe constraints against the $ox$ column as follows.
+The value of $ng$ is set to $1$ when we are about to start executing a new operation group (i.e., group count is decremented but we did not execute a `PUSH` operation). Using these variables, we can describe the constraints against the $ox$ column as follows.
 
 When executing `SPAN` or `RESPAN` operations the next value of `op_index` must be set to $0$:
 
@@ -544,7 +544,7 @@ To simplify constraint descriptions, we first define variables representing the 
 When a `SPAN` or a `RESPAN` operation is executed, we compute the values of the rows to be added to the op group table as follows:
 
 $$
-v_i = \alpha_0 + \alpha_1 \cdot a' + \alpha_2 \cdot (gc - i) + \alpha_3 \cdot h_{i} \text{ | degree } = 1
+v_i = \alpha_0 + \alpha_1 \cdot a' + \alpha_2 \cdot (gc - i) + \alpha_3 \cdot h_{i} \text{ | degree} = 1
 $$
 
 Where $i \in 1..7$. Thus, $v_1$ defines row value for group in $h_1$, $v_2$ defines row value for group $h_2$ etc. Note that batch address column comes from the next row of the block address column ($a'$).

--- a/docs/src/design/main.md
+++ b/docs/src/design/main.md
@@ -2,12 +2,21 @@
 In the following sections, we provide in-depth descriptions of Miden VM internals, including all AIR constraints for the proving system. We also provide rationale for making specific design choices.
 
 Throughout these sections we adopt the following notations and assumptions:
-* All arithmetic operations, unless noted otherwise, are assumed to be in a prime filed with modulus $p = 2^{64} - 2^{32} + 1$.
+* All arithmetic operations, unless noted otherwise, are assumed to be in a prime field with modulus $p = 2^{64} - 2^{32} + 1$.
 * A _binary_ value means a field element which is either $0$ or $1$.
-* We use lower-case letters to refer to individual field elements (e.g., $a$), and upper-case letters to refer to groups of $4$ elements or words (e.g., $A$). To refer to individual elements within a word, we use numerical subscripts. For example, $a_0$ is the first element of word $A$, $b_3$ is the last element of word $B$, etc.
+* We use lowercase letters to refer to individual field elements (e.g., $a$), and uppercase letters to refer to groups of $4$ elements, also referred to as words (e.g., $A$). To refer to individual elements within a word, we use numerical subscripts. For example, $a_0$ is the first element of word $A$, $b_3$ is the last element of word $B$, etc.
 * When describing AIR constraints:
   - For a column $x$, we denote the value in the current row simply as $x$, and the value in the next row of the column as $x'$. Thus, all transition constraints for Miden VM work with two consecutive rows of the execution trace.
   - For multiset equality constraints, we denote random values sent by the verifier after the prover commits to the main execution trace as $\alpha_0, \alpha_1, \alpha_2$ etc.
+  - To differentiate constraints from other formulas, we frequently use the following format for constraint equations.
+
+>$$
+x' - (x + y) = 0 \text{ | degree} = 1
+$$
+
+In the above, the constraint equation is followed by the implied algebraic degree of the constraint. This degree is determined by the number of multiplications between trace columns. If a constraint does not involve any multiplications between columns, its degree is $1$. If a constraint involves multiplication between two columns, its degree is $2$. If we need to multiply three columns together, the degree is $3$ ect.
+
+The maximum allowed constraint degree in Miden VM is $9$. If a constraint degree grows beyond that, we frequently need to introduce additional columns to reduce the degree.
 
 ## VM components
 Miden VM consists of several interconnected components, each providing a specific set of functionality. These components are:
@@ -31,13 +40,11 @@ As can be seen from the above, decoder, stack, and range checker components use 
 
 In addition to the components described previously, execution trace also contains $2$ system columns:
 
-* `clk` which is used to keep track of the current VM cycle. Values in these columns start out at $0$ and are incremented with each cycle.
+* `clk` which is used to keep track of the current VM cycle. Values in this column start out at $0$ and are incremented by $1$ with each cycle.
 * `fmp` which contains the value of the free memory pointer used for specifying the region of memory available to procedure locals.
 
 AIR constraints for the `fmp` column are described in [system operations](./stack/system_ops.md) section. For the `clk` column, the constraints are straightforward:
 
 >$$
-clk' - (clk + 1) = 0 \text{ | degree } = 1
+clk' - (clk + 1) = 0 \text{ | degree} = 1
 $$
-
-We frequently use the above notation for describing other AIR constraints. Specifically, the constraint is followed by its implied algebraic degree.

--- a/docs/src/design/stack/crypto_ops.md
+++ b/docs/src/design/stack/crypto_ops.md
@@ -1,5 +1,5 @@
 # Cryptographic operations
-In this section we describe the AIR constraint for Miden VM cryptographic operations.
+In this section we describe the AIR constraints for Miden VM cryptographic operations.
 
 Cryptographic operations in Miden VM are performed by the [Hash chiplet](../chiplets/hasher.md). Communication between the stack and the hash chiplet is accomplished via the chiplet bus $b_{chip}$. To make requests to and to read results from the chiplet bus we need to divide its current value by the value representing the request.
 
@@ -10,7 +10,7 @@ The `RPPERM` operation applies Rescue Prime permutation to the top $12$ elements
 
 ![rpperm](../../assets/design/stack/crypto_ops/RPPERM.png)
 
-In the above, $r$ (located in the helper register $h_0$) is the row address from the hash chiplet set by the prover nondeterministically.
+In the above, $r$ (located in the helper register $h_0$) is the row address from the hash chiplet set by the prover non-deterministically.
 
 For the `RPPERM` operation, we define input and output values as follows:
 
@@ -22,15 +22,15 @@ $$
 v_{output} = \alpha_0 + \alpha_1 \cdot op_{retstate} + \alpha_2 \cdot (h_0 + 7) + \sum_{j=0}^{11} (\alpha_{i+4} \cdot s_{11-i}')
 $$
 
-In the above, $op_{linhash}$ and $op_{retstate}$ are the unique [operation label](../chiplets/main.md#operation-labels) for initiating a linear hash and reading the full state of the hasher respectively. Also note that the term for $\alpha_3$ is missing from the above expressions because for Rescue Prime permutation computation the index column is expected to be set to $0$.
+In the above, $op_{linhash}$ and $op_{retstate}$ are the unique [operation labels](../chiplets/main.md#operation-labels) for initiating a linear hash and reading the full state of the hasher respectively. Also note that the term for $\alpha_3$ is missing from the above expressions because for Rescue Prime permutation computation the index column is expected to be set to $0$.
 
-Using the above values, we can describe constraint for the chiplet bus column as follows:
+Using the above values, we can describe the constraint for the chiplet bus column as follows:
 
 >$$
 b_{chip}' \cdot v_{input} \cdot v_{output} = b_{chip} \text{ | degree } = 3
 $$
 
-The above constrain enforces that the specified input and output rows must be present in the trace of the hash chiplet, and that they must be exactly $7$ rows apart.
+The above constraint enforces that the specified input and output rows must be present in the trace of the hash chiplet, and that they must be exactly $7$ rows apart.
 
 The effect of this operation on the rest of the stack is:
 * **No change** starting from position $12$.
@@ -48,27 +48,27 @@ The Merkle path itself is expected to be provided by the prover non-deterministi
 
 ![mpverify](../../assets/design/stack/crypto_ops/MPVERIFY.png)
 
-In the above, $r$ (located in the helper register $h_0$) is the row address from the hash chiplet set by the prover nondeterministically.
+In the above, $r$ (located in the helper register $h_0$) is the row address from the hash chiplet set by the prover non-deterministically.
 
 For the `MPVERIFY` operation, we define input and output values as follows:
 
 $$
-v_{input} = \alpha_0 + \alpha_1 \cdot op_{mpver} + \alpha_2 \cdot r + \alpha_3 \cdot i + \sum_{j=0}^3 \alpha_{j+8} \cdot s_{6 - j}
+v_{input} = \alpha_0 + \alpha_1 \cdot op_{mpver} + \alpha_2 \cdot r + \alpha_3 \cdot i + \sum_{j=0}^3 \alpha_{j+8} \cdot s_{5 - j}
 $$
 
 $$
-v_{output} = \alpha_0 + \alpha_1 \cdot op_{rethash} + \alpha_2 \cdot (h_0 + 8 \cdot s_0 - 1) + \sum_{j=0}^3\alpha_{j + 8} \cdot s_{10 - j}
+v_{output} = \alpha_0 + \alpha_1 \cdot op_{rethash} + \alpha_2 \cdot (h_0 + 8 \cdot s_0 - 1) + \sum_{j=0}^3\alpha_{j + 8} \cdot s_{9 - j}
 $$
 
-In the above, $op_{mpver}$ and $op_{rethash}$ are the unique [operation label](../chiplets/main.md#operation-labels) for initiating a Merkle path verification computation and reading the hash result respectively. The sum expression for inputs computes the value of the leaf node, while the sum expression for the output computes the value of the tree root.
+In the above, $op_{mpver}$ and $op_{rethash}$ are the unique [operation labels](../chiplets/main.md#operation-labels) for initiating a Merkle path verification computation and reading the hash result respectively. The sum expression for inputs computes the value of the leaf node, while the sum expression for the output computes the value of the tree root.
 
-Using the above values, we can describe constraint for the chiplet bus column as follows:
+Using the above values, we can describe the constraint for the chiplet bus column as follows:
 
 >$$
 b_{chip}' \cdot v_{input} \cdot v_{output} = b_{chip} \text{ | degree } = 3
 $$
 
-The above constrain enforces that the specified input and output rows must be present in the trace of the hash chiplet, and that they must be exactly $8 \cdot d - 1$ rows apart, where $d$ is the depth of the node.
+The above constraint enforces that the specified input and output rows must be present in the trace of the hash chiplet, and that they must be exactly $8 \cdot d - 1$ rows apart, where $d$ is the depth of the node.
 
 The effect of this operation on the rest of the stack is:
 * **No change** starting from position $0$.
@@ -87,7 +87,7 @@ The Merkle path for the node is expected to be provided by the prover non-determ
 
 ![mrupdate](../../assets/design/stack/crypto_ops/MRUPDATE.png)
 
-In the above, $r$ (located in the helper register $h_0$) is the row address from the hash chiplet set by the prover nondeterministically.
+In the above, $r$ (located in the helper register $h_0$) is the row address from the hash chiplet set by the prover non-deterministically.
 
 For the `MRUPDATE` operation, we define input and output values as follows:
 
@@ -107,15 +107,15 @@ $$
 v_{outputnew} = \alpha_0 + \alpha_1 \cdot op_{rethash} + \alpha_2 \cdot (r + 2 \cdot 8 \cdot d - 1) + \sum_{j=0}^3\alpha_{j + 8} \cdot s_{9 - j}'
 $$
 
-In the above, the first two expressions correspond to inputs and outputs for verifying the Merkle path between the old node value and the old tree root, while the last two expressions correspond to inputs and outputs for verifying the Merkle path between the new node value and the new tree root. Hash chiplet ensures the same set of sibling nodes are uses in both of these computations.
+In the above, the first two expressions correspond to inputs and outputs for verifying the Merkle path between the old node value and the old tree root, while the last two expressions correspond to inputs and outputs for verifying the Merkle path between the new node value and the new tree root. The hash chiplet ensures the same set of sibling nodes are uses in both of these computations.
 
-The $op_{mruold}$, $op_{mrunew}$, and $op_{rethash}$ are the unique [operation label](../chiplets/main.md#operation-labels) used by the above computations.
+The $op_{mruold}$, $op_{mrunew}$, and $op_{rethash}$ are the unique [operation labels](../chiplets/main.md#operation-labels) used by the above computations.
 
 > $$
 b_{chip}' \cdot v_{inputold} \cdot v_{outputold} \cdot v_{inputnew} \cdot v_{outputnew} = b_{chip} \text{ | degree } = 5
 $$
 
-The above constrain enforces that the specified input and output rows for both, the old and the new node/root combinations, must be present in the trace of the hash chiplet, and that they must be exactly $8 \cdot d - 1$ rows apart, where $d$ is the depth of the node. It also ensure that the computation for the old node/root combination is immediately followed by the computation for the new node/root combination.
+The above constraint enforces that the specified input and output rows for both, the old and the new node/root combinations, must be present in the trace of the hash chiplet, and that they must be exactly $8 \cdot d - 1$ rows apart, where $d$ is the depth of the node. It also ensures that the computation for the old node/root combination is immediately followed by the computation for the new node/root combination.
 
 The effect of this operation on the rest of the stack is:
 * **No change** for positions $0$ and $1$.

--- a/docs/src/design/stack/field_ops.md
+++ b/docs/src/design/stack/field_ops.md
@@ -1,5 +1,5 @@
 # Field Operations
-In this section we describe the AIR constraint for Miden VM field operations (i.e., arithmetic operations over field elements).
+In this section we describe the AIR constraints for Miden VM field operations (i.e., arithmetic operations over field elements).
 
 ## ADD
 Assume $a$ and $b$ are the elements at the top of the stack. The `ADD` operation computes $c \leftarrow (a + b)$. The diagram below illustrates this graphically.
@@ -9,7 +9,7 @@ Assume $a$ and $b$ are the elements at the top of the stack. The `ADD` operation
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0' - (s_0 + s_1) = 0 \text{ | degree } = 1
+s_0' - (s_0 + s_1) = 0 \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -23,7 +23,7 @@ Assume $a$ is the element at the top of the stack. The `NEG` operation computes 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0' + s_0 = 0 \text{ | degree } = 1
+s_0' + s_0 = 0 \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -67,7 +67,7 @@ Assume $a$ is the element at the top of the stack. The `INCR` operation computes
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0' - (s_0 + 1) = 0 \text{ | degree } = 1
+s_0' - (s_0 + 1) = 0 \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -85,7 +85,7 @@ s_0^2 - s_0 = 0 \text{ | degree } = 2
 $$
 
 >$$
-s_0' - (1 - s_0) = 0 \text{ | degree } = 1
+s_0' - (1 - s_0) = 0 \text{ | degree} = 1
 $$
 
 The first constraint ensures that the value in $s_0$ is binary, and the second constraint ensures the correctness of the boolean `NOT` operation.

--- a/docs/src/design/stack/io_ops.md
+++ b/docs/src/design/stack/io_ops.md
@@ -1,5 +1,5 @@
 # Input / output operations
-In this section we describe the AIR constraint for Miden VM input / output operations. These operations move values between the stack and other components of the VM such as program code (i.e., decoder), memory, and advice provider.
+In this section we describe the AIR constraints for Miden VM input / output operations. These operations move values between the stack and other components of the VM such as program code (i.e., decoder), memory, and advice provider.
 
 ### PUSH
 The `PUSH` operation pushes the provided immediate value onto the stack (i.e., sets the value of $s_0$ register). Currently, it is the only operation in Miden VM which carries an immediate value. The semantics of this operation are explained in the [decoder section](../decoder/main.html#handling-immediate-values).
@@ -15,7 +15,7 @@ Assume $a$ is the current depth of the stack stored in the stack bookkeeping reg
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0' - b_0 = 0 \text{ | degree } = 1
+s_0' - b_0 = 0 \text{ | degree} = 1
 $$
 
 The effect of this operation on the rest of the stack is:
@@ -96,7 +96,7 @@ Assume that the words with elements $v_0, v_1, v_2, v_3$ is located in memory at
 
 To simplify description of memory access request value, we first define the following variables:
 
-The value representing state of memory before the operation (values in registers $h_0, h_1, h_2$ are set by the prover nondeterministically):
+The value representing state of memory before the operation (values in registers $h_0, h_1, h_2$ are set by the prover non-deterministically):
 
 $$
 v_{old} = \alpha_4 \cdot s_0' + \sum_{i=2}^3\alpha_{i+4} \cdot h_i'
@@ -131,7 +131,7 @@ After the operation the contents of memory at address $a$ would be set to $u_0, 
 
 To simplify description of memory access request value, we first define the following variables:
 
-The value representing state of memory before the operation (set by the prover nondeterministically in registers $h_0, ..., h_3$):
+The value representing state of memory before the operation (set by the prover non-deterministically in registers $h_0, ..., h_3$):
 
 $$
 v_{old} = \sum_{i=0}^3\alpha_{i+4} \cdot h_i
@@ -166,7 +166,7 @@ After the operation the contents of memory at address $a$ would be set to $b, v_
 
 To simplify description of memory access request value, we first define the following variables:
 
-The value representing state of memory before the operation (set by the prover nondeterministically in registers $h_0, ..., h_3$):
+The value representing state of memory before the operation (set by the prover non-deterministically in registers $h_0, ..., h_3$):
 
 $$
 v_{old} = \sum_{i=0}^3\alpha_{i+4} \cdot h_i

--- a/docs/src/design/stack/op_constraints.md
+++ b/docs/src/design/stack/op_constraints.md
@@ -11,7 +11,7 @@ f_{dup} \cdot (s'_0 - s_0) = 0 \\
 f_{dup} \cdot (s'_{i+1} - s_i) = 0 \ \text{ for } i \in \{0, .., 14\}
 $$
 
-The first constrain enforces that the top stack item in the next row is the same as the top stack item in the current row. The second constraint enforces that all stack items (starting from item $0$) are shifted to the right by $1$. We also need to impose all the constraints discussed in the previous section, be we omit them here.
+The first constraint enforces that the top stack item in the next row is the same as the top stack item in the current row. The second constraint enforces that all stack items (starting from item $0$) are shifted to the right by $1$. We also need to impose all the constraints discussed in the previous section, be we omit them here.
 
 Let's write similar constraints for `DUP1` operation, which pushes a copy of the second stack item onto the stack:
 

--- a/docs/src/design/stack/stack_ops.md
+++ b/docs/src/design/stack/stack_ops.md
@@ -1,5 +1,5 @@
 # Stack Manipulation
-In this section we describe the AIR constraint for Miden VM stack manipulation operations. 
+In this section we describe the AIR constraints for Miden VM stack manipulation operations. 
 
 ## PAD
 The `PAD` operation pushes a $0$ onto the stack. The diagram below illustrates this graphically.
@@ -9,7 +9,7 @@ The `PAD` operation pushes a $0$ onto the stack. The diagram below illustrates t
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_{0}' = 0 \text{ | degree } = 1
+s_{0}' = 0 \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -30,7 +30,7 @@ The `DUP(n)` operations push a copy of the $n$-th stack element onto the stack. 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_{0}' - s_{n} = 0 \text{ for } n \in \{0, ..., 7, 9, 11, 13, 15\} \text{ | degree } = 1
+s_{0}' - s_{n} = 0 \text{ for } n \in \{0, ..., 7, 9, 11, 13, 15\} \text{ | degree} = 1
 $$
 
 where $n$ is the depth of the stack from where the element has been copied.
@@ -46,11 +46,11 @@ The `SWAP` operations swaps the top two element of the stack. The diagram below 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_{0}' - s_{1} = 0 \text{ | degree } = 1
+s_{0}' - s_{1} = 0 \text{ | degree} = 1
 $$
 
 >$$
-s_{1}' - s_{0} = 0 \text{ | degree } = 1
+s_{1}' - s_{0} = 0 \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -64,11 +64,11 @@ The `SWAPW` operation swaps stack elements $0, 1, 2, 3$ with elements $4, 5, 6, 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_{i}' - s_{i+4} = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree } = 1
+s_{i}' - s_{i+4} = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree} = 1
 $$
 
 >$$
-s_{i + 4}' - s_i = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree } = 1
+s_{i + 4}' - s_i = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -82,11 +82,11 @@ The `SWAPW2` operation swaps stack elements $0, 1, 2, 3$ with elements $8, 9, 10
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_i' - s_{i+8} = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree } = 1
+s_i' - s_{i+8} = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree} = 1
 $$
 
 >$$
-s_{i + 8}' - s_i = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree } = 1
+s_{i + 8}' - s_i = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -101,11 +101,11 @@ The `SWAPW3` operation swaps stack elements $0, 1, 2, 3$ with elements $12, 13, 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_i' - s_{i+12} = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree } = 1
+s_i' - s_{i+12} = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree} = 1
 $$
 
 >$$
-s_{i+12}' - s_i = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree } = 1
+s_{i+12}' - s_i = 0 \text{ for } i \in \{0, 1, 2, 3\} \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -120,11 +120,11 @@ The `SWAPDW` operation swaps stack elements $\{0, ..., 7\}$ with elements $\{8, 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_i' - s_{i+8} = 0 \text{ for } i \in \{0, ..., 7\}   \text{ | degree } = 1
+s_i' - s_{i+8} = 0 \text{ for } i \in \{0, ..., 7\}   \text{ | degree} = 1
 $$
 
 >$$
-s_{i+8}' - s_i = 0 \text{ for } i \in \{0, ..., 7\}   \text{ | degree } = 1
+s_{i+8}' - s_i = 0 \text{ for } i \in \{0, ..., 7\}   \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -138,7 +138,7 @@ The `MOVUP(n)` operation moves the $n$-th element of the stack to the top of the
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0' - s_n = 0 \text{ for } n \in \{2, ..., 8\} \text{ | degree } = 1
+s_0' - s_n = 0 \text{ for } n \in \{2, ..., 8\} \text{ | degree} = 1
 $$
 
 where $n$ is the depth of the element which is moved moved to the top of the stack.
@@ -155,7 +155,7 @@ The `MOVDN(n)` operation moves the top element of the stack to the $n$-th positi
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_n' - s_0 = 0 \text{ for } n \in \{2, ..., 8\} \text{ | degree } = 1
+s_n' - s_0 = 0 \text{ for } n \in \{2, ..., 8\} \text{ | degree} = 1
 $$
 
 where $n$ is the depth to which the top stack element is moved.

--- a/docs/src/design/stack/system_ops.md
+++ b/docs/src/design/stack/system_ops.md
@@ -1,5 +1,5 @@
 # System Operations
-In this section we describe the AIR constraint for Miden VM system operations.  
+In this section we describe the AIR constraints for Miden VM system operations.  
 
 ## NOOP
 The `NOOP` operation advances the cycle counter but does not change the state of the operand stack (i.e., the depth of the stack and the values on the stack remain the same). 
@@ -7,7 +7,7 @@ The `NOOP` operation advances the cycle counter but does not change the state of
 The `NOOP` operation does not impose any constraints besides the ones needed to ensure that the entire state of the stack is copied over. This constraint looks like so:
 
 >$$
-s'_i - s_i = 0 \ \text{ for } i \in \{0, .., 15\} \text { | degree } = 1
+s'_i - s_i = 0 \ \text{ for } i \in \{0, .., 15\} \text { | degree} = 1
 $$
 
 ## ASSERT
@@ -18,7 +18,7 @@ The `ASSERT` operation pops an element off the stack and checks if the popped el
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0 - 1 = 0 \text{ | degree } = 1
+s_0 - 1 = 0 \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -32,7 +32,7 @@ The `FMPADD` operation pops an element off the stack, adds the current value of 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0' - (s_0 + fmp) = 0 \text{ | degree } = 1
+s_0' - (s_0 + fmp) = 0 \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:
@@ -46,7 +46,7 @@ The `FMPUPDATE` operation pops an element off the stack and adds it to the curre
 The stack transition for this operation must follow the following constraint:
 
 >$$
-fmp' - (fmp + s_0) = 0 \text{ | degree } = 1
+fmp' - (fmp + s_0) = 0 \text{ | degree} = 1
 $$
 
 The effect on the rest of the stack is:

--- a/docs/src/design/stack/u32_ops.md
+++ b/docs/src/design/stack/u32_ops.md
@@ -57,15 +57,15 @@ Assume $a$ is the element at the top of the stack. The `U32SPLIT` operation comp
 To facilitate this operation, the prover sets values in $h_0, ..., h_3$ to 16-bit limbs of $a$ with $h_0$ being the least significant limb. Thus, stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_{0} = 2^{48} \cdot h_3 + 2^{32} \cdot h_2 + 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_{0} = 2^{48} \cdot h_3 + 2^{32} \cdot h_2 + 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 >$$
-s_{1}' = 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_{1}' = 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 >$$
-s_{0}' = 2^{16} \cdot h_3 + h_2 \text{ | degree } = 1
+s_{0}' = 2^{16} \cdot h_3 + h_2 \text{ | degree} = 1
 $$
 
 In addition to the above constraints, we also need to verify that values in $h_0, ..., h_3$ are smaller than $2^{16}$, which we can do using 16-bit range checks as described [previously](#range-checks). Also, we need to make sure that values in $h_0, ..., h_3$, when combined, form a valid field element, which we can do by putting a nondeterministic value $m$ into helper register $h_4$ and using the technique described [here](#checking-element-validity).
@@ -81,11 +81,11 @@ Assume $a$ and $b$ are the elements at the top of the stack. The `U32ASSERT2` ve
 To facilitate this operation, the prover sets values in $h_0$ and $h_1$ to low and high 16-bit limbs of $a$, and values in $h_2$ and $h_3$ to to low and high 16-bit limbs of $b$. Thus, stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0' = 2^{16} \cdot h_3 + h_2 \text{ | degree } = 1
+s_0' = 2^{16} \cdot h_3 + h_2 \text{ | degree} = 1
 $$
 
 >$$
-s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 In addition to the above constraints, we also need to verify that values in $h_0, ..., h_3$ are smaller than $2^{16}$, which we can do using 16-bit range checks as described [previously](#range-checks).
@@ -101,15 +101,15 @@ Assume $a$ and $b$ are the values at the top of the stack which are known to be 
 To facilitate this operation, the prover sets values in $h_0$, $h_1$, and $h_2$ to 16-bit limbs of $a+b$ with $h_0$ being the least significant limb. Value in $h_3$ is set to $0$. Thus, stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0 + s_1 = 2^{32} \cdot h_2 + 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_0 + s_1 = 2^{32} \cdot h_2 + 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 >$$
-s_0' = h_2 \text{ | degree } = 1
+s_0' = h_2 \text{ | degree} = 1
 $$
 
 >$$
-s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 In addition to the above constraints, we also need to verify that values in $h_0, ..., h_3$ are smaller than $2^{16}$, which we can do using 16-bit range checks as described [previously](#range-checks).
@@ -125,15 +125,15 @@ Assume $a$, $b$, $c$ are the values at the top of the stack which are known to b
 To facilitate this operation, the prover sets values in $h_0$, $h_1$, and $h_2$ to 16-bit limbs of $a+b+c$ with $h_0$ being the least significant limb. Value in $h_3$ is set to $0$. Thus, stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0 + s_1 + s_2 = 2^{32} \cdot h_2 + 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_0 + s_1 + s_2 = 2^{32} \cdot h_2 + 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 >$$
-s_0' = h_2 \text{ | degree } = 1
+s_0' = h_2 \text{ | degree} = 1
 $$
 
 >$$
-s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 In addition to the above constraints, we also need to verify that values in $h_0, ..., h_3$ are smaller than $2^{16}$, which we can do using 16-bit range checks as described [previously](#range-checks).
@@ -149,7 +149,7 @@ Assume $a$ and $b$ are the values at the top of the stack which are known to be 
 To facilitate this operation, the prover sets values in $h_0$ and $h_1$ to the low and the high 16-bit limbs of $a-b$ respectively. Values in $h_2$ and $h_3$ are set to $0$. Thus, stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_1 = s_0 + s_1' + 2^{32} \cdot s_0' \text{ | degree } = 1
+s_1 = s_0 + s_1' + 2^{32} \cdot s_0' \text{ | degree} = 1
 $$
 
 >$$
@@ -157,7 +157,7 @@ s_0'^2 - s_0' = 0 \text{ | degree } = 2
 $$
 
 >$$
-s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 In addition to the above constraints, we also need to verify that values in $h_0, ..., h_3$ are smaller than $2^{16}$, which we can do using 16-bit range checks as described [previously](#range-checks).
@@ -177,11 +177,11 @@ s_0 \cdot s_1 = 2^{48} \cdot h_3 + 2^{32} \cdot h_2 + 2^{16} \cdot h_1 + h_0 \te
 $$
 
 >$$
-s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 >$$
-s_0' = 2^{16} \cdot h_3 + h_2 \text{ | degree } = 1
+s_0' = 2^{16} \cdot h_3 + h_2 \text{ | degree} = 1
 $$
 
 In addition to the above constraints, we also need to verify that values in $h_0, ..., h_3$ are smaller than $2^{16}$, which we can do using 16-bit range checks as described [previously](#range-checks). Also, we need to make sure that values in $h_0, ..., h_3$, when combined, form a valid field element, which we can do by putting a nondeterministic value $m$ into helper register $h_4$ and using the technique described [here](#checking-element-validity).
@@ -201,11 +201,11 @@ s_0 \cdot s_1 + s_2 = 2^{48} \cdot h_3 + 2^{32} \cdot h_2 + 2^{16} \cdot h_1 + h
 $$
 
 >$$
-s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 >$$
-s_0' = 2^{16} \cdot h_3 + h_2 \text{ | degree } = 1
+s_0' = 2^{16} \cdot h_3 + h_2 \text{ | degree} = 1
 $$
 
 In addition to the above constraints, we also need to verify that values in $h_0, ..., h_3$ are smaller than $2^{16}$, which we can do using 16-bit range checks as described [previously](#range-checks). Also, we need to make sure that values in $h_0, ..., h_3$, when combined, form a valid field element, which we can do by putting a nondeterministic value $m$ into helper register $h_4$ and using the technique described [here](#checking-element-validity).
@@ -227,11 +227,11 @@ s_1 = s_0 \cdot s_1' + s_0' \text{ | degree } = 2
 $$
 
 >$$
-s_1 - s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree } = 1
+s_1 - s_1' = 2^{16} \cdot h_1 + h_0 \text{ | degree} = 1
 $$
 
 >$$
-s_0 - s_0' - 1= 2^{16} \cdot h_2 + h_3 \text{ | degree } = 1
+s_0 - s_0' - 1= 2^{16} \cdot h_2 + h_3 \text{ | degree} = 1
 $$
 
 The second constraint enforces that $s_1' \leq s_1$, while the third constraint enforces that $s_0' < s_0$.

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -193,11 +193,10 @@ impl Process {
 /// of the executed program, as well as building an execution trace for these computations.
 ///
 /// ## Execution trace
-/// Decoder execution trace currently consists of 22 columns as illustrated below (this will
-/// be increased to 23 columns in the future):
+/// Decoder execution trace currently consists of 23 columns as illustrated below:
 ///
-///  addr b0 b1 b2 b3 b4 b5 b6 h0 h1 h2 h3 h4 h5 h6 h7 in_span g_count op_idx c0 c1 c2
-/// ├────┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴───────┴───────┴──────┴──┴──┴──┤
+///  addr b0 b1 b2 b3 b4 b5 b6 h0 h1 h2 h3 h4 h5 h6 h7 in_span g_count op_idx c0 c1 c2 be
+/// ├────┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴───────┴───────┴──────┴──┴──┴──┴──┤
 ///
 /// In the above, the meaning of the columns is as follows:
 /// * addr column contains address of the hasher for the current block (row index from the
@@ -224,11 +223,13 @@ impl Process {
 /// * Operation batch flag columns c0, c1, c2 which indicate how many operation groups are in
 ///   a given operation batch. These flags are set only for SPAN or RESPAN operations, and are
 ///   set to ZEROs otherwise.
+/// * Operation bit extra column `be` which is used to reduce the degree of op flags for
+///   operations where the two most significant bits are ONE.
 ///
 /// In addition to the execution trace, the decoder also contains the following:
 /// - A set of hints used in construction of decoder-related columns in auxiliary trace segment.
 /// - An instance of [DebugInfo] which is only populated in debug mode. This debug_info instance
-///   includes operations executed by the VM and AsmOp decorators. AsmOp decorators are popoulated
+///   includes operations executed by the VM and AsmOp decorators. AsmOp decorators are populated
 ///   only when both the processor and assembler are in debug mode.
 pub struct Decoder {
     block_stack: BlockStack,


### PR DESCRIPTION
This PR assigns real opcode values (as described in #203) to all operations. It also adds one more column to the decoder to reduce degree of operation flags for high-degree operations (as discussed in the same issue).