### PR TITLE
Stack AIR constraints structure

### DIFF
--- a/air/benches/compute_op_flags.rs
+++ b/air/benches/compute_op_flags.rs
@@ -9,7 +9,7 @@ fn compute_op_flags(c: &mut Criterion) {
     group.bench_function("op_flags", |bench| {
         let frame = generate_evaluation_frame(36);
         bench.iter(|| {
-            let _flag = OpFlags::new(frame.clone());
+            let _flag = OpFlags::new(&frame);
         });
     });
 

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -56,6 +56,10 @@ impl Air for ProcessorAir {
             TransitionConstraintDegree::new(1), // clk' = clk + 1
         ];
 
+        // --- stack constraints -------------------------------------------------------------------
+        let mut stack_degrees = stack::get_transition_constraint_degrees();
+        main_degrees.append(&mut stack_degrees);
+
         // --- range checker ----------------------------------------------------------------------
         let mut range_checker_degrees = range::get_transition_constraint_degrees();
         main_degrees.append(&mut range_checker_degrees);
@@ -69,6 +73,7 @@ impl Air for ProcessorAir {
         // Define the transition constraint ranges.
         let constraint_ranges = TransitionConstraintRange::new(
             1,
+            stack::get_transition_constraint_count(),
             range::get_transition_constraint_count(),
             chiplets::get_transition_constraint_count(),
         );
@@ -190,6 +195,12 @@ impl Air for ProcessorAir {
         // --- system -----------------------------------------------------------------------------
         // clk' = clk + 1
         result[0] = next[CLK_COL_IDX] - (current[CLK_COL_IDX] + E::ONE);
+
+        // --- stack operations -------------------------------------------------------------------
+        stack::enforce_constraints::<E>(
+            frame,
+            select_result_range!(result, self.constraint_ranges.stack),
+        );
 
         // --- range checker ----------------------------------------------------------------------
         range::enforce_constraints::<E>(

--- a/air/src/stack/field_ops/mod.rs
+++ b/air/src/stack/field_ops/mod.rs
@@ -1,0 +1,143 @@
+use super::{op_flags::OpFlags, EvaluationFrame, Vec};
+use crate::{
+    stack::EvaluationFrameExt,
+    utils::{are_equal, is_binary},
+};
+use vm_core::FieldElement;
+use winter_air::TransitionConstraintDegree;
+
+#[cfg(test)]
+pub mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The number of transition constraints in all the field operations.
+pub const NUM_CONSTRAINTS: usize = 5;
+
+/// The degrees of constraints in individual stack operations of the field operations.
+pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
+    // Given it is a degree 7 operation, 7 is added to all the constraints
+    // constraints.
+
+    // There's one constraint in INCR field operation where 1 is added to the top
+    // element of the stack.
+    8,
+    // There's one constraint in INV field operation where the top element in the
+    // stack is replaced with it's inverse.
+    9,
+    // There's one constraint in NEG field operation where the top element in the
+    // stack is replaced with it's negation.
+    8,
+    // There are two  operations in NOT field operation. The first one checks if the
+    // top element in the stack is a boolean or not whereas the second one verifies if
+    // the first element in the next trace is a boolean not of first element in the current trace.
+    9, 8,
+];
+
+// FIELD OPERATIONS TRANSITION CONSTRAINTS
+// ================================================================================================
+
+/// Builds the transition constraint degrees for the field operations.
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    CONSTRAINT_DEGREES
+        .iter()
+        .map(|&degree| TransitionConstraintDegree::new(degree))
+        .collect()
+}
+
+/// Returns the number of transition constraints of the Field operations.
+pub fn get_transition_constraint_count() -> usize {
+    NUM_CONSTRAINTS
+}
+
+/// Enforces constraints of the Field operations.
+pub fn enforce_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: &OpFlags<E>,
+) -> usize {
+    let mut index = 0;
+
+    // Enforce constaints of the INCR operation.
+    index += enforce_incr_constraints(frame, result, op_flag.incr());
+    // Enforce constaints of the INV operation.
+    index += enforce_inv_constraints(frame, &mut result[index..], op_flag.inv());
+    // Enforce constaints of the NEG operation.
+    index += enforce_neg_constraints(frame, &mut result[index..], op_flag.neg());
+    // Enforce constaints of the NOT operation.
+    index += enforce_not_constraints(frame, &mut result[index..], op_flag.not());
+
+    index
+}
+
+// TRANSITION CONSTRAINT HELPERS
+// ================================================================================================
+
+/// Enforces constraints of the INCR operation. The INCR operation increments the
+/// top element in the stack by 1. Therefore, the following constraints are enforced:
+/// - The next element in the next frame should be equal to the addition of first element in the
+///   current frame with 1.
+pub fn enforce_incr_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+) -> usize {
+    // Enforces the first element in the next frame is incremented by 1.
+    result[0] = op_flag * are_equal(frame.stack_item(0) + E::ONE, frame.stack_item_next(0));
+
+    1
+}
+
+/// Enforces constraints of the INV operation. The INV operation updates the top element
+/// in the stack with its inverse. Therefore, the following constraints are enforced:
+/// - The next element in the next frame should be the inverse of frist element in the
+///   current frame.
+pub fn enforce_inv_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+) -> usize {
+    // Enforces the first element in the next frame is an inverse of the first element in the
+    // current frame.
+    result[0] = op_flag * are_equal(frame.stack_item(0) * frame.stack_item_next(0), E::ONE);
+
+    1
+}
+
+/// Enforces constraints of the NEG operation. The NEG operation updates the top element
+/// in the stack with its inverse. Therefore, the following constraints are enforced:
+/// - The next element in the next frame should be the negation of first element in the
+///   current frame, therefore, their sum should be 0.
+pub fn enforce_neg_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+) -> usize {
+    // Enforces the first element in the current frame is a negation of the first element in the
+    // next frame
+    result[0] = op_flag * are_equal(frame.stack_item(0) + frame.stack_item_next(0), E::ZERO);
+
+    1
+}
+
+/// Enforces constraints of the NOT operation. The NOT operation updates the top element
+/// in the stack with its bitwise not value. Therefore, the following constraints are
+/// enforced:
+/// - The top element in the stack should be a binary.
+/// - The first element of the next frame should be a binary not of the first element of
+/// the current frame.
+pub fn enforce_not_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+) -> usize {
+    // Enforces the top element in the current frame is a binary or not.
+    result[0] = op_flag * is_binary(frame.stack_item(0));
+
+    // Enforces the first element in the current frame is a binary not of the first element
+    // in the next frame.
+    result[1] = op_flag * are_equal(frame.stack_item_next(0) + frame.stack_item(0), E::ONE);
+
+    2
+}

