### PR TITLE
fix: minor code cleanup

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -7,7 +7,8 @@ extern crate alloc;
 use vm_core::{
     chiplets::hasher::Digest,
     utils::{collections::Vec, ByteWriter, Serializable},
-    ExtensionOf, ProgramOutputs, CLK_COL_IDX, FMP_COL_IDX, MIN_STACK_DEPTH, STACK_TRACE_OFFSET,
+    ExtensionOf, ProgramOutputs, CLK_COL_IDX, FMP_COL_IDX, MIN_STACK_DEPTH, ONE,
+    STACK_TRACE_OFFSET, ZERO,
 };
 use winter_air::{
     Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFrame,

--- a/air/src/stack/mod.rs
+++ b/air/src/stack/mod.rs
@@ -1,10 +1,9 @@
-use vm_core::{
-    utils::collections::Vec, ProgramOutputs, StarkField, FMP_COL_IDX, STACK_AUX_TRACE_OFFSET,
-};
-
 use super::{
     Assertion, AuxTraceRandElements, EvaluationFrame, Felt, FieldElement,
-    TransitionConstraintDegree, MIN_STACK_DEPTH, STACK_TRACE_OFFSET,
+    TransitionConstraintDegree, MIN_STACK_DEPTH, ONE, STACK_TRACE_OFFSET, ZERO,
+};
+use vm_core::{
+    utils::collections::Vec, ProgramOutputs, StarkField, FMP_COL_IDX, STACK_AUX_TRACE_OFFSET,
 };
 
 mod field_ops;
@@ -34,11 +33,11 @@ pub const NUM_AUX_ASSERTIONS: usize = 2;
 
 /// Build the transition constraint degrees for the stack module and all the stack operations.
 pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
-    // system operations contraints degrees.
+    // system operations constraints degrees.
     let mut degrees = system_ops::get_transition_constraint_degrees();
-    // field operations contraints degrees.
+    // field operations constraints degrees.
     degrees.append(&mut field_ops::get_transition_constraint_degrees());
-    // stack manipulation operations contraints degrees.
+    // stack manipulation operations constraints degrees.
     degrees.append(&mut stack_manipulation::get_transition_constraint_degrees());
 
     degrees
@@ -106,15 +105,15 @@ pub fn get_assertions_first_step(result: &mut Vec<Assertion<Felt>>, stack_inputs
 
     // if there are remaining slots on top of the stack without specified values, set them to ZERO.
     for i in stack_inputs.len()..MIN_STACK_DEPTH {
-        result.push(Assertion::single(STACK_TRACE_OFFSET + i, 0, Felt::ZERO));
+        result.push(Assertion::single(STACK_TRACE_OFFSET + i, 0, ZERO));
     }
 
     // get the initial values for the bookkeeping columns.
     let mut depth = MIN_STACK_DEPTH;
-    let mut overflow_addr = Felt::ZERO;
+    let mut overflow_addr = ZERO;
     if stack_inputs.len() > MIN_STACK_DEPTH {
         depth = stack_inputs.len();
-        overflow_addr = Felt::new(Felt::MODULUS - 1);
+        overflow_addr = -ONE;
     }
 
     // b0 should be initialized to the depth of the stack.
@@ -190,7 +189,7 @@ where
     E: FieldElement<BaseField = Felt>,
 {
     let mut value = E::ONE;
-    let mut prev_clk = Felt::ZERO;
+    let mut prev_clk = ZERO;
     let mut clk = Felt::from(Felt::MODULUS - init_values.len() as u64);
 
     // the values are in the overflow table in reverse order, since the deepest stack
@@ -201,7 +200,7 @@ where
             + alphas[2].mul_base(input)
             + alphas[3].mul_base(prev_clk);
         prev_clk = clk;
-        clk += Felt::ONE;
+        clk += ONE;
     }
 
     value

--- a/processor/src/range/mod.rs
+++ b/processor/src/range/mod.rs
@@ -1,4 +1,4 @@
-use super::{BTreeMap, Felt, FieldElement, Vec};
+use super::{BTreeMap, Felt, FieldElement, Vec, ONE, ZERO};
 use crate::RangeCheckTrace;
 use vm_core::utils::uninit_vector;
 
@@ -180,9 +180,9 @@ impl RangeChecker {
         // determine the number of padding rows needed to get to target trace length and pad the
         // table with the required number of rows.
         let num_padding_rows = target_len - trace_len - num_rand_rows;
-        trace[1][..num_padding_rows].fill(Felt::ZERO);
-        trace[2][..num_padding_rows].fill(Felt::ZERO);
-        trace[3][..num_padding_rows].fill(Felt::ZERO);
+        trace[1][..num_padding_rows].fill(ZERO);
+        trace[2][..num_padding_rows].fill(ZERO);
+        trace[3][..num_padding_rows].fill(ZERO);
 
         // Initialize the padded rows of the auxiliary column hints with the default flag, F0,
         // indicating s0 = s1 = ZERO.
@@ -202,8 +202,8 @@ impl RangeChecker {
 
         // fill in the first column to indicate where the 8-bit segment ends and where the
         // 16-bit segment begins
-        trace[0][..i].fill(Felt::ZERO);
-        trace[0][i..].fill(Felt::ONE);
+        trace[0][..i].fill(ZERO);
+        trace[0][i..].fill(ONE);
 
         // build the 16-bit segment of the trace table
         let start_16bit = i;
@@ -363,7 +363,7 @@ fn write_value(
     // if the number of lookups is 0, only one trace row is required
     if num_lookups == 0 {
         row_flags[*step] = RangeCheckFlag::F0;
-        write_trace_row(trace, step, Felt::ZERO, Felt::ZERO, value as u64);
+        write_trace_row(trace, step, ZERO, ZERO, value as u64);
         return;
     }
 
@@ -371,20 +371,20 @@ fn write_value(
     let (num_rows, num_lookups) = div_rem(num_lookups, 4);
     for _ in 0..num_rows {
         row_flags[*step] = RangeCheckFlag::F3;
-        write_trace_row(trace, step, Felt::ONE, Felt::ONE, value as u64);
+        write_trace_row(trace, step, ONE, ONE, value as u64);
     }
 
     // write rows which can support 2 lookups per row
     let (num_rows, num_lookups) = div_rem(num_lookups, 2);
     for _ in 0..num_rows {
         row_flags[*step] = RangeCheckFlag::F2;
-        write_trace_row(trace, step, Felt::ZERO, Felt::ONE, value as u64);
+        write_trace_row(trace, step, ZERO, ONE, value as u64);
     }
 
     // write rows which can support only one lookup per row
     for _ in 0..num_lookups {
         row_flags[*step] = RangeCheckFlag::F1;
-        write_trace_row(trace, step, Felt::ONE, Felt::ZERO, value as u64);
+        write_trace_row(trace, step, ONE, ZERO, value as u64);
     }
 }
 

--- a/processor/src/range/tests.rs
+++ b/processor/src/range/tests.rs
@@ -1,6 +1,5 @@
+use super::{BTreeMap, Felt, RangeChecker, ONE, ZERO};
 use crate::{utils::get_trace_len, RangeCheckTrace};
-
-use super::{BTreeMap, Felt, FieldElement, RangeChecker};
 use rand_utils::rand_array;
 use vm_core::{utils::ToElements, StarkField};
 
@@ -22,7 +21,7 @@ fn range_checks() {
 
     // skip the 8-bit portion of the trace
     let mut i = 0;
-    while trace[0][i] == Felt::ZERO {
+    while trace[0][i] == ZERO {
         i += 1
     }
 
@@ -65,10 +64,10 @@ fn range_checks_rand() {
 
 fn validate_row(trace: &[Vec<Felt>], row_idx: usize, value: u64, num_lookups: u64) {
     let (s0, s1) = match num_lookups {
-        0 => (Felt::ZERO, Felt::ZERO),
-        1 => (Felt::ONE, Felt::ZERO),
-        2 => (Felt::ZERO, Felt::ONE),
-        4 => (Felt::ONE, Felt::ONE),
+        0 => (ZERO, ZERO),
+        1 => (ONE, ZERO),
+        2 => (ZERO, ONE),
+        4 => (ONE, ONE),
         _ => panic!("invalid lookup value"),
     };
 
@@ -87,8 +86,8 @@ fn validate_trace(trace: &[Vec<Felt>], lookups: &[Felt]) {
     // --- validate the 8-bit segment of the trace ----------------------------
 
     // should start with a ZERO
-    assert_eq!(Felt::ZERO, trace[0][0]);
-    assert_eq!(Felt::ZERO, trace[3][0]);
+    assert_eq!(ZERO, trace[0][0]);
+    assert_eq!(ZERO, trace[3][0]);
 
     let mut lookups_8bit = BTreeMap::new();
 
@@ -96,7 +95,7 @@ fn validate_trace(trace: &[Vec<Felt>], lookups: &[Felt]) {
     // for each 8-bit value.
     let mut i = 0;
     let mut prev_value = 0u8;
-    while trace[0][i] == Felt::ZERO {
+    while trace[0][i] == ZERO {
         // make sure the value is an 8-bit value
         let value = trace[3][i].as_int();
         assert!(value <= 255, "not an 8-bit value");
@@ -129,7 +128,7 @@ fn validate_trace(trace: &[Vec<Felt>], lookups: &[Felt]) {
     let mut lookups_16bit = BTreeMap::new();
 
     // process the first row
-    assert_eq!(Felt::ZERO, trace[3][i]);
+    assert_eq!(ZERO, trace[3][i]);
     let count = get_lookup_count(trace, i);
     lookups_16bit.insert(0u16, count);
     i += 1;
@@ -138,7 +137,7 @@ fn validate_trace(trace: &[Vec<Felt>], lookups: &[Felt]) {
     let mut prev_value = 0u16;
     while i < trace_len {
         // segment identifier must be set to ONE
-        assert_eq!(Felt::ONE, trace[0][i]);
+        assert_eq!(ONE, trace[0][i]);
 
         // make sure the value is a 16-bit value
         let value = trace[3][i].as_int();
@@ -195,13 +194,13 @@ fn validate_trace(trace: &[Vec<Felt>], lookups: &[Felt]) {
 }
 
 fn get_lookup_count(trace: &[Vec<Felt>], step: usize) -> usize {
-    if trace[1][step] == Felt::ZERO && trace[2][step] == Felt::ZERO {
+    if trace[1][step] == ZERO && trace[2][step] == ZERO {
         0
-    } else if trace[1][step] == Felt::ONE && trace[2][step] == Felt::ZERO {
+    } else if trace[1][step] == ONE && trace[2][step] == ZERO {
         1
-    } else if trace[1][step] == Felt::ZERO && trace[2][step] == Felt::ONE {
+    } else if trace[1][step] == ZERO && trace[2][step] == ONE {
         2
-    } else if trace[1][step] == Felt::ONE && trace[2][step] == Felt::ONE {
+    } else if trace[1][step] == ONE && trace[2][step] == ONE {
         4
     } else {
         panic!("not a valid count");

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    BTreeMap, Felt, FieldElement, ProgramInputs, ProgramOutputs, StackTopState, StarkField, Vec,
-    MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS, STACK_TRACE_WIDTH, ZERO,
+    BTreeMap, Felt, FieldElement, ProgramInputs, ProgramOutputs, StackTopState, Vec,
+    MIN_STACK_DEPTH, NUM_STACK_HELPER_COLS, ONE, STACK_TRACE_WIDTH, ZERO,
 };
 use core::cmp;
 
@@ -80,7 +80,7 @@ impl Stack {
                 &init_values[..MIN_STACK_DEPTH],
                 init_trace_capacity,
                 depth,
-                Felt::new(Felt::MODULUS - 1),
+                -ONE,
             );
 
             (trace, overflow)

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -1,4 +1,4 @@
-use super::{Felt, FieldElement, SysTrace, Vec};
+use super::{Felt, FieldElement, SysTrace, Vec, ZERO};
 
 // CONSTANTS
 // ================================================================================================
@@ -28,7 +28,7 @@ impl System {
     /// Initializes the free memory pointer `fmp` used for local memory offsets to 2^30.
     pub fn new(init_trace_capacity: usize) -> Self {
         // set the first value of the fmp trace to 2^30.
-        let fmp = Felt::new(FMP_MIN);
+        let fmp = Felt::from(FMP_MIN);
         let mut fmp_trace = Felt::zeroed_vector(init_trace_capacity);
         fmp_trace[0] = fmp;
 
@@ -83,7 +83,7 @@ impl System {
 
         // complete the clk column by filling in all values after the last clock cycle. The values
         // in the clk column are equal to the index of the row in the trace table.
-        self.clk_trace.resize(trace_len, Felt::ZERO);
+        self.clk_trace.resize(trace_len, ZERO);
         for (i, clk) in self.clk_trace.iter_mut().enumerate().skip(clk) {
             // converting from u32 is OK here because max trace length is 2^32
             *clk = Felt::from(i as u32);
@@ -132,8 +132,8 @@ impl System {
         let current_capacity = self.clk_trace.len();
         if self.clk + 1 >= current_capacity as u32 {
             let new_length = current_capacity * 2;
-            self.clk_trace.resize(new_length, Felt::ZERO);
-            self.fmp_trace.resize(new_length, Felt::ZERO);
+            self.clk_trace.resize(new_length, ZERO);
+            self.fmp_trace.resize(new_length, ZERO);
         }
     }
 }


### PR DESCRIPTION
This PR contains minor code fixes and clean-ups:

* Replaced `Felt::ZERO` and `Felt::ONE` with just `ZERO` and `ONE` in several files.
* Replaced `Felt::new(Felt::MODULUS - 1)` with `-ONE` in several places.
* Made sure `h0` column of stack trace is initialized to `1/(init_depth - 16)` when `init_depth > 16`.