### PR TITLE
Advice operations refactoring

### DIFF
--- a/assembly/src/parsers/io_ops/constant_ops.rs
+++ b/assembly/src/parsers/io_ops/constant_ops.rs
@@ -35,7 +35,7 @@ const HEX_CHUNK_SIZE: usize = 16;
 /// It will return an error if no immediate value is provided or if any of parameter formats are
 /// invalid. It will also return an error if the op token is malformed or doesn't match the expected
 /// instruction.
-pub fn parse_push_constant(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
+pub fn parse_push(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
     validate_operation!(op, "push", 1..MAX_CONST_INPUTS);
 
     let param_idx = 1;
@@ -211,25 +211,22 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn push_invalid_panic() {
-        let mut span_ops: Vec<Operation> = Vec::new();
-        let pos = 0;
-
-        // wrong operation passed to parsing function
-        let op_mismatch = Token::new("pushw.0", pos);
-        parse_push(&mut span_ops, &op_mismatch).unwrap_err();
-    }
-
-    #[test]
     fn push_invalid() {
         // fails when immediate value is invalid or missing
         let mut span_ops: Vec<Operation> = Vec::new();
         let pos = 0;
 
+        // wrong operation passed to parsing function
+        let op_mismatch = Token::new("pushw.0", pos);
+        let expected = AssemblyError::unexpected_token(&op_mismatch, "push");
+        assert_eq!(
+            parse_push(&mut span_ops, &op_mismatch).unwrap_err(),
+            expected
+        );
+
         // missing value or variant
         let op_no_val = Token::new("push", pos);
-        let expected = AssemblyError::invalid_op(&op_no_val);
+        let expected = AssemblyError::missing_param(&op_no_val);
         assert_eq!(parse_push(&mut span_ops, &op_no_val).unwrap_err(), expected);
 
         // invalid value

--- a/assembly/src/parsers/io_ops/env_ops.rs
+++ b/assembly/src/parsers/io_ops/env_ops.rs
@@ -99,11 +99,7 @@ mod tests {
 
         // --- invalid env var --------------------------------------------------------------------
         let op_val_invalid = Token::new("invalid", pos);
-        let expected = AssemblyError::unexpected_token(&op_val_invalid, "sdepth");
-        assert_eq!(
-            parse_sdepth(&mut span_ops, &op_val_invalid).unwrap_err(),
-            expected
-        );
+        parse_sdepth(&mut span_ops, &op_val_invalid).unwrap_err();
     }
 
     #[test]

--- a/assembly/src/parsers/io_ops/mod.rs
+++ b/assembly/src/parsers/io_ops/mod.rs
@@ -2,72 +2,16 @@ use super::{
     super::validate_operation, parse_decimal_param, parse_element_param, parse_hex_param,
     parse_u32_param, push_value, AssemblyError, Felt, Operation, Token, Vec,
 };
+pub use adv_ops::{parse_adv_loadw, parse_adv_push};
+pub use constant_ops::parse_push;
+pub use env_ops::{parse_locaddr, parse_sdepth};
+pub use mem_ops::{parse_mem_read, parse_mem_write};
 use vm_core::{AdviceInjector, Decorator, DecoratorList};
 
 mod adv_ops;
 mod constant_ops;
 mod env_ops;
 mod mem_ops;
-use adv_ops::*;
-use constant_ops::*;
-pub use env_ops::*;
-pub use mem_ops::*;
-
-// PUSHING VALUES ONTO THE STACK (PUSH)
-// ================================================================================================
-
-/// Pushes constant or non-deterministic (advice) inputs onto the stack as
-/// specified by the operation variant and its parameter(s).
-///
-/// *CONSTANTS: `push.a`, `push.a.b`, `push.a.b.c...`*
-/// Pushes immediate values `a`, `b`, `c`, etc onto the stack in the order in which they're
-/// provided. Up to 16 values can be specified. All values must be valid field elements in decimal
-/// (e.g. 123) or hexadecimal (e.g. 0x7b) representation. When specifying values in hexadecimal
-/// format, it is possible to omit the periods between individual values as long as the total number
-/// of specified bytes is a multiple of 8.
-///
-/// *NON-DETERMINISTIC (ADVICE): `push.adv.n`*
-/// Removes the next `n` values from the advice tape and pushes them onto the stack. The number of
-/// items that can be read from the advice tape is limited to 16.
-///
-/// # Errors
-///
-/// Returns an `AssemblyError` if the op param is invalid, malformed, or doesn't match an expected
-/// `push` instruction
-pub fn parse_push(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    debug_assert_eq!(op.parts()[0], "push");
-    if op.num_parts() < 2 {
-        return Err(AssemblyError::invalid_op(op));
-    }
-
-    match op.parts()[1] {
-        "adv" => parse_push_adv(span_ops, op),
-        _ => parse_push_constant(span_ops, op),
-    }
-}
-
-// OVERWRITING VALUES ON THE STACK (LOAD)
-// ================================================================================================
-
-/// Overwrites the top 4 elements of the stack with a word (4 elements) loaded from the
-/// advice tape.
-///
-/// *NON-DETERMINISTIC (ADVICE): `loadw.adv`*
-/// Removes the next word (4 elements) from the advice tape and overwrites the top 4 elements of the
-/// stack with it. Fails if the advice tape has fewer than 4 elements.
-///
-/// # Errors
-///
-/// Returns an `AssemblyError` if the op param is invalid, malformed, or doesn't match an expected
-/// `loadw` instruction.
-pub fn parse_loadw_advice(span_ops: &mut Vec<Operation>, op: &Token) -> Result<(), AssemblyError> {
-    validate_operation!(op, "loadw.adv");
-
-    match op.parts()[1] {
-        "adv" => parse_loadw_adv(span_ops, op),
-        _ => Err(AssemblyError::invalid_op(op)),
-    }
-}
 
 // ADVICE INJECTORS
 // ================================================================================================
@@ -103,8 +47,8 @@ pub fn parse_adv_inject(
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_loadw_advice, parse_locaddr, parse_mem_read, parse_mem_write, parse_push,
-        parse_sdepth, AssemblyError, Operation, Token,
+        adv_ops::parse_adv_push, parse_adv_loadw, parse_locaddr, parse_mem_read, parse_mem_write,
+        parse_push, parse_sdepth, AssemblyError, Operation, Token,
     };
 
     // TEST HELPERS
@@ -121,6 +65,7 @@ mod tests {
 
         match base_op {
             "push" => parse_push(&mut span_ops, invalid_op).unwrap_err(),
+
             "sdepth" => parse_sdepth(&mut span_ops, invalid_op).unwrap_err(),
             "locaddr" => parse_locaddr(&mut span_ops, invalid_op, num_proc_locals).unwrap_err(),
 
@@ -152,7 +97,8 @@ mod tests {
                     .unwrap_err()
             }
 
-            "loadw" => parse_loadw_advice(&mut span_ops, invalid_op).unwrap_err(),
+            "adv_loadw" => parse_adv_loadw(&mut span_ops, invalid_op).unwrap_err(),
+            "adv_push" => parse_adv_push(&mut span_ops, invalid_op).unwrap_err(),
             _ => panic!(),
         }
     }

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -161,6 +161,7 @@ fn parse_op_token(
 
         // ----- input / output operations --------------------------------------------------------
         "push" => io_ops::parse_push(span_ops, op),
+
         "sdepth" => io_ops::parse_sdepth(span_ops, op),
         "locaddr" => io_ops::parse_locaddr(span_ops, op, num_proc_locals),
 
@@ -176,7 +177,9 @@ fn parse_op_token(
         "mem_storew" => io_ops::parse_mem_write(span_ops, op, num_proc_locals, false, false),
         "loc_storew" => io_ops::parse_mem_write(span_ops, op, num_proc_locals, true, false),
 
-        "loadw" => io_ops::parse_loadw_advice(span_ops, op),
+        "adv_push" => io_ops::parse_adv_push(span_ops, op),
+        "adv_loadw" => io_ops::parse_adv_loadw(span_ops, op),
+
         "adv" => io_ops::parse_adv_inject(span_ops, op, decorators),
 
         // ----- cryptographic operations ---------------------------------------------------------

--- a/docs/src/user_docs/assembly/io_operations.md
+++ b/docs/src/user_docs/assembly/io_operations.md
@@ -33,8 +33,8 @@ In both case the values must still encode valid field elements.
 
 | Instruction     | Stack_input | Stack_output | Notes                                      |
 | --------------- | ----------- | ------------ | ------------------------------------------ |
-| push.adv.*n* <br> - *(n cycles)*   | [ ... ]         | [a, ... ]    | $a \leftarrow tape.next()$ <br> Removes the next $n$ values from advice tape and pushes them onto the stack. Valid for $n \in \{1, ..., 16\}$. <br> Fails if the advice tape has fewer than $n$ values. |
-| loadw.adv <br> - *(1 cycle)*     | [0, 0, 0, 0, ... ] | [A, ... ] | $A \leftarrow tape.next\_word()$ <br> Removes the next word (4 elements) from the advice tape and overwrites the top four stack elements with it. <br> Fails if the advice tape has fewer than $4$ values. |
+| adv_push.*n* <br> - *(n cycles)*   | [ ... ]         | [a, ... ]    | $a \leftarrow tape.next()$ <br> Removes the next $n$ values from advice tape and pushes them onto the stack. Valid for $n \in \{1, ..., 16\}$. <br> Fails if the advice tape has fewer than $n$ values. |
+| adv_loadw <br> - *(1 cycle)*     | [0, 0, 0, 0, ... ] | [A, ... ] | $A \leftarrow tape.next\_word()$ <br> Removes the next word (4 elements) from the advice tape and overwrites the top four stack elements with it. <br> Fails if the advice tape has fewer than $4$ values. |
 
 ### Random access memory
 
@@ -44,9 +44,9 @@ Memory is guaranteed to be initialized to zeros. Thus, when reading from memory 
 
 | Instruction     | Stack_input | Stack_output | Notes                                      |
 | --------------- | ----------- | ------------ | ------------------------------------------ |
-| mem_load <br> - *(1 cycle)*  <br> mem_load.*a* <br> - *(2 cycles)*   | [a, ... ] | [v, ... ] | $a \leftarrow mem[a][0]$ <br> Reads a word (4 elements) from memory at address *a*, and pushes the first element of the word onto the stack. If $a$ is provided via the stack, it is removed from the stack first. <br> Fails if $a \ge 2^{32}$ |
+| mem_load <br> - *(1 cycle)*  <br> mem_load.*a* <br> - *(2 cycles)*   | [a, ... ] | [v, ... ] | $v \leftarrow mem[a][0]$ <br> Reads a word (4 elements) from memory at address *a*, and pushes the first element of the word onto the stack. If $a$ is provided via the stack, it is removed from the stack first. <br> Fails if $a \ge 2^{32}$ |
 | mem_loadw <br> - *(1 cycle)*  <br> mem_loadw.*a* <br> - *(2 cycles)*  | [a, 0, 0, 0, 0, ... ] | [A, ... ] | $A \leftarrow mem[a]$ <br> Reads a word from memory at address $a$ and overwrites top four stack elements with it. If $a$ is provided via the stack, it is removed from the stack first. <br> Fails if $a \ge 2^{32}$ |
-| mem_store <br> - *(1 cycle)*  <br> mem_store.*a*  <br> - *(2 cycles)*   | [a, v, ... ] | [v, ... ] | $[v, 0, 0, 0] \rightarrow mem[a]$ <br> Stores the top element of the stack as the first element of the word in memory at address $a$. All other elements of the word are not affected. If $a$ is provided via the stack, it is removed from the stack first. <br> Fails if $a \ge 2^{32}$ |
+| mem_store <br> - *(1 cycle)*  <br> mem_store.*a*  <br> - *(2 cycles)*   | [a, v, ... ] | [v, ... ] | $v \rightarrow mem[a][0]$ <br> Stores the top element of the stack as the first element of the word in memory at address $a$. All other elements of the word are not affected. If $a$ is provided via the stack, it is removed from the stack first. <br> Fails if $a \ge 2^{32}$ |
 | mem_storew <br> - *(1 cycle)*  <br> mem_storew.*a* <br> - *(2 cycles)*  | [a, A, ... ] | [A, ... ] | $A \rightarrow mem[a]$ <br> Stores the top four elements of the stack in memory at address $a$. If $a$ is provided via the stack, it is removed from the stack first. <br> Fails if $a \ge 2^{32}$ |
 
 The second way to access memory is via procedure locals using the instructions listed below. These instructions are available only in procedure context. The number of locals available to a given procedure must be specified at [procedure declaration](./code_organization.md#procedures) time, and trying to access more locals than was declared will result in a compile-time error. The number of locals per procedure is not limited, but the total number of locals available to all procedures at runtime must be smaller than $2^{32}$.
@@ -55,7 +55,7 @@ The second way to access memory is via procedure locals using the instructions l
 | --------------- | ----------- | ------------ | ------------------------------------------ |
 | loc_load.*i* <br> - *(3-4 cycles)*  | [ ... ] | [v, ... ] | $v \leftarrow local[i][0]$ <br> Reads a word (4 elements) from local memory at index *i*, and pushes the first element of the word onto the stack. |
 | loc_loadw.*i*  <br> - *(3-4 cycles)* | [0, 0, 0, 0, ... ] | [A, ... ] | $A \leftarrow local[i]$ <br> Reads a word from local memory at index $i$ and overwrites top four stack elements with it. |
-| loc_store.*i* <br> - *(3-4 cycles)*  | [v, ... ] | [v, ... ] | $[v, 0, 0, 0] \rightarrow local[i]$ <br> Stores the top element of the stack as the first element of the word in local memory at index $i$. All other elements of the word are not affected. |
+| loc_store.*i* <br> - *(3-4 cycles)*  | [v, ... ] | [v, ... ] | $v \rightarrow local[i][0]$ <br> Stores the top element of the stack as the first element of the word in local memory at index $i$. All other elements of the word are not affected. |
 | loc_storew.*i* <br> - *(3-4 cycles)*  | [A, ... ] | [A, ... ] | $A \rightarrow local[i]$ <br> Stores the top four elements of the stack in local memory at index $i$. |
 
 Unlike regular memory, procedure locals are not guaranteed to be initialized to zeros. Thus, when working with locals, one must assume that before a local memory address has been written to, it contains "garbage".

--- a/miden/tests/integration/operations/decorators/advice.rs
+++ b/miden/tests/integration/operations/decorators/advice.rs
@@ -6,7 +6,7 @@ use rand_utils::rand_value;
 
 #[test]
 fn advice_inject_u64div() {
-    let source = "begin adv.u64div push.adv.4 end";
+    let source = "begin adv.u64div adv_push.4 end";
 
     // get two random 64-bit integers and split them into 32-bit limbs
     let a = rand_value::<u64>();
@@ -45,7 +45,7 @@ fn advice_inject_u64div_repeat() {
         repeat.7 
             adv.u64div 
             drop drop
-            push.adv.2
+            adv_push.2
             push.2
             push.0
         end
@@ -78,7 +78,7 @@ fn advice_inject_u64div_repeat() {
 
 #[test]
 fn advice_inject_u64div_local_procedure() {
-    let source = "proc.foo adv.u64div push.adv.4 end begin exec.foo end";
+    let source = "proc.foo adv.u64div adv_push.4 end begin exec.foo end";
 
     // get two random 64-bit integers and split them into 32-bit limbs
     let a = rand_value::<u64>();
@@ -107,7 +107,7 @@ fn advice_inject_u64div_local_procedure() {
 
 #[test]
 fn advice_inject_u64div_conditional_execution() {
-    let source = "begin eq if.true adv.u64div push.adv.4 else padw end end";
+    let source = "begin eq if.true adv.u64div adv_push.4 else padw end end";
 
     // if branch
     let test = build_test!(source, &[8, 0, 4, 0, 1, 1]);

--- a/miden/tests/integration/operations/io_ops/adv_ops.rs
+++ b/miden/tests/integration/operations/io_ops/adv_ops.rs
@@ -5,7 +5,7 @@ use super::{build_op_test, TestError};
 
 #[test]
 fn push_adv() {
-    let asm_op = "push.adv";
+    let asm_op = "adv_push";
     let advice_tape = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
     let test_n = |n: usize| {
         let source = format!("{}.{}", asm_op, n);
@@ -27,7 +27,7 @@ fn push_adv() {
 #[test]
 fn push_adv_invalid() {
     // attempting to read from empty advice tape should throw an error
-    let test = build_op_test!("push.adv.1");
+    let test = build_op_test!("adv_push.1");
     test.expect_error(TestError::ExecutionError("EmptyAdviceTape"));
 }
 
@@ -36,7 +36,7 @@ fn push_adv_invalid() {
 
 #[test]
 fn loadw_adv() {
-    let asm_op = "loadw.adv";
+    let asm_op = "adv_loadw";
     let advice_tape = [1, 2, 3, 4];
     let mut final_stack = advice_tape;
     final_stack.reverse();
@@ -48,6 +48,6 @@ fn loadw_adv() {
 #[test]
 fn loadw_adv_invalid() {
     // attempting to read from empty advice tape should throw an error
-    let test = build_op_test!("loadw.adv", &[0, 0, 0, 0]);
+    let test = build_op_test!("adv_loadw", &[0, 0, 0, 0]);
     test.expect_error(TestError::ExecutionError("EmptyAdviceTape"));
 }

--- a/stdlib/asm/math/poly512.masm
+++ b/stdlib/asm/math/poly512.masm
@@ -80,7 +80,7 @@ proc.mod_12289
 
     adv.u64div
 
-    push.adv.2
+    adv_push.2
     u32assert.2
 
     swap
@@ -92,7 +92,7 @@ proc.mod_12289
     u32overflowing_madd
     drop
 
-    push.adv.2
+    adv_push.2
     drop
     u32assert
 

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -429,7 +429,7 @@ end
 export.unchecked_div
     adv.u64div          # inject the quotient and the remainder into the advice tape
 
-    push.adv.2          # read the quotient from the advice tape and make sure it consists of
+    adv_push.2          # read the quotient from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
@@ -451,7 +451,7 @@ export.unchecked_div
     eq.0
     assert
 
-    push.adv.2          # read the remainder from the advice tape and make sure it consists of
+    adv_push.2          # read the remainder from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     movup.7             # make sure the divisor is greater than the remainder. this also consumes
@@ -494,7 +494,7 @@ end
 export.unchecked_mod
     adv.u64div          # inject the quotient and the remainder into the advice tape
 
-    push.adv.2          # read the quotient from the advice tape and make sure it consists of
+    adv_push.2          # read the quotient from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
@@ -516,7 +516,7 @@ export.unchecked_mod
     eq.0
     assert
 
-    push.adv.2          # read the remainder from the advice tape and make sure it consists of
+    adv_push.2          # read the remainder from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     movup.5             # make sure the divisor is greater than the remainder. this also consumes
@@ -559,7 +559,7 @@ end
 export.unchecked_divmod
     adv.u64div          # inject the quotient and the remainder into the advice tape
 
-    push.adv.2          # read the quotient from the advice tape and make sure it consists of
+    adv_push.2          # read the quotient from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
@@ -581,7 +581,7 @@ export.unchecked_divmod
     eq.0
     assert
 
-    push.adv.2          # read the remainder from the advice tape and make sure it consists of
+    adv_push.2          # read the remainder from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     movup.7             # make sure the divisor is greater than the remainder. this also consumes

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -8167,7 +8167,7 @@ proc.mod_12289
 
     adv.u64div
 
-    push.adv.2
+    adv_push.2
     u32assert.2
 
     swap
@@ -8179,7 +8179,7 @@ proc.mod_12289
     u32overflowing_madd
     drop
 
-    push.adv.2
+    adv_push.2
     drop
     u32assert
 
@@ -13356,7 +13356,7 @@ end
 export.unchecked_div
     adv.u64div          # inject the quotient and the remainder into the advice tape
 
-    push.adv.2          # read the quotient from the advice tape and make sure it consists of
+    adv_push.2          # read the quotient from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
@@ -13378,7 +13378,7 @@ export.unchecked_div
     eq.0
     assert
 
-    push.adv.2          # read the remainder from the advice tape and make sure it consists of
+    adv_push.2          # read the remainder from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     movup.7             # make sure the divisor is greater than the remainder. this also consumes
@@ -13421,7 +13421,7 @@ end
 export.unchecked_mod
     adv.u64div          # inject the quotient and the remainder into the advice tape
 
-    push.adv.2          # read the quotient from the advice tape and make sure it consists of
+    adv_push.2          # read the quotient from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
@@ -13443,7 +13443,7 @@ export.unchecked_mod
     eq.0
     assert
 
-    push.adv.2          # read the remainder from the advice tape and make sure it consists of
+    adv_push.2          # read the remainder from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     movup.5             # make sure the divisor is greater than the remainder. this also consumes
@@ -13486,7 +13486,7 @@ end
 export.unchecked_divmod
     adv.u64div          # inject the quotient and the remainder into the advice tape
 
-    push.adv.2          # read the quotient from the advice tape and make sure it consists of
+    adv_push.2          # read the quotient from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     dup.3               # multiply quotient by the divisor and make sure the resulting value
@@ -13508,7 +13508,7 @@ export.unchecked_divmod
     eq.0
     assert
 
-    push.adv.2          # read the remainder from the advice tape and make sure it consists of
+    adv_push.2          # read the remainder from the advice tape and make sure it consists of
     u32assert.2         # 32-bit limbs
 
     movup.7             # make sure the divisor is greater than the remainder. this also consumes


### PR DESCRIPTION
Operations have been renamed and optimized:
`loadw.adv` --> `adv_loadw`
`push.adv.n` --> `adv_push.n`