--- a/air/src/stack/field_ops/tests.rs
+++ b/air/src/stack/field_ops/tests.rs
@@ -1,0 +1,132 @@
+use super::{enforce_constraints, EvaluationFrame, NUM_CONSTRAINTS};
+use crate::stack::op_flags::{generate_evaluation_frame, OpFlags};
+use core::ops::Neg;
+use vm_core::{Felt, FieldElement, Operation, ONE, STACK_TRACE_OFFSET, ZERO};
+
+use proptest::prelude::*;
+
+// RANDOMIZED TESTS
+// ================================================================================================
+
+proptest! {
+    // --------------------------------INCR test --------------------------------------------------
+
+    #[test]
+    fn test_incr_stack_operation(a in any::<u64>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_incr_test_frame(a);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+
+    // --------------------------------INV test --------------------------------------------------
+
+    #[test]
+    fn test_inv_stack_operation(a in any::<u64>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_inv_test_frame(a);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+    // --------------------------------NEG test --------------------------------------------------
+
+    #[test]
+    fn test_neg_stack_operation(a in any::<u64>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_neg_test_frame(a);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+}
+
+// UNIT TESTS
+// ================================================================================================
+
+// --------------------------------NOT test --------------------------------------------------
+
+#[test]
+fn test_not_stack_operation() {
+    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    // ----------------- top element is 1 -----------------------------------------------------
+    let a = ONE;
+    let frame = get_not_test_frame(a);
+    let result = get_constraint_evaluation(frame);
+    assert_eq!(expected, result);
+
+    // ----------------- top element is 0 -----------------------------------------------------
+    let a = ZERO;
+    let frame = get_not_test_frame(a);
+    let result = get_constraint_evaluation(frame);
+    assert_eq!(expected, result);
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Returns the result of stack operation constraint evaluations on the provided frame.
+fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
+    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    let op_flag = OpFlags::new(&frame);
+
+    enforce_constraints(&frame, &mut result, &op_flag);
+
+    result
+}
+
+/// Generates the correct current and next rows for the INCR operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_incr_test_frame(a: u64) -> EvaluationFrame<Felt> {
+    // frame initialised with a Incr operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::Incr.op_code() as usize);
+
+    // Set the output. First element in the next frame should be 1 + first
+    // element of the current frame.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a);
+    frame.next_mut()[STACK_TRACE_OFFSET] = Felt::new(a) + ONE;
+
+    frame
+}
+
+/// Generates the correct current and next rows for the INV operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_inv_test_frame(a: u64) -> EvaluationFrame<Felt> {
+    // frame initialised with a Inv operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::Inv.op_code() as usize);
+
+    // Set the output. First element in the next frame should be the inverse of
+    // the first element of the current frame.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a);
+    frame.next_mut()[STACK_TRACE_OFFSET] = Felt::new(a).inv();
+
+    frame
+}
+
+/// Generates the correct current and next rows for the NEG operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_neg_test_frame(a: u64) -> EvaluationFrame<Felt> {
+    // frame initialised with a Neg operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::Neg.op_code() as usize);
+
+    // Set the output. First element in the next frame should be the negation of
+    // the first element of the current frame.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a);
+    frame.next_mut()[STACK_TRACE_OFFSET] = Felt::new(a).neg();
+
+    frame
+}
+
+/// Generates the correct current and next rows for the NOT operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_not_test_frame(a: Felt) -> EvaluationFrame<Felt> {
+    // frame initialised with a NOT operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::Not.op_code() as usize);
+
+    // Set the output. First element in the next frame should be the binary not of
+    // the first element of the current frame.
+    frame.current_mut()[STACK_TRACE_OFFSET] = a;
+    frame.next_mut()[STACK_TRACE_OFFSET] = ONE - a;
+
+    frame
+}

