### PR TITLE
Refactor inputs/outputs and stack overflow handling at start/end

### DIFF
--- a/air/src/stack/mod.rs
+++ b/air/src/stack/mod.rs
@@ -1,3 +1,130 @@
-use super::EvaluationFrame;
+use vm_core::{utils::collections::Vec, StarkField, STACK_AUX_TRACE_OFFSET};
+
+use super::{
+    Assertion, AuxTraceRandElements, EvaluationFrame, Felt, FieldElement, MIN_STACK_DEPTH,
+    STACK_TRACE_OFFSET,
+};
 
 pub mod op_flags;
+
+// CONSTANTS
+// ================================================================================================
+
+const B0_COL_IDX: usize = STACK_TRACE_OFFSET + MIN_STACK_DEPTH;
+const B1_COL_IDX: usize = B0_COL_IDX + 1;
+
+// --- Main constraints ---------------------------------------------------------------------------
+
+/// The number of boundary constraints required by the Stack, which is all stack positions for
+/// inputs and outputs as well as the initial values of the bookkeeping columns.
+pub const NUM_ASSERTIONS: usize = MIN_STACK_DEPTH + 2;
+
+// --- Auxiliary column constraints ---------------------------------------------------------------
+
+/// The number of auxiliary assertions.
+pub const NUM_AUX_ASSERTIONS: usize = 1;
+
+// BOUNDARY CONSTRAINTS
+// ================================================================================================
+
+// --- MAIN TRACE ---------------------------------------------------------------------------------
+
+/// Returns the stack's boundary assertions for the main trace at the first step.
+pub fn get_assertions_first_step(result: &mut Vec<Assertion<Felt>>, stack_inputs: &[Felt]) {
+    // stack columns at the first step should be set to stack inputs, excluding overflow inputs.
+    for (i, &value) in stack_inputs.iter().take(MIN_STACK_DEPTH).enumerate() {
+        result.push(Assertion::single(STACK_TRACE_OFFSET + i, 0, value));
+    }
+
+    // if there are remaining slots on top of the stack without specified values, set them to ZERO.
+    for i in stack_inputs.len()..MIN_STACK_DEPTH {
+        result.push(Assertion::single(STACK_TRACE_OFFSET + i, 0, Felt::ZERO));
+    }
+
+    // get the initial values for the bookkeeping columns.
+    let mut depth = MIN_STACK_DEPTH;
+    let mut overflow_addr = Felt::ZERO;
+    if stack_inputs.len() > MIN_STACK_DEPTH {
+        depth = stack_inputs.len();
+        overflow_addr = Felt::new(Felt::MODULUS - 1);
+    }
+
+    // b0 should be initialized to the depth of the stack.
+    result.push(Assertion::single(B0_COL_IDX, 0, Felt::new(depth as u64)));
+
+    // b1 should be initialized to the address of the last row in the overflow table, which is 0
+    // when the overflow table is empty and -1 mod p when the stack is initialized with overflow.
+    result.push(Assertion::single(B1_COL_IDX, 0, overflow_addr));
+}
+
+/// Returns the stack's boundary assertions for the main trace at the last step.
+pub fn get_assertions_last_step(
+    result: &mut Vec<Assertion<Felt>>,
+    step: usize,
+    stack_outputs: &[Felt],
+) {
+    // stack columns at the last step should be set to stack outputs, excluding overflow outputs
+    for (i, &value) in stack_outputs.iter().take(MIN_STACK_DEPTH).enumerate() {
+        result.push(Assertion::single(STACK_TRACE_OFFSET + i, step, value));
+    }
+
+    // if there are remaining slots on top of the stack without specified values, set them to ZERO.
+    for i in stack_outputs.len()..MIN_STACK_DEPTH {
+        result.push(Assertion::single(STACK_TRACE_OFFSET + i, step, Felt::ZERO));
+    }
+}
+
+// --- AUXILIARY COLUMNS --------------------------------------------------------------------------
+
+/// Returns the stack's boundary assertions for auxiliary columns at the first step.
+pub fn get_aux_assertions_first_step<E: FieldElement>(
+    result: &mut Vec<Assertion<E>>,
+    alphas: &AuxTraceRandElements<E>,
+    stack_inputs: &[Felt],
+) where
+    E: FieldElement<BaseField = Felt>,
+{
+    let step = 0;
+    let value = if stack_inputs.len() > MIN_STACK_DEPTH {
+        get_overflow_table_init(
+            &stack_inputs[MIN_STACK_DEPTH..],
+            alphas.get_segment_elements(0),
+        )
+    } else {
+        E::ONE
+    };
+
+    result.push(Assertion::single(STACK_AUX_TRACE_OFFSET, step, value));
+}
+
+/// Returns the stack's boundary assertions for auxiliary columns at the last step.
+pub fn get_aux_assertions_last_step<E: FieldElement>(_result: &mut [Assertion<E>], _step: usize) {}
+
+// BOUNDARY CONSTRAINT HELPERS
+// ================================================================================================
+
+// --- AUX TRACE ----------------------------------------------------------------------------------
+
+/// Gets the initial value of the overflow table auxiliary column  from the provided sets of initial
+/// values and random elements.
+fn get_overflow_table_init<E: FieldElement>(init_values: &[Felt], alphas: &[E]) -> E
+where
+    E: FieldElement<BaseField = Felt>,
+{
+    let mut value = E::ONE;
+    let mut prev_clk = Felt::ZERO;
+    let mut clk = Felt::from(Felt::MODULUS - init_values.len() as u64);
+
+    // the values are in the overflow table in reverse order, since the deepest stack
+    // value is added to the overflow table first.
+    for &input in init_values.iter().rev() {
+        value *= alphas[0]
+            + alphas[1].mul_base(clk)
+            + alphas[2].mul_base(input)
+            + alphas[3].mul_base(prev_clk);
+        prev_clk = clk;
+        clk += Felt::ONE;
+    }
+
+    value
+}

