### PR TITLE
Ensuring stack depth consistency in docs

### DIFF
--- a/docs/src/user_docs/assembly/stack_manipulation.md
+++ b/docs/src/user_docs/assembly/stack_manipulation.md
@@ -1,5 +1,5 @@
 ## Stack manipulation
-Miden VM stack is a push-down stack of field elements. The stack has a maximum depth of $2^{16}$, but only the top $16$ elements are directly accessible via the instructions listed below.
+Miden VM stack is a push-down stack of field elements. The stack has a maximum depth of $2^{32}$, but only the top $16$ elements are directly accessible via the instructions listed below.
 
 In addition to the typical stack manipulation instructions such as `drop`, `dup`, `swap` etc., Miden assembly provides several conditional instructions which can be used to manipulate the stack based on some condition - e.g., conditional swap `cswap` or conditional drop `cdrop`.
 


### PR DESCRIPTION
## Describe your changes
Tiny inconsistency in our docs. In the [overview](https://maticnetwork.github.io/miden/intro/overview.html), we say depth is 2^32; in the [assembly user docs](https://maticnetwork.github.io/miden/user_docs/assembly/stack_manipulation.html), we say 2^16. 

I change it to 2^32 for now, however, I am not sure if this is entirely correct.

According to @bobbinth:

- Stack depth is theoretically unlimited, the overflow table can absorb as many items as needed
- VM can push at most 1 item onto the stack at each clock cycle, and because of the parameters we use (field, blowup factor) we cannot execute more than 2^29 cycles on the VM
- Limitation will change somewhat with the PR that grjte is working on now: ability to initialize the stack with a large number of values

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.