--- a/air/src/stack/op_flags/mod.rs
+++ b/air/src/stack/op_flags/mod.rs
@@ -61,11 +61,11 @@ impl<E: FieldElement> OpFlags<E> {
     // =================================================================================================
 
     /// Returns a new instance of [OpFlags] instantiated with all stack operation flags.
-    pub fn new(frame: EvaluationFrame<E>) -> Self {
-        let (degree_6_op_flags, degree_4_op_flags) = set_op_flags_degree_4_and_6(&frame);
+    pub fn new(frame: &EvaluationFrame<E>) -> Self {
+        let (degree_6_op_flags, degree_4_op_flags) = set_op_flags_degree_4_and_6(frame);
 
         Self {
-            degree7_op_flags: set_op_flags_degree_7(&frame),
+            degree7_op_flags: set_op_flags_degree_7(frame),
             degree6_op_flags: degree_6_op_flags,
             degree4_op_flags: degree_4_op_flags,
         }
@@ -77,402 +77,402 @@ impl<E: FieldElement> OpFlags<E> {
     // ------ Degree 7 operations with no shift -------------------------------------------------
 
     #[inline(always)]
-    fn noop(&self) -> E {
+    pub fn noop(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Noop.op_code())]
     }
 
     #[inline(always)]
-    fn eqz(&self) -> E {
+    pub fn eqz(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Eqz.op_code())]
     }
 
     #[inline(always)]
-    fn neg(&self) -> E {
+    pub fn neg(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Neg.op_code())]
     }
 
     #[inline(always)]
-    fn inv(&self) -> E {
+    pub fn inv(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Inv.op_code())]
     }
 
     #[inline(always)]
-    fn incr(&self) -> E {
+    pub fn incr(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Incr.op_code())]
     }
 
     #[inline(always)]
-    fn not(&self) -> E {
+    pub fn not(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Not.op_code())]
     }
 
     #[inline(always)]
-    fn fmpadd(&self) -> E {
+    pub fn fmpadd(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::FmpAdd.op_code())]
     }
 
     #[inline(always)]
-    fn mload(&self) -> E {
+    pub fn mload(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MLoad.op_code())]
     }
 
     #[inline(always)]
-    fn swap(&self) -> E {
+    pub fn swap(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Swap.op_code())]
     }
 
     #[inline(always)]
-    fn movup2(&self) -> E {
+    pub fn movup2(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovUp2.op_code())]
     }
 
     #[inline(always)]
-    fn movdn2(&self) -> E {
+    pub fn movdn2(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovDn2.op_code())]
     }
 
     #[inline(always)]
-    fn movup3(&self) -> E {
+    pub fn movup3(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovUp3.op_code())]
     }
 
     #[inline(always)]
-    fn movdn3(&self) -> E {
+    pub fn movdn3(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovDn3.op_code())]
     }
 
     #[inline(always)]
-    fn readw(&self) -> E {
+    pub fn readw(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::ReadW.op_code())]
     }
 
     #[inline(always)]
-    fn movup4(&self) -> E {
+    pub fn movup4(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovUp4.op_code())]
     }
 
     #[inline(always)]
-    fn movdn4(&self) -> E {
+    pub fn movdn4(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovDn4.op_code())]
     }
 
     #[inline(always)]
-    fn movup5(&self) -> E {
+    pub fn movup5(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovUp5.op_code())]
     }
 
     #[inline(always)]
-    fn movdn5(&self) -> E {
+    pub fn movdn5(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovDn5.op_code())]
     }
 
     #[inline(always)]
-    fn movup6(&self) -> E {
+    pub fn movup6(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovUp6.op_code())]
     }
 
     #[inline(always)]
-    fn movdn6(&self) -> E {
+    pub fn movdn6(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovDn6.op_code())]
     }
 
     #[inline(always)]
-    fn movup7(&self) -> E {
+    pub fn movup7(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovUp7.op_code())]
     }
 
     #[inline(always)]
-    fn movdn7(&self) -> E {
+    pub fn movdn7(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovDn7.op_code())]
     }
 
     #[inline(always)]
-    fn swapw(&self) -> E {
+    pub fn swapw(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::SwapW.op_code())]
     }
 
     #[inline(always)]
-    fn movup8(&self) -> E {
+    pub fn movup8(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovUp8.op_code())]
     }
 
     #[inline(always)]
