### PR TITLE
Add hasher lookups to the chiplets bus

### DIFF
--- a/core/src/chiplets/hasher.rs
+++ b/core/src/chiplets/hasher.rs
@@ -67,42 +67,42 @@ pub const TRACE_WIDTH: usize = NUM_SELECTORS + STATE_WIDTH + 2;
 pub const LINEAR_HASH: Selectors = [Felt::ONE, Felt::ZERO, Felt::ZERO];
 /// Unique label for the linear hash operation. Computed as 1 more than the binary composition of
 /// the chiplet and operation selectors [0, 1, 0, 0].
-pub const LINEAR_HASH_LABEL: Felt = Felt::new(3);
+pub const LINEAR_HASH_LABEL: u8 = 3;
 
 /// Specifies a start of Merkle path verification computation or absorption of a new path node
 /// into the hasher state.
 pub const MP_VERIFY: Selectors = [Felt::ONE, Felt::ZERO, Felt::ONE];
 /// Unique label for the merkle path verification operation. Computed as 1 more than the binary
 /// composition of the chiplet and operation selectors [0, 1, 0, 1].
-pub const MP_VERIFY_LABEL: Felt = Felt::new(11);
+pub const MP_VERIFY_LABEL: u8 = 11;
 
 /// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
 /// state for the "old" node value during Merkle root update computation.
 pub const MR_UPDATE_OLD: Selectors = [Felt::ONE, Felt::ONE, Felt::ZERO];
 /// Unique label for the merkle path update operation for an "old" node. Computed as 1 more than the
 /// binary composition of the chiplet and operation selectors [0, 1, 1, 0].
-pub const MR_UPDATE_OLD_LABEL: Felt = Felt::new(7);
+pub const MR_UPDATE_OLD_LABEL: u8 = 7;
 
 /// Specifies a start of Merkle path verification or absorption of a new path node into the hasher
 /// state for the "new" node value during Merkle root update computation.
 pub const MR_UPDATE_NEW: Selectors = [Felt::ONE, Felt::ONE, Felt::ONE];
 /// Unique label for the merkle path update operation for a "new" node. Computed as 1 more than the
 /// binary composition of the chiplet and operation selectors [0, 1, 1, 1].
-pub const MR_UPDATE_NEW_LABEL: Felt = Felt::new(15);
+pub const MR_UPDATE_NEW_LABEL: u8 = 15;
 
 /// Specifies a completion of a computation such that only the hash result (values in h0, h1, h2
 /// h3) is returned.
 pub const RETURN_HASH: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ZERO];
 /// Unique label for specifying the return of a hash result. Computed as 1 more than the binary
 /// composition of the chiplet and operation selectors [0, 0, 0, 0].
-pub const RETURN_HASH_LABEL: Felt = Felt::new(1);
+pub const RETURN_HASH_LABEL: u8 = 1;
 
 /// Specifies a completion of a computation such that the entire hasher state (values in h0 through
 /// h11) is returned.
 pub const RETURN_STATE: Selectors = [Felt::ZERO, Felt::ZERO, Felt::ONE];
 /// Unique label for specifying the return of the entire hasher state. Computed as 1 more than the
 /// binary composition of  the chiplet and operation selectors [0, 0, 0, 1]
-pub const RETURN_STATE_LABEL: Felt = Felt::new(9);
+pub const RETURN_STATE_LABEL: u8 = 9;
 
 // --- Column accessors in the auxiliary trace ----------------------------------------------------
 

--- a/core/src/chiplets/hasher.rs
+++ b/core/src/chiplets/hasher.rs
@@ -18,6 +18,9 @@ pub type Digest = <Hasher as HashFn>::Digest;
 /// is to be applied at a specific row of the hasher execution trace.
 pub type Selectors = [Felt; NUM_SELECTORS];
 
+/// Type for the Hasher's state.
+pub type HasherState = [Felt; STATE_WIDTH];
+
 // CONSTANTS
 // ================================================================================================
 

