### PR TITLE
Refactor hash chiplet constants and chiplets trace tests module

### DIFF
--- a/air/src/chiplets/hasher/mod.rs
+++ b/air/src/chiplets/hasher/mod.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::utils::{are_equal, binary_not, is_binary, EvaluationResult};
 use core::ops::Range;
 use vm_core::{
-    hasher::{
+    chiplets::hasher::{
         Hasher, CAPACITY_LEN, DIGEST_LEN, DIGEST_RANGE, HASH_CYCLE_LEN, NUM_SELECTORS, STATE_WIDTH,
     },
     utils::range as create_range,

--- a/air/src/chiplets/hasher/mod.rs
+++ b/air/src/chiplets/hasher/mod.rs
@@ -1,14 +1,11 @@
-use super::{
-    Assertion, EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree, Vec,
-    HASHER_TRACE_OFFSET,
-};
+use super::{Assertion, EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree, Vec};
 use crate::utils::{are_equal, binary_not, is_binary, EvaluationResult};
-use core::ops::Range;
-use vm_core::{
-    chiplets::hasher::{
+use vm_core::chiplets::{
+    hasher::{
         Hasher, CAPACITY_LEN, DIGEST_LEN, DIGEST_RANGE, HASH_CYCLE_LEN, NUM_SELECTORS, STATE_WIDTH,
     },
-    utils::range as create_range,
+    HASHER_NODE_INDEX_COL_IDX, HASHER_ROW_COL_IDX, HASHER_SELECTOR_COL_RANGE,
+    HASHER_STATE_COL_RANGE,
 };
 
 #[cfg(test)]
@@ -28,15 +25,6 @@ pub const NUM_PERIODIC_SELECTOR_COLUMNS: usize = 3;
 /// The total number of periodic columns used by the hash processor, which is the sum of the number
 /// of periodic selector columns plus the columns of round constants for the Rescue Hash permutation.
 pub const NUM_PERIODIC_COLUMNS: usize = STATE_WIDTH * 2 + NUM_PERIODIC_SELECTOR_COLUMNS;
-
-/// The column index range in the execution trace containing the selector columns in the hasher.
-const SELECTOR_COL_RANGE: Range<usize> = create_range(HASHER_TRACE_OFFSET, NUM_SELECTORS);
-/// The index of the hasher's row column in the execution trace.
-const ROW_COL_IDX: usize = SELECTOR_COL_RANGE.end;
-/// The range of columns in the execution trace that contain the hasher's state.
-const HASHER_STATE_COL_RANGE: Range<usize> = create_range(ROW_COL_IDX + 1, STATE_WIDTH);
-/// The index of the hasher's node index column in the execution trace.
-const NODE_INDEX_COL_IDX: usize = HASHER_STATE_COL_RANGE.end;
 
 // PERIODIC COLUMNS
 // ================================================================================================
@@ -63,7 +51,7 @@ pub fn get_periodic_column_values() -> Vec<Vec<Felt>> {
 
 /// Returns the boundary assertions for the hash chiplet at the first step.
 pub fn get_assertions_first_step(result: &mut Vec<Assertion<Felt>>) {
-    result.push(Assertion::single(ROW_COL_IDX, 0, Felt::ONE));
+    result.push(Assertion::single(HASHER_ROW_COL_IDX, 0, Felt::ONE));
 }
 
 // HASHER TRANSITION CONSTRAINTS
@@ -454,19 +442,19 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
 
     #[inline(always)]
     fn s(&self, idx: usize) -> E {
-        self.current()[SELECTOR_COL_RANGE.start + idx]
+        self.current()[HASHER_SELECTOR_COL_RANGE.start + idx]
     }
     #[inline(always)]
     fn s_next(&self, idx: usize) -> E {
-        self.next()[SELECTOR_COL_RANGE.start + idx]
+        self.next()[HASHER_SELECTOR_COL_RANGE.start + idx]
     }
     #[inline(always)]
     fn row(&self) -> E {
-        self.current()[ROW_COL_IDX]
+        self.current()[HASHER_ROW_COL_IDX]
     }
     #[inline(always)]
     fn row_next(&self) -> E {
-        self.next()[ROW_COL_IDX]
+        self.next()[HASHER_ROW_COL_IDX]
     }
     #[inline(always)]
     fn hash_state(&self) -> &[E] {
@@ -486,11 +474,11 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
     }
     #[inline(always)]
     fn i(&self) -> E {
-        self.current()[NODE_INDEX_COL_IDX]
+        self.current()[HASHER_NODE_INDEX_COL_IDX]
     }
     #[inline(always)]
     fn i_next(&self) -> E {
-        self.next()[NODE_INDEX_COL_IDX]
+        self.next()[HASHER_NODE_INDEX_COL_IDX]
     }
 
     // --- Intermediate variables & helpers -------------------------------------------------------

--- a/air/src/chiplets/hasher/tests.rs
+++ b/air/src/chiplets/hasher/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    enforce_constraints, Hasher, HASHER_STATE_COL_RANGE, NODE_INDEX_COL_IDX, NUM_CONSTRAINTS,
-    ROW_COL_IDX, SELECTOR_COL_RANGE,
+    enforce_constraints, Hasher, HASHER_NODE_INDEX_COL_IDX, HASHER_ROW_COL_IDX,
+    HASHER_SELECTOR_COL_RANGE, HASHER_STATE_COL_RANGE, NUM_CONSTRAINTS,
 };
 use rand_utils::rand_array;
 use vm_core::{
@@ -74,12 +74,12 @@ fn get_test_hashing_frame(
     let mut next = vec![Felt::ZERO; TRACE_WIDTH];
 
     // Set the selectors for the hash operation.
-    current[SELECTOR_COL_RANGE].copy_from_slice(&current_selectors);
-    next[SELECTOR_COL_RANGE].copy_from_slice(&next_selectors);
+    current[HASHER_SELECTOR_COL_RANGE].copy_from_slice(&current_selectors);
+    next[HASHER_SELECTOR_COL_RANGE].copy_from_slice(&next_selectors);
 
     // add the row values
-    current[ROW_COL_IDX] = Felt::new(cycle_row_num as u64);
-    next[ROW_COL_IDX] = Felt::new(cycle_row_num as u64 + 1);
+    current[HASHER_ROW_COL_IDX] = Felt::new(cycle_row_num as u64);
+    next[HASHER_ROW_COL_IDX] = Felt::new(cycle_row_num as u64 + 1);
 
     // Set the starting hasher state.
     let mut state = rand_array();
@@ -90,8 +90,8 @@ fn get_test_hashing_frame(
     next[HASHER_STATE_COL_RANGE].copy_from_slice(&state);
 
     // Set the node index values to zero for hash computations.
-    current[NODE_INDEX_COL_IDX] = Felt::ZERO;
-    next[NODE_INDEX_COL_IDX] = Felt::ZERO;
+    current[HASHER_NODE_INDEX_COL_IDX] = Felt::ZERO;
+    next[HASHER_NODE_INDEX_COL_IDX] = Felt::ZERO;
 
     EvaluationFrame::from_rows(current, next)
 }

--- a/air/src/chiplets/hasher/tests.rs
+++ b/air/src/chiplets/hasher/tests.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use rand_utils::rand_array;
 use vm_core::{
-    hasher::{apply_round, Selectors, LINEAR_HASH, STATE_WIDTH},
+    chiplets::hasher::{apply_round, Selectors, LINEAR_HASH, STATE_WIDTH},
     Felt, FieldElement, TRACE_WIDTH,
 };
 use winter_air::EvaluationFrame;

--- a/air/src/chiplets/mod.rs
+++ b/air/src/chiplets/mod.rs
@@ -1,6 +1,6 @@
 use super::{Assertion, EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree, Vec};
 use crate::utils::{are_equal, binary_not, is_binary};
-use vm_core::{chiplets::HASHER_TRACE_OFFSET, CHIPLETS_OFFSET};
+use vm_core::CHIPLETS_OFFSET;
 
 mod bitwise;
 mod hasher;

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 
 use vm_core::{
-    hasher::Digest,
+    chiplets::hasher::Digest,
     utils::{collections::Vec, ByteWriter, Serializable},
     ExtensionOf, CLK_COL_IDX, FMP_COL_IDX, MIN_STACK_DEPTH, STACK_TRACE_OFFSET,
 };

--- a/assembly/src/parsers/io_ops/mod.rs
+++ b/assembly/src/parsers/io_ops/mod.rs
@@ -257,7 +257,7 @@ pub fn parse_storew(
 ///   values (represented by 32-bit limbs), divides one value by another, and injects the quotient
 ///   and the remainder into the advice tape.
 pub fn parse_adv_inject(
-    span_ops: &mut Vec<Operation>,
+    span_ops: &mut [Operation],
     op: &Token,
     decorators: &mut DecoratorList,
 ) -> Result<(), AssemblyError> {

--- a/core/src/chiplets/mod.rs
+++ b/core/src/chiplets/mod.rs
@@ -27,6 +27,17 @@ pub const MEMORY_TRACE_OFFSET: usize = CHIPLETS_OFFSET + NUM_MEMORY_SELECTORS;
 
 // --- GLOBALLY-INDEXED CHIPLET COLUMN ACCESSORS --------------------------------------------------
 
+/// The column index range in the execution trace containing the selector columns in the hasher.
+pub const HASHER_SELECTOR_COL_RANGE: Range<usize> =
+    create_range(HASHER_TRACE_OFFSET, hasher::NUM_SELECTORS);
+/// The index of the hasher's row column in the execution trace.
+pub const HASHER_ROW_COL_IDX: usize = HASHER_SELECTOR_COL_RANGE.end;
+/// The range of columns in the execution trace that contain the hasher's state.
+pub const HASHER_STATE_COL_RANGE: Range<usize> =
+    create_range(HASHER_ROW_COL_IDX + 1, hasher::STATE_WIDTH);
+/// The index of the hasher's node index column in the execution trace.
+pub const HASHER_NODE_INDEX_COL_IDX: usize = HASHER_STATE_COL_RANGE.end;
+
 /// The range within the main trace of the bitwise selector columns.
 pub const BITWISE_SELECTOR_COL_RANGE: Range<usize> =
     create_range(BITWISE_TRACE_OFFSET, bitwise::NUM_SELECTORS);

--- a/core/src/inputs/mod.rs
+++ b/core/src/inputs/mod.rs
@@ -1,6 +1,6 @@
 use super::{
+    chiplets::hasher,
     errors::{AdviceSetError, InputError},
-    hasher,
     utils::IntoBytes,
     Felt, FieldElement, Word, MIN_STACK_DEPTH,
 };

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,7 +7,6 @@ extern crate alloc;
 use core::ops::Range;
 
 pub mod chiplets;
-pub use chiplets::hasher;
 pub mod decoder;
 pub mod errors;
 pub mod range;

--- a/core/src/program/blocks/span_block.rs
+++ b/core/src/program/blocks/span_block.rs
@@ -378,7 +378,7 @@ pub fn get_span_op_group_count(op_batches: &[OpBatch]) -> usize {
 /// - Assert the decorator list is in ascending order.
 /// - Assert the last op index in decorator list is less than the number of operations.
 #[cfg(debug_assertions)]
-fn validate_decorators(operations: &Vec<Operation>, decorators: &DecoratorList) {
+fn validate_decorators(operations: &[Operation], decorators: &DecoratorList) {
     if !decorators.is_empty() {
         // check if decorator list is sorted
         for i in 0..(decorators.len() - 1) {

--- a/core/src/program/mod.rs
+++ b/core/src/program/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    hasher::{self, Digest},
+    chiplets::hasher::{self, Digest},
     utils::{collections::Vec, Box},
     Felt, FieldElement, Operation,
 };

--- a/miden/tests/integration/operations/crypto_ops.rs
+++ b/miden/tests/integration/operations/crypto_ops.rs
@@ -1,6 +1,6 @@
 use rand_utils::rand_vector;
 use vm_core::{
-    hasher::{apply_permutation, hash_elements, STATE_WIDTH},
+    chiplets::hasher::{apply_permutation, hash_elements, STATE_WIDTH},
     AdviceSet, Felt, FieldElement, StarkField,
 };
 

--- a/processor/src/chiplets/hasher/mod.rs
+++ b/processor/src/chiplets/hasher/mod.rs
@@ -1,5 +1,5 @@
 use super::{Felt, FieldElement, OpBatch, StarkField, TraceFragment, Vec, Word, ZERO};
-use vm_core::hasher::{
+use vm_core::chiplets::hasher::{
     absorb_into_state, get_digest, init_state, init_state_from_words, Selectors, LINEAR_HASH,
     MP_VERIFY, MR_UPDATE_NEW, MR_UPDATE_OLD, RETURN_HASH, RETURN_STATE, STATE_WIDTH, TRACE_WIDTH,
 };

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use rand_utils::rand_array;
 use vm_core::{
-    hasher::{self, NUM_ROUNDS},
+    chiplets::hasher::{self, NUM_ROUNDS},
     AdviceSet, ONE, ZERO,
 };
 
@@ -413,7 +413,7 @@ fn assert_row_equal(trace: &[Vec<Felt>], row_idx: usize, values: &[Felt]) {
 }
 
 fn apply_permutation(mut state: HasherState) -> HasherState {
-    vm_core::hasher::apply_permutation(&mut state);
+    hasher::apply_permutation(&mut state);
     state
 }
 

--- a/processor/src/chiplets/hasher/trace.rs
+++ b/processor/src/chiplets/hasher/trace.rs
@@ -1,5 +1,7 @@
-use super::{Felt, FieldElement, HasherState, Selectors, TraceFragment, Vec, TRACE_WIDTH};
-use vm_core::hasher::{apply_round, NUM_ROUNDS, STATE_WIDTH};
+use super::{
+    Felt, FieldElement, HasherState, Selectors, TraceFragment, Vec, STATE_WIDTH, TRACE_WIDTH,
+};
+use vm_core::chiplets::hasher::{apply_round, NUM_ROUNDS};
 
 // HASHER TRACE
 // ================================================================================================

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -1,7 +1,9 @@
 use crate::{utils::get_trace_len, CodeBlock, ExecutionTrace, Operation, Process};
 use vm_core::{
-    chiplets::bitwise::{BITWISE_OR, OP_CYCLE_LEN},
-    hasher::{HASH_CYCLE_LEN, LINEAR_HASH, RETURN_STATE},
+    chiplets::{
+        bitwise::{BITWISE_OR, OP_CYCLE_LEN},
+        hasher::{HASH_CYCLE_LEN, LINEAR_HASH, RETURN_STATE},
+    },
     Felt, FieldElement, ProgramInputs, CHIPLETS_RANGE, CHIPLETS_WIDTH,
 };
 

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -3,12 +3,12 @@ use super::{
     StarkField, Vec, Word, MIN_TRACE_LEN, ONE, OP_BATCH_SIZE, ZERO,
 };
 use vm_core::{
+    chiplets::hasher::DIGEST_LEN,
     code_blocks::get_span_op_group_count,
     decoder::{
         NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS, OP_BATCH_1_GROUPS, OP_BATCH_2_GROUPS,
         OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS,
     },
-    hasher::DIGEST_LEN,
     AssemblyOp,
 };
 
@@ -27,7 +27,7 @@ mod tests;
 // CONSTANTS
 // ================================================================================================
 
-const HASH_CYCLE_LEN: Felt = Felt::new(vm_core::hasher::HASH_CYCLE_LEN as u64);
+const HASH_CYCLE_LEN: Felt = Felt::new(vm_core::chiplets::hasher::HASH_CYCLE_LEN as u64);
 
 // DECODER PROCESS EXTENSION
 // ================================================================================================

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -5,9 +5,9 @@
 extern crate alloc;
 
 use vm_core::{
+    chiplets::hasher::Digest,
     code_blocks::{CodeBlock, Join, Loop, OpBatch, Span, Split, OP_BATCH_SIZE, OP_GROUP_SIZE},
     errors::AdviceSetError,
-    hasher::Digest,
     utils::collections::{BTreeMap, Vec},
     AdviceInjector, Decorator, DecoratorIterator, Felt, FieldElement, Operation, Program,
     ProgramInputs, StackTopState, StarkField, Word, CHIPLETS_WIDTH, DECODER_TRACE_WIDTH,

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -219,7 +219,7 @@ mod tests {
     use crate::Word;
     use rand_utils::rand_vector;
     use vm_core::{
-        hasher::{apply_permutation, STATE_WIDTH},
+        chiplets::hasher::{apply_permutation, STATE_WIDTH},
         AdviceSet, ProgramInputs,
     };
 

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -32,7 +32,7 @@ pub const NUM_RAND_ROWS: usize = 1;
 // TYPE ALIASES
 // ================================================================================================
 
-type RandomCoin = vm_core::utils::RandomCoin<Felt, vm_core::hasher::Hasher>;
+type RandomCoin = vm_core::utils::RandomCoin<Felt, vm_core::chiplets::hasher::Hasher>;
 
 // VM EXECUTION TRACE
 // ================================================================================================

--- a/processor/src/trace/tests/chiplets/bitwise.rs
+++ b/processor/src/trace/tests/chiplets/bitwise.rs
@@ -1,23 +1,13 @@
 use super::{
-    super::{Trace, NUM_RAND_ROWS},
-    build_trace_from_ops, rand_array, ExecutionTrace, Felt, FieldElement, Operation, Word, ONE,
-    ZERO,
+    build_trace_from_ops, rand_array, rand_value, ExecutionTrace, Felt, FieldElement, Operation,
+    Trace, AUX_TRACE_RAND_ELEMENTS, CHIPLETS_AUX_TRACE_OFFSET, HASH_CYCLE_LEN, NUM_RAND_ROWS, ONE,
 };
-use rand_utils::rand_value;
-use vm_core::{
-    chiplets::{
-        bitwise::{
-            Selectors, BITWISE_AND, BITWISE_AND_LABEL, BITWISE_OR, BITWISE_OR_LABEL, BITWISE_XOR,
-            BITWISE_XOR_LABEL, OP_CYCLE_LEN,
-        },
-        hasher::HASH_CYCLE_LEN,
-        memory::{
-            ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, MEMORY_LABEL, NUM_ELEMENTS, U_COL_RANGE,
-            V_COL_RANGE,
-        },
-        BITWISE_A_COL_IDX, BITWISE_B_COL_IDX, BITWISE_OUTPUT_COL_IDX, BITWISE_TRACE_OFFSET,
+use vm_core::chiplets::{
+    bitwise::{
+        Selectors, BITWISE_AND, BITWISE_AND_LABEL, BITWISE_OR, BITWISE_OR_LABEL, BITWISE_XOR,
+        BITWISE_XOR_LABEL, OP_CYCLE_LEN,
     },
-    AUX_TRACE_RAND_ELEMENTS, CHIPLETS_AUX_TRACE_OFFSET,
+    BITWISE_A_COL_IDX, BITWISE_B_COL_IDX, BITWISE_OUTPUT_COL_IDX, BITWISE_TRACE_OFFSET,
 };
 
 /// Tests the generation of the `b_aux` bus column when only bitwise lookups are included. It
@@ -145,98 +135,6 @@ fn b_aux_trace_bitwise() {
     }
 }
 
-/// Tests the generation of the `b_aux` bus column when only memory lookups are included. It ensures
-/// that trace generation is correct when all of the following are true.
-///
-/// - All possible memory operations are called by the stack.
-/// - Some requests from the Stack and responses from Memory occur at the same cycle.
-/// - Multiple memory addresses are used.
-#[test]
-#[allow(clippy::needless_range_loop)]
-fn b_aux_trace_mem() {
-    let stack = [1, 2, 3, 4, 0];
-    let word = [ONE, Felt::new(2), Felt::new(3), Felt::new(4)];
-    let operations = vec![
-        Operation::MStoreW, // store [1, 2, 3, 4]
-        Operation::Drop,    // clear the stack
-        Operation::Drop,
-        Operation::Drop,
-        Operation::Drop,
-        Operation::MLoad,     // read the first value of the word
-        Operation::MovDn5,    // put address 0 and space for a full word at top of stack
-        Operation::MLoadW,    // load word from address 0 to stack
-        Operation::Push(ONE), // push a new value onto the stack
-        Operation::Push(ONE), // push a new address on to the stack
-        Operation::MStore,    // store 1 at address 1
-        Operation::Drop,      // ensure the stack overflow table is empty
-    ];
-    let mut trace = build_trace_from_ops(operations, &stack);
-
-    let rand_elements = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
-    let aux_columns = trace.build_aux_segment(&[], &rand_elements).unwrap();
-    let b_aux = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
-
-    assert_eq!(trace.length(), b_aux.len());
-    assert_eq!(ONE, b_aux[0]);
-    assert_eq!(ONE, b_aux[1]);
-
-    // The first memory request from the stack is sent when the `MStoreW` operation is executed, at
-    // cycle 1, so the request is included in the next row. (The trace begins by executing `span`).
-    let value = build_expected_memory(&rand_elements, ZERO, ZERO, Felt::new(1), [ZERO; 4], word);
-    let mut expected = value.inv();
-    assert_eq!(expected, b_aux[2]);
-
-    // Nothing changes after user operations that don't make requests to the Chiplets.
-    for row in 3..7 {
-        assert_eq!(expected, b_aux[row]);
-    }
-
-    // The next memory request from the stack is sent when `MLoad` is executed at cycle 6 and
-    // included at row 7
-    let value = build_expected_memory(&rand_elements, ZERO, ZERO, Felt::new(6), word, word);
-    expected *= value.inv();
-    assert_eq!(expected, b_aux[7]);
-
-    // Nothing changes in row 8.
-    assert_eq!(expected, b_aux[8]);
-
-    // Memory responses will be provided during the memory segment of the Chiplets trace,
-    // which starts after the hash for the span block at row 8. There will be 4 rows, corresponding
-    // to the four Memory operations.
-
-    // At cycle 8 `MLoadW` is requested by the stack and `MStoreW` is provided by memory
-    let value = build_expected_memory(&rand_elements, ZERO, ZERO, Felt::new(8), word, word);
-    expected *= value.inv();
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 8);
-    assert_eq!(expected, b_aux[9]);
-
-    // At cycle 9, `MLoad` is provided by memory.
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 9);
-    assert_eq!(expected, b_aux[10]);
-
-    // At cycle 10,  `MLoadW` is provided by memory.
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 10);
-    assert_eq!(expected, b_aux[11]);
-
-    // At cycle 11, `MStore` is requested by the stack and provided by memory.
-    let value = build_expected_memory(
-        &rand_elements,
-        ZERO,
-        ONE,
-        Felt::new(11),
-        [ZERO; 4],
-        [ONE, ZERO, ZERO, ZERO],
-    );
-    expected *= value.inv();
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 11);
-    assert_eq!(expected, b_aux[12]);
-
-    // The value in b_aux should be ONE now and for the rest of the trace.
-    for row in 12..trace.length() - NUM_RAND_ROWS {
-        assert_eq!(ONE, b_aux[row]);
-    }
-}
-
 // TEST HELPERS
 // ================================================================================================
 
@@ -264,44 +162,4 @@ fn build_expected_bitwise_from_trace(trace: &ExecutionTrace, alphas: &[Felt], ro
     let output = trace.main_trace.get_column(BITWISE_OUTPUT_COL_IDX)[row];
 
     build_expected_bitwise(alphas, op_id, a, b, output)
-}
-
-fn build_expected_memory(
-    alphas: &[Felt],
-    ctx: Felt,
-    addr: Felt,
-    clk: Felt,
-    old_word: Word,
-    new_word: Word,
-) -> Felt {
-    let mut old_word_value = ZERO;
-    let mut new_word_value = ZERO;
-
-    for i in 0..NUM_ELEMENTS {
-        old_word_value += alphas[i + 5] * old_word[i];
-        new_word_value += alphas[i + 9] * new_word[i];
-    }
-
-    alphas[0]
-        + alphas[1] * MEMORY_LABEL
-        + alphas[2] * ctx
-        + alphas[3] * addr
-        + alphas[4] * clk
-        + old_word_value
-        + new_word_value
-}
-
-fn build_expected_memory_from_trace(trace: &ExecutionTrace, alphas: &[Felt], row: usize) -> Felt {
-    let ctx = trace.main_trace.get_column(CTX_COL_IDX)[row];
-    let addr = trace.main_trace.get_column(ADDR_COL_IDX)[row];
-    let clk = trace.main_trace.get_column(CLK_COL_IDX)[row];
-    let mut old_word = [ZERO; NUM_ELEMENTS];
-    let mut new_word = [ZERO; NUM_ELEMENTS];
-
-    for i in 0..NUM_ELEMENTS {
-        old_word[i] = trace.main_trace.get_column(U_COL_RANGE.start + i)[row];
-        new_word[i] = trace.main_trace.get_column(V_COL_RANGE.start + i)[row];
-    }
-
-    build_expected_memory(alphas, ctx, addr, clk, old_word, new_word)
 }

--- a/processor/src/trace/tests/chiplets/memory.rs
+++ b/processor/src/trace/tests/chiplets/memory.rs
@@ -1,0 +1,142 @@
+use super::{
+    build_trace_from_ops, rand_array, ExecutionTrace, Felt, FieldElement, Operation, Trace, Word,
+    AUX_TRACE_RAND_ELEMENTS, CHIPLETS_AUX_TRACE_OFFSET, NUM_RAND_ROWS, ONE, ZERO,
+};
+use vm_core::chiplets::memory::{
+    ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, MEMORY_LABEL, NUM_ELEMENTS, U_COL_RANGE, V_COL_RANGE,
+};
+
+/// Tests the generation of the `b_aux` bus column when only memory lookups are included. It ensures
+/// that trace generation is correct when all of the following are true.
+///
+/// - All possible memory operations are called by the stack.
+/// - Some requests from the Stack and responses from Memory occur at the same cycle.
+/// - Multiple memory addresses are used.
+#[test]
+#[allow(clippy::needless_range_loop)]
+fn b_aux_trace_mem() {
+    let stack = [1, 2, 3, 4, 0];
+    let word = [ONE, Felt::new(2), Felt::new(3), Felt::new(4)];
+    let operations = vec![
+        Operation::MStoreW, // store [1, 2, 3, 4]
+        Operation::Drop,    // clear the stack
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::MLoad,     // read the first value of the word
+        Operation::MovDn5,    // put address 0 and space for a full word at top of stack
+        Operation::MLoadW,    // load word from address 0 to stack
+        Operation::Push(ONE), // push a new value onto the stack
+        Operation::Push(ONE), // push a new address on to the stack
+        Operation::MStore,    // store 1 at address 1
+        Operation::Drop,      // ensure the stack overflow table is empty
+    ];
+    let mut trace = build_trace_from_ops(operations, &stack);
+
+    let rand_elements = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
+    let aux_columns = trace.build_aux_segment(&[], &rand_elements).unwrap();
+    let b_aux = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
+
+    assert_eq!(trace.length(), b_aux.len());
+    assert_eq!(ONE, b_aux[0]);
+    assert_eq!(ONE, b_aux[1]);
+
+    // The first memory request from the stack is sent when the `MStoreW` operation is executed, at
+    // cycle 1, so the request is included in the next row. (The trace begins by executing `span`).
+    let value = build_expected_memory(&rand_elements, ZERO, ZERO, Felt::new(1), [ZERO; 4], word);
+    let mut expected = value.inv();
+    assert_eq!(expected, b_aux[2]);
+
+    // Nothing changes after user operations that don't make requests to the Chiplets.
+    for row in 3..7 {
+        assert_eq!(expected, b_aux[row]);
+    }
+
+    // The next memory request from the stack is sent when `MLoad` is executed at cycle 6 and
+    // included at row 7
+    let value = build_expected_memory(&rand_elements, ZERO, ZERO, Felt::new(6), word, word);
+    expected *= value.inv();
+    assert_eq!(expected, b_aux[7]);
+
+    // Nothing changes in row 8.
+    assert_eq!(expected, b_aux[8]);
+
+    // Memory responses will be provided during the memory segment of the Chiplets trace,
+    // which starts after the hash for the span block at row 8. There will be 4 rows, corresponding
+    // to the four Memory operations.
+
+    // At cycle 8 `MLoadW` is requested by the stack and `MStoreW` is provided by memory
+    let value = build_expected_memory(&rand_elements, ZERO, ZERO, Felt::new(8), word, word);
+    expected *= value.inv();
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 8);
+    assert_eq!(expected, b_aux[9]);
+
+    // At cycle 9, `MLoad` is provided by memory.
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 9);
+    assert_eq!(expected, b_aux[10]);
+
+    // At cycle 10,  `MLoadW` is provided by memory.
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 10);
+    assert_eq!(expected, b_aux[11]);
+
+    // At cycle 11, `MStore` is requested by the stack and provided by memory.
+    let value = build_expected_memory(
+        &rand_elements,
+        ZERO,
+        ONE,
+        Felt::new(11),
+        [ZERO; 4],
+        [ONE, ZERO, ZERO, ZERO],
+    );
+    expected *= value.inv();
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 11);
+    assert_eq!(expected, b_aux[12]);
+
+    // The value in b_aux should be ONE now and for the rest of the trace.
+    for row in 12..trace.length() - NUM_RAND_ROWS {
+        assert_eq!(ONE, b_aux[row]);
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+fn build_expected_memory(
+    alphas: &[Felt],
+    ctx: Felt,
+    addr: Felt,
+    clk: Felt,
+    old_word: Word,
+    new_word: Word,
+) -> Felt {
+    let mut old_word_value = ZERO;
+    let mut new_word_value = ZERO;
+
+    for i in 0..NUM_ELEMENTS {
+        old_word_value += alphas[i + 5] * old_word[i];
+        new_word_value += alphas[i + 9] * new_word[i];
+    }
+
+    alphas[0]
+        + alphas[1] * MEMORY_LABEL
+        + alphas[2] * ctx
+        + alphas[3] * addr
+        + alphas[4] * clk
+        + old_word_value
+        + new_word_value
+}
+
+fn build_expected_memory_from_trace(trace: &ExecutionTrace, alphas: &[Felt], row: usize) -> Felt {
+    let ctx = trace.main_trace.get_column(CTX_COL_IDX)[row];
+    let addr = trace.main_trace.get_column(ADDR_COL_IDX)[row];
+    let clk = trace.main_trace.get_column(CLK_COL_IDX)[row];
+    let mut old_word = [ZERO; NUM_ELEMENTS];
+    let mut new_word = [ZERO; NUM_ELEMENTS];
+
+    for i in 0..NUM_ELEMENTS {
+        old_word[i] = trace.main_trace.get_column(U_COL_RANGE.start + i)[row];
+        new_word[i] = trace.main_trace.get_column(V_COL_RANGE.start + i)[row];
+    }
+
+    build_expected_memory(alphas, ctx, addr, clk, old_word, new_word)
+}

--- a/processor/src/trace/tests/chiplets/mod.rs
+++ b/processor/src/trace/tests/chiplets/mod.rs
@@ -1,0 +1,12 @@
+use super::{
+    super::{Trace, NUM_RAND_ROWS},
+    build_trace_from_ops, rand_array, ExecutionTrace, Felt, FieldElement, Operation, Word, ONE,
+    ZERO,
+};
+use rand_utils::rand_value;
+use vm_core::{
+    chiplets::hasher::HASH_CYCLE_LEN, AUX_TRACE_RAND_ELEMENTS, CHIPLETS_AUX_TRACE_OFFSET,
+};
+
+mod bitwise;
+mod memory;

--- a/processor/src/trace/tests/hasher.rs
+++ b/processor/src/trace/tests/hasher.rs
@@ -4,7 +4,9 @@ use super::{
     Word, ONE, ZERO,
 };
 use crate::chiplets::SiblingTableRow;
-use vm_core::{hasher::P1_COL_IDX, AdviceSet, FieldElement, StarkField, AUX_TRACE_RAND_ELEMENTS};
+use vm_core::{
+    chiplets::hasher::P1_COL_IDX, AdviceSet, FieldElement, StarkField, AUX_TRACE_RAND_ELEMENTS,
+};
 
 // SIBLING TABLE TESTS
 // ================================================================================================

--- a/processor/src/trace/tests/range.rs
+++ b/processor/src/trace/tests/range.rs
@@ -2,7 +2,7 @@ use super::{build_trace_from_ops, Felt, FieldElement, Trace, NUM_RAND_ROWS};
 use crate::{ONE, ZERO};
 use rand_utils::rand_array;
 use vm_core::{
-    hasher::HASH_CYCLE_LEN,
+    chiplets::hasher::HASH_CYCLE_LEN,
     range::{P0_COL_IDX, P1_COL_IDX, Q_COL_IDX},
     Operation, AUX_TRACE_RAND_ELEMENTS,
 };

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -9,7 +9,7 @@ use winterfell::VerifierError;
 // ================================================================================================
 
 pub use assembly;
-pub use vm_core::hasher::Digest;
+pub use vm_core::chiplets::hasher::Digest;
 pub use winterfell::StarkProof;
 
 // VERIFIER


### PR DESCRIPTION
This PR is a precursor to the PR that will complete the inclusion of the hasher lookups in the b_chip bus column. It includes the following refactors:

- removes the re-export of the hasher module at the top level of `core` and switches imports to go through core::chiplets::hasher (rather than core::hasher)
- moves the index constants for identifying hasher columns within the main trace from `air` to `core`
- moves b_chip tests for memory and bitwise lookups into their own files