-    fn movdn8(&self) -> E {
+    pub fn movdn8(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MovDn8.op_code())]
     }
 
     #[inline(always)]
-    fn swapw2(&self) -> E {
+    pub fn swapw2(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::SwapW2.op_code())]
     }
 
     #[inline(always)]
-    fn swapw3(&self) -> E {
+    pub fn swapw3(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::SwapW3.op_code())]
     }
 
     #[inline(always)]
-    fn swapdw(&self) -> E {
+    pub fn swapdw(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::SwapDW.op_code())]
     }
 
     // ------ Degree 7 operations with left shift ----------------------------------------
 
     #[inline(always)]
-    fn assert(&self) -> E {
+    pub fn assert(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Assert.op_code())]
     }
 
     #[inline(always)]
-    fn eq(&self) -> E {
+    pub fn eq(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Eq.op_code())]
     }
 
     #[inline(always)]
-    fn add(&self) -> E {
+    pub fn add(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Add.op_code())]
     }
 
     #[inline(always)]
-    fn mul(&self) -> E {
+    pub fn mul(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Mul.op_code())]
     }
 
     #[inline(always)]
-    fn and(&self) -> E {
+    pub fn and(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::And.op_code())]
     }
 
     #[inline(always)]
-    fn or(&self) -> E {
+    pub fn or(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Or.op_code())]
     }
 
     #[inline(always)]
-    fn u32and(&self) -> E {
+    pub fn u32and(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::U32and.op_code())]
     }
 
     #[inline(always)]
-    fn u32xor(&self) -> E {
+    pub fn u32xor(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::U32xor.op_code())]
     }
 
     #[inline(always)]
-    fn drop(&self) -> E {
+    pub fn drop(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Drop.op_code())]
     }
 
     #[inline(always)]
-    fn cswap(&self) -> E {
+    pub fn cswap(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::CSwap.op_code())]
     }
 
     #[inline(always)]
-    fn cswapw(&self) -> E {
+    pub fn cswapw(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::CSwapW.op_code())]
     }
 
     #[inline(always)]
-    fn mloadw(&self) -> E {
+    pub fn mloadw(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MLoadW.op_code())]
     }
 
     #[inline(always)]
-    fn mstore(&self) -> E {
+    pub fn mstore(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MStore.op_code())]
     }
 
     #[inline(always)]
-    fn mstorew(&self) -> E {
+    pub fn mstorew(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::MStoreW.op_code())]
     }
 
     #[inline(always)]
-    fn fmpupdate(&self) -> E {
+    pub fn fmpupdate(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::FmpUpdate.op_code())]
     }
 
     // ------ Degree 7 operations with right shift -----------------------------------------------
 
     #[inline(always)]
-    fn pad(&self) -> E {
+    pub fn pad(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Pad.op_code())]
     }
 
     #[inline(always)]
-    fn dup(&self) -> E {
+    pub fn dup(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup0.op_code())]
     }
 
     #[inline(always)]
-    fn dup1(&self) -> E {
+    pub fn dup1(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup1.op_code())]
     }
 
     #[inline(always)]
-    fn dup2(&self) -> E {
+    pub fn dup2(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup2.op_code())]
     }
 
     #[inline(always)]
-    fn dup3(&self) -> E {
+    pub fn dup3(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup3.op_code())]
     }
 
     #[inline(always)]
-    fn dup4(&self) -> E {
+    pub fn dup4(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup4.op_code())]
     }
 
     #[inline(always)]
-    fn dup5(&self) -> E {
+    pub fn dup5(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup5.op_code())]
     }
 
     #[inline(always)]
-    fn dup6(&self) -> E {
+    pub fn dup6(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup6.op_code())]
     }
 
     #[inline(always)]
-    fn dup7(&self) -> E {
+    pub fn dup7(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup7.op_code())]
     }
 
     #[inline(always)]
-    fn dup9(&self) -> E {
+    pub fn dup9(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup9.op_code())]
     }
 
     #[inline(always)]
-    fn dup11(&self) -> E {
+    pub fn dup11(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup11.op_code())]
     }
 
     #[inline(always)]
-    fn dup13(&self) -> E {
+    pub fn dup13(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup13.op_code())]
     }
 
     #[inline(always)]
-    fn dup15(&self) -> E {
+    pub fn dup15(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Dup15.op_code())]
     }
 
     #[inline(always)]
-    fn read(&self) -> E {
+    pub fn read(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::Read.op_code())]
     }
 
     #[inline(always)]
-    fn sdepth(&self) -> E {
+    pub fn sdepth(&self) -> E {
         self.degree7_op_flags[get_op_index(Operation::SDepth.op_code())]
     }
 
     // ------ Degree 6 u32 operations  --------------------------------------------------------
 
     #[inline(always)]
-    fn u32add(&self) -> E {
+    pub fn u32add(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::U32add.op_code())]
     }
 
     #[inline(always)]
-    fn u32sub(&self) -> E {
+    pub fn u32sub(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::U32sub.op_code())]
     }
 
     #[inline(always)]
