### PR TITLE
docs(mdbook): update decoder constraints

### DIFF
--- a/docs/src/design/stack/op_constraints.md
+++ b/docs/src/design/stack/op_constraints.md
@@ -250,3 +250,26 @@ In the above:
 * $h_5$ is the helper register in the decoder which is set to $1$ when we are exiting a `LOOP` block, and to $0$ otherwise.
 
 Thus, similarly to the right-shift flag, we compute the value of the left-shift flag based on the prefix of the operation group which contains most left shift operations, and add in flag values for other operations which shift the stack to the left but are not a part of this group.
+
+### Control flow flag
+The control flow flag $f_{ctrl}$ is set to $1$ when a control flow operation is being executed by the VM, and to $0$ otherwise. Naively, this flag can be computed as follows:
+
+$$
+f_{ctrl} = f_{join} + f_{split} + f_{loop} + f_{repeat} + f_{span} + f_{respan} + f_{end} + f_{halt} \text{ | degree} = 6
+$$
+
+However, this can be computed more efficiently via the common operation prefixes for the two groups of control flow operations as follows.
+
+$$
+f_{span,join,split,loop} = b_6 \cdot (1 - b_5) \cdot b_4 \cdot b_3 \text{ | degree} = 4
+$$
+
+$$
+f_{end,repeat,respan,halt} = b_6 \cdot b_5 \cdot b_4  \text{ | degree} = 3
+$$
+
+$$
+f_{ctrl} = f_{span,join,split,loop} + f_{end,repeat,respan,halt} \text{ | degree} = 4
+$$
+
+Note that the degree of $f_{end,repeat,respan,halt}$ can be reduced to degree 2 using the extra column, but this will not affect the degree of the $f_{ctrl}$ constraint.


### PR DESCRIPTION
This PR updates the constraints in the decoder documentation as required by the new operation flag assignments.

- update degrees of decoder constraints
- define more efficient flag for control flow operations