--- a/air/src/stack/mod.rs
+++ b/air/src/stack/mod.rs
@@ -1,4 +1,4 @@
-use vm_core::{utils::collections::Vec, StarkField, STACK_AUX_TRACE_OFFSET};
+use vm_core::{utils::collections::Vec, ProgramOutputs, StarkField, STACK_AUX_TRACE_OFFSET};
 
 use super::{
     Assertion, AuxTraceRandElements, EvaluationFrame, Felt, FieldElement, MIN_STACK_DEPTH,
@@ -17,12 +17,12 @@ const B1_COL_IDX: usize = B0_COL_IDX + 1;
 
 /// The number of boundary constraints required by the Stack, which is all stack positions for
 /// inputs and outputs as well as the initial values of the bookkeeping columns.
-pub const NUM_ASSERTIONS: usize = MIN_STACK_DEPTH + 2;
+pub const NUM_ASSERTIONS: usize = 2 * MIN_STACK_DEPTH + 2;
 
 // --- Auxiliary column constraints ---------------------------------------------------------------
 
 /// The number of auxiliary assertions.
-pub const NUM_AUX_ASSERTIONS: usize = 1;
+pub const NUM_AUX_ASSERTIONS: usize = 2;
 
 // BOUNDARY CONSTRAINTS
 // ================================================================================================
@@ -61,16 +61,11 @@ pub fn get_assertions_first_step(result: &mut Vec<Assertion<Felt>>, stack_inputs
 pub fn get_assertions_last_step(
     result: &mut Vec<Assertion<Felt>>,
     step: usize,
-    stack_outputs: &[Felt],
+    outputs: &ProgramOutputs,
 ) {
     // stack columns at the last step should be set to stack outputs, excluding overflow outputs
-    for (i, &value) in stack_outputs.iter().take(MIN_STACK_DEPTH).enumerate() {
-        result.push(Assertion::single(STACK_TRACE_OFFSET + i, step, value));
-    }
-
-    // if there are remaining slots on top of the stack without specified values, set them to ZERO.
-    for i in stack_outputs.len()..MIN_STACK_DEPTH {
-        result.push(Assertion::single(STACK_TRACE_OFFSET + i, step, Felt::ZERO));
+    for (i, value) in outputs.stack_top().iter().enumerate() {
+        result.push(Assertion::single(STACK_TRACE_OFFSET + i, step, *value));
     }
 }
 
@@ -87,8 +82,8 @@ pub fn get_aux_assertions_first_step<E: FieldElement>(
     let step = 0;
     let value = if stack_inputs.len() > MIN_STACK_DEPTH {
         get_overflow_table_init(
-            &stack_inputs[MIN_STACK_DEPTH..],
             alphas.get_segment_elements(0),
+            &stack_inputs[MIN_STACK_DEPTH..],
         )
     } else {
         E::ONE
@@ -98,16 +93,31 @@ pub fn get_aux_assertions_first_step<E: FieldElement>(
 }
 
 /// Returns the stack's boundary assertions for auxiliary columns at the last step.
-pub fn get_aux_assertions_last_step<E: FieldElement>(_result: &mut [Assertion<E>], _step: usize) {}
+pub fn get_aux_assertions_last_step<E: FieldElement>(
+    result: &mut Vec<Assertion<E>>,
+    alphas: &AuxTraceRandElements<E>,
+    outputs: &ProgramOutputs,
+    step: usize,
+) where
+    E: FieldElement<BaseField = Felt>,
+{
+    let value = if outputs.has_overflow() {
+        get_overflow_table_final(alphas.get_segment_elements(0), outputs)
+    } else {
+        E::ONE
+    };
+
+    result.push(Assertion::single(STACK_AUX_TRACE_OFFSET, step, value));
+}
 
 // BOUNDARY CONSTRAINT HELPERS
 // ================================================================================================
 
 // --- AUX TRACE ----------------------------------------------------------------------------------
 
-/// Gets the initial value of the overflow table auxiliary column  from the provided sets of initial
+/// Gets the initial value of the overflow table auxiliary column from the provided sets of initial
 /// values and random elements.
-fn get_overflow_table_init<E: FieldElement>(init_values: &[Felt], alphas: &[E]) -> E
+fn get_overflow_table_init<E: FieldElement>(alphas: &[E], init_values: &[Felt]) -> E
 where
     E: FieldElement<BaseField = Felt>,
 {
@@ -124,6 +134,30 @@ where
             + alphas[3].mul_base(prev_clk);
         prev_clk = clk;
         clk += Felt::ONE;
+    }
+
+    value
+}
+
+/// Gets the final value of the overflow table auxiliary column from the provided program outputs
+/// and random elements.
+fn get_overflow_table_final<E: FieldElement>(alphas: &[E], outputs: &ProgramOutputs) -> E
+where
+    E: FieldElement<BaseField = Felt>,
+{
+    let mut value = E::ONE;
+
+    // When the overflow table is non-empty, we expect at least 2 addresses (the `prev` value of
+    // the first row and the address value(s) of the row(s)) and more than MIN_STACK_DEPTH
+    // elements in the stack.
+    let mut prev = outputs.overflow_prev();
+    for (clk, val) in outputs.stack_overflow() {
+        value *= alphas[0]
+            + alphas[1].mul_base(clk)
+            + alphas[2].mul_base(val)
+            + alphas[3].mul_base(prev);
+
+        prev = clk;
     }
 
     value

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -4,7 +4,6 @@ use crate::utils::{collections::Vec, string::String};
 #[derive(Clone, Debug)]
 pub enum InputError {
     NotFieldElement(u64, &'static str),
-    TooManyStackValues(usize, usize),
     DuplicateAdviceRoot([u8; 32]),
 }
 

--- a/core/src/inputs/mod.rs
+++ b/core/src/inputs/mod.rs
@@ -2,7 +2,7 @@ use super::{
     chiplets::hasher,
     errors::{AdviceSetError, InputError},
     utils::IntoBytes,
-    Felt, FieldElement, Word, MIN_STACK_DEPTH,
+    Felt, FieldElement, Word,
 };
 use core::convert::TryInto;
 use winter_utils::collections::{BTreeMap, Vec};
@@ -54,13 +54,6 @@ impl ProgramInputs {
         advice_tape: &[u64],
         advice_sets: Vec<AdviceSet>,
     ) -> Result<Self, InputError> {
-        if stack_init.len() > MIN_STACK_DEPTH {
-            return Err(InputError::TooManyStackValues(
-                MIN_STACK_DEPTH,
-                stack_init.len(),
-            ));
-        }
-
         // convert initial stack values into field elements
         let mut init_stack_elements = Vec::with_capacity(stack_init.len());
         for &value in stack_init.iter().rev() {

--- a/core/src/inputs/mod.rs
+++ b/core/src/inputs/mod.rs
@@ -18,8 +18,8 @@ pub use advice::AdviceSet;
 /// Miden VM programs can receive inputs in two ways:
 /// 1. The stack can be initialized to some set of values at the beginning of the program. These
 ///    inputs are public and must be shared with the verifier for them to verify a proof of the
-///    correct execution of a Miden program. The number of elements at the top of the stack which
-///    can receive initial value is limited to 16.
+///    correct execution of a Miden program. There is no limit to the number of elements at the top
+///    of the stack which can receive an initial value.
 /// 2. The program may request nondeterministic advice inputs from the prover. These inputs are
 ///    secret inputs. This means that the prover does not need to share them with the verifier.
 ///    There are two types of advice inputs: (1) a single advice tape which can contain any number

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,6 +24,9 @@ pub use operations::{
 mod inputs;
 pub use inputs::{AdviceSet, ProgramInputs};
 
+mod outputs;
+pub use outputs::ProgramOutputs;
+
 pub mod utils;
 use utils::range;
 

--- a/core/src/outputs.rs
+++ b/core/src/outputs.rs
@@ -1,0 +1,147 @@
+use crate::{StackTopState, MIN_STACK_DEPTH};
+
+use super::{Felt, StarkField};
+use winter_utils::collections::Vec;
+
+// PROGRAM OUTPUTS
+// ================================================================================================
+
+/// Output container for Miden VM programs.
+///
+/// Miden program outputs contain the full state of the stack at the end of execution as well as the
+/// addresses in the overflow table which are required to reconstruct the table (when combined with
+/// the overflow values from the stack state).
+///
+/// `stack` is expected to be ordered as if they elements were popped off the stack one by one.
+/// Thus, the value at the top of the stack is expected to be in the first position, and the order
+/// of the rest of the output elements will also match the order on the stack.
+///
+/// `overflow_addrs` is expected to start with the `prev` address value from the first row in the
+/// overflow table (the row representing the deepest element in the stack) and then be followed by
+/// the address (`clk` value) of each row in the table starting from the deepest element in the
+/// stack and finishing with the row which was added to the table last.
+#[derive(Debug, Clone, Default)]
+pub struct ProgramOutputs {
+    /// The elements on the stack at the end of execution.
+    stack: Vec<u64>,
+    /// The overflow table row addresse required to reconstruct the final state of the table.
+    overflow_addrs: Vec<u64>,
+}
+
+impl ProgramOutputs {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    pub fn new(stack: Vec<u64>, overflow_addrs: Vec<u64>) -> Self {
+        debug_assert!(
+            are_valid_elements(&stack),
+            "stack outputs contain values that are not valid field elements",
+        );
+        debug_assert!(
+            are_valid_elements(&overflow_addrs),
+            "overflow address outputs contain values that are not valid field elements",
+        );
+
+        Self {
+            stack,
+            overflow_addrs,
+        }
+    }
+
+    pub fn from_elements(stack: Vec<Felt>, overflow_addrs: Vec<Felt>) -> Self {
+        let stack = stack.iter().map(|&v| v.as_int()).collect::<Vec<_>>();
+        let overflow_addrs = overflow_addrs
+            .iter()
+            .map(|&v| v.as_int())
+            .collect::<Vec<_>>();
+
+        Self {
+            stack,
+            overflow_addrs,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the stack outputs, which is state of the stack at the end of execution converted to
+    /// integers.
+    pub fn stack(&self) -> &[u64] {
+        &self.stack
+    }
+
+    /// Returns the number of requested stack outputs or returns the full stack if fewer than the
+    /// requested number of stack values exist.
+    pub fn stack_outputs(&self, num_outputs: usize) -> &[u64] {
+        if num_outputs < self.stack.len() {
+            return &self.stack[..num_outputs];
+        }
+
+        &self.stack
+    }
+
+    /// Returns the state of the top of the stack at the end of execution.
+    pub fn stack_top(&self) -> StackTopState {
+        self.stack
+            .iter()
+            .take(MIN_STACK_DEPTH)
+            .map(|v| Felt::new(*v))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("failed to convert vector to array")
+    }
+
+    /// Returns the overflow address outputs, which are the addresses required to reconstruct the
+    /// overflow table (when combined with the stack overflow values) converted to integers.
+    pub fn overflow_addrs(&self) -> &[u64] {
+        &self.overflow_addrs
+    }
+
+    /// Returns true if the overflow table outputs are non-empty.
+    pub fn has_overflow(&self) -> bool {
+        !self.overflow_addrs.is_empty()
+    }
+
+    /// Returns the previous address `prev` for the first row in the stack overflow table
+    pub fn overflow_prev(&self) -> Felt {
+        Felt::new(self.overflow_addrs[0])
+    }
+
+    /// Returns (address, value) for all rows which were on the overflow table at the end of
+    /// execution in the order in which they were added to the table (deepest stack item first).
+    pub fn stack_overflow(&self) -> Vec<(Felt, Felt)> {
+        let mut overflow = Vec::with_capacity(self.overflow_addrs.len() - 1);
+        for (addr, val) in self
+            .overflow_addrs
+            .iter()
+            .skip(1)
+            .zip(self.stack.iter().skip(MIN_STACK_DEPTH).rev())
+        {
+            overflow.push((Felt::new(*addr), Felt::new(*val)));
+        }
+
+        overflow
+    }
+
+    // PUBLIC MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns mutable access to the stack outputs, to be used for testing or running examples.
+    /// TODO: this should be marked with #[cfg(test)] attribute, but that currently won't work with
+    /// the integration test handler util.
+    pub fn stack_mut(&mut self) -> &mut [u64] {
+        &mut self.stack
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Verify that each element in the provided slice of outputs is a valid field element.
+fn are_valid_elements(outputs: &[u64]) -> bool {
+    for val in outputs {
+        if *val >= Felt::MODULUS {
+            return false;
+        }
+    }
+    true
+}

--- a/docs/src/intro/overview.md
+++ b/docs/src/intro/overview.md
@@ -32,9 +32,10 @@ For example, if we wanted to provide a thousand public input values to the VM, w
 In the future, other ways of providing public inputs and reading public outputs (e.g., storage commitments) may be added to the VM.
 
 ### Stack depth restrictions
-For reasons explained [here](../design/stack/main.md), the VM imposes the following restrictions on stack depth:
-1. Stack depth cannot be smaller than $16$. When initializing a program with fewer than $16$ inputs, the VM will pad the stack with zeros to ensure the depth is $16$ at the beginning of execution. If an operation would result in the stack depth dropping below $16$, the VM will insert a zero at the deep end of the stack to make sure the depth stays at $16$.
-2. At the end of program execution, stack depth cannot be greater than $16$. If ensuring this manually is difficult, [finalize_stack](../user_docs/stdlib/sys.md) procedure can be called at the end of program execution. This procedure will remove items deep in the stack while keeping the top $16$ items untouched.
+For reasons explained [here](../design/stack/main.md), the VM imposes the restriction that the stack depth cannot be smaller than $16$. This has the following effects:
+
+- When initializing a program with fewer than $16$ inputs, the VM will pad the stack with zeros to ensure the depth is $16$ at the beginning of execution. 
+- If an operation would result in the stack depth dropping below $16$, the VM will insert a zero at the deep end of the stack to make sure the depth stays at $16$.
 
 ### Nondeterministic inputs
 The *advice provider* component is responsible for supplying nondeterministic inputs to the VM. These inputs only need to be known to the prover (i.e., they do not need to be shared with the verifier).

--- a/docs/src/user_docs/stdlib/sys.md
+++ b/docs/src/user_docs/stdlib/sys.md
@@ -3,4 +3,4 @@ Module `std::sys` contains a set of system-level utility procedures.
 
 | Procedure      | Description   |
 | -------------- | ------------- |
-| finalize_stack | Removes elements deep in the stack until the depth of the stack is exactly 16. The elements are removed in such a way that the top 16 elements of the stack remain unchanged.<br/>Input: Stack with 16 or more elements.<br/> Output: Stack with only the original top 16 elements. |
+| finalize_stack | Removes elements deep in the stack until the depth of the stack is exactly 16. The elements are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack would otherwise contain more than 16 elements at the end of execution, then adding a call to this function at the end will reduce the size of the public inputs that are shared with the verifier.<br/>Input: Stack with 16 or more elements.<br/> Output: Stack with only the original top 16 elements. |

--- a/docs/src/user_docs/stdlib/sys.md
+++ b/docs/src/user_docs/stdlib/sys.md
@@ -3,4 +3,4 @@ Module `std::sys` contains a set of system-level utility procedures.
 
 | Procedure      | Description   |
 | -------------- | ------------- |
-| finalize_stack | Removes elements deep in the stack until the depth of the stack is exactly 16. The elements are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack would otherwise contain more than 16 elements at the end of execution, then adding a call to this function at the end will reduce the size of the public inputs that are shared with the verifier.<br/>Input: Stack with 16 or more elements.<br/> Output: Stack with only the original top 16 elements. |
+| truncate_stack | Removes elements deep in the stack until the depth of the stack is exactly 16. The elements are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack would otherwise contain more than 16 elements at the end of execution, then adding a call to this function at the end will reduce the size of the public inputs that are shared with the verifier.<br/>Input: Stack with 16 or more elements.<br/> Output: Stack with only the original top 16 elements. |

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -70,6 +70,7 @@ pub struct OutputFile {
 }
 
 /// Helper methods to interact with the output file
+/// TODO: update output file reading/writing for new ProgramOutputs struct
 impl OutputFile {
     /// Returns a new [OutputFile] from the specified outputs vector
     pub fn new(outputs: Vec<u64>) -> Self {

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -3,6 +3,7 @@ use prover::StarkProof;
 use serde_derive::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::{fs, io::Write, time::Instant};
+use vm_core::ProgramOutputs;
 use vm_core::{chiplets::hasher::Digest, Program, ProgramInputs};
 use winter_utils::{Deserializable, SliceReader};
 
@@ -66,18 +67,24 @@ impl InputFile {
 /// Output file struct
 #[derive(Deserialize, Serialize, Debug)]
 pub struct OutputFile {
-    pub outputs: Vec<String>,
+    pub stack: Vec<String>,
+    pub overflow_addrs: Vec<String>,
 }
 
 /// Helper methods to interact with the output file
-/// TODO: update output file reading/writing for new ProgramOutputs struct
 impl OutputFile {
-    /// Returns a new [OutputFile] from the specified outputs vector
-    pub fn new(outputs: Vec<u64>) -> Self {
+    /// Returns a new [OutputFile] from the specified outputs vectors
+    pub fn new(outputs: ProgramOutputs) -> Self {
         Self {
-            outputs: outputs
+            stack: outputs
+                .stack()
                 .iter()
-                .map(|v| v.to_string())
+                .map(|&v| v.to_string())
+                .collect::<Vec<String>>(),
+            overflow_addrs: outputs
+                .overflow_addrs()
+                .iter()
+                .map(|&v| v.to_string())
                 .collect::<Vec<String>>(),
         }
     }
@@ -98,46 +105,47 @@ impl OutputFile {
             .map_err(|err| format!("Failed to open outputs file `{}` - {}", path.display(), err))?;
 
         // deserialize outputs data
-        let mut outputs: OutputFile = serde_json::from_str(&outputs_file)
+        let outputs: OutputFile = serde_json::from_str(&outputs_file)
             .map_err(|err| format!("Failed to deserialize outputs data - {}", err))?;
-
-        // The verify interface expects the stack outputs in reverse order so we reverse them here
-        outputs.outputs.reverse();
 
         Ok(outputs)
     }
 
     /// Write the output file
-    pub fn write(outputs: Vec<u64>, path: &Option<PathBuf>) -> Result<(), String> {
-        if let Some(path) = path {
-            // if path provided, create output file
-            println!("Creating output file `{}`", path.display());
+    pub fn write(outputs: ProgramOutputs, path: &PathBuf) -> Result<(), String> {
+        // if path provided, create output file
+        println!("Creating output file `{}`", path.display());
 
-            let file = fs::File::create(&path).map_err(|err| {
-                format!(
-                    "Failed to create output file `{}` - {}",
-                    path.display(),
-                    err
-                )
-            })?;
+        let file = fs::File::create(&path).map_err(|err| {
+            format!(
+                "Failed to create output file `{}` - {}",
+                path.display(),
+                err
+            )
+        })?;
 
-            println!("Writing data to output file");
+        println!("Writing data to output file");
 
-            // write outputs to output file
-            serde_json::to_writer_pretty(file, &Self::new(outputs))
-        } else {
-            println!("Output: {:?}", outputs);
-            Ok(())
-        }
-        .map_err(|err| format!("Failed to write output data - {}", err))
+        // write outputs to output file
+        serde_json::to_writer_pretty(file, &Self::new(outputs))
+            .map_err(|err| format!("Failed to write output data - {}", err))
     }
 
-    /// Converts outputs vector of String to vector of u64
-    pub fn outputs(&self) -> Vec<u64> {
-        self.outputs
+    /// Converts outputs vectors for stack and overflow addresses to [ProgramOutputs].
+    pub fn outputs(&self) -> ProgramOutputs {
+        let stack = self
+            .stack
             .iter()
             .map(|v| v.parse::<u64>().unwrap())
-            .collect::<Vec<u64>>()
+            .collect::<Vec<u64>>();
+
+        let overflow_addrs = self
+            .overflow_addrs
+            .iter()
+            .map(|v| v.parse::<u64>().unwrap())
+            .collect::<Vec<u64>>();
+
+        ProgramOutputs::new(stack, overflow_addrs)
     }
 }
 

--- a/miden/src/cli/prove.rs
+++ b/miden/src/cli/prove.rs
@@ -54,7 +54,6 @@ impl ProveCmd {
         let (outputs, proof) = prover::prove(
             &program,
             &input_data.get_program_inputs(),
-            self.num_outputs,
             &self.get_proof_security(),
         )
         .map_err(|err| format!("Failed to prove program - {:?}", err))?;

--- a/miden/src/cli/prove.rs
+++ b/miden/src/cli/prove.rs
@@ -1,5 +1,6 @@
 use super::data::{InputFile, OutputFile, ProgramFile, ProofFile};
 use air::ProofOptions;
+use crypto::Digest;
 use std::path::PathBuf;
 use std::time::Instant;
 use structopt::StructOpt;
@@ -47,7 +48,10 @@ impl ProveCmd {
         // load input data from file
         let input_data = InputFile::read(&self.input_file, &self.assembly_file)?;
 
-        println!("Proving program ...");
+        println!(
+            "Proving program with hash {}...",
+            hex::encode(program.hash().as_bytes())
+        );
         let now = Instant::now();
 
         // execute program and generate proof
@@ -58,13 +62,29 @@ impl ProveCmd {
         )
         .map_err(|err| format!("Failed to prove program - {:?}", err))?;
 
-        println!("Program proved in {} ms", now.elapsed().as_millis());
+        println!(
+            "Program with hash {} proved in {} ms",
+            hex::encode(program.hash().as_bytes()),
+            now.elapsed().as_millis()
+        );
 
         // write proof to file
         ProofFile::write(proof, &self.proof_file, &self.assembly_file)?;
 
-        // write outputs
-        OutputFile::write(outputs, &self.output_file)?;
+        // provide outputs
+        if let Some(output_path) = &self.output_file {
+            // write all outputs to specified file.
+            OutputFile::write(outputs, output_path)?;
+        } else {
+            // if no output path was provided, get the stack outputs for printing to the screen.
+            let stack_outputs = outputs.stack_outputs(self.num_outputs).to_vec();
+
+            // write all outputs to default location if none was provided
+            OutputFile::write(outputs, &self.assembly_file.with_extension("outputs"))?;
+
+            // print stack outputs to screen.
+            println!("Output: {:?}", stack_outputs);
+        }
 
         Ok(())
     }

--- a/miden/src/cli/run.rs
+++ b/miden/src/cli/run.rs
@@ -36,20 +36,15 @@ impl RunCmd {
         print!("Executing program... ");
         let now = Instant::now();
 
-        // generate execution trace
-        let trace = processor::execute(&program, &input_data.get_program_inputs())
-            .map_err(|err| format!("Failed to generate exection trace = {:?}", err))?;
+        // execute program and generate outputs
+        let (program_outputs, _) =
+            processor::execute(&program, &input_data.get_program_inputs())
+                .map_err(|err| format!("Failed to generate exection trace = {:?}", err))?;
 
         println!("done ({} ms)", now.elapsed().as_millis());
 
-        // extract outputs from execution trace
-        let outputs = trace.last_stack_state()[..self.num_outputs]
-            .iter()
-            .map(|&v| v.as_int())
-            .collect::<Vec<_>>();
-
         // write outputs to file
-        OutputFile::write(outputs, &self.output_file)?;
+        OutputFile::write(program_outputs.into(), &self.output_file)?;
 
         Ok(())
     }

--- a/miden/src/cli/run.rs
+++ b/miden/src/cli/run.rs
@@ -1,5 +1,5 @@
 use super::data::{InputFile, OutputFile, ProgramFile};
-use air::StarkField;
+use crypto::Digest;
 use std::path::PathBuf;
 use std::time::Instant;
 use structopt::StructOpt;
@@ -33,18 +33,28 @@ impl RunCmd {
         // load input data from file
         let input_data = InputFile::read(&self.input_file, &self.assembly_file)?;
 
-        print!("Executing program... ");
+        print!(
+            "Executing program with hash {}... ",
+            hex::encode(program.hash().as_bytes())
+        );
         let now = Instant::now();
 
         // execute program and generate outputs
-        let (program_outputs, _) =
-            processor::execute(&program, &input_data.get_program_inputs())
-                .map_err(|err| format!("Failed to generate exection trace = {:?}", err))?;
+        let trace = processor::execute(&program, &input_data.get_program_inputs())
+            .map_err(|err| format!("Failed to generate exection trace = {:?}", err))?;
 
         println!("done ({} ms)", now.elapsed().as_millis());
 
-        // write outputs to file
-        OutputFile::write(program_outputs.into(), &self.output_file)?;
+        if let Some(output_path) = &self.output_file {
+            // write outputs to file if one was specified
+            OutputFile::write(trace.program_outputs(), output_path)?;
+        } else {
+            // write the stack outputs to the screen.
+            println!(
+                "Output: {:?}",
+                trace.program_outputs().stack_outputs(self.num_outputs)
+            );
+        }
 
         Ok(())
     }

--- a/miden/src/examples/mod.rs
+++ b/miden/src/examples/mod.rs
@@ -70,8 +70,7 @@ impl ExampleOptions {
 
         // execute the program and generate the proof of execution
         let now = Instant::now();
-        let (outputs, proof) =
-            miden::prove(&program, &inputs, num_outputs, &proof_options).unwrap();
+        let (outputs, proof) = miden::prove(&program, &inputs, &proof_options).unwrap();
         println!("--------------------------------");
 
         println!(
@@ -79,9 +78,10 @@ impl ExampleOptions {
             //hex::encode(program.hash()), // TODO: include into message
             now.elapsed().as_millis()
         );
-        println!("Program output: {:?}", outputs);
+        println!("Program output: {:?}", outputs.stack_outputs(num_outputs));
         assert_eq!(
-            expected_result, outputs,
+            expected_result,
+            outputs.stack_outputs(num_outputs),
             "Program result was computed incorrectly"
         );
 
@@ -120,16 +120,16 @@ pub fn test_example(example: Example, fail: bool) {
         expected_result,
     } = example;
 
-    let (mut outputs, proof) =
-        miden::prove(&program, &inputs, num_outputs, &ProofOptions::default()).unwrap();
+    let (mut outputs, proof) = miden::prove(&program, &inputs, &ProofOptions::default()).unwrap();
 
     assert_eq!(
-        expected_result, outputs,
+        expected_result,
+        outputs.stack_outputs(num_outputs),
         "Program result was computed incorrectly"
     );
 
     if fail {
-        outputs[0] += 1;
+        outputs.stack_mut()[0] += 1;
         assert!(miden::verify(program.hash(), &pub_inputs, &outputs, proof).is_err())
     } else {
         assert!(miden::verify(program.hash(), &pub_inputs, &outputs, proof).is_ok());

--- a/miden/tests/integration/air/chiplets/bitwise.rs
+++ b/miden/tests/integration/air/chiplets/bitwise.rs
@@ -3,8 +3,7 @@ use crate::{build_op_test, build_test};
 #[test]
 fn bitwise_and() {
     // Test all bit input combinations: (1, 1), (1, 0), (0, 0). Then test larger numbers.
-    // the last drop at the end is added to make sure stack overflow table is empty at the end
-    let asm_op = "u32checked_and push.0 u32checked_and push.0 u32checked_and push.65535 push.137 u32checked_and drop";
+    let asm_op = "u32checked_and push.0 u32checked_and push.0 u32checked_and push.65535 push.137 u32checked_and";
     let pub_inputs = vec![1, 1];
 
     build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
@@ -13,8 +12,7 @@ fn bitwise_and() {
 #[test]
 fn bitwise_or() {
     // Test all bit input combinations: (1, 1), (1, 0), (0, 0). Then test larger numbers.
-    // the last drop at the end is added to make sure stack overflow table is empty at the end
-    let asm_op = "u32checked_or push.0 u32checked_or not push.0 u32checked_or push.65535 push.137 u32checked_or drop";
+    let asm_op = "u32checked_or push.0 u32checked_or not push.0 u32checked_or push.65535 push.137 u32checked_or";
     let pub_inputs = vec![1, 1];
 
     build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
@@ -23,8 +21,7 @@ fn bitwise_or() {
 #[test]
 fn bitwise_xor() {
     // Test all bit input combinations: (1, 1), (0, 0), (1, 0). Then test larger numbers
-    // the last drop at the end is added to make sure stack overflow table is empty at the end
-    let asm_op = "u32checked_xor push.0 u32checked_xor push.1 u32checked_xor push.65535 push.137 u32checked_xor drop";
+    let asm_op = "u32checked_xor push.0 u32checked_xor push.1 u32checked_xor push.65535 push.137 u32checked_xor";
     let pub_inputs = vec![1, 1];
 
     build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);

--- a/miden/tests/integration/air/chiplets/bitwise.rs
+++ b/miden/tests/integration/air/chiplets/bitwise.rs
@@ -7,7 +7,7 @@ fn bitwise_and() {
     let asm_op = "u32checked_and push.0 u32checked_and push.0 u32checked_and push.65535 push.137 u32checked_and drop";
     let pub_inputs = vec![1, 1];
 
-    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -17,7 +17,7 @@ fn bitwise_or() {
     let asm_op = "u32checked_or push.0 u32checked_or not push.0 u32checked_or push.65535 push.137 u32checked_or drop";
     let pub_inputs = vec![1, 1];
 
-    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -27,7 +27,7 @@ fn bitwise_xor() {
     let asm_op = "u32checked_xor push.0 u32checked_xor push.1 u32checked_xor push.65535 push.137 u32checked_xor drop";
     let pub_inputs = vec![1, 1];
 
-    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -35,5 +35,5 @@ fn all_operations() {
     let source = "begin u32checked_and push.0 u32checked_or push.0 u32checked_xor end";
     let pub_inputs = vec![1, 1];
 
-    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, false);
 }

--- a/miden/tests/integration/air/chiplets/hasher.rs
+++ b/miden/tests/integration/air/chiplets/hasher.rs
@@ -21,8 +21,7 @@ fn rphash() {
 
 #[test]
 fn mtree_get() {
-    // drop's are added at the end to make sure stack overflow is empty on exit
-    let asm_op = "mtree_get drop drop";
+    let asm_op = "mtree_get";
 
     let index = 3usize;
     let leaves = init_merkle_leaves(&[1, 2, 3, 4, 5, 6, 7, 8]);
@@ -52,8 +51,7 @@ fn mtree_set() {
 
 #[test]
 fn mtree_cwm() {
-    // drop's are added at the end to make sure stack overflow is empty on exit
-    let asm_op = "mtree_cwm drop drop";
+    let asm_op = "mtree_cwm";
     let (stack_inputs, tree) = build_mtree_update_test_inputs();
 
     build_op_test!(asm_op, &stack_inputs, &[], vec![tree]).prove_and_verify(stack_inputs, false);

--- a/miden/tests/integration/air/chiplets/hasher.rs
+++ b/miden/tests/integration/air/chiplets/hasher.rs
@@ -8,7 +8,7 @@ fn rpperm() {
     let asm_op = "rpperm";
     let pub_inputs = rand_vector::<u64>(8);
 
-    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -16,7 +16,7 @@ fn rphash() {
     let asm_op = "rphash";
     let pub_inputs = rand_vector::<u64>(8);
 
-    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -37,11 +37,8 @@ fn mtree_get() {
         tree.depth() as u64,
     ];
 
-    build_op_test!(asm_op, &stack_inputs, &[], vec![tree]).prove_and_verify(
-        stack_inputs.to_vec(),
-        0,
-        false,
-    );
+    build_op_test!(asm_op, &stack_inputs, &[], vec![tree])
+        .prove_and_verify(stack_inputs.to_vec(), false);
 }
 
 #[test]
@@ -49,11 +46,8 @@ fn mtree_set() {
     let asm_op = "mtree_set";
     let (stack_inputs, tree) = build_mtree_update_test_inputs();
 
-    build_op_test!(asm_op, &stack_inputs, &[], vec![tree]).prove_and_verify(
-        stack_inputs.to_vec(),
-        0,
-        false,
-    );
+    build_op_test!(asm_op, &stack_inputs, &[], vec![tree])
+        .prove_and_verify(stack_inputs.to_vec(), false);
 }
 
 #[test]
@@ -62,7 +56,7 @@ fn mtree_cwm() {
     let asm_op = "mtree_cwm drop drop";
     let (stack_inputs, tree) = build_mtree_update_test_inputs();
 
-    build_op_test!(asm_op, &stack_inputs, &[], vec![tree]).prove_and_verify(stack_inputs, 0, false);
+    build_op_test!(asm_op, &stack_inputs, &[], vec![tree]).prove_and_verify(stack_inputs, false);
 }
 
 /// Helper function that builds a test stack and Merkle tree for testing mtree updates.

--- a/miden/tests/integration/air/chiplets/memory.rs
+++ b/miden/tests/integration/air/chiplets/memory.rs
@@ -6,7 +6,7 @@ fn push() {
     // drop's are added at the end to make sure stack overflow is empty on exit
     let asm_op = "push.mem.0 swap drop";
 
-    build_op_test!(asm_op).prove_and_verify(vec![], 0, false);
+    build_op_test!(asm_op).prove_and_verify(vec![], false);
 }
 
 #[test]
@@ -14,7 +14,7 @@ fn pushw() {
     // drop's are added at the end to make sure stack overflow is empty on exit
     let asm_op = "pushw.mem.0 swapw drop drop drop drop";
 
-    build_op_test!(asm_op).prove_and_verify(vec![], 0, false);
+    build_op_test!(asm_op).prove_and_verify(vec![], false);
 }
 
 #[test]
@@ -22,7 +22,7 @@ fn pop() {
     let asm_op = "pop.mem.0";
     let pub_inputs = vec![1];
 
-    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn popw() {
     let asm_op = "popw.mem.0";
     let pub_inputs = vec![1, 2, 3, 4];
 
-    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -78,7 +78,7 @@ fn helper_popow() {
 fn load() {
     let asm_op = "loadw.mem.0";
 
-    build_op_test!(asm_op).prove_and_verify(vec![], 0, false);
+    build_op_test!(asm_op).prove_and_verify(vec![], false);
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn store() {
     let asm_op = "storew.mem.0";
     let pub_inputs = vec![1, 2, 3, 4];
 
-    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+    build_op_test!(asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -95,7 +95,7 @@ fn write_read() {
     let source = "begin popw.mem.0 pushw.mem.0 swapw drop drop drop drop end";
     let pub_inputs = vec![4, 3, 2, 1];
 
-    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -119,7 +119,7 @@ fn update() {
     let source = "begin pushw.mem.0 storew.mem.0 swapw drop drop drop drop end";
     let pub_inputs = vec![8, 7, 6, 5, 4, 3, 2, 1];
 
-    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 #[test]
@@ -127,5 +127,5 @@ fn incr_write_addr() {
     let source = "begin storew.mem.0 storew.mem.1 end";
     let pub_inputs = vec![4, 3, 2, 1];
 
-    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 1, false);
+    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, false);
 }

--- a/miden/tests/integration/air/chiplets/memory.rs
+++ b/miden/tests/integration/air/chiplets/memory.rs
@@ -3,16 +3,14 @@ use vm_core::utils::ToElements;
 
 #[test]
 fn push() {
-    // drop's are added at the end to make sure stack overflow is empty on exit
-    let asm_op = "push.mem.0 swap drop";
+    let asm_op = "push.mem.0 swap";
 
     build_op_test!(asm_op).prove_and_verify(vec![], false);
 }
 
 #[test]
 fn pushw() {
-    // drop's are added at the end to make sure stack overflow is empty on exit
-    let asm_op = "pushw.mem.0 swapw drop drop drop drop";
+    let asm_op = "pushw.mem.0 swapw";
 
     build_op_test!(asm_op).prove_and_verify(vec![], false);
 }
@@ -91,8 +89,7 @@ fn store() {
 
 #[test]
 fn write_read() {
-    // drop's are added at the end to make sure stack overflow is empty on exit
-    let source = "begin popw.mem.0 pushw.mem.0 swapw drop drop drop drop end";
+    let source = "begin popw.mem.0 pushw.mem.0 swapw end";
     let pub_inputs = vec![4, 3, 2, 1];
 
     build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, false);
@@ -100,9 +97,8 @@ fn write_read() {
 
 #[test]
 fn helper_write_read() {
-    // drop's are added at the end to make sure stack overflow is empty on exit
     // Sequence of operations: [Span, Pad, MStorew, Drop, Drop, Drop, Drop, Pad, MLoad, ... ]
-    let source = "begin popw.mem.0 push.mem.0 swapw drop end";
+    let source = "begin popw.mem.0 push.mem.0 swapw end";
     let pub_inputs = vec![4, 3, 2, 1];
 
     let trace = build_test!(source, &pub_inputs).execute().unwrap();
@@ -115,8 +111,7 @@ fn helper_write_read() {
 
 #[test]
 fn update() {
-    // drop's are added at the end to make sure stack overflow is empty on exit
-    let source = "begin pushw.mem.0 storew.mem.0 swapw drop drop drop drop end";
+    let source = "begin pushw.mem.0 storew.mem.0 swapw end";
     let pub_inputs = vec![8, 7, 6, 5, 4, 3, 2, 1];
 
     build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, false);

--- a/miden/tests/integration/air/chiplets/mod.rs
+++ b/miden/tests/integration/air/chiplets/mod.rs
@@ -16,5 +16,5 @@ fn chiplets() {
     end";
     let pub_inputs = rand_vector::<u64>(8);
 
-    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, 0, false);
+    build_test!(source, &pub_inputs).prove_and_verify(pub_inputs, false);
 }

--- a/miden/tests/integration/air/chiplets/mod.rs
+++ b/miden/tests/integration/air/chiplets/mod.rs
@@ -12,7 +12,6 @@ fn chiplets() {
         rpperm                          # hasher operation
         push.5 push.10 u32checked_or    # bitwise operation
         push.mem                        # memory operation
-        drop                            # make sure the stack overflow table is empty
     end";
     let pub_inputs = rand_vector::<u64>(8);
 

--- a/miden/tests/integration/air/mod.rs
+++ b/miden/tests/integration/air/mod.rs
@@ -1,2 +1,3 @@
 mod chiplets;
 mod range;
+mod stack;

--- a/miden/tests/integration/air/range.rs
+++ b/miden/tests/integration/air/range.rs
@@ -7,7 +7,7 @@ fn range_check_once() {
     let asm_op = "u32overflowing_add";
     let stack = vec![1, 1];
 
-    build_op_test!(asm_op, &stack).prove_and_verify(stack, 0, false);
+    build_op_test!(asm_op, &stack).prove_and_verify(stack, false);
 }
 
 /// Range checks multiple values a varying number of times, since each value is checked as an input.
@@ -16,7 +16,7 @@ fn range_check_once() {
 fn range_check_multi() {
     let source = "begin u32checked_add u32checked_add end";
     let stack = vec![5, 5, 5];
-    build_test!(source, &stack).prove_and_verify(stack, 0, false);
+    build_test!(source, &stack).prove_and_verify(stack, false);
 }
 
 /// Range checks the result of 1 + u32::MAX - 1, which is u32::MAX. Therefore, it requires range
@@ -26,5 +26,5 @@ fn range_check_u16max() {
     let asm_op = "u32overflowing_add";
     let stack = vec![1, (u32::MAX - 1) as u64];
 
-    build_op_test!(asm_op, &stack).prove_and_verify(stack, 0, false);
+    build_op_test!(asm_op, &stack).prove_and_verify(stack, false);
 }

--- a/miden/tests/integration/air/stack.rs
+++ b/miden/tests/integration/air/stack.rs
@@ -1,0 +1,70 @@
+use crate::build_op_test;
+
+/// Test empty starting stack with no overflow outputs.
+#[test]
+fn empty_input() {
+    let asm_op = "push.1 drop";
+    let pub_inputs = vec![];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 16, false);
+}
+
+/// Test an empty starting stack but enough outputs that the overflow table is non-empty at the end.
+#[test]
+fn empty_input_overflow_output() {
+    let asm_ops = "push.17 push.18";
+    let pub_inputs = vec![];
+
+    build_op_test!(&asm_ops, &pub_inputs).prove_and_verify(pub_inputs, 18, false);
+}
+
+/// Test starting stack with some inputs but not full with no overflow outputs.
+#[test]
+fn some_inputs() {
+    let asm_op = "push.5 drop";
+    let pub_inputs = vec![1, 2, 3, 4];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 16, false);
+}
+
+/// Test full starting stack with no overflow outputs.
+#[test]
+fn full_inputs() {
+    let asm_op = "push.17 drop";
+    let pub_inputs = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 16, false);
+}
+
+/// Test a script that finishes with enough outputs that the overflow table is non-empty at the end.
+#[test]
+fn full_inputs_overflow_outputs() {
+    let asm_ops = "push.17 push.18";
+    let pub_inputs = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+    build_op_test!(&asm_ops, &pub_inputs).prove_and_verify(pub_inputs, 18, false);
+}
+
+/// Test a script initialized with enough inputs that the overflow table is non-empty at the start
+/// but there's no overflow output at the end.
+#[test]
+fn overflow_inputs() {
+    let asm_op = "push.19 drop";
+    let pub_inputs = vec![
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+    ];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 16, false);
+}
+
+/// Test a script initialized with enough inputs that the overflow table is non-empty at the start
+/// and at the end.
+#[test]
+fn overflow_inputs_overflow_outputs() {
+    let asm_op = "push.19 push.20";
+    let pub_inputs = vec![
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+    ];
+
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 20, false);
+}

--- a/miden/tests/integration/air/stack.rs
+++ b/miden/tests/integration/air/stack.rs
@@ -6,7 +6,7 @@ fn empty_input() {
     let asm_op = "push.1 drop";
     let pub_inputs = vec![];
 
-    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 16, false);
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 /// Test an empty starting stack but enough outputs that the overflow table is non-empty at the end.
@@ -15,7 +15,7 @@ fn empty_input_overflow_output() {
     let asm_ops = "push.17 push.18";
     let pub_inputs = vec![];
 
-    build_op_test!(&asm_ops, &pub_inputs).prove_and_verify(pub_inputs, 18, false);
+    build_op_test!(&asm_ops, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 /// Test starting stack with some inputs but not full with no overflow outputs.
@@ -24,7 +24,7 @@ fn some_inputs() {
     let asm_op = "push.5 drop";
     let pub_inputs = vec![1, 2, 3, 4];
 
-    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 16, false);
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 /// Test full starting stack with no overflow outputs.
@@ -33,7 +33,7 @@ fn full_inputs() {
     let asm_op = "push.17 drop";
     let pub_inputs = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 16, false);
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 /// Test a script that finishes with enough outputs that the overflow table is non-empty at the end.
@@ -42,7 +42,7 @@ fn full_inputs_overflow_outputs() {
     let asm_ops = "push.17 push.18";
     let pub_inputs = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-    build_op_test!(&asm_ops, &pub_inputs).prove_and_verify(pub_inputs, 18, false);
+    build_op_test!(&asm_ops, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 /// Test a script initialized with enough inputs that the overflow table is non-empty at the start
@@ -50,11 +50,12 @@ fn full_inputs_overflow_outputs() {
 #[test]
 fn overflow_inputs() {
     let asm_op = "push.19 drop";
+
     let pub_inputs = vec![
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
     ];
 
-    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 16, false);
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }
 
 /// Test a script initialized with enough inputs that the overflow table is non-empty at the start
@@ -66,5 +67,5 @@ fn overflow_inputs_overflow_outputs() {
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
     ];
 
-    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, 20, false);
+    build_op_test!(&asm_op, &pub_inputs).prove_and_verify(pub_inputs, false);
 }

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -135,5 +135,5 @@ fn local_fn_call() {
     let test = build_test!(source, &[1, 2]);
     test.expect_stack(&[3]);
 
-    test.prove_and_verify(vec![1, 2], 1, false);
+    test.prove_and_verify(vec![1, 2], false);
 }

--- a/miden/tests/integration/helpers/mod.rs
+++ b/miden/tests/integration/helpers/mod.rs
@@ -1,7 +1,7 @@
 pub use miden::{ProofOptions, StarkProof};
 use processor::{ExecutionError, ExecutionTrace, Process, VmStateIterator};
 use proptest::prelude::*;
-pub use vm_core::{Felt, FieldElement, Program, ProgramInputs, MIN_STACK_DEPTH};
+pub use vm_core::{Felt, FieldElement, Program, ProgramInputs, ProgramOutputs, MIN_STACK_DEPTH};
 
 pub mod crypto;
 
@@ -149,23 +149,13 @@ impl Test {
     /// Compiles the test's code into a program, then generates and verifies a proof of execution
     /// using the given public inputs and the specified number of stack outputs. When `test_fail`
     /// is true, this function will force a failure by modifying the first output.
-    pub fn prove_and_verify(
-        &self,
-        pub_inputs: Vec<u64>,
-        num_stack_outputs: usize,
-        test_fail: bool,
-    ) {
+    pub fn prove_and_verify(&self, pub_inputs: Vec<u64>, test_fail: bool) {
         let program = self.compile();
-        let (mut outputs, proof) = prover::prove(
-            &program,
-            &self.inputs,
-            num_stack_outputs,
-            &ProofOptions::default(),
-        )
-        .unwrap();
+        let (mut outputs, proof) =
+            prover::prove(&program, &self.inputs, &ProofOptions::default()).unwrap();
 
         if test_fail {
-            outputs[0] += 1;
+            outputs.stack_mut()[0] += 1;
             assert!(miden::verify(program.hash(), &pub_inputs, &outputs, proof).is_err());
         } else {
             let result = miden::verify(program.hash(), &pub_inputs, &outputs, proof);

--- a/miden/tests/integration/main.rs
+++ b/miden/tests/integration/main.rs
@@ -17,7 +17,7 @@ fn simple_program() {
 #[test]
 fn multi_output_program() {
     let test = build_test!("begin mul movup.2 drop end", &[1, 2, 3]);
-    test.prove_and_verify(vec![1, 2, 3], 2, false);
+    test.prove_and_verify(vec![1, 2, 3], false);
 }
 
 // MACROS TO BUILD TESTS

--- a/miden/tests/integration/stdlib/sys.rs
+++ b/miden/tests/integration/stdlib/sys.rs
@@ -4,8 +4,8 @@ use rand_utils::rand_vector;
 use vm_core::MIN_STACK_DEPTH;
 
 #[test]
-fn finalize_stack() {
-    let source = "use.std::sys begin repeat.12 push.0 end exec.sys::finalize_stack end";
+fn truncate_stack() {
+    let source = "use.std::sys begin repeat.12 push.0 end exec.sys::truncate_stack end";
     let test = build_test!(
         source,
         &[16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
@@ -15,14 +15,14 @@ fn finalize_stack() {
 
 proptest! {
     #[test]
-    fn finalize_stack_proptest(test_values in prop::collection::vec(any::<u64>(), MIN_STACK_DEPTH), n in 1_usize..100) {
+    fn truncate_stack_proptest(test_values in prop::collection::vec(any::<u64>(), MIN_STACK_DEPTH), n in 1_usize..100) {
         let mut push_values = rand_vector::<u64>(n);
         let mut source_vec = vec!["use.std::sys".to_string(), "begin".to_string()];
         for value in push_values.iter() {
             let token = format!("push.{value}");
             source_vec.push(token);
         }
-        source_vec.push("exec.sys::finalize_stack".to_string());
+        source_vec.push("exec.sys::truncate_stack".to_string());
         source_vec.push("end".to_string());
         let source = source_vec.join(" ");
         let mut expected_values = test_values.clone();

--- a/processor/src/chiplets/bus/aux_trace.rs
+++ b/processor/src/chiplets/bus/aux_trace.rs
@@ -36,7 +36,7 @@ impl AuxTraceBuilder {
 // CHIPLETS LOOKUPS
 // ================================================================================================
 
-impl AuxColumnBuilder<ChipletsLookup, ChipletsLookupRow> for AuxTraceBuilder {
+impl AuxColumnBuilder<ChipletsLookup, ChipletsLookupRow, u32> for AuxTraceBuilder {
     /// This method is required, but because it is only called inside `build_row_values` which is
     /// overridden below, it is not used here and should not be called.
     fn get_table_rows(&self) -> &[ChipletsLookupRow] {

--- a/processor/src/chiplets/hasher/aux_trace.rs
+++ b/processor/src/chiplets/hasher/aux_trace.rs
@@ -54,7 +54,7 @@ impl AuxTraceBuilder {
     }
 }
 
-impl AuxColumnBuilder<SiblingTableUpdate, SiblingTableRow> for AuxTraceBuilder {
+impl AuxColumnBuilder<SiblingTableUpdate, SiblingTableRow, u32> for AuxTraceBuilder {
     /// Returns a list of rows which were added to and then removed from the sibling table.
     ///
     /// The order of the rows in the list is the same as the order in which the rows were added to

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -1,6 +1,6 @@
 use crate::{ExecutionError, Felt, Process, StarkField, Vec};
 use core::fmt;
-use vm_core::{utils::string::String, Operation, Word};
+use vm_core::{utils::string::String, Operation, ProgramOutputs, Word};
 
 /// VmState holds a current process state information at a specific clock cycle.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -42,7 +42,7 @@ pub struct VmStateIterator {
 }
 
 impl VmStateIterator {
-    pub(super) fn new(process: Process, result: Result<(), ExecutionError>) -> Self {
+    pub(super) fn new(process: Process, result: Result<ProgramOutputs, ExecutionError>) -> Self {
         Self {
             process,
             error: result.err(),

--- a/processor/src/stack/aux_trace.rs
+++ b/processor/src/stack/aux_trace.rs
@@ -9,9 +9,15 @@ use winterfell::Matrix;
 /// Describes how to construct execution traces of stack-related auxiliary trace segment columns
 /// (used in multiset checks).
 pub struct AuxTraceBuilder {
+    /// A list of updates made to the overflow table during program execution. For each update we
+    /// also track the cycle at which the update happened.
     pub(super) overflow_hints: Vec<(u64, OverflowTableUpdate)>,
+    /// A list of all rows that were added to and then removed from the overflow table.
     pub(super) overflow_table_rows: Vec<OverflowTableRow>,
+    /// The number of rows in the overflow table when execution begins.
     pub(super) num_init_rows: usize,
+    /// A list of indices into the `all_rows` vector which describes the rows remaining in the
+    /// overflow table at the end of execution.
     pub(super) final_rows: Vec<usize>,
 }
 

--- a/processor/src/stack/aux_trace.rs
+++ b/processor/src/stack/aux_trace.rs
@@ -12,6 +12,7 @@ pub struct AuxTraceBuilder {
     pub(super) overflow_hints: Vec<(u64, OverflowTableUpdate)>,
     pub(super) overflow_table_rows: Vec<OverflowTableRow>,
     pub(super) num_init_rows: usize,
+    pub(super) final_rows: Vec<usize>,
 }
 
 impl AuxTraceBuilder {
@@ -86,7 +87,12 @@ impl AuxColumnBuilder<OverflowTableUpdate, OverflowTableRow, u64> for AuxTraceBu
     }
 
     /// Returns the final value in the auxiliary column.
-    fn final_column_value<E: FieldElement<BaseField = Felt>>(&self, _row_values: &[E]) -> E {
-        E::ONE
+    fn final_column_value<E: FieldElement<BaseField = Felt>>(&self, row_values: &[E]) -> E {
+        let mut final_column_value = E::ONE;
+        for &row in &self.final_rows {
+            final_column_value *= row_values[row];
+        }
+
+        final_column_value
     }
 }

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    BTreeMap, Felt, FieldElement, ProgramInputs, StackTopState, StarkField, Vec, MIN_STACK_DEPTH,
-    NUM_STACK_HELPER_COLS, STACK_TRACE_WIDTH, ZERO,
+    BTreeMap, Felt, FieldElement, ProgramInputs, ProgramOutputs, StackTopState, StarkField, Vec,
+    MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS, STACK_TRACE_WIDTH, ZERO,
 };
 use core::cmp;
 
@@ -140,6 +140,12 @@ impl Stack {
         }
 
         result
+    }
+
+    /// Returns [ProgramOutputs] consisting of all values on the stack and all addresses in the
+    /// overflow table that are required to rebuild the rows in the overflow table.
+    pub fn get_outputs(&self) -> ProgramOutputs {
+        ProgramOutputs::from_elements(self.get_values(None), self.overflow.get_addrs())
     }
 
     /// Returns an execution trace of the top 16 stack slots and helper columns as a single array

--- a/processor/src/stack/overflow.rs
+++ b/processor/src/stack/overflow.rs
@@ -1,3 +1,5 @@
+use vm_core::StarkField;
+
 use super::{
     super::trace::LookupTableRow, AuxTraceBuilder, BTreeMap, Felt, FieldElement, Vec, ZERO,
 };
@@ -14,23 +16,25 @@ use super::{
 pub struct OverflowTable {
     /// A list of all rows that were added to and then removed from the overflow table.
     all_rows: Vec<OverflowTableRow>,
-    /// A list of indexes into the `all_rows` vector with describes the rows currently in the
+    /// A list of indices into the `all_rows` vector with describes the rows currently in the
     /// overflow table.
     active_rows: Vec<usize>,
     /// A list of updates made to the overflow table during program execution. For each update we
     /// also track the cycle at which the update happened.
-    update_trace: Vec<(u32, OverflowTableUpdate)>,
+    update_trace: Vec<(u64, OverflowTableUpdate)>,
     /// A map which records the full state of the overflow table at every cycle during which an
     /// update happened. This map is populated only when `trace_enabled` = true.
-    trace: BTreeMap<u32, Vec<Felt>>,
+    trace: BTreeMap<u64, Vec<Felt>>,
     /// A flag which specifies whether we should record the full state of the overflow table
     /// whenever an update happens. This is set to true only when executing programs for debug
     /// purposes.
     trace_enabled: bool,
+    ///TODO
+    num_init_rows: usize,
 }
 
 impl OverflowTable {
-    // CONSTRUCTOR
+    // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
     /// Returns a new [OverflowTable]. The returned table is empty.
     pub fn new(enable_trace: bool) -> Self {
@@ -40,14 +44,34 @@ impl OverflowTable {
             update_trace: Vec::new(),
             trace: BTreeMap::new(),
             trace_enabled: enable_trace,
+            num_init_rows: 0,
         }
+    }
+
+    /// Returns a new [OverflowTable]. The returned table contains a row for each of the provided
+    /// initial values, using a "negative" (mod p) `clk` value as the address for each of the rows,
+    /// since they are added before the first execution cycle.
+    ///
+    /// `init_values` is expected to be ordered such that values will be pushed onto the stack one
+    /// by one. Thus, the first item in the list will become the deepest item in the stack.
+    pub fn new_with_inputs(enable_trace: bool, init_values: &[Felt]) -> Self {
+        let mut overflow_table = Self::new(enable_trace);
+        overflow_table.num_init_rows = init_values.len();
+
+        let mut clk = Felt::MODULUS - init_values.len() as u64;
+        for val in init_values.iter().rev() {
+            overflow_table.push(*val, clk);
+            clk += 1;
+        }
+
+        overflow_table
     }
 
     // STATE MUTATORS
     // --------------------------------------------------------------------------------------------
 
     /// Pushes the specified value into the overflow table.
-    pub fn push(&mut self, value: Felt, clk: u32) {
+    pub fn push(&mut self, value: Felt, clk: u64) {
         // get the clock cycle of the row currently at the top of the overflow table. if the
         // overflow table is empty, this is set to ZERO.
         let prev = self
@@ -74,7 +98,7 @@ impl OverflowTable {
     /// cycle of the next value in the table.
     ///
     /// If after the top value is removed the table is empty, the returned clock cycle is ZERO.
-    pub fn pop(&mut self, clk: u32) -> (Felt, Felt) {
+    pub fn pop(&mut self, clk: u64) -> (Felt, Felt) {
         // remove the top entry from the table and determine which table row corresponds to it
         let last_row_idx = self.active_rows.pop().expect("overflow table is empty");
         let last_row = &self.all_rows[last_row_idx];
@@ -104,7 +128,7 @@ impl OverflowTable {
     }
 
     /// Appends the state of the overflow table at the specified clock cycle to the provided vector.
-    pub fn append_state_into(&self, target: &mut Vec<Felt>, clk: u32) {
+    pub fn append_state_into(&self, target: &mut Vec<Felt>, clk: u64) {
         if let Some(x) = self.trace.range(0..=clk).last() {
             for item in x.1.iter().rev() {
                 target.push(*item);
@@ -127,9 +151,23 @@ impl OverflowTable {
     /// the auxiliary trace column describing the state of the overflow table at every cycle.
     pub fn into_aux_builder(self) -> AuxTraceBuilder {
         AuxTraceBuilder {
+            num_init_rows: self.num_init_rows,
             overflow_hints: self.update_trace,
             overflow_table_rows: self.all_rows,
         }
+    }
+
+    // TEST ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    #[cfg(test)]
+    pub fn all_rows(&self) -> &[OverflowTableRow] {
+        &self.all_rows
+    }
+
+    #[cfg(test)]
+    pub fn active_rows(&self) -> &[usize] {
+        &self.active_rows
     }
 }
 
@@ -141,6 +179,7 @@ impl OverflowTable {
 /// - The clock cycle at which the stack item was pushed into the overflow table.
 /// - The clock cycle of the value which was at the top of the overflow table when this value
 ///   was pushed onto it.
+#[derive(Debug, PartialEq, Eq)]
 pub struct OverflowTableRow {
     val: Felt,
     clk: Felt,
@@ -148,10 +187,10 @@ pub struct OverflowTableRow {
 }
 
 impl OverflowTableRow {
-    pub fn new(clk: u32, val: Felt, prev: Felt) -> Self {
+    pub fn new(clk: u64, val: Felt, prev: Felt) -> Self {
         Self {
             val,
-            clk: Felt::new(clk as u64),
+            clk: Felt::new(clk),
             prev,
         }
     }

--- a/processor/src/stack/overflow.rs
+++ b/processor/src/stack/overflow.rs
@@ -16,7 +16,7 @@ use super::{
 pub struct OverflowTable {
     /// A list of all rows that were added to and then removed from the overflow table.
     all_rows: Vec<OverflowTableRow>,
-    /// A list of indices into the `all_rows` vector with describes the rows currently in the
+    /// A list of indices into the `all_rows` vector which describes the rows currently in the
     /// overflow table.
     active_rows: Vec<usize>,
     /// A list of updates made to the overflow table during program execution. For each update we
@@ -29,7 +29,7 @@ pub struct OverflowTable {
     /// whenever an update happens. This is set to true only when executing programs for debug
     /// purposes.
     trace_enabled: bool,
-    ///TODO
+    /// The number of rows in the overflow table when execution begins.
     num_init_rows: usize,
 }
 

--- a/processor/src/stack/tests.rs
+++ b/processor/src/stack/tests.rs
@@ -1,6 +1,8 @@
 use vm_core::{FieldElement, NUM_STACK_HELPER_COLS};
 
-use super::{Felt, ProgramInputs, Stack, StackTopState, MIN_STACK_DEPTH};
+use super::{
+    Felt, OverflowTableRow, ProgramInputs, Stack, StackTopState, StarkField, MIN_STACK_DEPTH,
+};
 
 #[test]
 fn initialize() {
@@ -11,7 +13,7 @@ fn initialize() {
 
     // Prepare the expected results.
     stack_inputs.reverse();
-    let expected_stack = build_stack(&[4, 3, 2, 1]);
+    let expected_stack = build_stack(&stack_inputs);
     let expected_helpers = [Felt::new(MIN_STACK_DEPTH as u64), Felt::ZERO, Felt::ZERO];
 
     // Check the stack state.
@@ -19,9 +21,44 @@ fn initialize() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_clk() as u32),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
+}
+
+#[test]
+fn initialize_overflow() {
+    // Initialize a new stack with enough initial values that the overflow table is non-empty.
+    let mut stack_inputs = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    ];
+    let inputs = ProgramInputs::new(&stack_inputs, &[], vec![]).unwrap();
+    let stack = Stack::new(&inputs, 4, false);
+
+    // Prepare the expected results.
+    stack_inputs.reverse();
+    let expected_stack = build_stack(&stack_inputs[..MIN_STACK_DEPTH]);
+    let expected_helpers = [Felt::new(19), Felt::new(Felt::MODULUS - 1), Felt::ZERO];
+    let init_addr = Felt::MODULUS - 3;
+    let expected_overflow_rows = vec![
+        OverflowTableRow::new(init_addr, Felt::new(1), Felt::ZERO),
+        OverflowTableRow::new(init_addr + 1, Felt::new(2), Felt::new(init_addr)),
+        OverflowTableRow::new(init_addr + 2, Felt::new(3), Felt::new(init_addr + 1)),
+    ];
+    let expected_overflow_active_rows = vec![0, 1, 2];
+
+    // Check the stack state.
+    assert_eq!(stack.trace_state(), expected_stack);
+
+    // Check the helper columns.
+    assert_eq!(
+        stack.trace.get_helpers_state_at(stack.current_clk()),
+        expected_helpers
+    );
+
+    // Check the overflow table state.
+    assert_eq!(stack.overflow.active_rows(), expected_overflow_active_rows);
+    assert_eq!(stack.overflow.all_rows(), expected_overflow_rows);
 }
 
 #[test]
@@ -43,7 +80,7 @@ fn shift_left() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_clk() as u32),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 
@@ -51,7 +88,7 @@ fn shift_left() {
     let mut stack = Stack::new(&inputs, 4, false);
     // Shift right twice to add 2 items to the overflow table.
     stack.shift_right(0);
-    let prev_overflow_addr = stack.current_clk();
+    let prev_overflow_addr = stack.current_clk() as usize;
     stack.advance_clock();
     stack.shift_right(0);
     stack.advance_clock();
@@ -69,7 +106,7 @@ fn shift_left() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_clk() as u32),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 
@@ -88,7 +125,7 @@ fn shift_left() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_clk() as u32),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 }
@@ -100,7 +137,7 @@ fn shift_right() {
 
     // ---- right shift an entire stack of minimum depth ------------------------------------------
     let expected_stack = build_stack(&[0, 4, 3, 2, 1]);
-    let expected_helpers = build_helpers_right(1, stack.current_clk() as u32);
+    let expected_helpers = build_helpers_right(1, stack.current_clk());
 
     stack.shift_right(0);
     stack.advance_clock();
@@ -110,13 +147,13 @@ fn shift_right() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_clk() as u32),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 
     // ---- right shift when the overflow table is non-empty --------------------------------------
     let expected_stack = build_stack(&[0, 0, 4, 3, 2, 1]);
-    let expected_helpers = build_helpers_right(2, stack.current_clk() as u32);
+    let expected_helpers = build_helpers_right(2, stack.current_clk());
 
     stack.shift_right(0);
     stack.advance_clock();
@@ -126,7 +163,7 @@ fn shift_right() {
 
     // Check the helper columns.
     assert_eq!(
-        stack.trace.get_helpers_state_at(stack.current_clk() as u32),
+        stack.trace.get_helpers_state_at(stack.current_clk()),
         expected_helpers
     );
 }

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -7,8 +7,8 @@ use super::{
 };
 use vm_core::{
     decoder::{NUM_USER_OP_HELPERS, USER_OP_HELPERS_OFFSET},
-    AUX_TRACE_RAND_ELEMENTS, AUX_TRACE_WIDTH, DECODER_TRACE_OFFSET, MIN_STACK_DEPTH, MIN_TRACE_LEN,
-    STACK_TRACE_OFFSET, TRACE_WIDTH, ZERO,
+    ProgramOutputs, AUX_TRACE_RAND_ELEMENTS, AUX_TRACE_WIDTH, DECODER_TRACE_OFFSET,
+    MIN_STACK_DEPTH, MIN_TRACE_LEN, STACK_TRACE_OFFSET, TRACE_WIDTH, ZERO,
 };
 use winterfell::{EvaluationFrame, Matrix, Serializable, Trace, TraceLayout};
 
@@ -58,6 +58,7 @@ pub struct ExecutionTrace {
     main_trace: Matrix<Felt>,
     aux_trace_hints: AuxTraceHints,
     program_hash: Digest,
+    program_outputs: ProgramOutputs,
 }
 
 impl ExecutionTrace {
@@ -70,7 +71,7 @@ impl ExecutionTrace {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Builds an execution trace for the provided process.
-    pub(super) fn new(process: Process) -> Self {
+    pub(super) fn new(process: Process, program_outputs: ProgramOutputs) -> Self {
         // use program hash to initialize random element generator; this generator will be used
         // to inject random values at the end of the trace; using program hash here is OK because
         // we are using random values only to stabilize constraint degrees, and not to achieve
@@ -85,6 +86,7 @@ impl ExecutionTrace {
             main_trace: Matrix::new(main_trace),
             aux_trace_hints,
             program_hash,
+            program_outputs,
         }
     }
 
@@ -94,6 +96,11 @@ impl ExecutionTrace {
     /// Returns hash of the program execution of which resulted in this execution trace.
     pub fn program_hash(&self) -> Digest {
         self.program_hash
+    }
+
+    /// Returns outputs of the program execution which resulted in this execution trace.
+    pub fn program_outputs(&self) -> ProgramOutputs {
+        self.program_outputs.clone()
     }
 
     /// Returns the initial state of the top 16 stack registers.

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -1,6 +1,9 @@
 use super::{ExecutionTrace, Felt, FieldElement, LookupTableRow, Process, Trace, NUM_RAND_ROWS};
 use rand_utils::rand_array;
-use vm_core::{code_blocks::CodeBlock, CodeBlockTable, Operation, ProgramInputs, Word, ONE, ZERO};
+use vm_core::{
+    code_blocks::CodeBlock, CodeBlockTable, Operation, ProgramInputs, ProgramOutputs, Word, ONE,
+    ZERO,
+};
 
 mod chiplets;
 mod hasher;
@@ -17,7 +20,7 @@ pub fn build_trace_from_block(program: &CodeBlock, stack: &[u64]) -> ExecutionTr
     process
         .execute_code_block(program, &CodeBlockTable::default())
         .unwrap();
-    ExecutionTrace::new(process)
+    ExecutionTrace::new(process, ProgramOutputs::default())
 }
 
 /// Builds a sample trace by executing a span block containing the specified operations. This
@@ -39,5 +42,5 @@ pub fn build_trace_from_ops_with_inputs(
     process
         .execute_code_block(&program, &CodeBlockTable::default())
         .unwrap();
-    ExecutionTrace::new(process)
+    ExecutionTrace::new(process, ProgramOutputs::default())
 }

--- a/processor/src/trace/utils.rs
+++ b/processor/src/trace/utils.rs
@@ -121,7 +121,7 @@ pub fn build_lookup_table_row_values<E: FieldElement<BaseField = Felt>, R: Looku
 
 /// Defines a builder responsible for building a single column in an auxiliary segment of the
 /// execution trace.
-pub trait AuxColumnBuilder<H: Copy, R: LookupTableRow> {
+pub trait AuxColumnBuilder<H: Copy, R: LookupTableRow, U: HintCycle> {
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------
 
@@ -130,7 +130,7 @@ pub trait AuxColumnBuilder<H: Copy, R: LookupTableRow> {
 
     /// Returns a sequence of hints which indicate how the table was updated. Each hint consists
     /// of a clock cycle at which the update happened as well as the hint describing the update.
-    fn get_table_hints(&self) -> &[(u32, H)];
+    fn get_table_hints(&self) -> &[(U, H)];
 
     /// Returns a value by which the current value of the column should be multiplied to get the
     /// next value. It is expected that this value should never be ZERO in practice.
@@ -154,14 +154,14 @@ pub trait AuxColumnBuilder<H: Copy, R: LookupTableRow> {
 
         // allocate memory for the running product column and set its initial value
         let mut result = unsafe { uninit_vector(main_trace.num_rows()) };
-        result[0] = self.init_column_value(alphas);
+        result[0] = self.init_column_value(&row_values);
 
         // keep track of the last updated row in the running product column
         let mut result_idx = 0_usize;
 
         // iterate through the list of updates and apply them one by one
         for (clk, hint) in self.get_table_hints() {
-            let clk = *clk as usize;
+            let clk = clk.as_index();
 
             // if we skipped some cycles since the last update was processed, values in the last
             // updated row should by copied over until the current cycle.
@@ -185,7 +185,7 @@ pub trait AuxColumnBuilder<H: Copy, R: LookupTableRow> {
         // the last value in the column is equal to the expected value, and fill in all the
         // remaining column values with the last value
         let last_value = result[result_idx];
-        assert_eq!(last_value, self.final_column_value(alphas));
+        assert_eq!(last_value, self.final_column_value(&row_values));
         if result_idx < result.len() - 1 {
             result[(result_idx + 1)..].fill(last_value);
         }
@@ -204,14 +204,33 @@ pub trait AuxColumnBuilder<H: Copy, R: LookupTableRow> {
 
     /// Returns the initial value in the auxiliary column. Default implementation of this method
     /// returns ONE.
-    fn init_column_value<E: FieldElement<BaseField = Felt>>(&self, _alphas: &[E]) -> E {
+    fn init_column_value<E: FieldElement<BaseField = Felt>>(&self, _row_values: &[E]) -> E {
         E::ONE
     }
 
     /// Returns the final value in the auxiliary column. Default implementation of this method
     /// returns ONE.
-    fn final_column_value<E: FieldElement<BaseField = Felt>>(&self, _alphas: &[E]) -> E {
+    fn final_column_value<E: FieldElement<BaseField = Felt>>(&self, _row_values: &[E]) -> E {
         E::ONE
+    }
+}
+
+/// Defines a simple trait to recognize the possible types of clock cycles associated with auxiliary
+/// column update hints.
+pub trait HintCycle {
+    /// Returns the cycle as a `usize` for indexing.
+    fn as_index(&self) -> usize;
+}
+
+impl HintCycle for u32 {
+    fn as_index(&self) -> usize {
+        *self as usize
+    }
+}
+
+impl HintCycle for u64 {
+    fn as_index(&self) -> usize {
+        *self as usize
     }
 }
 

--- a/stdlib/asm/sys.masm
+++ b/stdlib/asm/sys.masm
@@ -4,7 +4,7 @@
 # function at the end will reduce the size of the public inputs that are shared with the verifier.
 # Input: Stack with 16 or more elements.
 # Output: Stack with only the original top 16 elements.
-export.finalize_stack.4
+export.truncate_stack.4
     popw.local.0
     popw.local.1
     popw.local.2

--- a/stdlib/asm/sys.masm
+++ b/stdlib/asm/sys.masm
@@ -1,5 +1,7 @@
 # Removes elements deep in the stack until the depth of the stack is exactly 16. The elements
-# are removed in such a way that the top 16 elements of the stack remain unchanged.
+# are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack
+# would otherwise contain more than 16 elements at the end of execution, then adding a call to this 
+# function at the end will reduce the size of the public inputs that are shared with the verifier.
 # Input: Stack with 16 or more elements.
 # Output: Stack with only the original top 16 elements.
 export.finalize_stack.4

--- a/stdlib/docs/sys_std.md
+++ b/stdlib/docs/sys_std.md
@@ -2,4 +2,4 @@
 ## std::sys
 | Procedure | Description |
 | ----------- | ------------- |
-| finalize_stack.4 |  Removes elements deep in the stack until the depth of the stack is exactly 16. The elements<br /> are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack<br /> would otherwise contain more than 16 elements at the end of execution, then adding a call to this <br /> function at the end will reduce the size of the public inputs that are shared with the verifier.<br /> Input: Stack with 16 or more elements.<br /> Output: Stack with only the original top 16 elements. |
+| truncate_stack.4 |  Removes elements deep in the stack until the depth of the stack is exactly 16. The elements<br /> are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack<br /> would otherwise contain more than 16 elements at the end of execution, then adding a call to this <br /> function at the end will reduce the size of the public inputs that are shared with the verifier.<br /> Input: Stack with 16 or more elements.<br /> Output: Stack with only the original top 16 elements. |

--- a/stdlib/docs/sys_std.md
+++ b/stdlib/docs/sys_std.md
@@ -2,4 +2,4 @@
 ## std::sys
 | Procedure | Description |
 | ----------- | ------------- |
-| finalize_stack.4 |  Removes elements deep in the stack until the depth of the stack is exactly 16. The elements<br /> are removed in such a way that the top 16 elements of the stack remain unchanged.<br /> Input: Stack with 16 or more elements.<br /> Output: Stack with only the original top 16 elements. |
+| finalize_stack.4 |  Removes elements deep in the stack until the depth of the stack is exactly 16. The elements<br /> are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack<br /> would otherwise contain more than 16 elements at the end of execution, then adding a call to this <br /> function at the end will reduce the size of the public inputs that are shared with the verifier.<br /> Input: Stack with 16 or more elements.<br /> Output: Stack with only the original top 16 elements. |

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -14567,7 +14567,9 @@ end
 "),
 // ----- std::sys ---------------------------------------------------------------------------------
 ("std::sys", "# Removes elements deep in the stack until the depth of the stack is exactly 16. The elements
-# are removed in such a way that the top 16 elements of the stack remain unchanged.
+# are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack
+# would otherwise contain more than 16 elements at the end of execution, then adding a call to this 
+# function at the end will reduce the size of the public inputs that are shared with the verifier.
 # Input: Stack with 16 or more elements.
 # Output: Stack with only the original top 16 elements.
 export.finalize_stack.4

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -14572,7 +14572,7 @@ end
 # function at the end will reduce the size of the public inputs that are shared with the verifier.
 # Input: Stack with 16 or more elements.
 # Output: Stack with only the original top 16 elements.
-export.finalize_stack.4
+export.truncate_stack.4
     popw.local.0
     popw.local.1
     popw.local.2

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -38,13 +38,6 @@ pub fn verify(
     stack_outputs: &[u64],
     proof: StarkProof,
 ) -> Result<(), VerificationError> {
-    if stack_inputs.len() > MIN_STACK_DEPTH {
-        return Err(VerificationError::TooManyInputValues(
-            MIN_STACK_DEPTH,
-            stack_inputs.len(),
-        ));
-    }
-
     // convert stack inputs to field elements
     let mut stack_input_felts = Vec::with_capacity(stack_inputs.len());
     for &input in stack_inputs.iter().rev() {


### PR DESCRIPTION
This PR addresses #347 to remove the restriction on the number of inputs that can be provided and to remove the requirement that the stack overflow table be emptied before program execution ends.

- [x] enable providing more than 16 inputs
- [x] enable ending execution without emptying the stack overflow table
- [x] add new struct for program outputs (completed as part of the above), enabling more output flexibility in the future
- [x] add air tests for different possible numbers of inputs
- [x] add air tests for different possible final stack states (with/without overflow)
- [x] adjust boundary constraints for initial stack state and adds overflow constraint
- [x] adjust boundary constraints for final stack and adds overflow constraint
- [x] update existing tests to remove the extra `drop` instructions which are no longer needed
- [x] update docs & stdlib for new changes
- [x]  cleanup pass (any further docs updates and changes related to questions below, e.g. specification of num of outputs)
- [x] update CLI for new output handling


## Questions:

- the current change to outputs returns 16 elements from the top of the stack along with the rows on the stack overflow table (required for verifying the proof). However, we could all items on the stack as an array (in addition to extra info required for verifying the proof). We could also continue allowing specification of the number of outputs (currently removed)
- would we prefer to handle program outputs differently, especially regarding the verifier? For example, currently I've created a struct that can be provided to the verifier with the integer versions of program outputs, but maybe we'd rather do a vector u64 (for the stack) and a vector of tuples (for the overflow rows)
- should we rename `finalize_stack`?