-    fn u32mul(&self) -> E {
+    pub fn u32mul(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::U32mul.op_code())]
     }
 
     #[inline(always)]
-    fn u32div(&self) -> E {
+    pub fn u32div(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::U32div.op_code())]
     }
 
     #[inline(always)]
-    fn u32split(&self) -> E {
+    pub fn u32split(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::U32split.op_code())]
     }
 
     #[inline(always)]
-    fn u32assert2(&self) -> E {
+    pub fn u32assert2(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::U32assert2.op_code())]
     }
 
     #[inline(always)]
-    fn u32add3(&self) -> E {
+    pub fn u32add3(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::U32add3.op_code())]
     }
 
     #[inline(always)]
-    fn u32madd(&self) -> E {
+    pub fn u32madd(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::U32madd.op_code())]
     }
 
     // ------ Degree 6 non u32 operations  ---------------------------------------------------
 
     #[inline(always)]
-    fn rpperm(&self) -> E {
+    pub fn rpperm(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::RpPerm.op_code())]
     }
 
     #[inline(always)]
-    fn mpverify(&self) -> E {
+    pub fn mpverify(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::MpVerify.op_code())]
     }
 
     #[inline(always)]
-    fn span(&self) -> E {
+    pub fn span(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::Span.op_code())]
     }
 
     #[inline(always)]
-    fn join(&self) -> E {
+    pub fn join(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::Join.op_code())]
     }
 
     #[inline(always)]
-    fn split(&self) -> E {
+    pub fn split(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::Split.op_code())]
     }
 
     #[inline(always)]
