### PR TITLE
Fix range checker auxiliary column trace

### DIFF
--- a/miden/tests/integration/air/range.rs
+++ b/miden/tests/integration/air/range.rs
@@ -18,3 +18,13 @@ fn range_check_multi() {
     let stack = vec![5, 5, 5];
     build_test!(source, &stack).prove_and_verify(stack, 0, false);
 }
+
+/// Range checks the result of 1 + u32::MAX - 1, which is u32::MAX. Therefore, it requires range
+/// checks for u16::MAX, the last value in the range checker's 16-bit section.
+#[test]
+fn range_check_u16max() {
+    let asm_op = "u32overflowing_add";
+    let stack = vec![1, (u32::MAX - 1) as u64];
+
+    build_op_test!(asm_op, &stack).prove_and_verify(stack, 0, false);
+}

--- a/processor/src/range/aux_trace.rs
+++ b/processor/src/range/aux_trace.rs
@@ -102,7 +102,7 @@ impl AuxTraceBuilder {
         for (row_idx, &v) in v_col
             .iter()
             .enumerate()
-            .take(v_col.len() - 1)
+            .take(v_col.len() - NUM_RAND_ROWS)
             .skip(self.start_16bit)
         {
             // This is the 16-bit section, where the running product must be reduced.
@@ -197,7 +197,7 @@ impl AuxTraceBuilder {
             .iter()
             .zip(main_trace.get_column(V_COL_IDX).iter())
             .enumerate()
-            .take(main_trace.num_rows() - NUM_RAND_ROWS - 1)
+            .take(main_trace.num_rows() - NUM_RAND_ROWS)
             .skip(self.start_16bit)
         {
             p1_idx = row_idx + 1;

--- a/processor/src/range/mod.rs
+++ b/processor/src/range/mod.rs
@@ -225,6 +225,13 @@ impl RangeChecker {
             prev_value = value;
         }
 
+        // pad the trace with an extra row of 0 lookups for u16::MAX so that when b_range is built
+        // there is space for the inclusion of u16::MAX range check lookups before the trace ends.
+        // (When there is data at the end of the main trace, auxiliary bus columns always need to be
+        // one row longer than the main trace, since values in the bus column are based on data from
+        // the "current" row of the main trace but placed into the "next" row of the bus column.)
+        write_value(&mut trace, &mut i, 0, (u16::MAX).into(), &mut row_flags);
+
         RangeCheckTrace {
             trace,
             aux_builder: AuxTraceBuilder::new(self.cycle_range_checks, row_flags, start_16bit),
@@ -239,7 +246,13 @@ impl RangeChecker {
     /// to support all 16-bit lookups.
     fn build_8bit_lookup(&self) -> ([usize; 256], usize) {
         let mut result = [0; 256];
-        let mut num_16bit_rows = 0;
+
+        // pad the trace length by one, to account for an extra row of the u16::MAX value at the end
+        // of the 16-bit segment of the trace, required for building the `b_range` column.
+        let mut num_16bit_rows = 1;
+
+        // add a lookup for ZERO to account for the extra row of the u16::MAX value
+        result[0] = 1;
 
         let mut prev_value = 0u16;
         for (&value, &num_lookups) in self.lookups.iter() {


### PR DESCRIPTION
#342 raised an issue where verification failed when range checks of `u16::MAX` were required. This was due to 2 issues:

1. There was an indexing error in the generation of the execution trace for the `p1` column (now referred to in the docs as `b_range`) which caused lookups of `u16::MAX` not to be included in the `p1` column.
2. After fixing (1), verification continued to fail because there wasn't sufficient trace length in the `p1` column to hold the lookup value associated with the final range check value (u16::MAX). This is because data for these values comes from the "current" row, while lookups are included in the "next" row. The trace was only long enough to contain 1 additional row after the u16::MAX value in the range checker trace, which is always reserved for a random value. Therefore the lookup value for the u16::MAX row was being overwritten by the random value.

The solution was to pad the Range Checker's trace with an extra row of `u16::MAX` (with 0 lookups) at the end of the 16-bit segment of the trace. This also required adding another lookup of ZERO to the 8-bit segment of the trace.

The unit tests were updated accordingly, and an AIR test was also added to test for the specific failure found in #342.