### PR TITLE
Implement multi-context memory

### DIFF
--- a/air/src/stack/mod.rs
+++ b/air/src/stack/mod.rs
@@ -103,17 +103,14 @@ pub fn enforce_unique_constraints<E: FieldElement>(
 
     // system operations transition constraints.
     system_ops::enforce_constraints(frame, result, op_flag);
-
     constraint_offset += system_ops::get_transition_constraint_count();
 
     // field operations transition constraints.
     field_ops::enforce_constraints(frame, &mut result[constraint_offset..], op_flag);
-
     constraint_offset += field_ops::get_transition_constraint_count();
 
     // stack manipulation operations transition constraints.
     stack_manipulation::enforce_constraints(frame, &mut result[constraint_offset..], op_flag);
-
     constraint_offset += stack_manipulation::get_transition_constraint_count();
 
     constraint_offset

--- a/air/src/stack/op_flags/mod.rs
+++ b/air/src/stack/op_flags/mod.rs
@@ -1,7 +1,7 @@
 use super::EvaluationFrame;
 use crate::utils::binary_not;
 use vm_core::{
-    decoder::{NUM_OP_BITS, OP_BITS_RANGE, OP_BIT_EXTRA_COL_IDX, USER_OP_HELPERS_OFFSET},
+    decoder::{IS_LOOP_FLAG_COL_IDX, NUM_OP_BITS, OP_BITS_RANGE, OP_BIT_EXTRA_COL_IDX},
     Felt, FieldElement, Operation, DECODER_TRACE_OFFSET, ONE, TRACE_WIDTH, ZERO,
 };
 
@@ -229,6 +229,7 @@ impl<E: FieldElement> OpFlags<E> {
             + degree6_op_flags[13]
             + degree4_op_flags[6]
             + degree4_op_flags[7]
+            + degree4_op_flags[3]
             + degree4_op_flags[4] * binary_not(frame.is_loop());
 
         no_shift_flags[1] = no_shift_flags[0] + no_change_1_flag;
@@ -330,7 +331,7 @@ impl<E: FieldElement> OpFlags<E> {
             f010 + add3_madd_flag + split_loop_flag + degree4_op_flags[5] + shift_left_on_end;
 
         // Flag if the current operation being executed is a control flow operation.
-        let control_flow = f111 + f1011;
+        let control_flow = f111 + f1011 + degree4_op_flags[3];
 
         Self {
             degree7_op_flags,
@@ -905,7 +906,7 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
 
     #[inline]
     fn is_loop(&self) -> E {
-        self.current()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4]
+        self.current()[DECODER_TRACE_OFFSET + IS_LOOP_FLAG_COL_IDX]
     }
 }
 
@@ -934,7 +935,7 @@ pub const fn get_right_shift(idx: usize) -> usize {
 }
 
 /// Accepts an integer which is a unique representation of an operation and returns
-/// a trace constaining the op bits of the operation.
+/// a trace containing the op bits of the operation.
 pub fn generate_evaluation_frame(opcode: usize) -> EvaluationFrame<Felt> {
     let operation_bit_array = get_op_bits(opcode);
 

--- a/air/src/stack/op_flags/tests.rs
+++ b/air/src/stack/op_flags/tests.rs
@@ -5,7 +5,7 @@ use super::{
     DEGREE_6_OPCODE_ENDS, DEGREE_6_OPCODE_STARTS, DEGREE_7_OPCODE_ENDS, DEGREE_7_OPCODE_STARTS,
     NUM_DEGREE_4_OPS, NUM_DEGREE_6_OPS, NUM_DEGREE_7_OPS,
 };
-use vm_core::{decoder::USER_OP_HELPERS_OFFSET, Operation, DECODER_TRACE_OFFSET, ONE, ZERO};
+use vm_core::{decoder::IS_LOOP_FLAG_COL_IDX, Operation, DECODER_TRACE_OFFSET, ONE, ZERO};
 
 /// Asserts the op flag to ONE for degree 7 operation which is being executed in the current
 /// frame; assert all the other operation flags to ZERO as they are not present in the current
@@ -13,7 +13,7 @@ use vm_core::{decoder::USER_OP_HELPERS_OFFSET, Operation, DECODER_TRACE_OFFSET, 
 #[test]
 fn degree_7_op_flags() {
     for i in DEGREE_7_OPCODE_STARTS..=DEGREE_7_OPCODE_ENDS {
-        // frame initialised with a degree 7 operation using it's unique opcode.
+        // frame initialized with a degree 7 operation using it's unique opcode.
         let frame = generate_evaluation_frame(i);
 
         // All the operation flags are generated for the given frame.
@@ -541,7 +541,7 @@ fn composite_flags() {
 
     // ----------------------------------- left shift -----------------------------------------------
 
-    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4] = ONE;
+    frame.current_mut()[DECODER_TRACE_OFFSET + IS_LOOP_FLAG_COL_IDX] = ONE;
 
     // All the operation flags are generated for the given frame.
     let op_flags = OpFlags::new(&frame);

--- a/air/src/stack/stack_manipulation/mod.rs
+++ b/air/src/stack/stack_manipulation/mod.rs
@@ -46,7 +46,7 @@ pub fn enforce_constraints<E: FieldElement>(
 ) -> usize {
     let mut index = 0;
 
-    // Enforce constaints of the SWAP operations.
+    // Enforce constraints of the SWAP operations.
     index += enforce_swap_constraints(frame, result, op_flag.swap());
 
     index

--- a/core/src/decoder/mod.rs
+++ b/core/src/decoder/mod.rs
@@ -64,8 +64,17 @@ pub const OP_BATCH_2_GROUPS: [Felt; NUM_OP_BATCH_FLAGS] = [ZERO, ZERO, ONE];
 /// Operation batch consists of 1 operation group.
 pub const OP_BATCH_1_GROUPS: [Felt; NUM_OP_BATCH_FLAGS] = [ZERO, ONE, ONE];
 
-// Index of the op bits extra column in the decoder trace.
+/// Index of the op bits extra column in the decoder trace.
 pub const OP_BIT_EXTRA_COL_IDX: usize = OP_BATCH_FLAGS_RANGE.end;
+
+/// Index of a flag column which indicates whether an ending block is a body of a loop.
+pub const IS_LOOP_BODY_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 4;
+
+/// Index of a flag column which indicates whether an ending block is a LOOP block.
+pub const IS_LOOP_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 5;
+
+/// Index of a flag column which indicates whether an ending block is a CALL block.
+pub const IS_CALL_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 6;
 
 // --- Column accessors in the auxiliary columns --------------------------------------------------
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -61,34 +61,35 @@ pub const NUM_STACK_HELPER_COLS: usize = 3;
 // ------------------------------------------------------------------------------------------------
 
 //      system          decoder           stack      range checks       chiplets
-//    (2 columns)     (23 columns)    (19 columns)    (4 columns)     (18 columns)
+//    (3 columns)     (23 columns)    (19 columns)    (4 columns)     (18 columns)
 // ├───────────────┴───────────────┴───────────────┴───────────────┴─────────────────┤
 
 pub const SYS_TRACE_OFFSET: usize = 0;
-pub const SYS_TRACE_WIDTH: usize = 2;
+pub const SYS_TRACE_WIDTH: usize = 3;
 pub const SYS_TRACE_RANGE: Range<usize> = range(SYS_TRACE_OFFSET, SYS_TRACE_WIDTH);
 
 pub const CLK_COL_IDX: usize = SYS_TRACE_OFFSET;
 pub const FMP_COL_IDX: usize = SYS_TRACE_OFFSET + 1;
+pub const CTX_COL_IDX: usize = SYS_TRACE_OFFSET + 2;
 
 // decoder trace
-pub const DECODER_TRACE_OFFSET: usize = SYS_TRACE_OFFSET + SYS_TRACE_WIDTH;
+pub const DECODER_TRACE_OFFSET: usize = SYS_TRACE_RANGE.end;
 pub const DECODER_TRACE_WIDTH: usize = 23;
 pub const DECODER_TRACE_RANGE: Range<usize> = range(DECODER_TRACE_OFFSET, DECODER_TRACE_WIDTH);
 
 // Stack trace
-pub const STACK_TRACE_OFFSET: usize = DECODER_TRACE_OFFSET + DECODER_TRACE_WIDTH;
+pub const STACK_TRACE_OFFSET: usize = DECODER_TRACE_RANGE.end;
 pub const STACK_TRACE_WIDTH: usize = MIN_STACK_DEPTH + NUM_STACK_HELPER_COLS;
 pub const STACK_TRACE_RANGE: Range<usize> = range(STACK_TRACE_OFFSET, STACK_TRACE_WIDTH);
 
 // Range check trace
-pub const RANGE_CHECK_TRACE_OFFSET: usize = STACK_TRACE_OFFSET + STACK_TRACE_WIDTH;
+pub const RANGE_CHECK_TRACE_OFFSET: usize = STACK_TRACE_RANGE.end;
 pub const RANGE_CHECK_TRACE_WIDTH: usize = 4;
 pub const RANGE_CHECK_TRACE_RANGE: Range<usize> =
     range(RANGE_CHECK_TRACE_OFFSET, RANGE_CHECK_TRACE_WIDTH);
 
 // Chiplets trace
-pub const CHIPLETS_OFFSET: usize = RANGE_CHECK_TRACE_OFFSET + RANGE_CHECK_TRACE_WIDTH;
+pub const CHIPLETS_OFFSET: usize = RANGE_CHECK_TRACE_RANGE.end;
 pub const CHIPLETS_WIDTH: usize = 18;
 pub const CHIPLETS_RANGE: Range<usize> = range(CHIPLETS_OFFSET, CHIPLETS_WIDTH);
 

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -169,7 +169,7 @@ fn test_exec_iter() {
             ]
             .to_elements(),
             fmp: next_fmp,
-            memory: mem.clone(),
+            memory: mem,
         },
         VmState {
             clk: 15,

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -19,6 +19,7 @@ fn test_exec_iter() {
     let expected_states = vec![
         VmState {
             clk: 0,
+            ctx: 0,
             op: None,
             asmop: None,
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
@@ -27,6 +28,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 1,
+            ctx: 0,
             op: Some(Operation::Span),
             asmop: None,
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1].to_elements(),
@@ -35,6 +37,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 2,
+            ctx: 0,
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new("mem_storew.1".to_string(), 3, 1)),
             stack: [0, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
@@ -43,6 +46,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 3,
+            ctx: 0,
             op: Some(Operation::Incr),
             asmop: Some(AsmOpInfo::new("mem_storew.1".to_string(), 3, 2)),
             stack: [1, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2].to_elements(),
@@ -51,6 +55,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 4,
+            ctx: 0,
             op: Some(Operation::MStoreW),
             asmop: Some(AsmOpInfo::new("mem_storew.1".to_string(), 3, 3)),
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
@@ -59,6 +64,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 5,
+            ctx: 0,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("dropw".to_string(), 4, 1)),
             stack: [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].to_elements(),
@@ -67,6 +73,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 6,
+            ctx: 0,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("dropw".to_string(), 4, 2)),
             stack: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0].to_elements(),
@@ -75,6 +82,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 7,
+            ctx: 0,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("dropw".to_string(), 4, 3)),
             stack: [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
@@ -83,6 +91,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 8,
+            ctx: 0,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("dropw".to_string(), 4, 4)),
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
@@ -91,6 +100,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 9,
+            ctx: 0,
             op: Some(Operation::Push(Felt::new(17))),
             asmop: Some(AsmOpInfo::new("push.17".to_string(), 1, 1)),
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0].to_elements(),
@@ -99,6 +109,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 10,
+            ctx: 0,
             op: Some(Operation::Noop),
             asmop: None,
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
@@ -107,6 +118,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 11,
+            ctx: 0,
             op: Some(Operation::Push(Felt::new(1))),
             asmop: None,
             stack: [1, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
@@ -115,6 +127,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 12,
+            ctx: 0,
             op: Some(Operation::FmpUpdate),
             asmop: None,
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
@@ -123,6 +136,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 13,
+            ctx: 0,
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new("loc_store.0".to_string(), 3, 1)),
             stack: [0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0].to_elements(),
@@ -131,6 +145,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 14,
+            ctx: 0,
             op: Some(Operation::FmpAdd),
             asmop: Some(AsmOpInfo::new("loc_store.0".to_string(), 3, 2)),
             stack: [
@@ -158,6 +173,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 15,
+            ctx: 0,
             op: Some(Operation::MStore),
             asmop: Some(AsmOpInfo::new("loc_store.0".to_string(), 3, 3)),
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
@@ -169,6 +185,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 16,
+            ctx: 0,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("drop".to_string(), 1, 1)),
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -144,13 +144,15 @@ fn local_fn_call_with_mem_access() {
     // calling foo, the value saved into memory[0] before calling foo should still be there.
     let source = "
         proc.foo
-            pop.mem.0
+            mem_store.0
+            drop
         end
 
         begin
-            pop.mem.0
+            mem_store.0
+            drop
             call.foo
-            push.mem.0
+            mem_load.0
             eq.7
         end";
 

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -129,11 +129,33 @@ fn local_fn_call() {
         end
 
         begin
-            exec.foo
+            call.foo
         end";
 
     let test = build_test!(source, &[1, 2]);
     test.expect_stack(&[3]);
 
     test.prove_and_verify(vec![1, 2], false);
+}
+
+#[test]
+fn local_fn_call_with_mem_access() {
+    // foo should be executed in a different memory context; thus, when we read from memory after
+    // calling foo, the value saved into memory[0] before calling foo should still be there.
+    let source = "
+        proc.foo
+            pop.mem.0
+        end
+
+        begin
+            pop.mem.0
+            call.foo
+            push.mem.0
+            eq.7
+        end";
+
+    let test = build_test!(source, &[3, 7]);
+    test.expect_stack(&[1]);
+
+    test.prove_and_verify(vec![3, 7], false);
 }

--- a/miden/tests/integration/helpers/mod.rs
+++ b/miden/tests/integration/helpers/mod.rs
@@ -105,7 +105,7 @@ impl Test {
         process.execute(&program).unwrap();
 
         // validate the memory state
-        let mem_state = process.get_memory_value(mem_addr).unwrap();
+        let mem_state = process.get_memory_value(0, mem_addr).unwrap();
         let expected_mem: Vec<Felt> = expected_mem.iter().map(|&v| Felt::new(v)).collect();
         assert_eq!(expected_mem, mem_state);
 

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -1,14 +1,15 @@
+use super::{
+    BTreeMap, ChipletsBus, Felt, FieldElement, StarkField, TraceFragment, Vec, Word, ONE, ZERO,
+};
 use crate::{
     range::RangeChecker,
     trace::LookupTableRow,
     utils::{split_element_u32_into_u16, split_u32_into_u16},
 };
-
-use super::{
-    BTreeMap, ChipletsBus, Felt, FieldElement, RangeInclusive, StarkField, TraceFragment, Vec,
-    Word, ONE, ZERO,
-};
 use vm_core::chiplets::memory::MEMORY_LABEL;
+
+mod segment;
+use segment::MemorySegmentTrace;
 
 #[cfg(test)]
 mod tests;
@@ -27,8 +28,11 @@ const INIT_MEM_VALUE: Word = [ZERO; 4];
 /// This component is responsible for tracking current memory state of the VM, as well as for
 /// building an execution trace of all memory accesses.
 ///
-/// The memory is word-addressable. That is, four field elements are located at each memory
-/// address, and we can read and write elements to/from memory in batches of four.
+/// The memory is comprised of one or more segments, each segment accessible from a specific
+/// execution context. The root (kernel) context has context ID 0, and all additional contexts
+/// have increasing IDs. Within each segment, the memory is word-addressable. That is, four field
+/// elements are located at each memory address, and we can read and write elements to/from memory
+/// in batches of four.
 ///
 /// Memory for a a given address is always initialized to zeros. That is, reading from an address
 /// before writing to it will return four ZERO elements.
@@ -40,7 +44,9 @@ const INIT_MEM_VALUE: Word = [ZERO; 4];
 /// ├─────┴──────┴─────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴───────┤
 ///
 /// In the above, the meaning of the columns is as follows:
-/// - `ctx` contains context ID. Currently, context ID is always set to ZERO.
+/// - `ctx` contains execution context ID. Values in this column must increase monotonically but
+///   there can be gaps between two consecutive context IDs of up to 2^32. Also, two consecutive
+///   values can be the same.
 /// - `addr` contains memory address. Values in this column must increase monotonically for a
 ///   given context but there can be gaps between two consecutive values of up to 2^32. Also,
 ///   two consecutive values can be the same.
@@ -63,30 +69,17 @@ const INIT_MEM_VALUE: Word = [ZERO; 4];
 ///   clock cycles computed as described above.
 ///
 /// For the first row of the trace, values in `d0`, `d1`, and `d_inv` are set to zeros.
+#[derive(Default)]
 pub struct Memory {
-    /// Current clock cycle of the VM.
-    clk: u32,
+    /// Memory segment traces sorted by their execution context ID.
+    trace: BTreeMap<u32, MemorySegmentTrace>,
 
-    /// Memory access trace sorted first by address and then by clock cycle.
-    trace: BTreeMap<u64, Vec<(Felt, Word)>>,
-
-    /// Total number of entries in the trace; tracked separately so that we don't have to sum up
-    /// length of all vectors in the trace map all the time.
+    /// Total number of entries in the trace (across all contexts); tracked separately so that we
+    /// don't have to sum up lengths of all address trace vectors for all contexts all the time.
     num_trace_rows: usize,
 }
 
 impl Memory {
-    // CONSTRUCTOR
-    // --------------------------------------------------------------------------------------------
-    /// Returns a new [Memory] initialized with an empty trace.
-    pub fn new() -> Self {
-        Self {
-            clk: 0,
-            trace: BTreeMap::new(),
-            num_trace_rows: 0,
-        }
-    }
-
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
@@ -96,150 +89,105 @@ impl Memory {
         self.num_trace_rows
     }
 
-    /// Returns the address and clock cycle of the first trace row, or None if the trace is empty.
-    fn get_first_row_info(&self) -> Option<(Felt, Felt)> {
-        match self.trace.iter().next() {
-            Some((&addr, addr_trace)) => {
-                let clk = addr_trace[0].0;
-                Some((Felt::new(addr), clk))
-            }
+    /// Returns a word located at the specified context/address, or None if the address hasn't
+    /// been accessed previously.
+    ///
+    /// Unlike read() which modifies the memory access trace, this method returns the value at the
+    /// specified address (if one exists) without altering the memory access trace.
+    pub fn get_value(&self, ctx: u32, addr: u64) -> Option<Word> {
+        match self.trace.get(&ctx) {
+            Some(segment) => segment.get_value(addr),
             None => None,
         }
     }
 
-    /// Returns a word located at the specified address, or None if the address hasn't been
-    /// accessed previously.
-    /// Unlike read() that modifies the underlying map, get_value() only attempts to read
-    /// or return None when no value exists.
-    pub fn get_value(&self, addr: u64) -> Option<Word> {
-        match self.trace.get(&addr) {
-            Some(addr_trace) => addr_trace.last().map(|(_, value)| *value),
-            None => None,
-        }
-    }
-
-    /// Returns the value at the specified address which should be used as the "old value" for a
+    /// Returns the word at the specified context/address which should be used as the "old value" for a
     /// write request. It will be the previously stored value, if one exists, or initialized memory.
-    pub fn get_old_value(&self, addr: Felt) -> Word {
+    pub fn get_old_value(&self, ctx: u32, addr: Felt) -> Word {
         // get the stored word or return [0, 0, 0, 0], since the memory is initialized with zeros
-        self.get_value(addr.as_int()).unwrap_or(INIT_MEM_VALUE)
+        self.get_value(ctx, addr.as_int()).unwrap_or(INIT_MEM_VALUE)
     }
 
-    /// Returns values within a range of addresses, or optionally all values at the beginning of
-    /// the specified cycle.
-    /// TODO: refactor to something like `pub fn get_state_at(&self, clk: u64)-> Vec<(u64, Word)>`
-    pub fn get_values_at(&self, range: RangeInclusive<u64>, clk: u64) -> Vec<(u64, Word)> {
-        let mut data: Vec<(u64, Word)> = Vec::new();
-
+    /// Returns the entire memory state for the specified execution context at the specified cycle.
+    /// The state is returned as a vector of (address, value) tuples, and includes addresses which
+    /// have been accessed at least once.
+    pub fn get_state_at(&self, ctx: u32, clk: u32) -> Vec<(u64, Word)> {
         if clk == 0 {
-            return data;
+            return vec![];
         }
 
-        // Because we want to view the memory state at the beginning of the specified cycle, we
-        // view the memory state at the previous cycle, as the current memory state is at the
-        // end of the current cycle.
-        let search_step = clk - 1;
-
-        for (&addr, addr_trace) in self.trace.range(range) {
-            match addr_trace.binary_search_by(|(x, _)| x.as_int().cmp(&search_step)) {
-                Ok(i) => data.push((addr, addr_trace[i].1)),
-                Err(i) => {
-                    // Binary search finds the index of the data with the specified clock cycle.
-                    // Decrement the index to get the trace from the previously accessed clock cycle
-                    // to insert into the results.
-                    if i > 0 {
-                        data.push((addr, addr_trace[i - 1].1));
-                    }
-                }
-            }
+        match self.trace.get(&ctx) {
+            Some(segment) => segment.get_state_at(clk),
+            None => vec![],
         }
-
-        data
     }
 
     // STATE ACCESSORS AND MUTATORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a word (4 elements) located in memory at the specified address.
+    /// Returns a word located in memory at the specified context/address.
     ///
     /// If the specified address hasn't been previously written to, four ZERO elements are
     /// returned. This effectively implies that memory is initialized to ZERO.
-    pub fn read(&mut self, addr: Felt) -> Word {
+    pub fn read(&mut self, ctx: u32, addr: Felt, clk: u32) -> Word {
         self.num_trace_rows += 1;
-        let clk = Felt::from(self.clk);
-
-        // look up the previous value in the appropriate address trace and add (clk, prev_value)
-        // to it; if this is the first time we access this address, create address trace for it
-        // with entry (clk, [ZERO, 4]). in both cases, return the last value in the address trace.
         self.trace
-            .entry(addr.as_int())
-            .and_modify(|addr_trace| {
-                let last_value = addr_trace.last().expect("empty address trace").1;
-                addr_trace.push((clk, last_value));
-            })
-            .or_insert_with(|| vec![(clk, INIT_MEM_VALUE)])
-            .last()
-            .expect("empty address trace")
-            .1
+            .entry(ctx)
+            .or_insert_with(MemorySegmentTrace::default)
+            .read(addr, Felt::from(clk))
     }
 
-    /// Writes the provided word (4 elements) at the specified address.
-    pub fn write(&mut self, addr: Felt, value: Word) {
+    /// Writes the provided word at the specified context/address.
+    pub fn write(&mut self, ctx: u32, addr: Felt, clk: u32, value: Word) {
         self.num_trace_rows += 1;
-        let clk = Felt::from(self.clk);
-
-        // add a tuple (clk, value) to the appropriate address trace; if this is the first time
-        // we access this address, initialize address trace.
         self.trace
-            .entry(addr.as_int())
-            .and_modify(|addr_trace| addr_trace.push((clk, value)))
-            .or_insert_with(|| vec![(clk, value)]);
-    }
-
-    // CONTEXT MANAGEMENT
-    // --------------------------------------------------------------------------------------------
-
-    /// Increments the clock cycle.
-    pub fn advance_clock(&mut self) {
-        self.clk += 1;
+            .entry(ctx)
+            .or_insert_with(MemorySegmentTrace::default)
+            .write(addr, Felt::from(clk), value);
     }
 
     // EXECUTION TRACE GENERATION
     // --------------------------------------------------------------------------------------------
 
-    /// Add all of the range checks required by the [Memory] processor to the provided
-    /// [RangeChecker] processor instance, along with their row in the finalized execution trace.
+    /// Adds all of the range checks required by the [Memory] chiplet to the provided
+    /// [RangeChecker] chiplet instance, along with their row in the finalized execution trace.
     pub fn append_range_checks(&self, memory_start_row: usize, range: &mut RangeChecker) {
         // set the previous address and clock cycle to the first address and clock cycle of the
         // trace; we also adjust the clock cycle so that delta value for the first row would end
         // up being ZERO. if the trace is empty, return without any further processing.
-        let (mut prev_addr, mut prev_clk) = match self.get_first_row_info() {
-            Some((addr, clk)) => (addr.as_int(), clk.as_int() - 1),
+        let (mut prev_ctx, mut prev_addr, mut prev_clk) = match self.get_first_row_info() {
+            Some((ctx, addr, clk)) => (ctx, addr, clk.as_int() - 1),
             None => return,
         };
 
-        let mut row = memory_start_row as u32;
         // op range check index
-        for (&addr, addr_trace) in self.trace.iter() {
-            // when we start a new address, we set the previous value to all zeros. the effect of
-            // this is that memory is always initialized to zero.
-            for (clk, _) in addr_trace {
-                let clk = clk.as_int();
+        let mut row = memory_start_row as u32;
 
-                // compute delta as difference either between addresses or clock cycles
-                let delta = if prev_addr != addr {
-                    addr - prev_addr
-                } else {
-                    clk - prev_clk - 1
-                };
+        for (&ctx, segment) in self.trace.iter() {
+            for (&addr, addr_trace) in segment.inner().iter() {
+                // when we start a new address, we set the previous value to all zeros. the effect of
+                // this is that memory is always initialized to zero.
+                for (clk, _) in addr_trace {
+                    let clk = clk.as_int();
 
-                let (delta_hi, delta_lo) = split_u32_into_u16(delta);
-                range.add_mem_checks(row, &[delta_lo, delta_hi]);
+                    // compute delta as difference between context IDs, addresses, or clock cycles
+                    let delta = if prev_ctx != ctx {
+                        (ctx - prev_ctx) as u64
+                    } else if prev_addr != addr {
+                        addr - prev_addr
+                    } else {
+                        clk - prev_clk - 1
+                    };
 
-                // update values for the next iteration of the loop
-                prev_addr = addr;
-                prev_clk = clk;
-                row += 1;
+                    let (delta_hi, delta_lo) = split_u32_into_u16(delta);
+                    range.add_mem_checks(row, &[delta_lo, delta_hi]);
+
+                    // update values for the next iteration of the loop
+                    prev_ctx = ctx;
+                    prev_addr = addr;
+                    prev_clk = clk;
+                    row += 1;
+                }
             }
         }
     }
@@ -256,71 +204,89 @@ impl Memory {
         // set the pervious address and clock cycle to the first address and clock cycle of the
         // trace; we also adjust the clock cycle so that delta value for the first row would end
         // up being ZERO. if the trace is empty, return without any further processing.
-        let (mut prev_addr, mut prev_clk) = match self.get_first_row_info() {
-            Some((addr, clk)) => (addr, clk - ONE),
+        let (mut prev_ctx, mut prev_addr, mut prev_clk) = match self.get_first_row_info() {
+            Some((ctx, addr, clk)) => (Felt::from(ctx), Felt::from(addr), clk - ONE),
             None => return,
         };
 
         // iterate through addresses in ascending order, and write trace row for each memory access
         // into the trace. we expect the trace to be 14 columns wide.
         let mut i = 0;
-        for (addr, addr_trace) in self.trace {
-            // when we start a new address, we set the previous value to all zeros. the effect of
-            // this is that memory is always initialized to zero.
-            let addr = Felt::new(addr);
-            let mut prev_value = INIT_MEM_VALUE;
-            for (clk, value) in addr_trace {
-                trace.set(i, 0, ZERO); // ctx
-                trace.set(i, 1, addr);
-                trace.set(i, 2, clk);
-                trace.set(i, 3, prev_value[0]);
-                trace.set(i, 4, prev_value[1]);
-                trace.set(i, 5, prev_value[2]);
-                trace.set(i, 6, prev_value[3]);
-                trace.set(i, 7, value[0]);
-                trace.set(i, 8, value[1]);
-                trace.set(i, 9, value[2]);
-                trace.set(i, 10, value[3]);
 
-                // compute delta as difference either between addresses or clock cycles
-                let delta = if prev_addr != addr {
-                    addr - prev_addr
-                } else {
-                    clk - prev_clk - ONE
-                };
+        for (ctx, segment) in self.trace {
+            let ctx = Felt::from(ctx);
+            for (addr, addr_trace) in segment.into_inner() {
+                // when we start a new address, we set the previous value to all zeros. the effect of
+                // this is that memory is always initialized to zero.
+                let addr = Felt::new(addr);
+                let mut prev_value = INIT_MEM_VALUE;
+                for (clk, value) in addr_trace {
+                    trace.set(i, 0, ctx);
+                    trace.set(i, 1, addr);
+                    trace.set(i, 2, clk);
+                    trace.set(i, 3, prev_value[0]);
+                    trace.set(i, 4, prev_value[1]);
+                    trace.set(i, 5, prev_value[2]);
+                    trace.set(i, 6, prev_value[3]);
+                    trace.set(i, 7, value[0]);
+                    trace.set(i, 8, value[1]);
+                    trace.set(i, 9, value[2]);
+                    trace.set(i, 10, value[3]);
 
-                let (delta_hi, delta_lo) = split_element_u32_into_u16(delta);
-                trace.set(i, 11, delta_lo);
-                trace.set(i, 12, delta_hi);
-                // TODO: switch to batch inversion to improve efficiency.
-                trace.set(i, 13, delta.inv());
+                    // compute delta as difference between context IDs, addresses, or clock cycles
+                    let delta = if prev_ctx != ctx {
+                        ctx - prev_ctx
+                    } else if prev_addr != addr {
+                        addr - prev_addr
+                    } else {
+                        clk - prev_clk - ONE
+                    };
 
-                // provide the memory access data to the chiplets bus.
-                let memory_lookup = MemoryLookup::new(addr, clk.as_int() as u32, prev_value, value);
-                chiplets_bus.provide_memory_operation(memory_lookup, (memory_start_row + i) as u32);
+                    let (delta_hi, delta_lo) = split_element_u32_into_u16(delta);
+                    trace.set(i, 11, delta_lo);
+                    trace.set(i, 12, delta_hi);
+                    // TODO: switch to batch inversion to improve efficiency.
+                    trace.set(i, 13, delta.inv());
 
-                // update values for the next iteration of the loop
-                prev_addr = addr;
-                prev_clk = clk;
-                prev_value = value;
-                i += 1;
+                    // provide the memory access data to the chiplets bus.
+                    let memory_lookup = MemoryLookup::new(ctx, addr, clk, prev_value, value);
+                    chiplets_bus
+                        .provide_memory_operation(memory_lookup, (memory_start_row + i) as u32);
+
+                    // update values for the next iteration of the loop
+                    prev_ctx = ctx;
+                    prev_addr = addr;
+                    prev_clk = clk;
+                    prev_value = value;
+                    i += 1;
+                }
             }
         }
+    }
+
+    // HELPER METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the context, address, and clock cycle of the first trace row, or None if the trace
+    /// is empty.
+    fn get_first_row_info(&self) -> Option<(u32, u64, Felt)> {
+        let (ctx, segment) = match self.trace.iter().next() {
+            Some((&ctx, segment)) => (ctx, segment),
+            None => return None,
+        };
+
+        let (&addr, addr_trace) = segment.inner().iter().next().expect("empty memory segment");
+
+        Some((ctx, addr, addr_trace[0].0))
     }
 
     // TEST HELPERS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns current size of the memory (in words).
+    /// Returns current size of the memory (in words) across all contexts.
     #[cfg(test)]
     pub fn size(&self) -> usize {
-        self.trace.len()
-    }
-}
-
-impl Default for Memory {
-    fn default() -> Self {
-        Self::new()
+        self.trace.iter().fold(0, |acc, (_, s)| acc + s.size())
     }
 }
 
@@ -332,17 +298,27 @@ impl Default for Memory {
 pub struct MemoryLookup {
     ctx: Felt,
     addr: Felt,
-    clk: u32,
+    clk: Felt,
     old_word: Word,
     new_word: Word,
 }
 
 impl MemoryLookup {
-    pub fn new(addr: Felt, clk: u32, old_word: Word, new_word: Word) -> Self {
+    pub fn new(ctx: Felt, addr: Felt, clk: Felt, old_word: Word, new_word: Word) -> Self {
         Self {
-            ctx: ZERO,
+            ctx,
             addr,
             clk,
+            old_word,
+            new_word,
+        }
+    }
+
+    pub fn from_ints(ctx: u32, addr: Felt, clk: u32, old_word: Word, new_word: Word) -> Self {
+        Self {
+            ctx: Felt::from(ctx),
+            addr,
+            clk: Felt::from(clk),
             old_word,
             new_word,
         }
@@ -372,7 +348,7 @@ impl LookupTableRow for MemoryLookup {
             + alphas[1].mul_base(MEMORY_LABEL)
             + alphas[2].mul_base(self.ctx)
             + alphas[3].mul_base(self.addr)
-            + alphas[4].mul_base(Felt::from(self.clk))
+            + alphas[4].mul_base(self.clk)
             + old_word_value
             + new_word_value
     }

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -103,9 +103,9 @@ impl Memory {
 
     /// Returns the word at the specified context/address which should be used as the "old value" for a
     /// write request. It will be the previously stored value, if one exists, or initialized memory.
-    pub fn get_old_value(&self, ctx: u32, addr: Felt) -> Word {
+    pub fn get_old_value(&self, ctx: u32, addr: u64) -> Word {
         // get the stored word or return [0, 0, 0, 0], since the memory is initialized with zeros
-        self.get_value(ctx, addr.as_int()).unwrap_or(INIT_MEM_VALUE)
+        self.get_value(ctx, addr).unwrap_or(INIT_MEM_VALUE)
     }
 
     /// Returns the entire memory state for the specified execution context at the specified cycle.

--- a/processor/src/chiplets/memory/segment.rs
+++ b/processor/src/chiplets/memory/segment.rs
@@ -1,0 +1,112 @@
+use super::{BTreeMap, Felt, StarkField, Vec, Word, INIT_MEM_VALUE};
+
+// MEMORY SEGMENT TRACE
+// ================================================================================================
+
+/// Memory access trace for a single segment sorted first by address and then by clock cycle.
+#[derive(Default)]
+pub struct MemorySegmentTrace(BTreeMap<u64, Vec<(Felt, Word)>>);
+
+impl MemorySegmentTrace {
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a word located at the specified address, or None if the address hasn't been
+    /// accessed previously.
+    ///
+    /// Unlike read() which modifies the memory access trace, this method returns the value at the
+    /// specified address (if one exists) without altering the memory access trace.
+    pub fn get_value(&self, addr: u64) -> Option<Word> {
+        match self.0.get(&addr) {
+            Some(addr_trace) => addr_trace.last().map(|(_, value)| *value),
+            None => None,
+        }
+    }
+
+    /// Returns the entire memory state at the beginning of the specified cycle.
+    pub fn get_state_at(&self, clk: u32) -> Vec<(u64, Word)> {
+        let mut result: Vec<(u64, Word)> = Vec::new();
+
+        if clk == 0 {
+            return result;
+        }
+
+        // Because we want to view the memory state at the beginning of the specified cycle, we
+        // view the memory state at the previous cycle, as the current memory state is at the
+        // end of the current cycle.
+        let search_clk = (clk - 1) as u64;
+
+        for (&addr, addr_trace) in self.0.iter() {
+            match addr_trace.binary_search_by(|(x, _)| x.as_int().cmp(&search_clk)) {
+                Ok(i) => result.push((addr, addr_trace[i].1)),
+                Err(i) => {
+                    // Binary search finds the index of the data with the specified clock cycle.
+                    // Decrement the index to get the trace from the previously accessed clock
+                    // cycle to insert into the results.
+                    if i > 0 {
+                        result.push((addr, addr_trace[i - 1].1));
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a word located in memory at the specified address. The memory access is assumed
+    /// to happen at the provided clock cycle.
+    ///
+    /// If the specified address hasn't been previously written to, four ZERO elements are
+    /// returned. This effectively implies that memory is initialized to ZERO.
+    pub fn read(&mut self, addr: Felt, clk: Felt) -> Word {
+        // look up the previous value in the appropriate address trace and add (clk, prev_value)
+        // to it; if this is the first time we access this address, create address trace for it
+        // with entry (clk, [ZERO, 4]). in both cases, return the last value in the address trace.
+        self.0
+            .entry(addr.as_int())
+            .and_modify(|addr_trace| {
+                let last_value = addr_trace.last().expect("empty address trace").1;
+                addr_trace.push((clk, last_value));
+            })
+            .or_insert_with(|| vec![(clk, INIT_MEM_VALUE)])
+            .last()
+            .expect("empty address trace")
+            .1
+    }
+
+    /// Writes the provided word at the specified address. The memory access is assumed to happen
+    /// at the provided clock cycle.
+    pub fn write(&mut self, addr: Felt, clk: Felt, value: Word) {
+        // add a tuple (clk, value) to the appropriate address trace; if this is the first time
+        // we access this address, initialize address trace.
+        self.0
+            .entry(addr.as_int())
+            .and_modify(|addr_trace| addr_trace.push((clk, value)))
+            .or_insert_with(|| vec![(clk, value)]);
+    }
+
+    // INNER VALUE ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a reference to the map underlying this memory segment trace.
+    pub(super) fn inner(&self) -> &BTreeMap<u64, Vec<(Felt, Word)>> {
+        &self.0
+    }
+
+    /// Returns a map underlying this memory segment trace while consuming self.
+    pub(super) fn into_inner(self) -> BTreeMap<u64, Vec<(Felt, Word)>> {
+        self.0
+    }
+
+    // HELPER FUNCTIONS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns current size (in words) of this memory segment.
+    #[cfg(test)]
+    pub fn size(&self) -> usize {
+        self.0.len()
+    }
+}

--- a/processor/src/chiplets/memory/segment.rs
+++ b/processor/src/chiplets/memory/segment.rs
@@ -4,6 +4,10 @@ use super::{BTreeMap, Felt, StarkField, Vec, Word, INIT_MEM_VALUE};
 // ================================================================================================
 
 /// Memory access trace for a single segment sorted first by address and then by clock cycle.
+///
+/// A memory segment is an isolated address space accessible from a specific execution context.
+/// Within each segment, the memory is word-addressable. That is, four field elements are located
+/// at each memory address, and we can read and write elements to/from memory in batches of four.
 #[derive(Default)]
 pub struct MemorySegmentTrace(BTreeMap<u64, Vec<(Felt, Word)>>);
 
@@ -31,9 +35,9 @@ impl MemorySegmentTrace {
             return result;
         }
 
-        // Because we want to view the memory state at the beginning of the specified cycle, we
-        // view the memory state at the previous cycle, as the current memory state is at the
-        // end of the current cycle.
+        // since we record memory state at the end of a given cycle, to get memory state at the end
+        // of a cycle, we need to look at the previous cycle. that is, memory state at the end of
+        // the previous cycle is the same as memory state the the beginning of the current cycle.
         let search_clk = (clk - 1) as u64;
 
         for (&addr, addr_trace) in self.0.iter() {

--- a/processor/src/chiplets/memory/tests.rs
+++ b/processor/src/chiplets/memory/tests.rs
@@ -214,29 +214,40 @@ fn mem_multi_context() {
     assert_eq!(2, mem.size());
     assert_eq!(3, mem.trace_len());
 
-    // read a value from ctx = 0, addr = 0; clk = 8
-    assert_eq!(value1, mem.read(0, ZERO, 8));
-    assert_eq!(2, mem.size());
+    // write a value into ctx = 3, addr = 0; clk = 7
+    let value3 = [ZERO, ZERO, ONE, ZERO];
+    mem.write(3, ZERO, 7, value3);
+    assert_eq!(value3, mem.get_value(3, 0).unwrap());
+    assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
+
+    // read a value from ctx = 0, addr = 0; clk = 9
+    assert_eq!(value1, mem.read(0, ZERO, 9));
+    assert_eq!(3, mem.size());
+    assert_eq!(5, mem.trace_len());
 
     // check generated trace and memory data provided to the ChipletsBus; rows should be sorted by
     // address and then clock cycle
-    let (trace, chiplets_bus) = build_trace(mem, 4);
+    let (trace, chiplets_bus) = build_trace(mem, 5);
 
     // ctx = 0, addr = 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
     let memory_access = MemoryLookup::from_ints(0, ZERO, 1, [ZERO; 4], value1);
     prev_row = verify_memory_access(&trace, &chiplets_bus, 0, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(0, ZERO, 8, value1, value1);
+    let memory_access = MemoryLookup::from_ints(0, ZERO, 9, value1, value1);
     prev_row = verify_memory_access(&trace, &chiplets_bus, 1, &memory_access, prev_row);
+
+    // ctx = 3, addr = 0
+    let memory_access = MemoryLookup::from_ints(3, ZERO, 7, [ZERO; 4], value3);
+    prev_row = verify_memory_access(&trace, &chiplets_bus, 2, &memory_access, prev_row);
 
     // ctx = 3, addr = 1
     let memory_access = MemoryLookup::from_ints(3, ONE, 4, [ZERO; 4], value2);
-    prev_row = verify_memory_access(&trace, &chiplets_bus, 2, &memory_access, prev_row);
+    prev_row = verify_memory_access(&trace, &chiplets_bus, 3, &memory_access, prev_row);
 
     let memory_access = MemoryLookup::from_ints(3, ONE, 6, value2, value2);
-    verify_memory_access(&trace, &chiplets_bus, 3, &memory_access, prev_row);
+    verify_memory_access(&trace, &chiplets_bus, 4, &memory_access, prev_row);
 }
 
 #[test]

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -264,7 +264,7 @@ impl Chiplets {
     ///
     /// This also modifies the memory access trace.
     pub fn write_mem(&mut self, ctx: u32, addr: Felt, word: Word) -> Word {
-        let old_word = self.memory.get_old_value(ctx, addr);
+        let old_word = self.memory.get_old_value(ctx, addr.as_int());
         self.memory.write(ctx, addr, self.clk, word);
 
         // send the memory write request to the bus
@@ -279,7 +279,7 @@ impl Chiplets {
     ///
     /// This also modifies the memory access trace.
     pub fn write_mem_single(&mut self, ctx: u32, addr: Felt, value: Felt) -> Word {
-        let old_word = self.memory.get_old_value(ctx, addr);
+        let old_word = self.memory.get_old_value(ctx, addr.as_int());
         let new_word = [value, old_word[1], old_word[2], old_word[3]];
 
         self.memory.write(ctx, addr, self.clk, new_word);

--- a/processor/src/decoder/aux_hints.rs
+++ b/processor/src/decoder/aux_hints.rs
@@ -149,7 +149,7 @@ impl AuxTraceHints {
         child2_hash: Option<Word>,
     ) {
         // insert the hint with the relevant update
-        let hint = BlockTableUpdate::BlockStarted(block_info.block_type.num_children());
+        let hint = BlockTableUpdate::BlockStarted(block_info.num_children());
         self.block_exec_hints.push((clk, hint));
 
         // create a row which would be inserted into the block stack table

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -1,0 +1,191 @@
+use super::{Felt, Vec, ONE, ZERO};
+
+// BLOCK STACK
+// ================================================================================================
+
+/// Keeps track of code blocks which are currently being executed by the VM.
+#[derive(Default)]
+pub struct BlockStack {
+    blocks: Vec<BlockInfo>,
+}
+
+impl BlockStack {
+    // STATE ACCESSORS AND MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Pushes a new code block onto the block stack and returns the address of the block's parent.
+    /// block_type can be anything except for CALL block.
+    ///
+    /// The block is identified by its address, and we also need to know what type of a block this
+    /// is. Other information (i.e., the block's parent, whether the block is a body of
+    /// a loop or a first child of a JOIN block) is determined from the information already on the
+    /// stack.
+    ///
+    /// For non-CALL blocks, we set parent context and free memory pointer to zero values.
+    ///
+    /// # Panics
+    /// Panics if the block type is a CALL block.
+    pub fn push(&mut self, addr: Felt, block_type: BlockType) -> Felt {
+        assert_ne!(block_type, BlockType::Call, "cannot be a call block");
+        let (parent_addr, is_loop_body, is_first_child) = self.get_new_block_context();
+        self.blocks.push(BlockInfo {
+            addr,
+            block_type,
+            parent_addr,
+            parent_ctx: 0,
+            parent_fmp: ZERO,
+            is_loop_body,
+            is_first_child,
+        });
+        parent_addr
+    }
+
+    /// Pushes a new CALL block onto the block stack and returns the address of the block's parent.
+    ///
+    /// This is similar to pushing any other block onto the stack but unlike with all other blocks,
+    /// we initialize parent context and free memory pointer with the specified values.
+    pub fn push_call(&mut self, addr: Felt, parent_ctx: u32, parent_fmp: Felt) -> Felt {
+        let (parent_addr, is_loop_body, is_first_child) = self.get_new_block_context();
+        self.blocks.push(BlockInfo {
+            addr,
+            block_type: BlockType::Call,
+            parent_addr,
+            parent_ctx,
+            parent_fmp,
+            is_loop_body,
+            is_first_child,
+        });
+        parent_addr
+    }
+
+    /// Removes a block from the top of the stack and returns it.
+    pub fn pop(&mut self) -> BlockInfo {
+        let block = self.blocks.pop().expect("block stack is empty");
+        // if the parent block is a JOIN block (i.e., we just finished executing a child of a JOIN
+        // block) and if the first_child_executed hasn't been set to true yet, set it to true
+        if let Some(parent) = self.blocks.last_mut() {
+            if let BlockType::Join(first_child_executed) = parent.block_type {
+                if !first_child_executed {
+                    parent.block_type = BlockType::Join(true);
+                }
+            }
+        }
+        block
+    }
+
+    /// Returns a reference to a block at the top of the stack.
+    pub fn peek(&self) -> &BlockInfo {
+        self.blocks.last().expect("block stack is empty")
+    }
+
+    /// Returns a mutable reference to a block at the top of the stack.
+    pub fn peek_mut(&mut self) -> &mut BlockInfo {
+        self.blocks.last_mut().expect("block stack is empty")
+    }
+
+    // HELPER METHODS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns context information for a block which is about to be pushed onto the block stack.
+    ///
+    /// Context information consists of a tuple (parent_addr, is_loop_body, is_first_child), where:
+    /// - parent_addr is the address of the block currently at the top of the stack.
+    /// - is_loop_body is set to true if the newly added block will be a body of a loop.
+    /// - is_first_child is set to true if the newly added block will be a first child in the
+    ///   JOIN block.
+    fn get_new_block_context(&self) -> (Felt, bool, bool) {
+        match self.blocks.last() {
+            Some(parent) => match parent.block_type {
+                // if the current block is a LOOP block, the new block must be a loop body
+                BlockType::Loop(loop_entered) => {
+                    debug_assert!(loop_entered, "parent is un-entered loop");
+                    (parent.addr, true, false)
+                }
+                // if the current block is a JOIN block, figure out if the new block is the first
+                // or the second child
+                BlockType::Join(first_child_executed) => {
+                    (parent.addr, false, !first_child_executed)
+                }
+                _ => (parent.addr, false, false),
+            },
+            // if the block stack is empty, a new block is neither a body of a loop nor the first
+            // child of a JOIN block; also, we set the parent address to ZERO.
+            None => (ZERO, false, false),
+        }
+    }
+}
+
+// BLOCK INFO
+// ================================================================================================
+
+/// Contains basic information about a code block.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockInfo {
+    pub addr: Felt,
+    block_type: BlockType,
+    pub parent_addr: Felt,
+    pub parent_ctx: u32,
+    pub parent_fmp: Felt,
+    pub is_loop_body: bool,
+    pub is_first_child: bool,
+}
+
+impl BlockInfo {
+    /// Returns ONE if the this block is a LOOP block and the body of the loop was executed at
+    /// least once; otherwise, returns ZERO.
+    pub fn is_entered_loop(&self) -> Felt {
+        if self.block_type == BlockType::Loop(true) {
+            ONE
+        } else {
+            ZERO
+        }
+    }
+
+    /// Returns ONE if this block is a body of a LOOP block; otherwise returns ZERO.
+    pub fn is_loop_body(&self) -> Felt {
+        if self.is_loop_body {
+            ONE
+        } else {
+            ZERO
+        }
+    }
+
+    /// Returns ONE if this block is a CALL block; otherwise returns ZERO.
+    pub fn is_call(&self) -> Felt {
+        match self.block_type {
+            BlockType::Call => ONE,
+            _ => ZERO,
+        }
+    }
+
+    /// Returns the number of children a block has. This is an integer between 0 and 2 (both
+    /// inclusive).
+    pub fn num_children(&self) -> u32 {
+        match self.block_type {
+            BlockType::Join(_) => 2,
+            BlockType::Split => 1,
+            BlockType::Loop(is_entered) => {
+                if is_entered {
+                    1
+                } else {
+                    0
+                }
+            }
+            BlockType::Call => 1,
+            BlockType::Span => 0,
+        }
+    }
+}
+
+// BLOCK TYPE
+// ================================================================================================
+
+/// Specifies type of a code block with additional info for some block types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockType {
+    Join(bool), // internal value set to true when the first child is fully executed
+    Split,
+    Loop(bool), // internal value set to false if the loop is never entered
+    Call,
+    Span,
+}

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -193,7 +193,7 @@ impl Process {
     /// Ends decoding of a CALL block.
     pub(super) fn end_call_block(&mut self, block: &Call) -> Result<(), ExecutionError> {
         // this appends a row with END operation to the decoder trace; the returned values contain
-        // execution context and free memory pointer to executing the CALL block
+        // execution context and free memory pointer prior to executing the CALL block
         let (ctx, fmp) = self.decoder.end_control_block(block.hash().into());
 
         // send the end of control block to the chiplets bus to handle the final hash request.

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -15,6 +15,9 @@ use vm_core::{
 mod trace;
 use trace::DecoderTrace;
 
+mod block_stack;
+use block_stack::{BlockInfo, BlockStack, BlockType};
+
 mod aux_hints;
 pub use aux_hints::{
     AuxTraceHints, BlockHashTableRow, BlockStackTableRow, BlockTableUpdate, OpGroupTableRow,
@@ -171,27 +174,38 @@ impl Process {
             .hash_control_block(fn_hash, [ZERO; 4], block.hash());
 
         // start decoding the CALL block; this appends a row with CALL operation to the decoder
-        // trace. when CALL operation is executed, the rest of the VM state does not change
-        self.decoder.start_call(fn_hash, addr);
+        // trace and records the state of execution context and free memory pointer in the block
+        // stack table. these will be used to restore ctx/fmp after the function returns.
+        let ctx = self.system.ctx();
+        let fmp = self.system.fmp();
+        self.decoder.start_call(fn_hash, addr, ctx, fmp);
         self.execute_op(Operation::Noop)?;
 
-        // set the execution context to the current clock cycle (this ensures that the context is
-        // globally unique), and reset the free memory pointer
-        self.system.set_ctx(self.system.clk() as u32);
+        // for the next row, set the execution context to the current clock cycle (this ensures
+        // that the context is globally unique), and reset the free memory pointer
+        self.system.set_ctx(self.system.clk());
         self.system.set_fmp(Felt::from(FMP_MIN));
         Ok(())
     }
 
-    ///  Ends decoding of a CALL block.
+    /// Ends decoding of a CALL block.
     pub(super) fn end_call_block(&mut self, block: &Call) -> Result<(), ExecutionError> {
-        // this appends a row with END operation to the decoder trace. when END operation is
-        // executed the rest of the VM state does not change
-        self.decoder.end_control_block(block.hash().into());
+        // this appends a row with END operation to the decoder trace; the returned values contain
+        // execution context and free memory pointer to executing the CALL block
+        let (ctx, fmp) = self.decoder.end_control_block(block.hash().into());
 
         // send the end of control block to the chiplets bus to handle the final hash request.
         self.chiplets.read_hash_result();
 
-        self.execute_op(Operation::Noop)
+        self.execute_op(Operation::Noop)?;
+
+        // when returning from a function call, reset the context and the free memory pointer to
+        // what they were before the call; we do this after the self.execute_op() call above to
+        // make sure the values are updated for the next cycle of the VM (not the cycle in which
+        // the END operation is executed).
+        self.system.set_ctx(ctx);
+        self.system.set_fmp(fmp);
+        Ok(())
     }
 
     // SPAN BLOCK
@@ -299,7 +313,7 @@ impl Decoder {
     /// Returns an empty instance of [Decoder].
     pub fn new(in_debug_mode: bool) -> Self {
         Self {
-            block_stack: BlockStack::new(),
+            block_stack: BlockStack::default(),
             span_context: None,
             trace: DecoderTrace::new(),
             aux_hints: AuxTraceHints::new(),
@@ -446,12 +460,12 @@ impl Decoder {
     ///
     /// This pushes a block with ID=addr onto the block stack and appends execution of a CALL
     /// operation to the trace.
-    pub fn start_call(&mut self, fn_hash: Word, addr: Felt) {
+    pub fn start_call(&mut self, fn_hash: Word, addr: Felt, parent_ctx: u32, parent_fmp: Felt) {
         // get the current clock cycle here (before the trace table is updated)
         let clk = self.trace_len() as u32;
 
-        // append a CALL row to the execution trace
-        let parent_addr = self.block_stack.push(addr, BlockType::Call);
+        // push CALL block info onto the block stack and append a CALL row to the execution trace
+        let parent_addr = self.block_stack.push_call(addr, parent_ctx, parent_fmp);
         self.trace
             .append_block_start(parent_addr, Operation::Call, fn_hash, [ZERO; 4]);
 
@@ -467,24 +481,30 @@ impl Decoder {
     ///
     /// This appends an execution of an END operation to the trace. The top block on the block
     /// stack is also popped.
-    pub fn end_control_block(&mut self, block_hash: Word) {
+    ///
+    /// If the ended block is a CALL block, this method will return values to which execution
+    /// context and free memory pointers were set before the CALL block started executing. For
+    /// non-CALL blocks these values are set to zeros and should be ignored.
+    pub fn end_control_block(&mut self, block_hash: Word) -> (u32, Felt) {
         // get the current clock cycle here (before the trace table is updated)
-        let clk = self.trace_len();
+        let clk = self.trace_len() as u32;
 
-        // add an END row to the trace
+        // remove the block from the top of the block stack and add an END row to the trace
         let block_info = self.block_stack.pop();
         self.trace.append_block_end(
             block_info.addr,
             block_hash,
             block_info.is_loop_body(),
             block_info.is_entered_loop(),
+            block_info.is_call(),
         );
 
         // mark this cycle as the cycle at which block execution has ended
-        self.aux_hints
-            .block_ended(clk as u32, block_info.is_first_child);
+        self.aux_hints.block_ended(clk, block_info.is_first_child);
 
         self.debug_info.append_operation(Operation::End);
+
+        (block_info.parent_ctx, block_info.parent_fmp)
     }
 
     // SPAN BLOCK
@@ -686,153 +706,6 @@ impl Default for Decoder {
     }
 }
 
-// BLOCK STACK
-// ================================================================================================
-
-/// Keeps track of code blocks which are currently being executed by the VM.
-struct BlockStack {
-    blocks: Vec<BlockInfo>,
-}
-
-impl BlockStack {
-    /// Returns an empty [BlockStack].
-    pub fn new() -> Self {
-        Self { blocks: Vec::new() }
-    }
-
-    /// Pushes a new code block onto the block stack and returns the address of the block's parent.
-    ///
-    /// The block is identified by its address, and we also need to know what type of a block this
-    /// is. Other information (i.e., the block's parent, whether the block is a body of
-    /// a loop or a first child of a JOIN block) is determined from the information already on the
-    /// stack.
-    pub fn push(&mut self, addr: Felt, block_type: BlockType) -> Felt {
-        let (parent_addr, is_loop_body, is_first_child) = match self.blocks.last() {
-            Some(parent) => match parent.block_type {
-                // if the parent is a LOOP block, this block must be a loop body
-                BlockType::Loop(loop_entered) => {
-                    debug_assert!(loop_entered, "parent is un-entered loop");
-                    (parent.addr, true, false)
-                }
-                // if the parent is a JOIN block, figure out if this block is the first or the
-                // second child
-                BlockType::Join(first_child_executed) => {
-                    (parent.addr, false, !first_child_executed)
-                }
-                _ => (parent.addr, false, false),
-            },
-            // if the block has no parent, it is neither a body of a loop nor the first child of
-            // a JOIN block; also, we set the parent address to ZERO.
-            None => (ZERO, false, false),
-        };
-
-        self.blocks.push(BlockInfo {
-            addr,
-            block_type,
-            parent_addr,
-            is_loop_body,
-            is_first_child,
-        });
-        parent_addr
-    }
-
-    /// Removes a block from the top of the stack and returns it.
-    pub fn pop(&mut self) -> BlockInfo {
-        let block = self.blocks.pop().expect("block stack is empty");
-        // if the parent block is a JOIN block (i.e., we just finished executing a child of a JOIN
-        // block) and if the first_child_executed hasn't been set to true yet, set it to true
-        if let Some(parent) = self.blocks.last_mut() {
-            if let BlockType::Join(first_child_executed) = parent.block_type {
-                if !first_child_executed {
-                    parent.block_type = BlockType::Join(true);
-                }
-            }
-        }
-        block
-    }
-
-    /// Returns a reference to a block at the top of the stack.
-    pub fn peek(&self) -> &BlockInfo {
-        self.blocks.last().expect("block stack is empty")
-    }
-
-    /// Returns a mutable reference to a block at the top of the stack.
-    pub fn peek_mut(&mut self) -> &mut BlockInfo {
-        self.blocks.last_mut().expect("block stack is empty")
-    }
-}
-
-/// Contains basic information about a code block.
-#[derive(Debug, Clone, Copy)]
-pub struct BlockInfo {
-    addr: Felt,
-    block_type: BlockType,
-    parent_addr: Felt,
-    is_loop_body: bool,
-    is_first_child: bool,
-}
-
-impl BlockInfo {
-    /// Returns ONE if the this block is a LOOP block and the body of the loop was executed at
-    /// least once; otherwise, returns ZERO.
-    pub fn is_entered_loop(&self) -> Felt {
-        if self.block_type == BlockType::Loop(true) {
-            ONE
-        } else {
-            ZERO
-        }
-    }
-
-    /// Returns ONE if this block is a body of a LOOP block; otherwise returns ZERO.
-    pub fn is_loop_body(&self) -> Felt {
-        if self.is_loop_body {
-            ONE
-        } else {
-            ZERO
-        }
-    }
-
-    /// Returns ONE if this block is the first child of a JOIN block; otherwise returns ZERO.
-    #[allow(dead_code)]
-    pub fn is_first_child(&self) -> Felt {
-        if self.is_first_child {
-            ONE
-        } else {
-            ZERO
-        }
-    }
-}
-
-/// Specifies type of a code block with additional info for some block types.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BlockType {
-    Join(bool), // internal value set to true when the first child is fully executed
-    Split,
-    Loop(bool), // internal value set to false if the loop is never entered
-    Call,
-    Span,
-}
-
-impl BlockType {
-    /// Returns the number of children a block has. This is an integer between 0 and 2 (both
-    /// inclusive).
-    pub fn num_children(&self) -> u32 {
-        match self {
-            Self::Join(_) => 2,
-            Self::Split => 1,
-            Self::Loop(is_entered) => {
-                if *is_entered {
-                    1
-                } else {
-                    0
-                }
-            }
-            Self::Call => 1,
-            Self::Span => 0,
-        }
-    }
-}
-
 // SPAN CONTEXT
 // ================================================================================================
 
@@ -841,18 +714,10 @@ impl BlockType {
 ///   encoded as opcodes (7 bits) appended one after another into a single field element, with the
 ///   next operation to be executed located at the least significant position.
 /// - Number of operation groups left to be executed in the entire SPAN block.
+#[derive(Default)]
 struct SpanContext {
     group_ops_left: Felt,
     num_groups_left: Felt,
-}
-
-impl Default for SpanContext {
-    fn default() -> Self {
-        Self {
-            group_ops_left: ZERO,
-            num_groups_left: ZERO,
-        }
-    }
 }
 
 // HELPER FUNCTIONS

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -13,17 +13,23 @@ use vm_core::{
         OP_BIT_EXTRA_COL_IDX, OP_INDEX_COL_IDX,
     },
     utils::collections::Vec,
-    CodeBlockTable, StarkField, DECODER_TRACE_RANGE, DECODER_TRACE_WIDTH, ONE, ZERO,
+    CodeBlockTable, StarkField, CTX_COL_IDX, DECODER_TRACE_RANGE, DECODER_TRACE_WIDTH, FMP_COL_IDX,
+    ONE, SYS_TRACE_RANGE, SYS_TRACE_WIDTH, ZERO,
 };
 
 // CONSTANTS
 // ================================================================================================
 
+const TWO: Felt = Felt::new(2);
+const EIGHT: Felt = Felt::new(8);
+
 const INIT_ADDR: Felt = ONE;
+const FMP_MIN: Felt = Felt::new(crate::FMP_MIN);
 
 // TYPE ALIASES
 // ================================================================================================
 
+type SystemTrace = [Vec<Felt>; SYS_TRACE_WIDTH];
 type DecoderTrace = [Vec<Felt>; DECODER_TRACE_WIDTH];
 
 // SPAN BLOCK TESTS
@@ -88,7 +94,7 @@ fn span_block_one_group() {
 
 #[test]
 fn span_block_small() {
-    let iv = [Felt::new(1), Felt::new(2)];
+    let iv = [ONE, TWO];
     let ops = vec![
         Operation::Push(iv[0]),
         Operation::Push(iv[1]),
@@ -145,8 +151,8 @@ fn span_block_small() {
     // the groups are imm(1), imm(2), and op group with a single NOOP
     let expected_ogt_rows = vec![
         OpGroupTableRow::new(INIT_ADDR, Felt::new(3), iv[0]),
-        OpGroupTableRow::new(INIT_ADDR, Felt::new(2), iv[1]),
-        OpGroupTableRow::new(INIT_ADDR, Felt::new(1), ZERO),
+        OpGroupTableRow::new(INIT_ADDR, TWO, iv[1]),
+        OpGroupTableRow::new(INIT_ADDR, ONE, ZERO),
     ];
     assert_eq!(expected_ogt_rows, aux_hints.op_group_table_rows());
 
@@ -168,13 +174,7 @@ fn span_block_small() {
 
 #[test]
 fn span_block() {
-    let iv = [
-        Felt::new(1),
-        Felt::new(2),
-        Felt::new(3),
-        Felt::new(4),
-        Felt::new(5),
-    ];
+    let iv = [ONE, TWO, Felt::new(3), Felt::new(4), Felt::new(5)];
     let ops = vec![
         Operation::Push(iv[0]),
         Operation::Push(iv[1]),
@@ -267,8 +267,8 @@ fn span_block() {
         OpGroupTableRow::new(INIT_ADDR, Felt::new(5), batch0_groups[3]),
         OpGroupTableRow::new(INIT_ADDR, Felt::new(4), batch0_groups[4]),
         OpGroupTableRow::new(INIT_ADDR, Felt::new(3), batch0_groups[5]),
-        OpGroupTableRow::new(INIT_ADDR, Felt::new(2), batch0_groups[6]),
-        OpGroupTableRow::new(INIT_ADDR, Felt::new(1), batch0_groups[7]),
+        OpGroupTableRow::new(INIT_ADDR, TWO, batch0_groups[6]),
+        OpGroupTableRow::new(INIT_ADDR, ONE, batch0_groups[7]),
     ];
     assert_eq!(expected_ogt_rows, aux_hints.op_group_table_rows());
 
@@ -291,14 +291,14 @@ fn span_block() {
 #[test]
 fn span_block_with_respan() {
     let iv = [
-        Felt::new(1),
-        Felt::new(2),
+        ONE,
+        TWO,
         Felt::new(3),
         Felt::new(4),
         Felt::new(5),
         Felt::new(6),
         Felt::new(7),
-        Felt::new(8),
+        EIGHT,
         Felt::new(9),
     ];
 
@@ -330,7 +330,7 @@ fn span_block_with_respan() {
     // NOOP inserted by the processor to make sure the group doesn't end with a PUSH
     check_op_decoding(&trace, 8, INIT_ADDR, Operation::Noop, 4, 7, 1);
     // RESPAN since the previous batch is full
-    let batch1_addr = INIT_ADDR + Felt::new(8);
+    let batch1_addr = INIT_ADDR + EIGHT;
     check_op_decoding(&trace, 9, INIT_ADDR, Operation::Respan, 4, 0, 0);
     check_op_decoding(&trace, 10, batch1_addr, Operation::Push(iv[7]), 3, 0, 1);
     check_op_decoding(&trace, 11, batch1_addr, Operation::Add, 2, 1, 1);
@@ -397,14 +397,14 @@ fn span_block_with_respan() {
         OpGroupTableRow::new(INIT_ADDR, Felt::new(11), batch0_groups[1]),
         OpGroupTableRow::new(INIT_ADDR, Felt::new(10), batch0_groups[2]),
         OpGroupTableRow::new(INIT_ADDR, Felt::new(9), batch0_groups[3]),
-        OpGroupTableRow::new(INIT_ADDR, Felt::new(8), batch0_groups[4]),
+        OpGroupTableRow::new(INIT_ADDR, EIGHT, batch0_groups[4]),
         OpGroupTableRow::new(INIT_ADDR, Felt::new(7), batch0_groups[5]),
         OpGroupTableRow::new(INIT_ADDR, Felt::new(6), batch0_groups[6]),
         OpGroupTableRow::new(INIT_ADDR, Felt::new(5), batch0_groups[7]),
         // skipping the first group of batch 1
         OpGroupTableRow::new(batch1_addr, Felt::new(3), batch1_groups[1]),
-        OpGroupTableRow::new(batch1_addr, Felt::new(2), batch1_groups[2]),
-        OpGroupTableRow::new(batch1_addr, Felt::new(1), batch1_groups[3]),
+        OpGroupTableRow::new(batch1_addr, TWO, batch1_groups[2]),
+        OpGroupTableRow::new(batch1_addr, ONE, batch1_groups[3]),
     ];
     assert_eq!(expected_ogt_rows, aux_hints.op_group_table_rows());
 
@@ -442,7 +442,7 @@ fn join_block() {
     // --- check block address, op_bits, group count, op_index, and in_span columns ---------------
     check_op_decoding(&trace, 0, ZERO, Operation::Join, 0, 0, 0);
     // starting first span
-    let span1_addr = INIT_ADDR + Felt::new(8);
+    let span1_addr = INIT_ADDR + EIGHT;
     check_op_decoding(&trace, 1, INIT_ADDR, Operation::Span, 1, 0, 0);
     check_op_decoding(&trace, 2, span1_addr, Operation::Mul, 0, 0, 1);
     check_op_decoding(&trace, 3, span1_addr, Operation::End, 0, 0, 0);
@@ -527,7 +527,7 @@ fn split_block_true() {
     let (trace, aux_hints, trace_len) = build_trace(&[1], &program);
 
     // --- check block address, op_bits, group count, op_index, and in_span columns ---------------
-    let span_addr = INIT_ADDR + Felt::new(8);
+    let span_addr = INIT_ADDR + EIGHT;
     check_op_decoding(&trace, 0, ZERO, Operation::Split, 0, 0, 0);
     check_op_decoding(&trace, 1, INIT_ADDR, Operation::Span, 1, 0, 0);
     check_op_decoding(&trace, 2, span_addr, Operation::Mul, 0, 0, 1);
@@ -597,7 +597,7 @@ fn split_block_false() {
     let (trace, aux_hints, trace_len) = build_trace(&[0], &program);
 
     // --- check block address, op_bits, group count, op_index, and in_span columns ---------------
-    let span_addr = INIT_ADDR + Felt::new(8);
+    let span_addr = INIT_ADDR + EIGHT;
     check_op_decoding(&trace, 0, ZERO, Operation::Split, 0, 0, 0);
     check_op_decoding(&trace, 1, INIT_ADDR, Operation::Span, 1, 0, 0);
     check_op_decoding(&trace, 2, span_addr, Operation::Add, 0, 0, 1);
@@ -669,7 +669,7 @@ fn loop_block() {
     let (trace, aux_hints, trace_len) = build_trace(&[0, 1], &program);
 
     // --- check block address, op_bits, group count, op_index, and in_span columns ---------------
-    let body_addr = INIT_ADDR + Felt::new(8);
+    let body_addr = INIT_ADDR + EIGHT;
     check_op_decoding(&trace, 0, ZERO, Operation::Loop, 0, 0, 0);
     check_op_decoding(&trace, 1, INIT_ADDR, Operation::Span, 1, 0, 0);
     check_op_decoding(&trace, 2, body_addr, Operation::Pad, 0, 0, 1);
@@ -793,7 +793,7 @@ fn loop_block_repeat() {
     let (trace, aux_hints, trace_len) = build_trace(&[0, 1, 1], &program);
 
     // --- check block address, op_bits, group count, op_index, and in_span columns ---------------
-    let iter1_addr = INIT_ADDR + Felt::new(8);
+    let iter1_addr = INIT_ADDR + EIGHT;
     let iter2_addr = INIT_ADDR + Felt::new(16);
 
     check_op_decoding(&trace, 0, ZERO, Operation::Loop, 0, 0, 0);
@@ -877,6 +877,202 @@ fn loop_block_repeat() {
     assert_eq!(expected_rows, aux_hints.block_hash_table_rows());
 }
 
+// CALL BLOCK TESTS
+// ================================================================================================
+
+#[test]
+fn call_block() {
+    // build a program which looks like this:
+    //
+    // proc.foo
+    //     fmp <- fmp + 1
+    // end
+    //
+    // being
+    //    fmp <- fmp + 2
+    //    call.foo
+    //    stack[0] <- fmp
+    // end
+
+    let span1 = CodeBlock::new_span(vec![Operation::Push(TWO), Operation::FmpUpdate]);
+    let span2 = CodeBlock::new_span(vec![Operation::Push(ONE), Operation::FmpUpdate]);
+    let span3 = CodeBlock::new_span(vec![Operation::FmpAdd]);
+
+    let fn_block = CodeBlock::new_call(span2.hash());
+    let join1 = CodeBlock::new_join([span1.clone(), fn_block.clone()]);
+    let program = CodeBlock::new_join([join1.clone(), span3.clone()]);
+
+    let (sys_trace, dec_trace, aux_hints, trace_len) = build_call_trace(&program, span2.clone());
+
+    // --- check block address, op_bits, group count, op_index, and in_span columns ---------------
+    check_op_decoding(&dec_trace, 0, ZERO, Operation::Join, 0, 0, 0);
+    // starting the internal JOIN block
+    let join1_addr = INIT_ADDR + EIGHT;
+    check_op_decoding(&dec_trace, 1, INIT_ADDR, Operation::Join, 0, 0, 0);
+    // starting first SPAN block
+    let span1_addr = join1_addr + EIGHT;
+    check_op_decoding(&dec_trace, 2, join1_addr, Operation::Span, 2, 0, 0);
+    check_op_decoding(&dec_trace, 3, span1_addr, Operation::Push(TWO), 1, 0, 1);
+    check_op_decoding(&dec_trace, 4, span1_addr, Operation::FmpUpdate, 0, 1, 1);
+    check_op_decoding(&dec_trace, 5, span1_addr, Operation::End, 0, 0, 0);
+    // starting CALL block
+    let call_addr = span1_addr + EIGHT;
+    check_op_decoding(&dec_trace, 6, join1_addr, Operation::Call, 0, 0, 0);
+    // starting second SPAN block
+    let span2_addr = call_addr + EIGHT;
+    check_op_decoding(&dec_trace, 7, call_addr, Operation::Span, 2, 0, 0);
+    check_op_decoding(&dec_trace, 8, span2_addr, Operation::Push(ONE), 1, 0, 1);
+    check_op_decoding(&dec_trace, 9, span2_addr, Operation::FmpUpdate, 0, 1, 1);
+    check_op_decoding(&dec_trace, 10, span2_addr, Operation::End, 0, 0, 0);
+    // ending CALL block
+    check_op_decoding(&dec_trace, 11, call_addr, Operation::End, 0, 0, 0);
+    // ending internal JOIN block
+    check_op_decoding(&dec_trace, 12, join1_addr, Operation::End, 0, 0, 0);
+    // starting the 3rd SPAN block
+    let span3_addr = span2_addr + EIGHT;
+    check_op_decoding(&dec_trace, 13, INIT_ADDR, Operation::Span, 1, 0, 0);
+    check_op_decoding(&dec_trace, 14, span3_addr, Operation::FmpAdd, 0, 0, 1);
+    check_op_decoding(&dec_trace, 15, span3_addr, Operation::End, 0, 0, 0);
+    // ending the program
+    check_op_decoding(&dec_trace, 16, INIT_ADDR, Operation::End, 0, 0, 0);
+    check_op_decoding(&dec_trace, 17, ZERO, Operation::Halt, 0, 0, 0);
+
+    // --- check hasher state columns -------------------------------------------------------------
+    // in the first row, the hasher state is set to hashes of (join1, span3)
+    let join1_hash: Word = join1.hash().into();
+    let span3_hash: Word = span3.hash().into();
+    assert_eq!(join1_hash, get_hasher_state1(&dec_trace, 0));
+    assert_eq!(span3_hash, get_hasher_state2(&dec_trace, 0));
+
+    // in the second row, the hasher state is set to hashes of (span1, fn_block)
+    let span1_hash: Word = span1.hash().into();
+    let fn_block_hash: Word = fn_block.hash().into();
+    assert_eq!(span1_hash, get_hasher_state1(&dec_trace, 1));
+    assert_eq!(fn_block_hash, get_hasher_state2(&dec_trace, 1));
+
+    // at the end of the first SPAN, the hasher state is set to the hash of the first child
+    assert_eq!(span1_hash, get_hasher_state1(&dec_trace, 5));
+    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 5));
+
+    // in the 7th row, we start the CALL block which hash span2 as its only child
+    let span2_hash: Word = span2.hash().into();
+    assert_eq!(span2_hash, get_hasher_state1(&dec_trace, 6));
+    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 5));
+
+    // span2 ends in the 11th row
+    assert_eq!(span2_hash, get_hasher_state1(&dec_trace, 10));
+    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 10));
+
+    // CALL block ends in the 12th row; the second to last element of the hasher state
+    // is set to ONE because we are existing the CALL block
+    assert_eq!(fn_block_hash, get_hasher_state1(&dec_trace, 11));
+    assert_eq!([ZERO, ZERO, ONE, ZERO], get_hasher_state2(&dec_trace, 11));
+
+    // internal JOIN block ends in the 13th row
+    assert_eq!(join1_hash, get_hasher_state1(&dec_trace, 12));
+    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 12));
+
+    // span3 ends in the 14th row
+    assert_eq!(span3_hash, get_hasher_state1(&dec_trace, 15));
+    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 15));
+
+    // the program ends in the 17th row
+    let program_hash: Word = program.hash().into();
+    assert_eq!(program_hash, get_hasher_state1(&dec_trace, 16));
+    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 16));
+
+    // HALT opcode and program hash gets propagated to the last row
+    for i in 17..trace_len {
+        assert!(contains_op(&dec_trace, i, Operation::Halt));
+        assert_eq!(ONE, dec_trace[OP_BIT_EXTRA_COL_IDX][i]);
+        assert_eq!(program_hash, get_hasher_state1(&dec_trace, i));
+    }
+
+    // --- check the ctx column -------------------------------------------------------------------
+
+    // for the first 7 cycles, we are in the root context
+    for i in 0..7 {
+        assert_eq!(sys_trace[CTX_COL_IDX][i], ZERO);
+    }
+
+    // when CALL operation is executed, we switch to the new context
+    for i in 7..12 {
+        assert_eq!(sys_trace[CTX_COL_IDX][i], Felt::new(7));
+    }
+
+    // once the CALL block exited, we go back to the root context
+    for i in 12..trace_len {
+        assert_eq!(sys_trace[CTX_COL_IDX][i], ZERO);
+    }
+
+    // --- check the fmp column -------------------------------------------------------------------
+
+    // for the first 5 cycles fmp stays at initial value
+    for i in 0..5 {
+        assert_eq!(sys_trace[FMP_COL_IDX][i], FMP_MIN);
+    }
+
+    // when the first FmpUpdate is executed, fmp gets gets incremented by 2
+    for i in 5..7 {
+        assert_eq!(sys_trace[FMP_COL_IDX][i], FMP_MIN + TWO);
+    }
+
+    // when CALL operation is executed, fmp gets reset to the initial value
+    for i in 7..10 {
+        assert_eq!(sys_trace[FMP_COL_IDX][i], FMP_MIN);
+    }
+
+    // when the second FmpUpdate is executed, fmp gets gets incremented by 1
+    for i in 10..12 {
+        assert_eq!(sys_trace[FMP_COL_IDX][i], FMP_MIN + ONE);
+    }
+
+    // once the CALL block exited, fmp gets reset back to FMP_MIN + 2, and it remains unchanged
+    // until the end of the trace
+    for i in 12..trace_len {
+        assert_eq!(sys_trace[FMP_COL_IDX][i], FMP_MIN + TWO);
+    }
+
+    // --- check block execution hints ------------------------------------------------------------
+    let expected_hints = vec![
+        (0, BlockTableUpdate::BlockStarted(2)),
+        (1, BlockTableUpdate::BlockStarted(2)),
+        (2, BlockTableUpdate::BlockStarted(0)),
+        (5, BlockTableUpdate::BlockEnded(true)),
+        (6, BlockTableUpdate::BlockStarted(1)),
+        (7, BlockTableUpdate::BlockStarted(0)),
+        (10, BlockTableUpdate::BlockEnded(false)),
+        (11, BlockTableUpdate::BlockEnded(false)),
+        (12, BlockTableUpdate::BlockEnded(true)),
+        (13, BlockTableUpdate::BlockStarted(0)),
+        (15, BlockTableUpdate::BlockEnded(false)),
+        (16, BlockTableUpdate::BlockEnded(false)),
+    ];
+    assert_eq!(expected_hints, aux_hints.block_exec_hints());
+
+    // --- check block stack table rows -----------------------------------------------------------
+    let expected_rows = vec![
+        BlockStackTableRow::new_test(INIT_ADDR, ZERO, false),
+        BlockStackTableRow::new_test(join1_addr, INIT_ADDR, false),
+        BlockStackTableRow::new_test(span1_addr, join1_addr, false),
+        BlockStackTableRow::new_test(call_addr, join1_addr, false),
+        BlockStackTableRow::new_test(span2_addr, call_addr, false),
+        BlockStackTableRow::new_test(span3_addr, INIT_ADDR, false),
+    ];
+    assert_eq!(expected_rows, aux_hints.block_stack_table_rows());
+
+    // --- check block hash table hints ----------------------------------------------------------
+    let expected_rows = vec![
+        BlockHashTableRow::from_program_hash(program_hash),
+        BlockHashTableRow::new_test(INIT_ADDR, join1_hash, true, false),
+        BlockHashTableRow::new_test(INIT_ADDR, span3_hash, false, false),
+        BlockHashTableRow::new_test(join1_addr, span1_hash, true, false),
+        BlockHashTableRow::new_test(join1_addr, fn_block_hash, false, false),
+        BlockHashTableRow::new_test(call_addr, span2_hash, false, false),
+    ];
+    assert_eq!(expected_rows, aux_hints.block_hash_table_rows());
+}
+
 // HELPER REGISTERS TESTS
 // ================================================================================================
 #[test]
@@ -928,6 +1124,35 @@ fn build_trace(stack: &[u64], program: &CodeBlock) -> (DecoderTrace, AuxTraceHin
         aux_hints.decoder,
         trace_len,
     )
+}
+
+fn build_call_trace(
+    program: &CodeBlock,
+    fn_block: CodeBlock,
+) -> (SystemTrace, DecoderTrace, AuxTraceHints, usize) {
+    let inputs = ProgramInputs::new(&[], &[], vec![]).unwrap();
+    let mut process = Process::new(inputs);
+
+    // build code block table
+    let mut cb_table = CodeBlockTable::default();
+    cb_table.insert(fn_block);
+
+    process.execute_code_block(program, &cb_table).unwrap();
+
+    let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
+    let trace_len = get_trace_len(&trace) - ExecutionTrace::NUM_RAND_ROWS;
+
+    let sys_trace = trace[SYS_TRACE_RANGE]
+        .to_vec()
+        .try_into()
+        .expect("failed to convert vector to array");
+
+    let decoder_trace = trace[DECODER_TRACE_RANGE]
+        .to_vec()
+        .try_into()
+        .expect("failed to convert vector to array");
+
+    (sys_trace, decoder_trace, aux_hints.decoder, trace_len)
 }
 
 // OPCODES

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -964,7 +964,7 @@ fn call_block() {
     assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 10));
 
     // CALL block ends in the 12th row; the second to last element of the hasher state
-    // is set to ONE because we are existing the CALL block
+    // is set to ONE because we are exiting the CALL block
     assert_eq!(fn_block_hash, get_hasher_state1(&dec_trace, 11));
     assert_eq!([ZERO, ZERO, ONE, ZERO], get_hasher_state2(&dec_trace, 11));
 

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -127,7 +127,7 @@ impl DecoderTrace {
     /// - Set the block address to the specified address.
     /// - Set op_bits to END opcode.
     /// - Put the provided block hash into the first 4 elements of the hasher state.
-    /// - Set the remaining 4 elements of the hasher state to [is_loop_body, is_loop, 0, 0].
+    /// - Set the remaining 4 elements of the hasher state to [is_loop_body, is_loop, is_call, 0].
     /// - Set in_span to ZERO.
     /// - Copy over op group count from the previous row. This group count must be ZERO.
     /// - Set operation index register to ZERO.
@@ -138,6 +138,7 @@ impl DecoderTrace {
         block_hash: Word,
         is_loop_body: Felt,
         is_loop: Felt,
+        is_call: Felt,
     ) {
         debug_assert!(is_loop_body.as_int() <= 1, "invalid loop body");
         debug_assert!(is_loop.as_int() <= 1, "invalid is loop");
@@ -152,7 +153,7 @@ impl DecoderTrace {
 
         self.hasher_trace[4].push(is_loop_body);
         self.hasher_trace[5].push(is_loop);
-        self.hasher_trace[6].push(ZERO);
+        self.hasher_trace[6].push(is_call);
         self.hasher_trace[7].push(ZERO);
 
         self.in_span_trace.push(ZERO);

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -393,8 +393,9 @@ impl Process {
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
-    pub fn get_memory_value(&self, addr: u64) -> Option<Word> {
-        self.chiplets.get_mem_value(addr)
+
+    pub fn get_memory_value(&self, ctx: u32, addr: u64) -> Option<Word> {
+        self.chiplets.get_mem_value(ctx, addr)
     }
 
     pub fn to_components(self) -> (System, Decoder, Stack, RangeChecker, Chiplets) {


### PR DESCRIPTION
This PR adds support for multiple memory contexts. Specifically:

- [x] Add context column to the system trace.
- [x] Update memory chiplet to enable multiple contexts (not just context with ID 0).
- [x] Update decoder to switch between contexts when `call` block is entered/exited.

This PR does not yet include:
- Stack depth manipulations when `CALL` operation is executed.
- Inclusion of `ctx`, `fmtp` and stack depth into block stack table.
- Documentation updates.

These will be addressed in future PRs.