### PR TITLE
Stack input / output ordering fix

### DIFF
--- a/core/src/inputs/mod.rs
+++ b/core/src/inputs/mod.rs
@@ -40,6 +40,10 @@ impl ProgramInputs {
     /// Returns [ProgramInputs] instantiated with the specified initial stack values, advice tape
     /// values, and advice sets.
     ///
+    /// The initial stack values are put onto the stack in the order as if they were pushed onto
+    /// the stack one by one. The result of this is that the last value in the `stack_init` slice
+    /// will end up at the top of the stack.
+    ///
     /// # Errors
     /// Returns an error if:
     /// - The number initial stack values is greater than 16.

--- a/docs/src/intro/overview.md
+++ b/docs/src/intro/overview.md
@@ -6,7 +6,7 @@ Miden VM consists of three high-level components as illustrated below.
 ![](../assets/intro/vm_components.png)
 
 These components are:
-* **Stack** which is a push-down stack where each item is a field element. Most assembly instructions operate with values located on the stack. The stack can grow up to $2^{16}$ items deep, however, only the top 16 items are directly accessible.
+* **Stack** which is a push-down stack where each item is a field element. Most assembly instructions operate with values located on the stack. The stack can grow up to $2^{32}$ items deep, however, only the top 16 items are directly accessible.
 * **Memory** which is a linear random-access read-write memory. The memory is word-addressable, meaning, four elements are located at each address, and we can read and write elements to/from memory in batches of four. Memory addresses can be in the range $[0, 2^{32})$.
 * **Advice provider** which is a way for the prover to provide nondeterministic inputs to the VM. The advice provider contains a single *advice tape* and unlimited number of *advice sets*. The latter contain structured data which can be interpreted as a set of Merkle paths.
 
@@ -30,6 +30,11 @@ Having only 16 elements to describe public inputs and outputs of a program may s
 For example, if we wanted to provide a thousand public input values to the VM, we could put these values into a Merkle tree, initialize the stack with the root of this tree, initialize the advice provider with the tree itself, and then retrieve values from the tree during program execution using `mtree_get` instruction (described [here](../user_docs/assembly/cryptographic_operations.md#hashing-and-merkle-trees)).
 
 In the future, other ways of providing public inputs and reading public outputs (e.g., storage commitments) may be added to the VM.
+
+### Stack depth restrictions
+For reasons explained [here](../design/stack/main.md), the VM imposes the following restrictions on stack depth:
+1. Stack depth cannot be smaller than $16$. When initializing a program with fewer than $16$ inputs, the VM will pad the stack with zeros to ensure the depth is $16$ at the beginning of execution. If an operation would result in the stack depth dropping below $16$, the VM will insert a zero at the deep end of the stack to make sure the depth stays at $16$.
+2. At the end of program execution, stack depth cannot be greater than $16$. If ensuring this manually is difficult, [finalize_stack](../user_docs/stdlib/sys.md) procedure can be called at the end of program execution. This procedure will remove items deep in the stack while keeping the top $16$ items untouched.
 
 ### Nondeterministic inputs
 The *advice provider* component is responsible for supplying nondeterministic inputs to the VM. These inputs only need to be known to the prover (i.e., they do not need to be shared with the verifier).

--- a/docs/src/user_docs/main.md
+++ b/docs/src/user_docs/main.md
@@ -1,5 +1,8 @@
 # User Documentation
+In the following sections, we provide developer-focused documentation useful to those who want to develop on Miden VM or build compilers from higher-level languages to Miden VM.
 
+This documentation consists of two high-level sections:
+- [Miden assembly](./assembly/main.md) which provides a detailed description of Miden assembly language, which is the native language of Miden VM.
+- [Miden Standard Library](./stdlib/main.md) which provides descriptions of all procedures available in Miden Standard Library.
 
-- [Miden Assembly](./assembly/main.md)
-- [Miden Standard Library](./stdlib/main.md)
+For info on how to run programs on Miden VM, please refer to the [usage](../intro/usage.md) section in the introduction.

--- a/miden/tests/integration/main.rs
+++ b/miden/tests/integration/main.rs
@@ -14,6 +14,12 @@ fn simple_program() {
     build_test!("begin push.1 push.2 add end").expect_stack(&[3]);
 }
 
+#[test]
+fn multi_io_program() {
+    let test = build_test!("begin mul movup.2 drop end", &[1, 2, 3]);
+    test.prove_and_verify(vec![1, 2, 3], 2, false);
+}
+
 // MACROS TO BUILD TESTS
 // ================================================================================================
 

--- a/miden/tests/integration/main.rs
+++ b/miden/tests/integration/main.rs
@@ -15,7 +15,7 @@ fn simple_program() {
 }
 
 #[test]
-fn multi_io_program() {
+fn multi_output_program() {
     let test = build_test!("begin mul movup.2 drop end", &[1, 2, 3]);
     test.prove_and_verify(vec![1, 2, 3], 2, false);
 }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -17,8 +17,16 @@ pub use winterfell::StarkProof;
 /// Returns Ok(()) if the specified program was executed correctly against the specified inputs
 /// and outputs.
 ///
-/// Specifically, verifies that if a program with the specified `program_hash` is executed with the
-/// provided `public_inputs` and some secret inputs, and the result is equal to the `outputs`.
+/// Specifically, verifies that if a program with the specified `program_hash` is executed against
+/// the provided `stack_inputs` and some secret inputs, the result is equal to the `stack_outputs`.
+///
+/// Stack inputs are expected to be provided in the order as if they were pushed onto the stack
+/// one by one. Thus, the last value in the `stack_inputs` slice is expected to be the value at
+/// the top of the stack.
+///
+/// Stack outputs are expected to be provided in the order as if they were popped off the stack
+/// one by one. Thus, the value at the top of the stack is expected to be be in the first position
+/// of the `stack_outputs` slice. This the reverse of order of `stack_inputs` slice.
 ///
 /// # Errors
 /// Returns an error if the provided proof does not prove a correct execution of the program.
@@ -54,7 +62,7 @@ pub fn verify(
 
     // convert stack outputs to field elements
     let mut stack_output_felts = Vec::with_capacity(stack_outputs.len());
-    for &output in stack_outputs.iter().rev() {
+    for &output in stack_outputs.iter() {
         stack_output_felts.push(
             output
                 .try_into()

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -20,13 +20,15 @@ pub use winterfell::StarkProof;
 /// Specifically, verifies that if a program with the specified `program_hash` is executed against
 /// the provided `stack_inputs` and some secret inputs, the result is equal to the `stack_outputs`.
 ///
-/// Stack inputs are expected to be provided in the order as if they were pushed onto the stack
-/// one by one. Thus, the last value in the `stack_inputs` slice is expected to be the value at
-/// the top of the stack.
+/// Stack inputs are expected to be ordered as if they would be pushed onto the stack one by one.
+/// Thus, their expected order on the stack will be the reverse of the order in which they are
+/// provided, and the last value in the `stack_inputs` slice is expected to be the value at the top
+/// of the stack.
 ///
-/// Stack outputs are expected to be provided in the order as if they were popped off the stack
-/// one by one. Thus, the value at the top of the stack is expected to be be in the first position
-/// of the `stack_outputs` slice. This the reverse of order of `stack_inputs` slice.
+/// Stack outputs are expected to be ordered as if they would be popped off the stack one by one.
+/// Thus, the value at the top of the stack is expected to be be in the first position of the
+/// `stack_outputs` slice, and the order of the rest of the output elements will also match the
+/// order on the stack. This the reverse of order of `stack_inputs` slice.
 ///
 /// # Errors
 /// Returns an error if the provided proof does not prove a correct execution of the program.


### PR DESCRIPTION
This PR fixes a bug reported in #342 - specifically, the one where output ordering had to be reversed the the verifier to accept the proof. It also adds documentation to clarify expected ordering of inputs and outputs, as well as a note on stack depth restrictions.