### PR TITLE
Update multiset and range checker documentation

### DIFF
--- a/docs/src/design/chiplets/bitwise.md
+++ b/docs/src/design/chiplets/bitwise.md
@@ -141,28 +141,38 @@ $$
 
 ## Bitwise chiplet bus constraints
 
-To provide the results of bitwise operations to the chiplets bus, we want to include values of $a$, $b$ and $z$ at the last row of the cycle. Denoting the random values received from the verifier as $\alpha_0, \alpha_1$, etc., this can be achieved using the following:
+To simplify the notation for describing bitwise constraints on the chiplet bus, we'll first define variable $u$, which represents how $a$, $b$, and $z$ in the execution trace are reduced to a single value. Denoting the random values received from the verifier as $\alpha_0, \alpha_1$, etc., this can be achieved as follows.
 
-> $$
-v_i = (1-k_1) \cdot (\alpha_1 \cdot a + \alpha_2 \cdot b + \alpha_3 \cdot z)
+$$
+u = \alpha_1 \cdot a + \alpha_2 \cdot b + \alpha_3 \cdot z
 $$
 
-Thus, when $k_1 = 0$, $(\alpha_1 \cdot a + \alpha_2 \cdot b + \alpha_3 \cdot z)$ gets included into the product.
+To request a bitwise operation, the prover will provide the values of $a$, $b$, and $z$ non-deterministically to the [stack](../stack/u32_ops.md#u32and) (the component that makes bitwise requests). The lookup can then be performed by dividing $\left(\alpha_0 + u\right)$ out of the bus column:
 
-Then, setting $m = 1 - k_1$, we can compute the permutation product as follows:
+$$
+b'_{chip} \cdot \left(\alpha_0 + u\right) = b_{chip}
+$$
 
-> $$
+To provide the results of bitwise operations to the chiplets bus, we want to include values of $a$, $b$ and $z$ at the last row of the cycle.
+
+First, we'll define another intermediate variable $v_i$. It will include $u$ into the product when $k_1 = 0$. ($u_i$ represents the value of $u$ for row $i$ of the trace.)
+
+$$
+v_i = (1-k_1) \cdot u_i
+$$
+
+Then, setting $m = 1 - k_1$, we can compute the permutation product from the bitwise chiplet as follows:
+
+$$
 \prod_{i=0}^n ((\alpha_0 + v_i) \cdot m_i + 1 - m_i)
 $$
 
 The above ensures that when $1 - k_1 = 0$ (which is true for all rows in the 8-row cycle except for the last one), the product does not change. Otherwise, $(\alpha_0 + v_i)$ gets included into the product.
 
-## Requesting bitwise operations
-
-To perform a lookup into this table (request a bitwise operation from the chiplets bus), we need to know values of $a$, $b$, $z$ (which the prover will provide non-deterministically). The lookup can then be performed by including the following into the lookup product:
+The constraints for the two sides of the bus communication are combined as follows:
 
 > $$
-\left(\alpha_0 + (\alpha_1 \cdot a + \alpha_2 \cdot b + \alpha_3 \cdot z)\right)
+b'_{chip} \cdot \left(\alpha_0 + u_i\right) = b_{chip} \cdot ((\alpha_0 + v_i) \cdot m_i + 1 - m_i) \text{ | degree} = 4
 $$
 
 ## Reducing the number of rows

--- a/docs/src/design/chiplets/main.md
+++ b/docs/src/design/chiplets/main.md
@@ -14,7 +14,7 @@ Each chiplet executes its computations separately from the rest of the VM and pr
 
 The chiplets must be explicitly connected to the rest of the VM in order for it to use their operations. This connection must prove that all specialized operations which a given VM component claimed to offload to one of the chiplets were in fact executed by the correct chiplet with the same set of inputs and outputs as those used by the offloading component.
 
-This is achieved via a bus called $b_{chip}$ where a request can be sent to any chiplet and a corresponding response will be sent back by that chiplet.
+This is achieved via a [bus](./multiset.md#communication-buses) called $b_{chip}$ where a request can be sent to any chiplet and a corresponding response will be sent back by that chiplet.
 
 The bus is implemented as a single [running product column](../multiset.md) where:
 
@@ -27,7 +27,14 @@ Note that the order of the requests and responses does not matter, as long as th
 
 ### Chiplet bus constraints
 
-The chiplet bus constraints are defined by the [hash](./hasher.md#hash-chiplet-bus-constraints), [bitwise](./bitwise.md#bitwise-chiplet-bus-constraints), and [memory](./memory.md#memory-row-value) chiplets and the components which send lookup requests ([bitwise](../stack/u32_ops.md#u32and), [memory](../stack/io_ops.md#memory-access-operations), and [cryptographic hash operations](../stack/crypto_ops.md) from the stack, and [hash operations](../decoder/main.md#program-block-hashing) for program block hashing from the decoder).
+The chiplet bus constraints are defined by the components that use it to communicate.
+
+Lookup requests are sent to the chiplets bus by the following components:
+
+- The stack sends requests for [bitwise](../stack/u32_ops.md#u32and), [memory](../stack/io_ops.md#memory-access-operations), and [cryptographic hash operations](../stack/crypto_ops.md).
+- The decoder sends requests for [hash operations](../decoder/main.md#program-block-hashing) for program block hashing.
+
+Responses are provided by the [hash](./hasher.md#hash-chiplet-bus-constraints), [bitwise](./bitwise.md#bitwise-chiplet-bus-constraints), and [memory](./memory.md#memory-row-value) chiplets.
 
 ## Chiplets module trace
 

--- a/docs/src/design/range.md
+++ b/docs/src/design/range.md
@@ -189,6 +189,7 @@ As previously described, the columns have the following meanings:
 - $v$ contains the values to be range checked. 
   - During the 8-bit section of the trace (when $t = 0$), these values go from $0$ to $255$ and must either stay the same or increase by one at each step.
   - During the 16-bit section of the trace (when $t = 1$), these values go from $0$ to $65535$. Values must either stay the same or increase by less than $256$ at each step.
+  - The final 2 rows of the 16-bit section of the trace must both equal $65535$. The extra value of $65535$ is required in order to [pad the trace](./multiset.md#length-of-running-product-columns) so the [$b_{range}$](#communication-bus) running product bus column can be computed correctly.
 
 ### Execution trace constraints
 
@@ -274,7 +275,13 @@ In addition to the transition constraints described above, we also need to enfor
 
 ### Communication bus
 
-$b_{range}$ is the [bus](./multiset.md#communication-buses) that connects components which require 16-bit range checks to the range-checked values in the 16-bit section of the Range Checker. The other communication with $b_{range}$ comes from the [stack](./stack/u32_ops.md) and the [memory chiplet](./chiplets/memory.md).
+$b_{range}$ is the [bus](./multiset.md#communication-buses) that connects components which require 16-bit range checks to the range-checked values in the 16-bit section of the range checker. The bus constraints are defined by the components that use it to communicate.
+
+Requests are sent to the range checker bus by the following components:
+- The Stack sends requests for 16-bit range checks during some [`u32` operations](./stack/u32_ops.md#range-checks).
+- The [Memory chiplet](./chiplets/memory.md) sends requests for 16-bit range checks against the values in the $d_0$ and $d_1$ trace columns to enforce internal consistency.
+
+Responses are provided by the range checker as follows.
 
 Once again, we'll make use of variable $z$, which represents how a row in the execution trace is reduced to a single value.
 

--- a/docs/src/design/range.md
+++ b/docs/src/design/range.md
@@ -24,10 +24,10 @@ $$
 
 Together, these constraints guarantee that all values in column $v$ are between $0$ and $255$ (inclusive).
 
-We can then add another column $p_0$, which will keep a running product of values in $v$ offset by random value $\alpha$ (provided by the verifier). Transition constraints for column $p_0$ would look like so:
+We can then add another column $p_0$, which will keep a running product of values in $v$ offset by random value $\alpha_0$ (provided by the verifier). Transition constraints for column $p_0$ would look like so:
 
 $$
-p'_0 - p_0 \cdot (\alpha + v) = 0
+p'_0 - p_0 \cdot (\alpha_0 + v) = 0
 $$
 
 Using these two columns we can check if some other column in the execution trace is a permutation of values in $v$. Let's call this other column $x$. We can compute the running product of $x$ in the same way as we compute the running product for $v$. Then, we can check that the last value in $p_0$ is the same as the final value for the running product of $x$ (this is the permutation check).
@@ -77,10 +77,10 @@ Thus, for example, when $s_0 = 1$ and $s_1 = 1$, $f_3 = 1$ and $f_0 = f_1 = f_2 
 Then, we'll update transition constraints for $p_0$ like so:
 
 $$
-p'_0 - p_0 \cdot \left((\alpha + v)^4 \cdot f_3 + (\alpha + v)^2 \cdot f_2 + (\alpha + v) \cdot f_1 + f_0\right) = 0
+p'_0 - p_0 \cdot \left((\alpha_0 + v)^4 \cdot f_3 + (\alpha_0 + v)^2 \cdot f_2 + (\alpha_0 + v) \cdot f_1 + f_0\right) = 0
 $$
 
-The above ensures that when $f_0 = 1$, $p_0$ remains the same, when $f_1 = 1$, $p_0$ is multiplied by $(\alpha + v)$, when $f_2 = 1$, $p_0$ is multiplied by $(\alpha + v)^2$, and when $f_3 = 1$, $p_0$ is multiplied by $(\alpha + v)^4$.
+The above ensures that when $f_0 = 1$, $p_0$ remains the same, when $f_1 = 1$, $p_0$ is multiplied by $(\alpha_0 + v)$, when $f_2 = 1$, $p_0$ is multiplied by $(\alpha_0 + v)^2$, and when $f_3 = 1$, $p_0$ is multiplied by $(\alpha_0 + v)^4$.
 
 We also need to ensure that values in columns $s_0$ and $s_1$ are binary (either $0$ or $1$). This can be done with the following constraints:
 
@@ -120,7 +120,7 @@ $$
 We would enforce:
 
 $$
-p'_1 - p_1 \cdot (\alpha + u' - u) = 0
+p'_1 - p_1 \cdot (\alpha_0 + u' - u) = 0
 $$
 
 Where $p_1$ is another running product column. At the end of the execution trace, we would check that $p_0 = p_1$. This would ensure that as we move from one row to another, values in column $u$ increase by at most $255$ (we are basically performing an 8-bit range check on increments of column $u$). Now, our table can look like this:
@@ -132,7 +132,7 @@ We still may need to include some unneeded rows because we can not "jump" by mor
 We also need to add another running product column $p_2$ to support permutation checks against column $u$. The constraint that we'll need to impose against this column is identical to the constraint we imposed against column $p_0$ and will look like so:
 
 $$
-p'_2 - p_2 \cdot \left((\alpha + u)^4 \cdot f_3 + (\alpha + u)^2 \cdot f_2 + (\alpha + u) \cdot f_1 + f_0\right) = 0
+p'_2 - p_2 \cdot \left((\alpha_0 + u)^4 \cdot f_3 + (\alpha_0 + u)^2 \cdot f_2 + (\alpha_0 + u) \cdot f_1 + f_0\right) = 0
 $$
 
 Overall, with this construction we have the following:
@@ -152,8 +152,8 @@ First, we can just stack the tables on top of each other. We'll need to add a co
 
 Second, we can merge running product columns $p_0$ and $p_1$ into a single column. We'll do it like so:
 
-- When $t = 0$, we'll multiply the current value of the column by the 8-bit value (offset by random $\alpha$) that we want to add into the running product.
-- When $t = 1$, we'll divide the current value of the column by the 8-bit value (offset by random $\alpha$) which we'd like to remove from the running product.
+- When $t = 0$, we'll multiply the current value of the column by the 8-bit value (offset by random $\alpha_0$) that we want to add into the running product.
+- When $t = 1$, we'll divide the current value of the column by the 8-bit value (offset by random $\alpha_0$) which we'd like to remove from the running product.
 
 In the end, if we added and then removed all the same values, the value in this column (let's call it $p_0$) should equal to $1$, and we can check this condition via a boundary constraint.
 
@@ -196,31 +196,37 @@ As previously described, the columns have the following meanings:
 First, we'll need to make sure that all selector flags are binary. This can be done with the following constraints:
 
 > $$
-t^2 - t = 0
+t^2 - t = 0 \text{ | degree} = 2
 $$
 
 > $$
-s_0^2 - s_0 = 0
+s_0^2 - s_0 = 0 \text{ | degree} = 2
 $$
 
 > $$
-s_1^2 - s_1 = 0
+s_1^2 - s_1 = 0 \text{ | degree} = 2
+$$
+
+Next, we need to constrain the row transitions in the 8-bit section of the table so that as we move from one row to the next the value either stays the same or increases by 1.
+
+> $$
+(1 - t') \cdot (v' - v) \cdot (v' - v - 1) = 0 \text{ | degree} = 3
 $$
 
 Next, we need to make sure that values in column $t$ can "flip" from $0$ to $1$ only once. The following constraint enforces this:
 
 > $$
-t \cdot (1 - t') = 0
+t \cdot (1 - t') = 0 \text{ | degree} = 2
 $$
 
-Next, we need to make sure that when column $t$ "flips" from $0$ to $1$ (we are moving from the 8-bit section of the table to the 16-bit section), the current value in column $v$ is equal to $255$, and the next value is reset to $0$. This can be done with the following constraints:
+Finally, we need to make sure that when column $t$ "flips" from $0$ to $1$ (we are moving from the 8-bit section of the table to the 16-bit section), the current value in column $v$ is equal to $255$, and the next value is reset to $0$. This can be done with the following constraints:
 
 > $$
-(1 - t) \cdot t' \cdot (v - 255) = 0
+(1 - t) \cdot t' \cdot (v - 255) = 0 \text{ | degree} = 3
 $$
 
 > $$
-(1 - t) \cdot t' \cdot v' = 0
+(1 - t) \cdot t' \cdot v' = 0 \text{ | degree} = 3
 $$
 
 In addition to the transition constraints described above, we also need to enforce the following boundary constraints:
@@ -242,7 +248,7 @@ The running product column $p_0$ is used to keep track of the state of the table
 To simplify the notation, we'll first define variable $z$, which represents how a row in the execution trace is reduced to a single value.
 
 $$
-z = (\alpha + v)^4 \cdot f_3 + (\alpha + v)^2 \cdot f_2 + (\alpha + v) \cdot f_1 + f_0
+z = (\alpha_0 + v)^4 \cdot f_3 + (\alpha_0 + v)^2 \cdot f_2 + (\alpha_0 + v) \cdot f_1 + f_0
 $$
 
 In the 8-bit section ($t = 0$), one, two, or four 8-bit range checks are added to the virtual table at each step and $p_0$ is updated as follows:
@@ -256,15 +262,15 @@ Note that if $f_0$ is true then the value of $p_0$ does not change, so no 8-bit 
 In the 16-bit section ($t = 1$), one 8-bit range check is removed from the virtual table at each step and $p_0$ is updated as follows:
 
 $$
-p'_0 \cdot (\alpha + v' - v) = p_0
+p'_0 \cdot (\alpha_0 + v' - v) = p_0
 $$
 
-The above actually enforces that $p'_0 = p_0 / (\alpha + v' - v)$.
+The above actually enforces that $p'_0 = p_0 / (\alpha_0 + v' - v)$.
 
 These two updates, which first build up the product and then reduce it, can be combined into a single constraint:
 
 > $$
-p'_0 \cdot ((\alpha + v' - v) \cdot t - t + 1) = p_0 \cdot (z - z \cdot t + t)
+p'_0 \cdot ((\alpha_0 + v' - v) \cdot t - t + 1) = p_0 \cdot (z - z \cdot t + t) \text{ | degree} = 8
 $$
 
 Thus, if the prover arranged the 8-bit and the 16-bit sections of the table correctly and $p_0$ was initialized to $1$, we should end up with $p_0 = 1$ at the end of the trace.
@@ -286,13 +292,13 @@ Responses are provided by the range checker as follows.
 Once again, we'll make use of variable $z$, which represents how a row in the execution trace is reduced to a single value.
 
 $$
-z = (\alpha + v)^4 \cdot f_3 + (\alpha + v)^2 \cdot f_2 + (\alpha + v) \cdot f_1 + f_0
+z = (\alpha_0 + v)^4 \cdot f_3 + (\alpha_0 + v)^2 \cdot f_2 + (\alpha_0 + v) \cdot f_1 + f_0
 $$
 
 Only the 16-bit section of the trace should be included in the $b_{range}$ bus column. Transition constraints for this are fairly straightforward:
 
 > $$
-b'_{range} = b_{range} \cdot (z \cdot t - t + 1)
+b'_{range} = b_{range} \cdot (z \cdot t - t + 1) \text{ | degree} = 8
 $$
 
 Thus, when $t = 0$, the value in $b_{range}$ does not change, but when $t = 1$, the next value in $b_{range}$ is computed by multiplying the current value by $z$.


### PR DESCRIPTION
This PR addresses some outstanding documentation clarifications & improvements from #364.

- minor improvements to multiset/chiplets descriptions for clarity and consistency
- add degrees to range checker constraint formulas
- switch range checker constraints to use $\alpha_i$