-    fn loop_op(&self) -> E {
+    pub fn loop_op(&self) -> E {
         self.degree6_op_flags[get_op_index(Operation::Loop.op_code())]
     }
 
     // ------ Degree 4 stack operations  -----------------------------------------------------
 
     #[inline(always)]
-    fn mrupdate(&self) -> E {
+    pub fn mrupdate(&self) -> E {
         self.degree4_op_flags[get_op_index(Operation::MrUpdate(true).op_code())]
     }
 
     #[inline(always)]
-    fn push(&self) -> E {
+    pub fn push(&self) -> E {
         self.degree4_op_flags[get_op_index(Operation::Push(ONE).op_code())]
     }
 
     #[inline(always)]
-    fn end(&self) -> E {
+    pub fn end(&self) -> E {
         self.degree4_op_flags[get_op_index(Operation::End.op_code())]
     }
 
     #[inline(always)]
-    fn repeat(&self) -> E {
+    pub fn repeat(&self) -> E {
         self.degree4_op_flags[get_op_index(Operation::Repeat.op_code())]
     }
 
     #[inline(always)]
-    fn respan(&self) -> E {
+    pub fn respan(&self) -> E {
         self.degree4_op_flags[get_op_index(Operation::Respan.op_code())]
     }
 
     #[inline(always)]
-    fn halt(&self) -> E {
+    pub fn halt(&self) -> E {
         self.degree4_op_flags[get_op_index(Operation::Halt.op_code())]
     }
 }
@@ -494,7 +494,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
 
     #[inline]
     fn op_bit(&self, idx: usize) -> E {
-        self.current()[DECODER_TRACE_OFFSET + OP_BITS_RANGE.end - idx - 1]
+        self.current()[DECODER_TRACE_OFFSET + OP_BITS_RANGE.start + idx]
     }
 
     #[inline]
@@ -662,8 +662,8 @@ pub fn generate_evaluation_frame(opcode: usize) -> EvaluationFrame<Felt> {
     // set helper value in the decoder. It will be ONE only in the case of a
     // degree four operation.
     current[DECODER_TRACE_OFFSET + OP_BIT_EXTRA_COL_IDX] = current
-        [DECODER_TRACE_OFFSET + OP_BITS_RANGE.start]
-        * current[DECODER_TRACE_OFFSET + OP_BITS_RANGE.start + 1];
+        [DECODER_TRACE_OFFSET + OP_BITS_RANGE.end - 1]
+        * current[DECODER_TRACE_OFFSET + OP_BITS_RANGE.end - 2];
 
     EvaluationFrame::<Felt>::from_rows(current, next)
 }
@@ -676,10 +676,10 @@ pub fn get_op_bits(opcode: usize) -> [Felt; NUM_OP_BITS] {
     // initialise the bit array with 0.
     let mut bit_array = [ZERO; NUM_OP_BITS];
 
-    for i in 0..NUM_OP_BITS {
+    for i in bit_array.iter_mut() {
         // returns the least significant bit of the opcode.
         let bit = opcode_copy & 1;
-        bit_array[7 - i - 1] = Felt::new(bit as u64);
+        *i = Felt::new(bit as u64);
         // one left shift.
         opcode_copy >>= 1;
     }

--- a/air/src/stack/op_flags/tests.rs
+++ b/air/src/stack/op_flags/tests.rs
@@ -17,7 +17,7 @@ fn degree_7_op_flags() {
         let frame = generate_evaluation_frame(i);
 
         // All the operation flags are generated for the given frame.
-        let op_flags = OpFlags::new(frame);
+        let op_flags = OpFlags::new(&frame);
 
         // index of the operation flag in the op_flag's degree seven array.
         let idx_in_degree7_flags = get_op_index(i as u8);
@@ -54,7 +54,7 @@ fn degree_6_op_flags() {
         let frame = generate_evaluation_frame(i);
 
         // All the operation flags are generated for the given frame.
-        let op_flags = OpFlags::new(frame);
+        let op_flags = OpFlags::new(&frame);
 
         // index of the operation flag in the op_flag's degree six array.
         let idx_in_degree6_flags = get_op_index(i as u8);
@@ -93,7 +93,7 @@ fn degree_4_op_flags() {
         let frame = generate_evaluation_frame(i);
 
         // All the operation flags are generated for the given frame.
-        let op_flags = OpFlags::new(frame);
+        let op_flags = OpFlags::new(&frame);
 
         // index of the operation flag in the op_flag's degree four array.
         let idx_in_degree4_flags = get_op_index(i as u8);

--- a/air/src/stack/stack_manipulation/mod.rs
+++ b/air/src/stack/stack_manipulation/mod.rs
@@ -1,0 +1,78 @@
+use super::{op_flags::OpFlags, EvaluationFrame, Vec};
+use crate::{stack::EvaluationFrameExt, utils::are_equal};
+use vm_core::FieldElement;
+use winter_air::TransitionConstraintDegree;
+
+#[cfg(test)]
+pub mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The number of unique transition constraints in stack manipulation operations.
+pub const NUM_CONSTRAINTS: usize = 2;
+
+/// The degrees of constraints in individual stack manipulation operations.
+pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
+    // Given it is a degree 7 operation, 7 is added to all the individual constraints
+    // degree.
+
+    // There are two unique constraints in SWAP stack manipulation operation in which the first
+    // element in the current frame is swapped with the second element.
+    8, 8,
+];
+
+// STACK MANIPULATION OPERATIONS TRANSITION CONSTRAINTS
+// ================================================================================================
+
+/// Builds the transition constraint degrees for the stack manipulation operations.
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    CONSTRAINT_DEGREES
+        .iter()
+        .map(|&degree| TransitionConstraintDegree::new(degree))
+        .collect()
+}
+
+/// Returns the number of transition constraints for the stack manipulation operations.
+pub fn get_transition_constraint_count() -> usize {
+    NUM_CONSTRAINTS
+}
+
+/// Enforces constraints for the stack manipulation operations.
+pub fn enforce_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: &OpFlags<E>,
+) -> usize {
+    let mut index = 0;
+
+    // Enforce constaints of the SWAP operations.
+    index += enforce_swap_constraints(frame, result, op_flag.swap());
+
+    index
+}
+
+// TRANSITION CONSTRAINT HELPERS
+// ================================================================================================
+
+/// Enforces constraints of the SWAP operation. The SWAP operation swaps the first
+/// two elements in the stack. Therefore, the following constraints are enforced:
+/// - The first element in the current frame should be equal to the second element in the
+///   next frame.
+/// - The second element in the current frame should be equal to the first element in the
+///   next frame.
+pub fn enforce_swap_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+) -> usize {
+    // Enforces the first element in the current frame is same as to the second element in the
+    // next frame
+    result[0] = op_flag * are_equal(frame.stack_item(0), frame.stack_item_next(1));
+
+    // Enforces the second element in the current frame is same as to the first element in the
+    // next frame
+    result[1] = op_flag * are_equal(frame.stack_item(1), frame.stack_item_next(0));
+
+    2
+}

--- a/air/src/stack/stack_manipulation/tests.rs
+++ b/air/src/stack/stack_manipulation/tests.rs
@@ -1,0 +1,47 @@
+use super::{enforce_constraints, EvaluationFrame, NUM_CONSTRAINTS};
+use crate::stack::op_flags::{generate_evaluation_frame, OpFlags};
+use vm_core::{Felt, FieldElement, Operation, STACK_TRACE_OFFSET};
+
+use proptest::prelude::*;
+
+// RANDOMIZED TESTS
+// ================================================================================================
+
+proptest! {
+    #[test]
+    fn test_stack_operation(a in any::<u64>(), b in any::<u64>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_swap_test_frame(a, b);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Returns the result of SWAP operation constraint evaluations on the provided frame.
+fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
+    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    let op_flag = &OpFlags::new(&frame);
+
+    enforce_constraints(&frame, &mut result, op_flag);
+
+    result
+}
+
+/// Generates the correct current and next rows for the SWAP operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_swap_test_frame(a: u64, b: u64) -> EvaluationFrame<Felt> {
+    // frame initialised with a swap operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::Swap.op_code() as usize);
+
+    // Set the output.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a);
+    frame.current_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(b);
+    frame.next_mut()[STACK_TRACE_OFFSET] = Felt::new(b);
+    frame.next_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(a);
+
+    frame
+}

--- a/air/src/stack/system_ops/mod.rs
+++ b/air/src/stack/system_ops/mod.rs
@@ -1,0 +1,70 @@
+use super::{op_flags::OpFlags, EvaluationFrame, Vec};
+use crate::{stack::EvaluationFrameExt, utils::are_equal};
+use vm_core::FieldElement;
+use winter_air::TransitionConstraintDegree;
+
+#[cfg(test)]
+pub mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The number of unique transition constraints in system operations.
+pub const NUM_CONSTRAINTS: usize = 1;
+
+/// The degrees of constraints in individual system operations of the system ops.
+pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
+    // Given it is a degree 7 operation, 7 is added to all the individual constraints
+    // degree.
+
+    // There's one unique constraint in FMPADD system operation in which the top element in the
+    // stack is is incremented by fmp register value.
+    8,
+];
+
+// SYSTEM OPERATIONS TRANSITION CONSTRAINTS
+// ================================================================================================
+
+/// Builds the transition constraint degrees for the system operations.
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    CONSTRAINT_DEGREES
+        .iter()
+        .map(|&degree| TransitionConstraintDegree::new(degree))
+        .collect()
+}
+
+/// Returns the number of transition constraints for the system operations.
+pub fn get_transition_constraint_count() -> usize {
+    NUM_CONSTRAINTS
+}
+
+/// Enforces constraints for all the system operations.
+pub fn enforce_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: &OpFlags<E>,
+) -> usize {
+    let mut index = 0;
+
+    index += enforce_fmpadd_constraints(frame, result, op_flag.fmpadd());
+
+    index
+}
+
+// TRANSITION CONSTRAINT HELPERS
+// ================================================================================================
+
+/// Enforces unique constraints of the FMPADD operation. The FMPADD operation increments the
+/// top element in the stack by fmp value. Therefore, the following constraints are enforced:
+/// - The first element in the next frame should be equal to the addition of the first element
+///   in the current frame and the fmp value.
+pub fn enforce_fmpadd_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+) -> usize {
+    // Enforces the first element in the next frame is incremented by fmp value.
+    result[0] = op_flag * are_equal(frame.stack_item(0) + frame.fmp(), frame.stack_item_next(0));
+
+    1
+}

--- a/air/src/stack/system_ops/tests.rs
+++ b/air/src/stack/system_ops/tests.rs
@@ -1,0 +1,47 @@
+use super::{enforce_constraints, EvaluationFrame, NUM_CONSTRAINTS};
+use crate::stack::op_flags::{generate_evaluation_frame, OpFlags};
+use vm_core::{Felt, FieldElement, Operation, FMP_COL_IDX, STACK_TRACE_OFFSET};
+
+use proptest::prelude::*;
+
+// RANDOMIZED TESTS
+// ================================================================================================
+
+proptest! {
+    #[test]
+    fn test_stack_operation(a in any::<u64>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_system_test_frame(a);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Returns the result of stack operation constraint evaluations on the provided frame.
+fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
+    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    let op_flag = &OpFlags::new(&frame);
+
+    enforce_constraints(&frame, &mut result, op_flag);
+
+    result
+}
+
+/// Generates the correct current and next rows for the fmpadd operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_system_test_frame(a: u64) -> EvaluationFrame<Felt> {
+    // frame initialised with a fmpadd operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::FmpAdd.op_code() as usize);
+
+    // Set the output. First element in the next frame should be incremented
+    // by value present in the fmp register.
+    frame.current_mut()[FMP_COL_IDX] = Felt::new(a);
+    frame.next_mut()[STACK_TRACE_OFFSET] =
+        frame.current()[STACK_TRACE_OFFSET] + frame.current()[FMP_COL_IDX];
+
+    frame
+}

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -51,16 +51,24 @@ impl<E: FieldElement> EvaluationResult<E> for Vec<E> {
 /// indices can be handled easily during transition evaluation.
 #[derive(Debug)]
 pub struct TransitionConstraintRange {
+    pub(super) stack: Range<usize>,
     pub(super) range_checker: Range<usize>,
     pub(super) chiplets: Range<usize>,
 }
 
 impl TransitionConstraintRange {
-    pub fn new(sys: usize, range_checker_len: usize, chiplets_len: usize) -> Self {
-        let range_checker = create_range(sys, range_checker_len);
+    pub fn new(
+        sys: usize,
+        stack_len: usize,
+        range_checker_len: usize,
+        chiplets_len: usize,
+    ) -> Self {
+        let stack = create_range(sys, stack_len);
+        let range_checker = create_range(stack.end, range_checker_len);
         let chiplets = create_range(range_checker.end, chiplets_len);
 
         Self {
+            stack,
             range_checker,
             chiplets,
         }
@@ -87,27 +95,40 @@ mod tests {
     #[test]
     fn transition_constraint_ranges() {
         let sys_constraints_len = 1;
-        let range_constraints_len = 2;
-        let aux_constraints_len = 3;
+        let stack_constraints_len = 2;
+        let range_constraints_len = 3;
+        let aux_constraints_len = 4;
 
         let constraint_ranges = TransitionConstraintRange::new(
             sys_constraints_len,
+            stack_constraints_len,
             range_constraints_len,
             aux_constraints_len,
         );
 
-        assert_eq!(constraint_ranges.range_checker.start, sys_constraints_len);
+        assert_eq!(constraint_ranges.stack.start, sys_constraints_len);
+        assert_eq!(
+            constraint_ranges.stack.end,
+            sys_constraints_len + stack_constraints_len
+        );
+        assert_eq!(
+            constraint_ranges.range_checker.start,
+            sys_constraints_len + stack_constraints_len
+        );
         assert_eq!(
             constraint_ranges.range_checker.end,
-            sys_constraints_len + range_constraints_len
+            sys_constraints_len + stack_constraints_len + range_constraints_len
         );
         assert_eq!(
             constraint_ranges.chiplets.start,
-            sys_constraints_len + range_constraints_len
+            sys_constraints_len + stack_constraints_len + range_constraints_len
         );
         assert_eq!(
             constraint_ranges.chiplets.end,
-            sys_constraints_len + range_constraints_len + aux_constraints_len
+            sys_constraints_len
+                + stack_constraints_len
+                + range_constraints_len
+                + aux_constraints_len
         );
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod chiplets;
 pub mod decoder;
 pub mod errors;
 pub mod range;
+pub mod stack;
 
 pub use math::{fields::f64::BaseElement as Felt, ExtensionOf, FieldElement, StarkField};
 

--- a/core/src/stack/mod.rs
+++ b/core/src/stack/mod.rs
@@ -1,0 +1,31 @@
+use super::{range, Range};
+
+// CONSTANTS
+// ================================================================================================
+
+/// Length of a stack word.
+pub const WORD_LENGTH: usize = 4;
+
+/// Index at which the first word starts in the stack trace.
+pub const WORD1_OFFSET: usize = 0;
+
+/// Location of first word in the stack trace.
+pub const WORD1_RANGE: Range<usize> = range(WORD1_OFFSET, WORD_LENGTH);
+
+/// Index at which the second word starts in the stack trace.
+pub const WORD2_OFFSET: usize = WORD1_RANGE.end;
+
+/// Location of second word in the stack trace.
+pub const WORD2_RANGE: Range<usize> = range(WORD2_OFFSET, WORD_LENGTH);
+
+/// Index at which the third word starts in the stack trace.
+pub const WORD3_OFFSET: usize = WORD2_RANGE.end;
+
+/// Location of third word in the stack trace.
+pub const WORD3_RANGE: Range<usize> = range(WORD3_OFFSET, WORD_LENGTH);
+
+/// Index at which the fourth word starts in the stack trace.
+pub const WORD4_OFFSET: usize = WORD3_RANGE.end;
+
+/// Location of fourth word in the stack trace.
+pub const WORD4_RANGE: Range<usize> = range(WORD4_OFFSET, WORD_LENGTH);

--- a/miden/tests/integration/air/stack/field_ops.rs
+++ b/miden/tests/integration/air/stack/field_ops.rs
@@ -1,0 +1,28 @@
+use crate::build_op_test;
+
+#[test]
+fn incr() {
+    // Test on random input state.
+    let asm_op = "add.1 add.1 push.0 add.1 add.1 eq assert";
+    let pub_inputs = vec![0];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
+}
+
+#[test]
+fn neg() {
+    // Test on random input state.
+    let asm_op = "dup.0 neg add eq.0 assert";
+    let pub_inputs = vec![7];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
+}
+
+#[test]
+fn not() {
+    // Test on random input state.
+    let asm_op = "dup.0 not add eq.1 assert";
+    let pub_inputs = vec![1];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
+}

--- a/miden/tests/integration/air/stack/mod.rs
+++ b/miden/tests/integration/air/stack/mod.rs
@@ -1,5 +1,8 @@
 use crate::build_op_test;
 
+mod field_ops;
+mod stack_manipualtion_ops;
+
 /// Test empty starting stack with no overflow outputs.
 #[test]
 fn empty_input() {

--- a/miden/tests/integration/air/stack/stack_manipualtion_ops.rs
+++ b/miden/tests/integration/air/stack/stack_manipualtion_ops.rs
@@ -1,0 +1,10 @@
+use crate::build_op_test;
+
+#[test]
+fn swap() {
+    // Test on random input state.
+    let asm_op = "swap push.0 swap push.34 swap drop drop";
+    let pub_inputs = vec![7, 69];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
+}


### PR DESCRIPTION
This PR introduces a structure for the stack operations AIR constraints to the VM. Simple operations constraints were implemented from different logical group which doesn't require a stack shift, interaction with chiplets and helper variables in decoder. 