### PR TITLE
[DRAFT]Introduce mtree.has operation to the assembly

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-air"
-version = "0.2.0"
+version = "0.3.0"
 description = "Algebraic intermediate representation of Miden VM processor"
 authors = ["miden contributors"]
 readme = "README.md"
@@ -20,9 +20,9 @@ default = ["std"]
 std = ["vm-core/std", "winter-air/std"]
 
 [dependencies]
-vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.3", default-features = false }
 winter-air = { package = "winter-air", version = "0.4", default-features = false }
 
 [dev-dependencies]
-proptest = "1.0.0"
+proptest = "1.0"
 rand-utils = { package = "winter-rand-utils", version = "0.4" }

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly"
-version = "0.2.0"
+version = "0.3.0"
 description = "Miden VM assembly language"
 authors = ["miden contributors"]
 readme = "README.md"
@@ -24,8 +24,8 @@ default = ["std"]
 std = ["vm-core/std"]
 
 [dependencies]
-vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
-vm-stdlib = { package = "miden-stdlib", path = "../stdlib", version = "0.1", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.3", default-features = false }
+vm-stdlib = { package = "miden-stdlib", path = "../stdlib", version = "0.2", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/assembly/src/parsers/crypto_ops.rs
+++ b/assembly/src/parsers/crypto_ops.rs
@@ -83,14 +83,14 @@ pub(super) fn parse_rpperm(span_ops: &mut Vec<Operation>, op: &Token) -> Result<
 /// the top):
 /// - Root of the Merkle tree, 4 elements.
 /// - Node which needs to be checked, 4 elements.
-/// 
+///
 /// After the operations are executed, the stack will be arranged as follows:
 /// - bit flag, 1 element.
 /// - Root of the Merkle tree, 4 elements.
 /// - Node which was checked, 4 elements.
-/// 
+///
 /// This operation takes 1 VM cycle.
-/// 
+///
 /// # Errors:
 /// Returns an AssemblyError if the operation is malformed.
 pub(super) fn parse_mtree_has(

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -169,6 +169,7 @@ fn parse_op_token(
         "rphash" => crypto_ops::parse_rphash(span_ops, op),
         "rpperm" => crypto_ops::parse_rpperm(span_ops, op),
 
+        "mtree_has" => crypto_ops::parse_mtree_has(span_ops, op, decorators),
         "mtree_get" => crypto_ops::parse_mtree_get(span_ops, op, decorators),
         "mtree_set" => crypto_ops::parse_mtree_set(span_ops, op, decorators),
         "mtree_cwm" => crypto_ops::parse_mtree_cwm(span_ops, op, decorators),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.2.0"
+version = "0.3.0"
 description = "Miden VM core components"
 authors = ["miden contributors"]
 readme = "README.md"

--- a/core/src/inputs/advice/merkle_tree.rs
+++ b/core/src/inputs/advice/merkle_tree.rs
@@ -66,6 +66,11 @@ impl MerkleTree {
         log2(self.nodes.len() / 2)
     }
 
+    /// Returns if a node is present in the Merkle tree or not.
+    pub fn is_node_present(&self, node: Word) -> bool {
+        self.nodes.contains(&node)
+    }
+
     /// Returns a node at the specified depth and index.
     ///
     /// # Errors
@@ -165,6 +170,23 @@ mod tests {
         int_to_node(7),
         int_to_node(8),
     ];
+
+    #[test]
+    fn is_node_present() {
+        let tree = super::MerkleTree::new(LEAVES4.to_vec()).unwrap();
+
+        // ------------ when node is in the merkle tree ---------------------------
+        assert!(tree.is_node_present(int_to_node(1)));
+        assert!(tree.is_node_present(int_to_node(2)));
+        assert!(tree.is_node_present(int_to_node(3)));
+        assert!(tree.is_node_present(int_to_node(4)));
+
+        // ------------ when node is not in the merkle tree ---------------------------
+        assert!(!tree.is_node_present(int_to_node(5)));
+        assert!(!tree.is_node_present(int_to_node(7)));
+        assert!(!tree.is_node_present(int_to_node(420)));
+        assert!(!tree.is_node_present(int_to_node(654)));
+    }
 
     #[test]
     fn build_merkle_tree() {

--- a/core/src/inputs/advice/mod.rs
+++ b/core/src/inputs/advice/mod.rs
@@ -49,6 +49,18 @@ impl AdviceSet {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
+    /// Returns if the node is present in the advice set or not.
+    ///
+    /// # Panic
+    /// Panics if the advise set is not a Merkle tree.
+    pub fn is_node_present(&self, value: Word) -> bool {
+        if let Self::MerkleTree(tree) = self {
+            tree.is_node_present(value)
+        } else {
+            panic!("The node value is not being fetched from a Merkle Tree")
+        }
+    }
+
     /// Returns a root of this advice set.
     pub fn root(&self) -> Word {
         match self {

--- a/core/src/operations/decorators/advice.rs
+++ b/core/src/operations/decorators/advice.rs
@@ -10,6 +10,13 @@ pub enum AdviceInjector {
     /// - root of the tree, 4 elements
     MerkleNode,
 
+    /// Injects a boolean value at the head of the advice tape if the input node is present in the
+    /// Merkle tree with the specified input root. The stack is expected to be arranged as follows
+    /// (from the top):
+    /// - Root of the tree, 4 elements.
+    /// - Node which needs to be checked, 4 elements.
+    MerkleNodePresent,
+
     /// Injects the result of u64 division (both the quotient and the remainder) at the head of
     /// the advice tape. The stack is expected to be arranged as follows (from the top):
     /// - divisor split into two 32-bit elements
@@ -24,6 +31,7 @@ impl fmt::Display for AdviceInjector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MerkleNode => write!(f, "merkle_node"),
+            Self::MerkleNodePresent => write!(f, "merkle_node_present"),
             Self::DivResultU64 => write!(f, "div_result_u64"),
         }
     }

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden"
-version = "0.2.0"
+version = "0.3.0"
 description="Miden virtual machine"
 authors = ["miden contributors"]
 readme="README.md"
@@ -31,26 +31,26 @@ executable = ["crypto", "env_logger", "hex/std", "std", "serde/std", "serde_deri
 std = ["air/std", "assembly/std", "log/std", "processor/std", "prover/std", "verifier/std", "vm-core/std"]
 
 [dependencies]
-air = { package = "miden-air", path = "../air", version = "0.2", default-features = false }
-assembly = { package = "miden-assembly", path = "../assembly", version = "0.2", default-features = false }
+air = { package = "miden-air", path = "../air", version = "0.3", default-features = false }
+assembly = { package = "miden-assembly", path = "../assembly", version = "0.3", default-features = false }
 crypto = { package = "winter-crypto", version = "0.4", default-features = false, optional = true }
 env_logger = { version = "0.9", default-features = false, optional = true }
 hex = { version = "0.4", optional = true }
 log = { version = "0.4", default-features = false }
-processor = { package = "miden-processor", path = "../processor", version = "0.2", default-features = false }
-prover = { package = "miden-prover", path = "../prover", version = "0.2", default-features = false }
+processor = { package = "miden-processor", path = "../processor", version = "0.3", default-features = false }
+prover = { package = "miden-prover", path = "../prover", version = "0.3", default-features = false }
 serde = {version = "1.0.117", optional = true }
 serde_derive = {version = "1.0.117", optional = true }
 serde_json = {version = "1.0.59", optional = true }
 structopt = { version = "0.3", default-features = false, optional = true }
-verifier = { package = "miden-verifier", path = "../verifier", version = "0.2", default-features = false }
+verifier = { package = "miden-verifier", path = "../verifier", version = "0.3", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.4", optional = true }
-vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.3", default-features = false }
 
 [dev-dependencies]
-blake3 = "1.3.1"
+blake3 = "1.3"
 num-bigint = "0.4"
 proptest = "1.0.0"
 rand-utils = { package = "winter-rand-utils", version = "0.4" }
-sha2 = "0.10.2"
-sha3 = "0.10.1"
+sha2 = "0.10"
+sha3 = "0.10"

--- a/miden/tests/integration/operations/crypto_ops.rs
+++ b/miden/tests/integration/operations/crypto_ops.rs
@@ -91,6 +91,73 @@ fn rphash() {
 }
 
 #[test]
+fn mtree_has() {
+    let asm_op = "mtree_has";
+
+    let leaves = init_merkle_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
+    let tree = AdviceSet::new_merkle_tree(leaves.clone()).unwrap();
+
+    // stack inputs when the node is in the merkle tree.
+    let stack_inputs = [
+        leaves[2][0].as_int(),
+        leaves[2][1].as_int(),
+        leaves[2][2].as_int(),
+        leaves[2][3].as_int(),
+        tree.root()[0].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[3].as_int(),
+    ];
+
+    let final_stack = [
+        1u64,
+        tree.root()[3].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[0].as_int(),
+        leaves[2][3].as_int(),
+        leaves[2][2].as_int(),
+        leaves[2][1].as_int(),
+        leaves[2][0].as_int(),
+    ];
+
+    let test = build_op_test!(asm_op, &stack_inputs, &[], vec![tree]);
+    test.expect_stack(&final_stack);
+
+    // node not present in the merkle tree
+    let leaves_not_in_leaf = init_merkle_leaf(447);
+
+    let leaves = init_merkle_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
+    let tree = AdviceSet::new_merkle_tree(leaves).unwrap();
+
+    let stack_inputs = [
+        leaves_not_in_leaf[0].as_int(),
+        leaves_not_in_leaf[1].as_int(),
+        leaves_not_in_leaf[2].as_int(),
+        leaves_not_in_leaf[3].as_int(),
+        tree.root()[0].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[3].as_int(),
+    ];
+
+    let final_stack = [
+        0u64,
+        tree.root()[3].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[0].as_int(),
+        leaves_not_in_leaf[3].as_int(),
+        leaves_not_in_leaf[2].as_int(),
+        leaves_not_in_leaf[1].as_int(),
+        leaves_not_in_leaf[0].as_int(),
+    ];
+
+    let test = build_op_test!(asm_op, &stack_inputs, &[], vec![tree]);
+    test.expect_stack(&final_stack);
+}
+
+#[test]
 fn mtree_get() {
     let asm_op = "mtree_get";
 

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-processor"
-version = "0.2.0"
+version = "0.3.0"
 description = "Miden VM processor"
 authors = ["miden contributors"]
 readme = "README.md"
@@ -25,11 +25,11 @@ std = ["vm-core/std", "winterfell/std", "log/std"]
 
 [dependencies]
 log = "0.4.14"
-vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.3", default-features = false }
 winterfell = { package = "winter-prover", version = "0.4", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
-logtest = { version = "2.0.0", default-features = false  }
-miden-assembly = { package = "miden-assembly", path = "../assembly", version = "0.2", default-features = false }
+logtest = { version = "2.0", default-features = false  }
+miden-assembly = { package = "miden-assembly", path = "../assembly", version = "0.3", default-features = false }
 rand-utils = { package = "winter-rand-utils", version = "0.4" }

--- a/processor/src/advice/mod.rs
+++ b/processor/src/advice/mod.rs
@@ -69,6 +69,24 @@ impl AdviceProvider {
         self.sets.contains_key(&root.into_bytes())
     }
 
+    /// Returns a boolean value if the node is present in the Merkle tree with the specified root.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - A Merkle tree for the specified root cannot be found in this advice provider.
+    pub fn is_node_present(&mut self, root: Word, node: Word) -> Result<bool, ExecutionError> {
+        // look up the advice set and return an error if none is found
+        let advice_set = self
+            .sets
+            .get(&root.into_bytes())
+            .ok_or_else(|| ExecutionError::AdviceSetNotFound(root.into_bytes()))?;
+
+        // get the boolean value of the node being present in the merkle tree.
+        let flag = advice_set.is_node_present(node);
+
+        Ok(flag)
+    }
+
     /// Returns a node at the specified index in a Merkle tree with the specified root.
     ///
     /// # Errors

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-prover"
-version = "0.2.0"
+version = "0.3.0"
 description = "Miden VM prover"
 authors = ["miden contributors"]
 readme = "README.md"
@@ -17,8 +17,8 @@ default = ["std"]
 std = ["air/std", "processor/std", "prover/std", "log/std", "vm-core/std"]
 
 [dependencies]
-air = { package = "miden-air", path = "../air", version = "0.2", default-features = false }
-processor = { package = "miden-processor", path = "../processor", version = "0.2", default-features = false }
+air = { package = "miden-air", path = "../air", version = "0.3", default-features = false }
+processor = { package = "miden-processor", path = "../processor", version = "0.3", default-features = false }
 prover = { package = "winter-prover", version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false }
-vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.3", default-features = false }

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-stdlib"
-version = "0.1.0"
+version = "0.2.0"
 description = "Miden VM standard library"
 authors = ["miden contributors"]
 readme = "README.md"
@@ -16,4 +16,4 @@ bench = false
 doctest = false
 
 [dependencies]
-vm-core = { package = "miden-core", default-features = false, path = "../core", version = "0.2" }
+vm-core = { package = "miden-core", default-features = false, path = "../core", version = "0.3" }

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -73,6 +73,6 @@ mod tests {
     #[test]
     fn lib_version() {
         let stdlib = super::StdLibrary::default();
-        assert_eq!("0.1.0", stdlib.version())
+        assert_eq!("0.2.0", stdlib.version())
     }
 }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-verifier"
-version = "0.2.0"
+version = "0.3.0"
 description="Miden VM execution verifier"
 authors = ["miden contributors"]
 readme="README.md"
@@ -20,7 +20,7 @@ default = ["std"]
 std = ["air/std", "assembly/std", "vm-core/std", "winterfell/std"]
 
 [dependencies]
-air = { package = "miden-air", path = "../air", version = "0.2", default-features = false }
-assembly = { package = "miden-assembly", path = "../assembly", version = "0.2", default-features = false }
-vm-core = { package = "miden-core", path = "../core", version = "0.2", default-features = false }
+air = { package = "miden-air", path = "../air", version = "0.3", default-features = false }
+assembly = { package = "miden-assembly", path = "../assembly", version = "0.3", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.3", default-features = false }
 winterfell = { package = "winter-verifier", version = "0.4", default-features = false }


### PR DESCRIPTION
`mtree.has` assembly operation checks if a given input node is present in the merkle tree with a input root or not. 