--- a/processor/src/chiplets/bitwise/mod.rs
+++ b/processor/src/chiplets/bitwise/mod.rs
@@ -200,8 +200,8 @@ impl Bitwise {
     pub fn fill_trace(
         self,
         trace: &mut TraceFragment,
-        bitwise_start_row: usize,
         chiplets_bus: &mut ChipletsBus,
+        bitwise_start_row: usize,
     ) {
         // make sure fragment dimensions are consistent with the dimensions of this trace
         debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace lengths");

--- a/processor/src/chiplets/bitwise/tests.rs
+++ b/processor/src/chiplets/bitwise/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{ChipletsLookup, ChipletsLookupRow},
+    super::bus::{ChipletsLookup, ChipletsLookupRow},
     Bitwise, BitwiseLookup, ChipletsBus, Felt, StarkField, TraceFragment, A_COL_IDX, BITWISE_AND,
     BITWISE_AND_LABEL, BITWISE_OR, BITWISE_OR_LABEL, BITWISE_XOR, BITWISE_XOR_LABEL, B_COL_IDX,
     OP_CYCLE_LEN, OUTPUT_COL_IDX, PREV_OUTPUT_COL_IDX, TRACE_WIDTH,
@@ -305,7 +305,7 @@ fn build_trace(bitwise: Bitwise, num_rows: usize) -> (Vec<Vec<Felt>>, ChipletsBu
         .map(|_| vec![Felt::new(0); num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
-    bitwise.fill_trace(&mut fragment, 0, &mut chiplets_bus);
+    bitwise.fill_trace(&mut fragment, &mut chiplets_bus, 0);
 
     (trace, chiplets_bus)
 }

--- a/processor/src/chiplets/bus/aux_trace.rs
+++ b/processor/src/chiplets/bus/aux_trace.rs
@@ -21,15 +21,15 @@ impl AuxTraceBuilder {
     // --------------------------------------------------------------------------------------------
 
     /// Builds and returns the Chiplets's auxiliary trace columns. Currently this consists of
-    /// a single bus column `b_aux` describing chiplet lookups requested by the stack and
+    /// a single bus column `b_chip` describing chiplet lookups requested by the stack and
     /// provided by chiplets in the Chiplets module.
     pub fn build_aux_columns<E: FieldElement<BaseField = Felt>>(
         &self,
         main_trace: &Matrix<Felt>,
         rand_elements: &[E],
     ) -> Vec<Vec<E>> {
-        let b_aux = self.build_aux_column(main_trace, rand_elements);
-        vec![b_aux]
+        let b_chip = self.build_aux_column(main_trace, rand_elements);
+        vec![b_chip]
     }
 }
 

--- a/processor/src/chiplets/bus/mod.rs
+++ b/processor/src/chiplets/bus/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    BTreeMap, BitwiseLookup, ChipletsLookup, ChipletsLookupRow, Felt, FieldElement, MemoryLookup,
-    Vec,
+    hasher::HasherLookup, BTreeMap, BitwiseLookup, Felt, FieldElement, LookupTableRow,
+    MemoryLookup, Vec,
 };
 
 mod aux_trace;
@@ -26,14 +26,21 @@ pub struct ChipletsBus {
     lookup_hints: BTreeMap<usize, ChipletsLookup>,
     request_rows: Vec<ChipletsLookupRow>,
     response_rows: Vec<ChipletsLookupRow>,
+    // TODO: remove queued requests by refactoring the hasher/decoder interactions so that the
+    // lookups are built as they are requested. This will be made easier by removing state info from
+    // the HasherLookup struct. Primarily it will require a refactor of `hash_span_block`,
+    // `start_span_block`, `respan`, and `end_span_block`.
+    queued_requests: Vec<HasherLookup>,
 }
 
 impl ChipletsBus {
     // LOOKUP MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// Requests a lookup at the specified cycle.
-    fn request_operation(&mut self, cycle: usize) {
+    /// Requests lookups for a single operation at the specified cycle. A Hasher operation request
+    /// will always contain multiple lookups, while Bitwise and Memory requests will only contain a
+    /// single lookup.
+    fn request_lookup(&mut self, cycle: usize) {
         // all requests are sent from the stack before responses are provided (during Chiplets trace
         // finalization). requests are guaranteed not to share cycles with other requests, since
         // only one operation will be executed at a time.
@@ -44,7 +51,7 @@ impl ChipletsBus {
 
     /// Provides lookup data at the specified cycle, which is the row of the AuxTable execution
     /// trace that contains this lookup row.
-    fn provide_operation(&mut self, response_cycle: usize) {
+    fn provide_lookup(&mut self, response_cycle: usize) {
         // results are guaranteed not to share cycles with other results, but they might share
         // a cycle with a request which has already been sent.
         let response_idx = self.response_rows.len();
@@ -58,25 +65,59 @@ impl ChipletsBus {
             .or_insert_with(|| ChipletsLookup::Response(response_idx));
     }
 
-    // MEMORY LOOKUPS
+    // HASHER LOOKUPS
     // --------------------------------------------------------------------------------------------
 
-    /// Sends a request for the specified memory access. When `old_word` and `new_word` are the
-    /// same in the MemoryLookup, this is a read request. When they are different, it's a write
-    /// request. The memory value is requested at `cycle`. This request is expected to originate
-    /// from operation executors.
-    pub fn request_memory_operation(&mut self, lookup: MemoryLookup, cycle: usize) {
-        self.request_operation(cycle);
-        self.request_rows.push(ChipletsLookupRow::Memory(lookup));
+    /// Requests lookups for the initial row and result row of Hash operations from the Hash
+    /// Chiplet at the specified `cycle`. This request is expected to originate from operation
+    /// executors requesting a hash operation for the Stack where all operation lookups must be
+    /// included at the same cycle. For simple permutations this will require 2 lookups, while for
+    /// a Merkle root update it will require 4 lookups.
+    pub fn request_hasher_operation(&mut self, lookups: &[HasherLookup], cycle: usize) {
+        debug_assert!(
+            lookups.len() == 2 || lookups.len() == 4,
+            "incorrect number of lookup rows for hasher operation request"
+        );
+        self.request_lookup(cycle);
+        self.request_rows
+            .push(ChipletsLookupRow::HasherMulti(lookups.to_vec()));
     }
 
-    /// Provides the data of the specified memory access.  When `old_word` and `new_word` are the
-    /// same in the MemoryLookup, this is a read request. When they are different, it's a write  
-    /// request. The memory access data is provided at cycle `response_cycle`, which is the row of
-    /// the execution trace that contains this Memory row.
-    pub fn provide_memory_operation(&mut self, lookup: MemoryLookup, response_cycle: usize) {
-        self.provide_operation(response_cycle);
-        self.response_rows.push(ChipletsLookupRow::Memory(lookup));
+    /// Requests the specified lookup from the Hash Chiplet at the specified `cycle`. Single lookup
+    /// requests are expected to originate from the decoder during control block decoding.
+    pub fn request_hasher_lookup(&mut self, lookup: HasherLookup, cycle: usize) {
+        self.request_lookup(cycle);
+        self.request_rows.push(ChipletsLookupRow::Hasher(lookup));
+    }
+
+    /// Adds the request for the specified lookup to a queue from which it can be sent later when
+    /// the cycle of the request is known. Queued requests are expected to originate from the
+    /// decoder, since the hash is computed at the start of each control block, but the decoder
+    /// does not request intermediate and final lookups until the end of the control block or until
+    /// a `RESPAN` in the case of `SPAN` blocks with more than one operation batch.
+    pub fn enqueue_hasher_request(&mut self, lookup: HasherLookup) {
+        self.queued_requests.push(lookup);
+    }
+
+    /// Pops the top HasherLookup request off the queue and sends it to the bus. This request is
+    /// expected to originate from the decoder as it continues or finalizes control blocks with
+    /// `RESPAN` or `END`.
+    pub fn send_queued_hasher_request(&mut self, cycle: usize) {
+        let lookup = self.queued_requests.pop();
+        debug_assert!(lookup.is_some(), "no queued requests");
+
+        if let Some(lookup) = lookup {
+            self.request_hasher_lookup(lookup, cycle);
+        }
+    }
+
+    /// Provides the data of a hash chiplet operation contained in the [Hasher] table. The hash
+    /// lookup value is provided at cycle `response_cycle`, which is the row of the execution trace
+    /// that contains this Hasher row. It will always be either the first or last row of a Hasher
+    /// operation cycle.
+    pub fn provide_hasher_lookup(&mut self, lookup: HasherLookup, response_cycle: usize) {
+        self.provide_lookup(response_cycle);
+        self.response_rows.push(ChipletsLookupRow::Hasher(lookup));
     }
 
     // BITWISE LOOKUPS
@@ -85,7 +126,7 @@ impl ChipletsBus {
     /// Requests the specified bitwise lookup at the specified `cycle`. This request is expected to
     /// originate from operation executors.
     pub fn request_bitwise_operation(&mut self, lookup: BitwiseLookup, cycle: usize) {
-        self.request_operation(cycle);
+        self.request_lookup(cycle);
         self.request_rows.push(ChipletsLookupRow::Bitwise(lookup));
     }
 
@@ -93,8 +134,29 @@ impl ChipletsBus {
     /// is provided at cycle `response_cycle`, which is the row of the execution trace that contains
     /// this Bitwise row. It will always be the final row of a Bitwise operation cycle.
     pub fn provide_bitwise_operation(&mut self, lookup: BitwiseLookup, response_cycle: usize) {
-        self.provide_operation(response_cycle);
+        self.provide_lookup(response_cycle);
         self.response_rows.push(ChipletsLookupRow::Bitwise(lookup));
+    }
+
+    // MEMORY LOOKUPS
+    // --------------------------------------------------------------------------------------------
+
+    /// Sends a request for the specified memory access. When `old_word` and `new_word` are the
+    /// same in the MemoryLookup, this is a read request. When they are different, it's a write
+    /// request. The memory value is requested at `cycle`. This request is expected to originate
+    /// from operation executors.
+    pub fn request_memory_operation(&mut self, lookup: MemoryLookup, cycle: usize) {
+        self.request_lookup(cycle);
+        self.request_rows.push(ChipletsLookupRow::Memory(lookup));
+    }
+
+    /// Provides the data of the specified memory access.  When `old_word` and `new_word` are the
+    /// same in the MemoryLookup, this is a read request. When they are different, it's a write  
+    /// request. The memory access data is provided at cycle `response_cycle`, which is the row of
+    /// the execution trace that contains this Memory row.
+    pub fn provide_memory_operation(&mut self, lookup: MemoryLookup, response_cycle: usize) {
+        self.provide_lookup(response_cycle);
+        self.response_rows.push(ChipletsLookupRow::Memory(lookup));
     }
 
     // AUX TRACE BUILDER GENERATION
@@ -124,6 +186,38 @@ impl ChipletsBus {
     /// Returns the ith lookup response provided by the Chiplets module.
     #[cfg(test)]
     pub(super) fn get_response_row(&self, i: usize) -> ChipletsLookupRow {
-        self.response_rows[i]
+        self.response_rows[i].clone()
+    }
+}
+
+// CHIPLETS LOOKUPS
+// ================================================================================================
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) enum ChipletsLookup {
+    Request(usize),
+    Response(usize),
+    RequestAndResponse((usize, usize)),
+}
+
+// TODO: investigate alternative approaches, since this is heavy (e.g. read from execution trace)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ChipletsLookupRow {
+    Hasher(HasherLookup),
+    HasherMulti(Vec<HasherLookup>),
+    Bitwise(BitwiseLookup),
+    Memory(MemoryLookup),
+}
+
+impl LookupTableRow for ChipletsLookupRow {
+    fn to_value<E: FieldElement<BaseField = Felt>>(&self, alphas: &[E]) -> E {
+        match self {
+            ChipletsLookupRow::HasherMulti(lookups) => lookups
+                .iter()
+                .fold(E::ONE, |acc, row| acc * row.to_value(alphas)),
+            ChipletsLookupRow::Hasher(row) => row.to_value(alphas),
+            ChipletsLookupRow::Bitwise(row) => row.to_value(alphas),
+            ChipletsLookupRow::Memory(row) => row.to_value(alphas),
+        }
     }
 }

--- a/processor/src/chiplets/hasher/lookups.rs
+++ b/processor/src/chiplets/hasher/lookups.rs
@@ -1,0 +1,137 @@
+use super::{Felt, FieldElement, HasherState, LookupTableRow, StarkField};
+use vm_core::chiplets::hasher::{
+    CAPACITY_LEN, DIGEST_RANGE, LINEAR_HASH_LABEL, MP_VERIFY_LABEL, MR_UPDATE_NEW_LABEL,
+    MR_UPDATE_OLD_LABEL, RETURN_HASH_LABEL, RETURN_STATE_LABEL, STATE_WIDTH,
+};
+
+// CONSTANTS
+// ================================================================================================
+const NUM_HEADER_ALPHAS: usize = 4;
+
+// HASHER LOOKUPS
+// ================================================================================================
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HasherLookupContext {
+    Start,
+    // TODO: benchmark removing this and getting it from the trace instead
+    Absorb(HasherState),
+    Return,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct HasherLookup {
+    // unique label identifying the hash operation
+    label: u8,
+    // TODO: benchmark removing this and getting it from the trace instead
+    // hasher state
+    state: HasherState,
+    // row address in the Hasher table
+    addr: u32,
+    // node index
+    index: Felt,
+    // context
+    context: HasherLookupContext,
+}
+
+impl HasherLookup {
+    pub(super) fn new(
+        label: u8,
+        state: HasherState,
+        addr: u32,
+        index: Felt,
+        context: HasherLookupContext,
+    ) -> Self {
+        Self {
+            label,
+            state,
+            addr,
+            index,
+            context,
+        }
+    }
+
+    /// The cycle at which the lookup is provided by the hasher.
+    pub(super) fn cycle(&self) -> usize {
+        // the hasher's addresses start from one instead of zero, so the cycle at which each lookup
+        // is provided is one less than its address
+        self.addr as usize - 1
+    }
+
+    fn get_header_value<E: FieldElement<BaseField = Felt>>(&self, alphas: &[E]) -> E {
+        let transition_label = match self.context {
+            HasherLookupContext::Start => E::from(self.label) + E::from(16_u8),
+            _ => E::from(self.label) + E::from(32_u8),
+        };
+
+        alphas[0]
+            + alphas[1].mul(transition_label)
+            + alphas[2].mul(E::from(self.addr))
+            + alphas[3].mul_base(self.index)
+    }
+}
+
+impl LookupTableRow for HasherLookup {
+    /// Reduces this row to a single field element in the field specified by E. This requires
+    /// at least 16 alpha values.
+    fn to_value<E: FieldElement<BaseField = Felt>>(&self, alphas: &[E]) -> E {
+        let header = self.get_header_value(&alphas[..NUM_HEADER_ALPHAS]);
+        let alphas = &alphas[NUM_HEADER_ALPHAS..(NUM_HEADER_ALPHAS + STATE_WIDTH)];
+
+        match self.context {
+            HasherLookupContext::Start => {
+                if self.label == LINEAR_HASH_LABEL {
+                    header + build_value(alphas, &self.state)
+                } else {
+                    assert!(
+                        self.label == MR_UPDATE_OLD_LABEL
+                            || self.label == MR_UPDATE_NEW_LABEL
+                            || self.label == MP_VERIFY_LABEL,
+                        "unrecognized hash operation"
+                    );
+                    let bit = (self.index.as_int() >> 1) & 1;
+                    let left_word = build_value(&alphas[DIGEST_RANGE], &self.state[DIGEST_RANGE]);
+                    let right_word =
+                        build_value(&alphas[DIGEST_RANGE], &self.state[DIGEST_RANGE.end..]);
+
+                    header + E::from(1 - bit).mul(left_word) + E::from(bit).mul(right_word)
+                }
+            }
+            HasherLookupContext::Absorb(next_state) => {
+                assert!(
+                    self.label == LINEAR_HASH_LABEL,
+                    "unrecognized hash operation"
+                );
+                let next_state_value =
+                    build_value(&alphas[CAPACITY_LEN..], &next_state[CAPACITY_LEN..]);
+                let state_value = build_value(&alphas[CAPACITY_LEN..], &self.state[CAPACITY_LEN..]);
+
+                header + next_state_value - state_value
+            }
+            HasherLookupContext::Return => {
+                if self.label == RETURN_STATE_LABEL {
+                    header + build_value(alphas, &self.state)
+                } else {
+                    assert!(
+                        self.label == RETURN_HASH_LABEL,
+                        "unrecognized hash operation"
+                    );
+                    header + build_value(&alphas[DIGEST_RANGE], &self.state[DIGEST_RANGE])
+                }
+            }
+        }
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Builds the value from alphas and elements of matching lengths. This can be used to build the
+/// value for a single word or for the entire state.
+fn build_value<E: FieldElement<BaseField = Felt>>(alphas: &[E], elements: &[Felt]) -> E {
+    let mut value = E::ZERO;
+    for (&alpha, &element) in alphas.iter().zip(elements.iter()) {
+        value += alpha.mul_base(element);
+    }
+    value
+}

--- a/processor/src/chiplets/hasher/mod.rs
+++ b/processor/src/chiplets/hasher/mod.rs
@@ -1,4 +1,4 @@
-use super::{Felt, FieldElement, OpBatch, StarkField, TraceFragment, Vec, Word, ZERO};
+use super::{Felt, FieldElement, HasherState, OpBatch, StarkField, TraceFragment, Vec, Word, ZERO};
 use vm_core::chiplets::hasher::{
     absorb_into_state, get_digest, init_state, init_state_from_words, Selectors, LINEAR_HASH,
     MP_VERIFY, MR_UPDATE_NEW, MR_UPDATE_OLD, RETURN_HASH, RETURN_STATE, STATE_WIDTH, TRACE_WIDTH,
@@ -12,11 +12,6 @@ pub use aux_trace::{AuxTraceBuilder, SiblingTableRow, SiblingTableUpdate};
 
 #[cfg(test)]
 mod tests;
-
-// TYPE ALIASES
-// ================================================================================================
-
-pub(super) type HasherState = [Felt; STATE_WIDTH];
 
 // HASH PROCESSOR
 // ================================================================================================

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    init_state_from_words, AuxTraceBuilder, Felt, Hasher, HasherState, Selectors, SiblingTableRow,
-    SiblingTableUpdate, TraceFragment, Word, LINEAR_HASH, MP_VERIFY, MR_UPDATE_NEW, MR_UPDATE_OLD,
-    RETURN_HASH, RETURN_STATE, TRACE_WIDTH,
+    init_state_from_words, AuxTraceBuilder, ChipletsBus, Felt, Hasher, HasherState, Selectors,
+    SiblingTableRow, SiblingTableUpdate, TraceFragment, Word, LINEAR_HASH, MP_VERIFY,
+    MR_UPDATE_NEW, MR_UPDATE_OLD, RETURN_HASH, RETURN_STATE, TRACE_WIDTH,
 };
 use rand_utils::rand_array;
 use vm_core::{
@@ -19,7 +19,7 @@ fn hasher_permute() {
     // initialize the hasher and perform one permutation
     let mut hasher = Hasher::default();
     let init_state: HasherState = rand_array();
-    let (addr, final_state) = hasher.permute(init_state);
+    let (addr, final_state, _) = hasher.permute(init_state);
 
     // address of the permutation should be ONE (as hasher address starts at ONE)
     assert_eq!(ONE, addr);
@@ -46,10 +46,10 @@ fn hasher_permute() {
     // initialize the hasher and perform two permutations
     let mut hasher = Hasher::default();
     let init_state1: HasherState = rand_array();
-    let (addr1, final_state1) = hasher.permute(init_state1);
+    let (addr1, final_state1, _) = hasher.permute(init_state1);
 
     let init_state2: HasherState = rand_array();
-    let (addr2, final_state2) = hasher.permute(init_state2);
+    let (addr2, final_state2, _) = hasher.permute(init_state2);
 
     // make sure the returned addresses are correct (they must be 8 rows apart)
     assert_eq!(ONE, addr1);
@@ -308,7 +308,7 @@ fn build_trace(hasher: Hasher, num_rows: usize) -> (Vec<Vec<Felt>>, AuxTraceBuil
         .map(|_| vec![Felt::new(0); num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
-    let aux_trace_builder = hasher.fill_trace(&mut fragment);
+    let aux_trace_builder = hasher.fill_trace(&mut fragment, &mut ChipletsBus::default());
     (trace, aux_trace_builder)
 }
 

--- a/processor/src/chiplets/hasher/trace.rs
+++ b/processor/src/chiplets/hasher/trace.rs
@@ -1,6 +1,4 @@
-use super::{
-    Felt, FieldElement, HasherState, Selectors, TraceFragment, Vec, STATE_WIDTH, TRACE_WIDTH,
-};
+use super::{Felt, HasherState, Selectors, TraceFragment, Vec, STATE_WIDTH, TRACE_WIDTH, ZERO};
 use vm_core::chiplets::hasher::{apply_round, NUM_ROUNDS};
 
 // HASHER TRACE
@@ -68,7 +66,7 @@ impl HasherTrace {
         // - the last two selectors are carried over from row to row; the first selector is set
         //   to ZERO.
         // - hasher state is updated by applying a single round of the hash function for every row.
-        let next_selectors = [Felt::ZERO, init_selectors[1], init_selectors[2]];
+        let next_selectors = [ZERO, init_selectors[1], init_selectors[2]];
         for i in 0..NUM_ROUNDS - 1 {
             apply_round(state, i);
             self.append_row(next_selectors, state, rest_index);
@@ -90,13 +88,7 @@ impl HasherTrace {
         init_selectors: Selectors,
         final_selectors: Selectors,
     ) {
-        self.append_permutation_with_index(
-            state,
-            init_selectors,
-            final_selectors,
-            Felt::ZERO,
-            Felt::ZERO,
-        );
+        self.append_permutation_with_index(state, init_selectors, final_selectors, ZERO, ZERO);
     }
 
     /// Appends a new row to the execution trace based on the supplied parameters.

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -248,8 +248,8 @@ impl Memory {
     pub fn fill_trace(
         self,
         trace: &mut TraceFragment,
-        memory_start_row: usize,
         chiplets_bus: &mut ChipletsBus,
+        memory_start_row: usize,
     ) {
         debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace lengths");
 

--- a/processor/src/chiplets/memory/tests.rs
+++ b/processor/src/chiplets/memory/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{ChipletsLookup, ChipletsLookupRow},
+    super::bus::{ChipletsLookup, ChipletsLookupRow},
     ChipletsBus, Felt, FieldElement, Memory, MemoryLookup, StarkField, TraceFragment, ONE, ZERO,
 };
 use vm_core::MEMORY_TRACE_WIDTH;
@@ -254,7 +254,7 @@ fn build_trace(mem: Memory, num_rows: usize) -> (Vec<Vec<Felt>>, ChipletsBus) {
         .map(|_| vec![Felt::ZERO; num_rows])
         .collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
-    mem.fill_trace(&mut fragment, 0, &mut chiplets_bus);
+    mem.fill_trace(&mut fragment, &mut chiplets_bus, 0);
 
     (trace, chiplets_bus)
 }

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -147,16 +147,15 @@ impl Chiplets {
     // HASH CHIPLET ACCESSORS FOR CONTROL BLOCK DECODING
     // --------------------------------------------------------------------------------------------
 
-    /// Requests the hash of the provided words from the Hash chiplet and returns the result
-    /// hash(h1, h2).
+    /// Requests the hash of the provided words from the Hash chiplet and checks the result
+    /// hash(h1, h2) against the provided `expected_result`.
     ///
-    /// The returned tuple also contains the row address of the execution trace at which hash
-    /// computation started.
-    pub fn hash_control_block(&mut self, h1: Word, h2: Word, expected: Digest) -> Felt {
+    /// It returns the row address of the execution trace at which the hash computation started.
+    pub fn hash_control_block(&mut self, h1: Word, h2: Word, expected_result: Digest) -> Felt {
         let (addr, result, lookups) = self.hasher.merge(h1, h2);
 
         // make sure the result computed by the hasher is the same as the expected block hash
-        debug_assert_eq!(expected, result.into());
+        debug_assert_eq!(expected_result, result.into());
 
         // send the request for the hash initialization
         self.bus.request_hasher_lookup(lookups[0], self.clk);
@@ -168,20 +167,19 @@ impl Chiplets {
     }
 
     /// Requests computation a sequential hash of all operation batches in the list from the Hash
-    /// chiplet and returns the result.
+    /// chiplet and checks the result against the provided `expected_result`.
     ///
-    /// The returned tuple also contains the row address of the execution trace at which hash
-    /// computation started.
+    /// It returns the row address of the execution trace at which the hash computation started.
     pub fn hash_span_block(
         &mut self,
         op_batches: &[OpBatch],
         num_op_groups: usize,
-        expected: Digest,
+        expected_result: Digest,
     ) -> Felt {
         let (addr, result, lookups) = self.hasher.hash_span_block(op_batches, num_op_groups);
 
         // make sure the result computed by the hasher is the same as the expected block hash
-        debug_assert_eq!(expected, result.into());
+        debug_assert_eq!(expected_result, result.into());
 
         // send the request for the hash initialization
         self.bus.request_hasher_lookup(lookups[0], self.clk);

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -6,6 +6,7 @@ use crate::{trace::LookupTableRow, ExecutionError};
 use core::ops::RangeInclusive;
 use vm_core::{
     chiplets::bitwise::{BITWISE_AND_LABEL, BITWISE_OR_LABEL, BITWISE_XOR_LABEL},
+    chiplets::hasher::HasherState,
     code_blocks::OpBatch,
 };
 
@@ -13,8 +14,8 @@ mod bitwise;
 use bitwise::{Bitwise, BitwiseLookup};
 
 mod hasher;
+use hasher::Hasher;
 pub use hasher::{AuxTraceBuilder as HasherAuxTraceBuilder, SiblingTableRow};
-use hasher::{Hasher, HasherState};
 
 mod memory;
 use memory::{Memory, MemoryLookup};

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -254,7 +254,7 @@ impl Process {
         // preceded by a RESPAN operation; executing RESPAN operation does not change the state
         // of the stack
         for op_batch in block.op_batches().iter().skip(1) {
-            self.decoder.respan(op_batch);
+            self.respan(op_batch);
             self.execute_op(Operation::Noop)?;
             self.execute_op_batch(op_batch, &mut decorators, op_offset)?;
             op_offset += op_batch.ops().len();

--- a/processor/src/trace/decoder/tests.rs
+++ b/processor/src/trace/decoder/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     super::{
         tests::{build_trace_from_block, build_trace_from_ops},
+        utils::build_span_with_respan_ops,
         LookupTableRow, Trace, NUM_RAND_ROWS,
     },
     Felt,
@@ -10,7 +11,6 @@ use rand_utils::rand_array;
 use vm_core::{
     code_blocks::CodeBlock,
     decoder::{P1_COL_IDX, P2_COL_IDX, P3_COL_IDX},
-    utils::ToElements,
     FieldElement, Operation, AUX_TRACE_RAND_ELEMENTS, ONE, ZERO,
 };
 
@@ -713,34 +713,4 @@ fn decoder_p3_trace_two_batches() {
     for i in 20..(p3.len() - NUM_RAND_ROWS) {
         assert_eq!(ONE, p3[i]);
     }
-}
-
-// HELPER FUNCTIONS
-// ================================================================================================
-
-fn build_span_with_respan_ops() -> (Vec<Operation>, Vec<Felt>) {
-    let iv = [1, 3, 5, 7, 9, 11, 13, 15, 17].to_elements();
-    let ops = vec![
-        Operation::Push(iv[0]),
-        Operation::Push(iv[1]),
-        Operation::Push(iv[2]),
-        Operation::Push(iv[3]),
-        Operation::Push(iv[4]),
-        Operation::Push(iv[5]),
-        Operation::Push(iv[6]),
-        // next batch
-        Operation::Push(iv[7]),
-        Operation::Push(iv[8]),
-        Operation::Add,
-        // drops to make sure stack overflow is empty on exit
-        Operation::Drop,
-        Operation::Drop,
-        Operation::Drop,
-        Operation::Drop,
-        Operation::Drop,
-        Operation::Drop,
-        Operation::Drop,
-        Operation::Drop,
-    ];
-    (ops, iv)
 }

--- a/processor/src/trace/tests/chiplets/bitwise.rs
+++ b/processor/src/trace/tests/chiplets/bitwise.rs
@@ -15,6 +15,10 @@ use vm_core::chiplets::{
 ///
 /// - All possible bitwise operations are called by the stack.
 /// - Some requests from the Stack and responses from the Bitwise chiplet occur at the same cycle.
+///
+/// Note: Communication with the Hash chiplet is also required, due to the span block decoding, but
+/// for this test we set those values explicitly, enforcing only that the same initial and final
+/// values are requested & provided.
 #[test]
 #[allow(clippy::needless_range_loop)]
 fn b_aux_trace_bitwise() {
@@ -53,6 +57,9 @@ fn b_aux_trace_bitwise() {
 
     assert_eq!(trace.length(), b_aux.len());
     assert_eq!(ONE, b_aux[0]);
+
+    // At cycle 0 the span hash initialization is requested from the decoder and provided by the
+    // hash chiplet, so the trace should still equal one.
     assert_eq!(ONE, b_aux[1]);
 
     // The first bitwise request from the stack is sent when the `U32and` operation is executed at
@@ -85,7 +92,18 @@ fn b_aux_trace_bitwise() {
     assert_eq!(expected, b_aux[5]);
 
     // Nothing changes during user operations with no requests to the Chiplets.
-    for row in 6..16 {
+    for row in 6..8 {
+        assert_eq!(expected, b_aux[row]);
+    }
+
+    // At cycle 7 the hasher provides the result of the `SPAN` hash. Since this test is for changes
+    // from bitwise lookups, just set it explicitly and save the multiplied-in value for later.
+    assert_ne!(expected, b_aux[8]);
+    let span_result = b_aux[8] * b_aux[7].inv();
+    expected = b_aux[8];
+
+    // Nothing changes during user operations with no requests to the Chiplets.
+    for row in 9..16 {
         assert_eq!(expected, b_aux[row]);
     }
 
@@ -109,8 +127,19 @@ fn b_aux_trace_bitwise() {
     expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_1_row - 1);
     assert_eq!(expected, b_aux[response_1_row]);
 
+    // Nothing changes until the decoder requests the result of the `SPAN` hash at cycle 21.
+    for row in response_1_row..21 {
+        assert_eq!(expected, b_aux[row]);
+    }
+
+    // At cycle 21 the decoder requests the span hash. We set this as the inverse of the previously
+    // identified `span_result`, since this test is for consistency of the bitwise lookups.
+    assert_ne!(expected, b_aux[22]);
+    expected *= span_result.inv();
+    assert_eq!(expected, b_aux[22]);
+
     // Nothing changes until the next time the Bitwise chiplet responds.
-    for row in response_1_row..response_2_row {
+    for row in 23..response_2_row {
         assert_eq!(expected, b_aux[row]);
     }
 

--- a/processor/src/trace/tests/chiplets/bitwise.rs
+++ b/processor/src/trace/tests/chiplets/bitwise.rs
@@ -138,8 +138,8 @@ fn b_aux_trace_bitwise() {
 // TEST HELPERS
 // ================================================================================================
 
-fn build_expected_bitwise(alphas: &[Felt], op_id: Felt, a: Felt, b: Felt, result: Felt) -> Felt {
-    alphas[0] + alphas[1] * op_id + alphas[2] * a + alphas[3] * b + alphas[4] * result
+fn build_expected_bitwise(alphas: &[Felt], label: Felt, a: Felt, b: Felt, result: Felt) -> Felt {
+    alphas[0] + alphas[1] * label + alphas[2] * a + alphas[3] * b + alphas[4] * result
 }
 
 fn build_expected_bitwise_from_trace(trace: &ExecutionTrace, alphas: &[Felt], row: usize) -> Felt {

--- a/processor/src/trace/tests/chiplets/hasher.rs
+++ b/processor/src/trace/tests/chiplets/hasher.rs
@@ -1,0 +1,724 @@
+use core::ops::Range;
+
+use super::{
+    build_span_with_respan_ops, build_trace_from_block, build_trace_from_ops_with_inputs,
+    rand_array, ExecutionTrace, Felt, FieldElement, Operation, Trace, AUX_TRACE_RAND_ELEMENTS,
+    CHIPLETS_AUX_TRACE_OFFSET, NUM_RAND_ROWS, ONE, ZERO,
+};
+
+use vm_core::{
+    chiplets::{
+        hasher::{
+            apply_permutation, init_state_from_words, HasherState, Selectors, CAPACITY_LEN,
+            DIGEST_RANGE, HASH_CYCLE_LEN, LINEAR_HASH, LINEAR_HASH_LABEL, MP_VERIFY,
+            MP_VERIFY_LABEL, MR_UPDATE_NEW, MR_UPDATE_NEW_LABEL, MR_UPDATE_OLD,
+            MR_UPDATE_OLD_LABEL, RETURN_HASH, RETURN_HASH_LABEL, RETURN_STATE, RETURN_STATE_LABEL,
+            STATE_WIDTH,
+        },
+        HASHER_NODE_INDEX_COL_IDX, HASHER_ROW_COL_IDX, HASHER_STATE_COL_RANGE, HASHER_TRACE_OFFSET,
+    },
+    code_blocks::CodeBlock,
+    utils::range,
+    AdviceSet, ProgramInputs, StarkField, Word, DECODER_TRACE_OFFSET,
+};
+
+// CONSTANTS
+// ================================================================================================
+
+const DECODER_HASHER_STATE_RANGE: Range<usize> = range(
+    DECODER_TRACE_OFFSET + vm_core::decoder::HASHER_STATE_OFFSET,
+    vm_core::decoder::NUM_HASHER_COLUMNS,
+);
+
+// TESTS
+// ================================================================================================
+
+/// Tests the generation of the `b_chip` bus column when the hasher only performs a single `SPAN`
+/// with one operation batch.
+#[test]
+#[allow(clippy::needless_range_loop)]
+pub fn b_chip_span() {
+    let program = CodeBlock::new_span(vec![Operation::Add, Operation::Mul]);
+    let mut trace = build_trace_from_block(&program, &[]);
+
+    let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
+    let aux_columns = trace.build_aux_segment(&[], &alphas).unwrap();
+    let b_chip = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
+
+    assert_eq!(trace.length(), b_chip.len());
+    assert_eq!(ONE, b_chip[0]);
+
+    // at the first cycle the following are added for inclusion in the next row:
+    // - the initialization of the span hash is requested by the decoder
+    // - the initialization of the span hash is provided by the hasher
+
+    // initialize the request state with capacity equal to the number of operation groups.
+    let mut state = [ZERO; STATE_WIDTH];
+    state[0] = ONE;
+    fill_state_from_decoder(&trace, &mut state, 0);
+    // request the initialization of the span hash
+    let request_init = build_expected(
+        &alphas,
+        LINEAR_HASH_LABEL,
+        state,
+        [ZERO; STATE_WIDTH],
+        ONE,
+        ZERO,
+    );
+    let mut expected = request_init.inv();
+
+    // provide the initialization of the span hash
+    expected *= build_expected_from_trace(&trace, &alphas, 0);
+    assert_eq!(expected, b_chip[1]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 2..4 {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // At cycle 3 the decoder requests the result of the span hash.
+    apply_permutation(&mut state);
+    let request_result = build_expected(
+        &alphas,
+        RETURN_HASH_LABEL,
+        state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(HASH_CYCLE_LEN as u64),
+        ZERO,
+    );
+    expected *= request_result.inv();
+    assert_eq!(expected, b_chip[4]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 5..HASH_CYCLE_LEN {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // At the end of the hash cycle, the result of the span hash is provided by the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, HASH_CYCLE_LEN - 1);
+    assert_eq!(expected, b_chip[HASH_CYCLE_LEN]);
+
+    // The value in b_chip should be ONE now and for the rest of the trace.
+    for row in HASH_CYCLE_LEN..trace.length() - NUM_RAND_ROWS {
+        assert_eq!(ONE, b_chip[row]);
+    }
+}
+
+/// Tests the generation of the `b_chip` bus column when the hasher only performs a `SPAN` but it
+/// includes multiple batches.
+#[test]
+#[allow(clippy::needless_range_loop)]
+pub fn b_chip_span_with_respan() {
+    let (ops, _) = build_span_with_respan_ops();
+    let program = CodeBlock::new_span(ops);
+    let mut trace = build_trace_from_block(&program, &[]);
+
+    let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
+    let aux_columns = trace.build_aux_segment(&[], &alphas).unwrap();
+    let b_chip = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
+
+    assert_eq!(trace.length(), b_chip.len());
+    assert_eq!(ONE, b_chip[0]);
+
+    // at cycle 0 the following are added for inclusion in the next row:
+    // - the initialization of the span hash is requested by the decoder
+    // - the initialization of the span hash is provided by the hasher
+
+    // initialize the request state with capacity equal to the number of operation groups.
+    let mut state = [ZERO; STATE_WIDTH];
+    state[0] = Felt::new(12);
+    fill_state_from_decoder(&trace, &mut state, 0);
+    // request the initialization of the span hash
+    let request_init = build_expected(
+        &alphas,
+        LINEAR_HASH_LABEL,
+        state,
+        [ZERO; STATE_WIDTH],
+        ONE,
+        ZERO,
+    );
+    let mut expected = request_init.inv();
+
+    // provide the initialization of the span hash
+    expected *= build_expected_from_trace(&trace, &alphas, 0);
+    assert_eq!(expected, b_chip[1]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 2..8 {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // At the end of the first hash cycle at cycle 7, the absorption of the next operation batch is
+    // provided by the hasher.
+    expected *= build_expected_from_trace(&trace, &alphas, 7);
+    assert_eq!(expected, b_chip[8]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    assert_eq!(expected, b_chip[9]);
+
+    // At cycle 9, after the first operation batch, the decoder initiates a respan and requests the
+    // absorption of the next operation batch.
+    apply_permutation(&mut state);
+    let prev_state = state;
+    // get the state with the next absorbed batch.
+    absorb_state_from_decoder(&trace, &mut state, 9);
+    let request_respan = build_expected(
+        &alphas,
+        LINEAR_HASH_LABEL,
+        prev_state,
+        state,
+        Felt::new(8),
+        ZERO,
+    );
+    expected *= request_respan.inv();
+    assert_eq!(expected, b_chip[10]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 11..16 {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // At cycle 15 at the end of the second hash cycle, the result of the span hash is provided by
+    // the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, 15);
+    assert_eq!(expected, b_chip[16]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 17..22 {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // At cycle 21, after the second operation batch, the decoder ends the SPAN block and requests
+    // its hash.
+    apply_permutation(&mut state);
+    let request_result = build_expected(
+        &alphas,
+        RETURN_HASH_LABEL,
+        state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(16),
+        ZERO,
+    );
+    expected *= request_result.inv();
+    assert_eq!(expected, b_chip[22]);
+
+    // The value in b_chip should be ONE now and for the rest of the trace.
+    for row in 22..trace.length() - NUM_RAND_ROWS {
+        assert_eq!(ONE, b_chip[row]);
+    }
+}
+
+/// Tests the generation of the `b_chip` bus column when the hasher performs a merge of two code
+/// blocks requested by the decoder. (This also requires a `SPAN` block.)
+#[test]
+#[allow(clippy::needless_range_loop)]
+pub fn b_chip_merge() {
+    let t_branch = CodeBlock::new_span(vec![Operation::Add]);
+    let f_branch = CodeBlock::new_span(vec![Operation::Mul]);
+    let program = CodeBlock::new_split(t_branch, f_branch);
+    let mut trace = build_trace_from_block(&program, &[]);
+
+    let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
+    let aux_columns = trace.build_aux_segment(&[], &alphas).unwrap();
+    let b_chip = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
+
+    assert_eq!(trace.length(), b_chip.len());
+    assert_eq!(ONE, b_chip[0]);
+
+    // at cycle 0 the following are added for inclusion in the next row:
+    // - the initialization of the merge of the split's child hashes is requested by the decoder
+    // - the initialization of the code block merge is provided by the hasher
+
+    // initialize the request state with capacity equal to the number of operation groups.
+    let mut split_state = [ZERO; STATE_WIDTH];
+    split_state[0] = Felt::new(8);
+    fill_state_from_decoder(&trace, &mut split_state, 0);
+    // request the initialization of the span hash
+    let split_init = build_expected(
+        &alphas,
+        LINEAR_HASH_LABEL,
+        split_state,
+        [ZERO; STATE_WIDTH],
+        ONE,
+        ZERO,
+    );
+    let mut expected = split_init.inv();
+
+    // provide the initialization of the span hash
+    expected *= build_expected_from_trace(&trace, &alphas, 0);
+    assert_eq!(expected, b_chip[1]);
+
+    // at cycle 1 the initialization of the span block hash for the false branch is requested by the
+    // decoder
+    let mut f_branch_state = [ZERO; STATE_WIDTH];
+    f_branch_state[0] = Felt::new(1);
+    fill_state_from_decoder(&trace, &mut f_branch_state, 1);
+    // request the initialization of the false branch hash
+    let f_branch_init = build_expected(
+        &alphas,
+        LINEAR_HASH_LABEL,
+        f_branch_state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(9),
+        ZERO,
+    );
+    expected *= f_branch_init.inv();
+    assert_eq!(expected, b_chip[2]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    assert_eq!(expected, b_chip[3]);
+
+    // at cycle 3 the result hash of the span block for the false branch is requested by the decoder
+    apply_permutation(&mut f_branch_state);
+    let f_branch_result = build_expected(
+        &alphas,
+        RETURN_HASH_LABEL,
+        f_branch_state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(16),
+        ZERO,
+    );
+    expected *= f_branch_result.inv();
+    assert_eq!(expected, b_chip[4]);
+
+    // at cycle 4 the result of the split code block's hash is requested by the decoder
+    apply_permutation(&mut split_state);
+    let split_result = build_expected(
+        &alphas,
+        RETURN_HASH_LABEL,
+        split_state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(8),
+        ZERO,
+    );
+    expected *= split_result.inv();
+    assert_eq!(expected, b_chip[5]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 6..8 {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // at cycle 7 the result of the merge is provided by the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, 7);
+    assert_eq!(expected, b_chip[8]);
+
+    // at cycle 8 the initialization of the hash of the span block for the false branch is provided
+    // by the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, 8);
+    assert_eq!(expected, b_chip[9]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 9..16 {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // at cycle 15 the result of the span block for the false branch is provided by the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, 15);
+    assert_eq!(expected, b_chip[16]);
+
+    // The value in b_chip should be ONE now and for the rest of the trace.
+    for row in 16..trace.length() - NUM_RAND_ROWS {
+        assert_eq!(ONE, b_chip[row]);
+    }
+}
+
+/// Tests the generation of the `b_chip` bus column when the hasher performs a permutation
+/// requested by the `RpPerm` user operation.
+#[test]
+#[allow(clippy::needless_range_loop)]
+pub fn b_chip_permutation() {
+    let program = CodeBlock::new_span(vec![Operation::RpPerm]);
+    let stack = vec![8, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8];
+    let mut trace = build_trace_from_block(&program, &stack);
+
+    let mut rpperm_state: [Felt; STATE_WIDTH] = stack
+        .iter()
+        .map(|v| Felt::new(*v))
+        .collect::<Vec<_>>()
+        .try_into()
+        .expect("failed to convert vector to array");
+    let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
+    let aux_columns = trace.build_aux_segment(&[], &alphas).unwrap();
+    let b_chip = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
+
+    assert_eq!(trace.length(), b_chip.len());
+    assert_eq!(ONE, b_chip[0]);
+
+    // at cycle 0 the following are added for inclusion in the next row:
+    // - the initialization of the span hash is requested by the decoder
+    // - the initialization of the span hash is provided by the hasher
+
+    // initialize the request state with capacity equal to the number of operation groups.
+    let mut span_state = [ZERO; STATE_WIDTH];
+    span_state[0] = ONE;
+    fill_state_from_decoder(&trace, &mut span_state, 0);
+    // request the initialization of the span hash
+    let span_init = build_expected(
+        &alphas,
+        LINEAR_HASH_LABEL,
+        span_state,
+        [ZERO; STATE_WIDTH],
+        ONE,
+        ZERO,
+    );
+    let mut expected = span_init.inv();
+    // provide the initialization of the span hash
+    expected *= build_expected_from_trace(&trace, &alphas, 0);
+    assert_eq!(expected, b_chip[1]);
+
+    // at cycle 1 rpperm is executed and the initialization and result of the hash are both
+    // requested by the stack.
+    let rpperm_init = build_expected(
+        &alphas,
+        LINEAR_HASH_LABEL,
+        rpperm_state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(9),
+        ZERO,
+    );
+    // request the rpperm initialization.
+    expected *= rpperm_init.inv();
+    apply_permutation(&mut rpperm_state);
+    let rpperm_result = build_expected(
+        &alphas,
+        RETURN_STATE_LABEL,
+        rpperm_state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(16),
+        ZERO,
+    );
+    // request the rpperm result.
+    expected *= rpperm_result.inv();
+    assert_eq!(expected, b_chip[2]);
+
+    // at cycle 2 the result of the span hash is requested by the decoder
+    apply_permutation(&mut span_state);
+    let span_result = build_expected(
+        &alphas,
+        RETURN_HASH_LABEL,
+        span_state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(8),
+        ZERO,
+    );
+    expected *= span_result.inv();
+    assert_eq!(expected, b_chip[3]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 4..8 {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // at cycle 7 the result of the span hash is provided by the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, 7);
+    assert_eq!(expected, b_chip[8]);
+
+    // at cycle 8 the initialization of the rpperm hash is provided by the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, 8);
+    assert_eq!(expected, b_chip[9]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 10..16 {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // at cycle 15 the result of the rpperm hash is provided by the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, 15);
+    assert_eq!(expected, b_chip[16]);
+
+    // The value in b_chip should be ONE now and for the rest of the trace.
+    for row in 16..trace.length() - NUM_RAND_ROWS {
+        assert_eq!(ONE, b_chip[row]);
+    }
+}
+
+/// Tests the generation of the `b_chip` bus column when the hasher performs a Merkle path
+/// verification requested by the `MpVerify` user operation.
+#[test]
+#[allow(clippy::needless_range_loop)]
+fn b_chip_mpverify() {
+    let index = 5usize;
+    let leaves = init_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
+    let tree = AdviceSet::new_merkle_tree(leaves.to_vec()).unwrap();
+
+    let stack_inputs = [
+        tree.root()[0].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[3].as_int(),
+        leaves[index][0].as_int(),
+        leaves[index][1].as_int(),
+        leaves[index][2].as_int(),
+        leaves[index][3].as_int(),
+        index as u64,
+        tree.depth() as u64,
+    ];
+    let inputs = ProgramInputs::new(&stack_inputs, &[], vec![tree.clone()]).unwrap();
+
+    let mut trace = build_trace_from_ops_with_inputs(vec![Operation::MpVerify], inputs);
+    let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
+    let aux_columns = trace.build_aux_segment(&[], &alphas).unwrap();
+    let b_chip = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
+
+    assert_eq!(trace.length(), b_chip.len());
+    assert_eq!(ONE, b_chip[0]);
+
+    // at cycle 0 the following are added for inclusion in the next row:
+    // - the initialization of the span hash is requested by the decoder
+    // - the initialization of the span hash is provided by the hasher
+
+    // initialize the request state with capacity equal to the number of operation groups.
+    let mut span_state = [ZERO; STATE_WIDTH];
+    span_state[0] = ONE;
+    fill_state_from_decoder(&trace, &mut span_state, 0);
+    // request the initialization of the span hash
+    let span_init = build_expected(
+        &alphas,
+        LINEAR_HASH_LABEL,
+        span_state,
+        [ZERO; STATE_WIDTH],
+        ONE,
+        ZERO,
+    );
+    let mut expected = span_init.inv();
+    // provide the initialization of the span hash
+    expected *= build_expected_from_trace(&trace, &alphas, 0);
+    assert_eq!(expected, b_chip[1]);
+
+    // at cycle 1 a merkle path verification is executed and the initialization and result of the
+    // hash are both requested by the stack.
+    let path = tree
+        .get_path(tree.depth(), index as u64)
+        .expect("failed to get Merkle tree path");
+    let mp_state = init_state_from_words(
+        &[path[0][0], path[0][1], path[0][2], path[0][3]],
+        &[
+            leaves[index][0],
+            leaves[index][1],
+            leaves[index][2],
+            leaves[index][3],
+        ],
+    );
+    let mp_init = build_expected(
+        &alphas,
+        MP_VERIFY_LABEL,
+        mp_state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(9),
+        Felt::new(index as u64),
+    );
+    // request the initialization of the Merkle path verification
+    expected *= mp_init.inv();
+
+    let mp_verify_complete = HASH_CYCLE_LEN + (tree.depth() as usize) * HASH_CYCLE_LEN;
+    let mp_result = build_expected(
+        &alphas,
+        RETURN_HASH_LABEL,
+        // for the return hash, only the state digest matters, and it should match the root
+        [
+            ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
+            tree.root()[0],
+            tree.root()[1],
+            tree.root()[2],
+            tree.root()[3],
+            ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
+        ],
+        [ZERO; STATE_WIDTH],
+        Felt::new(mp_verify_complete as u64),
+        Felt::new(index as u64 >> tree.depth()),
+    );
+    // request the result of the Merkle path verification
+    expected *= mp_result.inv();
+    assert_eq!(expected, b_chip[2]);
+
+    // at cycle 2 the result of the span hash is requested by the decoder
+    apply_permutation(&mut span_state);
+    let span_result = build_expected(
+        &alphas,
+        RETURN_HASH_LABEL,
+        span_state,
+        [ZERO; STATE_WIDTH],
+        Felt::new(8),
+        ZERO,
+    );
+    expected *= span_result.inv();
+    assert_eq!(expected, b_chip[3]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 3..8 {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // at cycle 7 the result of the span hash is provided by the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, 7);
+    assert_eq!(expected, b_chip[8]);
+
+    // at cycle 8 the initialization of the merkle path is provided by the hasher
+    expected *= build_expected_from_trace(&trace, &alphas, 8);
+    assert_eq!(expected, b_chip[9]);
+
+    // Nothing changes when there is no communication with the hash chiplet.
+    for row in 10..(mp_verify_complete) {
+        assert_eq!(expected, b_chip[row]);
+    }
+
+    // when the merkle path verification has been completed the hasher provides the result
+    expected *= build_expected_from_trace(&trace, &alphas, mp_verify_complete - 1);
+    assert_eq!(expected, b_chip[mp_verify_complete]);
+
+    // The value in b_chip should be ONE now and for the rest of the trace.
+    for row in mp_verify_complete..trace.length() - NUM_RAND_ROWS {
+        assert_eq!(ONE, b_chip[row]);
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Reduces the provided hasher row information to an expected value.
+fn build_expected(
+    alphas: &[Felt],
+    label: u8,
+    state: HasherState,
+    next_state: HasherState,
+    addr: Felt,
+    index: Felt,
+) -> Felt {
+    let first_cycle_row = addr_to_cycle_row(addr) == 0;
+    let transition_label = if first_cycle_row {
+        label + 16_u8
+    } else {
+        label + 32_u8
+    };
+    let header =
+        alphas[0] + alphas[1] * Felt::from(transition_label) + alphas[2] * addr + alphas[3] * index;
+    let mut value = header;
+
+    if (first_cycle_row && label == LINEAR_HASH_LABEL) || label == RETURN_STATE_LABEL {
+        // include the entire state (words a, b, c)
+        value += build_value(&alphas[4..16], &state);
+    } else if label == LINEAR_HASH_LABEL {
+        // include the delta between the next and current rate elements (words b and c)
+        value += build_value(&alphas[8..16], &next_state[CAPACITY_LEN..]);
+        value -= build_value(&alphas[8..16], &state[CAPACITY_LEN..]);
+    } else if label == RETURN_HASH_LABEL {
+        // include the digest (word b)
+        value += build_value(&alphas[8..12], &state[DIGEST_RANGE]);
+    } else {
+        assert!(
+            label == MP_VERIFY_LABEL
+                || label == MR_UPDATE_NEW_LABEL
+                || label == MR_UPDATE_OLD_LABEL
+        );
+        let bit = (index.as_int() >> 1) & 1;
+        let left_word = build_value(&alphas[8..12], &state[DIGEST_RANGE]);
+        let right_word = build_value(&alphas[8..12], &state[DIGEST_RANGE.end..]);
+
+        value += Felt::new(1 - bit) * left_word + Felt::new(bit) * right_word;
+    }
+
+    value
+}
+
+/// Reduces the specified row in the execution trace to an expected value representing a hash
+/// operation lookup.
+fn build_expected_from_trace(trace: &ExecutionTrace, alphas: &[Felt], row: usize) -> Felt {
+    let s0 = trace.main_trace.get_column(HASHER_TRACE_OFFSET)[row];
+    let s1 = trace.main_trace.get_column(HASHER_TRACE_OFFSET + 1)[row];
+    let s2 = trace.main_trace.get_column(HASHER_TRACE_OFFSET + 2)[row];
+    let selectors: Selectors = [s0, s1, s2];
+
+    let label = get_label_from_selectors(selectors)
+        .expect("unrecognized hasher operation label in hasher trace");
+
+    let addr = trace.main_trace.get_column(HASHER_ROW_COL_IDX)[row];
+    let index = trace.main_trace.get_column(HASHER_NODE_INDEX_COL_IDX)[row];
+
+    let cycle_row = addr_to_cycle_row(addr);
+
+    let mut state = [ZERO; STATE_WIDTH];
+    let mut next_state = [ZERO; STATE_WIDTH];
+    for (i, col_idx) in HASHER_STATE_COL_RANGE.enumerate() {
+        state[i] = trace.main_trace.get_column(col_idx)[row];
+        if cycle_row == 7 && label == LINEAR_HASH_LABEL {
+            // fill the next state with the elements being absorbed.
+            next_state[i] = trace.main_trace.get_column(col_idx)[row + 1];
+        }
+    }
+
+    build_expected(alphas, label, state, next_state, addr, index)
+}
+
+/// Builds a value from alphas and elements of matching lengths. This can be used to build the
+/// value for a single word or for the entire state.
+fn build_value(alphas: &[Felt], elements: &[Felt]) -> Felt {
+    let mut value = ZERO;
+    for (&alpha, &element) in alphas.iter().zip(elements.iter()) {
+        value += alpha * element;
+    }
+    value
+}
+
+/// Returns the hash operation label for the specified selectors.
+fn get_label_from_selectors(selectors: Selectors) -> Option<u8> {
+    if selectors == LINEAR_HASH {
+        Some(LINEAR_HASH_LABEL)
+    } else if selectors == MP_VERIFY {
+        Some(MP_VERIFY_LABEL)
+    } else if selectors == MR_UPDATE_OLD {
+        Some(MR_UPDATE_OLD_LABEL)
+    } else if selectors == MR_UPDATE_NEW {
+        Some(MR_UPDATE_NEW_LABEL)
+    } else if selectors == RETURN_HASH {
+        Some(RETURN_HASH_LABEL)
+    } else if selectors == RETURN_STATE {
+        Some(RETURN_STATE_LABEL)
+    } else {
+        None
+    }
+}
+
+/// Populates the provided HasherState with the state stored in the decoder's execution trace at the
+/// specified row.
+fn fill_state_from_decoder(trace: &ExecutionTrace, state: &mut HasherState, row: usize) {
+    for (i, col_idx) in DECODER_HASHER_STATE_RANGE.enumerate() {
+        state[CAPACITY_LEN + i] = trace.main_trace.get_column(col_idx)[row];
+    }
+}
+
+/// Absorbs the elements specified in the decoder's execution trace helper columns at the specified
+/// row into the provided HasherState.
+fn absorb_state_from_decoder(trace: &ExecutionTrace, state: &mut HasherState, row: usize) {
+    for (i, col_idx) in DECODER_HASHER_STATE_RANGE.enumerate() {
+        state[CAPACITY_LEN + i] += trace.main_trace.get_column(col_idx)[row];
+    }
+}
+
+/// Returns the row of the hash cycle which corresponds to the provided Hasher address.
+fn addr_to_cycle_row(addr: Felt) -> usize {
+    let cycle = (addr.as_int() - 1) as usize;
+    let cycle_row = cycle % HASH_CYCLE_LEN;
+    debug_assert!(
+        cycle_row == 0 || cycle_row == HASH_CYCLE_LEN - 1,
+        "invalid address for hasher lookup"
+    );
+
+    cycle_row
+}
+
+/// Initializes Merkle tree leaves with the specified values.
+fn init_leaves(values: &[u64]) -> Vec<Word> {
+    values.iter().map(|&v| init_leaf(v)).collect()
+}
+
+/// Initializes a Merkle tree leaf with the specified value.
+fn init_leaf(value: u64) -> Word {
+    [Felt::new(value), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+}

--- a/processor/src/trace/tests/chiplets/mod.rs
+++ b/processor/src/trace/tests/chiplets/mod.rs
@@ -1,7 +1,7 @@
 use super::{
-    super::{Trace, NUM_RAND_ROWS},
-    build_trace_from_ops, rand_array, ExecutionTrace, Felt, FieldElement, Operation, Word, ONE,
-    ZERO,
+    super::{utils::build_span_with_respan_ops, Trace, NUM_RAND_ROWS},
+    build_trace_from_block, build_trace_from_ops, build_trace_from_ops_with_inputs, rand_array,
+    ExecutionTrace, Felt, FieldElement, Operation, Word, ONE, ZERO,
 };
 use rand_utils::rand_value;
 use vm_core::{
@@ -9,4 +9,5 @@ use vm_core::{
 };
 
 mod bitwise;
+mod hasher;
 mod memory;

--- a/processor/src/trace/utils.rs
+++ b/processor/src/trace/utils.rs
@@ -214,3 +214,35 @@ pub trait AuxColumnBuilder<H: Copy, R: LookupTableRow> {
         E::ONE
     }
 }
+
+// TEST HELPERS
+// ================================================================================================
+#[cfg(test)]
+use vm_core::{utils::ToElements, Operation};
+#[cfg(test)]
+pub fn build_span_with_respan_ops() -> (Vec<Operation>, Vec<Felt>) {
+    let iv = [1, 3, 5, 7, 9, 11, 13, 15, 17].to_elements();
+    let ops = vec![
+        Operation::Push(iv[0]),
+        Operation::Push(iv[1]),
+        Operation::Push(iv[2]),
+        Operation::Push(iv[3]),
+        Operation::Push(iv[4]),
+        Operation::Push(iv[5]),
+        Operation::Push(iv[6]),
+        // next batch
+        Operation::Push(iv[7]),
+        Operation::Push(iv[8]),
+        Operation::Add,
+        // drops to make sure stack overflow is empty on exit
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+        Operation::Drop,
+    ];
+    (ops, iv)
+}


### PR DESCRIPTION
This PR adds hasher lookups to the chiplets bus b_chip auxiliary column.

- [x] add unit tests for communication about HasherLookups on the chiplets bus. One test each was added for 2/3 operations from the stack (`op_rpperm` and `op_mpverify`, but not `op_mrupdate`) and all interactions with the decoder (span block decoding and code block merges).
- [x] add hasher lookups to the chiplets bus, requesting them from the stack and decoder and providing them from the Hash chiplet
- [x] document the new HasherLookup handling
- [x] update the unit tests for the chiplets bus trace relating to the communications with the bitwise and memory chiplets, since each of them also includes some communication with the hasher (to decode the span block)

I left comments in a few specific spots where I opted for simplicity but think things could be improved. (And I'm happy to make those changes in this PR - just wanted to get most of the complexity handled fairly cleanly first)

After this PR is merged, the following related changes will still be needed

- update mdbook description of the operation label in the hasher chiplet design docs
- update mdbook description of the chiplets and b_chip bus column
- update [unit tests in the hasher module](https://github.com/maticnetwork/miden/blob/next/processor/src/trace/tests/chiplets/hasher.rs) to test that lookups were correctly recorded
- add a unit test to the [hasher chiplet trace unit tests](https://github.com/maticnetwork/miden/blob/next/processor/src/trace/tests/chiplets/hasher.rs) for merkle root update
- add a unit test to the [chiplet trace unit tests](https://github.com/maticnetwork/miden/blob/next/processor/src/trace/tests/chiplets/mod.rs) for lookups from multiple chiplets
- update the Chiplets module's inline documentation to add an execution trace visual layout and additional description
- switch the type for the operation labels for Memory and Bitwise to u8