### PR TITLE
Implement syscall operation

### DIFF
--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -223,9 +223,41 @@ impl AssemblyError {
         }
     }
 
+    pub fn undefined_kernel_proc(token: &Token, label: &str) -> Self {
+        AssemblyError {
+            message: format!("undefined kernel procedure: {}", label),
+            step: token.pos(),
+            op: token.to_string(),
+        }
+    }
+
     pub fn proc_export_not_allowed(token: &Token, label: &str) -> Self {
         AssemblyError {
             message: format!("exported procedures not allowed in this context: {}", label),
+            step: token.pos(),
+            op: token.to_string(),
+        }
+    }
+
+    pub fn proc_not_in_kernel(token: &Token, label: &str) -> Self {
+        AssemblyError {
+            message: format!("procedure '{}' is not a part of the kernel", label),
+            step: token.pos(),
+            op: token.to_string(),
+        }
+    }
+
+    pub fn syscall_in_kernel(token: &Token) -> Self {
+        AssemblyError {
+            message: "syscall inside kernel".to_string(),
+            step: token.pos(),
+            op: token.to_string(),
+        }
+    }
+
+    pub fn call_in_kernel(token: &Token) -> Self {
+        AssemblyError {
+            message: "call inside kernel".to_string(),
             step: token.pos(),
             op: token.to_string(),
         }

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -28,6 +28,7 @@ impl<'a> Token<'a> {
     pub const REPEAT: &'static str = "repeat";
     pub const EXEC: &'static str = "exec";
     pub const CALL: &'static str = "call";
+    pub const SYSCALL: &'static str = "syscall";
     pub const END: &'static str = "end";
 
     // CONSTRUCTOR
@@ -76,6 +77,7 @@ impl<'a> Token<'a> {
                 | Self::REPEAT
                 | Self::EXEC
                 | Self::CALL
+                | Self::SYSCALL
                 | Self::END
         )
     }
@@ -196,6 +198,15 @@ impl<'a> Token<'a> {
 
     pub fn parse_call(&self) -> Result<String, AssemblyError> {
         assert_eq!(Self::CALL, self.parts[0], "not a call");
+        match self.num_parts() {
+            1 => Err(AssemblyError::missing_param(self)),
+            2 => validate_proc_invocation_label(self.parts[1], self),
+            _ => Err(AssemblyError::extra_param(self)),
+        }
+    }
+
+    pub fn parse_syscall(&self) -> Result<String, AssemblyError> {
+        assert_eq!(Self::SYSCALL, self.parts[0], "not a syscall");
         match self.num_parts() {
             1 => Err(AssemblyError::missing_param(self)),
             2 => validate_proc_invocation_label(self.parts[1], self),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,7 @@ pub mod stack;
 pub use math::{fields::f64::BaseElement as Felt, ExtensionOf, FieldElement, StarkField};
 
 mod program;
-pub use program::{blocks as code_blocks, CodeBlockTable, Library, Program};
+pub use program::{blocks as code_blocks, CodeBlockTable, Kernel, Library, Program};
 
 mod operations;
 pub use operations::{

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -36,6 +36,9 @@ pub enum Operation {
     /// Marks the beginning of a function call.
     Call,
 
+    /// Marks the beginning of a kernel call.
+    SysCall,
+
     /// Marks the beginning of a span code block.
     Span,
 
@@ -451,7 +454,7 @@ impl Operation {
 
             Self::MrUpdate(_) => 0b0110_0000,
             Self::Push(_)   => 0b0110_0100,
-            // <empty>      => 0b0110_1000
+            Self::SysCall   => 0b0110_1000,
             Self::Call      => 0b0110_1100,
             Self::End       => 0b0111_0000,
             Self::Repeat    => 0b0111_0100,
@@ -499,6 +502,7 @@ impl fmt::Display for Operation {
             Self::Split => write!(f, "split"),
             Self::Loop => write!(f, "loop"),
             Self::Call => writeln!(f, "call"),
+            Self::SysCall => writeln!(f, "syscall"),
             Self::Span => write!(f, "span"),
             Self::End => write!(f, "end"),
             Self::Repeat => write!(f, "repeat"),

--- a/core/src/program/blocks/call_block.rs
+++ b/core/src/program/blocks/call_block.rs
@@ -16,6 +16,7 @@ use super::{fmt, hasher, Digest};
 pub struct Call {
     hash: Digest,
     fn_hash: Digest,
+    is_syscall: bool,
 }
 
 impl Call {
@@ -24,7 +25,23 @@ impl Call {
     /// Returns a new [Call] block instantiated with the specified function body hash.
     pub fn new(fn_hash: Digest) -> Self {
         let hash = hasher::merge(&[fn_hash, Digest::default()]);
-        Self { hash, fn_hash }
+        Self {
+            hash,
+            fn_hash,
+            is_syscall: false,
+        }
+    }
+
+    /// Returns a new [Call] block instantiated with the specified function body hash and marked
+    /// as a kernel call.
+    pub fn new_syscall(fn_hash: Digest) -> Self {
+        // TODO: make hash computation different from regular call
+        let hash = hasher::merge(&[fn_hash, Digest::default()]);
+        Self {
+            hash,
+            fn_hash,
+            is_syscall: true,
+        }
     }
 
     // PUBLIC ACCESSORS
@@ -39,10 +56,26 @@ impl Call {
     pub fn fn_hash(&self) -> Digest {
         self.fn_hash
     }
+
+    /// Returns true if this call block corresponds to a kernel call.
+    pub fn is_syscall(&self) -> bool {
+        self.is_syscall
+    }
 }
 
 impl fmt::Display for Call {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "call.{:?}", self.fn_hash) // TODO
+        if self.is_syscall {
+            write!(f, "syscall.0x")?;
+        } else {
+            write!(f, "call.0x")?;
+        }
+
+        let fn_hash_bytes: [u8; 32] = self.fn_hash.into();
+        for byte in fn_hash_bytes {
+            write!(f, "{:02x}", byte)?;
+        }
+
+        Ok(())
     }
 }

--- a/core/src/program/blocks/mod.rs
+++ b/core/src/program/blocks/mod.rs
@@ -66,6 +66,11 @@ impl CodeBlock {
         Self::Call(Call::new(fn_hash))
     }
 
+    pub fn new_syscall(_fn_hash: Digest) -> Self {
+        unimplemented!()
+        // TODO: create a Call block
+    }
+
     /// TODO: add comments
     pub fn new_proxy(code_hash: Digest) -> Self {
         Self::Proxy(Proxy::new(code_hash))

--- a/core/src/program/blocks/mod.rs
+++ b/core/src/program/blocks/mod.rs
@@ -66,9 +66,9 @@ impl CodeBlock {
         Self::Call(Call::new(fn_hash))
     }
 
-    pub fn new_syscall(_fn_hash: Digest) -> Self {
-        unimplemented!()
-        // TODO: create a Call block
+    /// TODO: add comments
+    pub fn new_syscall(fn_hash: Digest) -> Self {
+        Self::Call(Call::new_syscall(fn_hash))
     }
 
     /// TODO: add comments

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -1,4 +1,8 @@
-use crate::{build_test, helpers::TestError};
+use crate::{
+    build_test,
+    helpers::{Test, TestError},
+};
+use vm_core::ProgramInputs;
 
 // SIMPLE FLOW CONTROL TESTS
 // ================================================================================================
@@ -183,4 +187,29 @@ fn local_fn_call_with_mem_access() {
     test.expect_stack(&[1]);
 
     test.prove_and_verify(vec![3, 7], false);
+}
+
+#[test]
+fn simple_syscall() {
+    let kernel_source = "
+        export.foo
+            add
+        end
+    ";
+
+    let program_source = "
+        begin
+            syscall.foo
+        end";
+
+    // TODO: update and use macro?
+    let test = Test {
+        source: program_source.to_string(),
+        kernel: Some(kernel_source.to_string()),
+        inputs: ProgramInputs::from_stack_inputs(&[1, 2]).unwrap(),
+        in_debug_mode: false,
+    };
+    test.expect_stack(&[3]);
+
+    test.prove_and_verify(vec![1, 2], false);
 }

--- a/miden/tests/integration/main.rs
+++ b/miden/tests/integration/main.rs
@@ -107,6 +107,7 @@ macro_rules! build_test_by_mode {
 
         $crate::helpers::Test {
             source: String::from($source),
+            kernel: None,
             inputs,
             in_debug_mode: $in_debug_mode,
         }
@@ -117,6 +118,7 @@ macro_rules! build_test_by_mode {
 
         $crate::helpers::Test {
             source: String::from($source),
+            kernel: None,
             inputs,
             in_debug_mode: $in_debug_mode,
         }

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -1,4 +1,4 @@
-use crate::{utils::get_trace_len, CodeBlock, ExecutionTrace, Operation, Process};
+use crate::{utils::get_trace_len, CodeBlock, ExecutionTrace, Kernel, Operation, Process};
 use vm_core::{
     chiplets::{
         bitwise::{BITWISE_XOR, OP_CYCLE_LEN},
@@ -96,7 +96,7 @@ fn build_trace(stack: &[u64], operations: Vec<Operation>) -> (ChipletsTrace, usi
     let mut process = Process::new(inputs);
     let program = CodeBlock::new_span(operations);
     process
-        .execute_code_block(&program, &CodeBlockTable::default())
+        .execute_code_block(&program, &Kernel::default(), &CodeBlockTable::default())
         .unwrap();
 
     let (trace, _) = ExecutionTrace::test_finalize_trace(process);

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -3,7 +3,7 @@ use super::{
     OpGroupTableRow, OpGroupTableUpdate,
 };
 use crate::{
-    decoder::block_stack::ExecutionContextInfo, utils::get_trace_len, ExecutionTrace, Felt,
+    decoder::block_stack::ExecutionContextInfo, utils::get_trace_len, ExecutionTrace, Felt, Kernel,
     Operation, Process, ProgramInputs, Word,
 };
 use rand_utils::rand_value;
@@ -1123,7 +1123,7 @@ fn build_trace(stack: &[u64], program: &CodeBlock) -> (DecoderTrace, AuxTraceHin
     let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
     let mut process = Process::new(inputs);
     process
-        .execute_code_block(program, &CodeBlockTable::default())
+        .execute_code_block(program, &Kernel::default(), &CodeBlockTable::default())
         .unwrap();
 
     let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
@@ -1150,7 +1150,9 @@ fn build_call_trace(
     let mut cb_table = CodeBlockTable::default();
     cb_table.insert(fn_block);
 
-    process.execute_code_block(program, &cb_table).unwrap();
+    process
+        .execute_code_block(program, &Kernel::default(), &cb_table)
+        .unwrap();
 
     let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
     let trace_len = get_trace_len(&trace) - ExecutionTrace::NUM_RAND_ROWS;

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -19,5 +19,6 @@ pub enum ExecutionError {
     NotBinaryValue(Felt),
     NotU32Value(Felt),
     ProverError(ProverError),
+    SyscallTargetNotInKernel(Digest),
     UnexecutableCodeBlock(CodeBlock),
 }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -14,9 +14,9 @@ use vm_core::{
         Call, CodeBlock, Join, Loop, OpBatch, Span, Split, OP_BATCH_SIZE, OP_GROUP_SIZE,
     },
     utils::collections::{BTreeMap, Vec},
-    AdviceInjector, CodeBlockTable, Decorator, DecoratorIterator, Felt, FieldElement, Operation,
-    StackTopState, StarkField, Word, CHIPLETS_WIDTH, DECODER_TRACE_WIDTH, MIN_TRACE_LEN, ONE,
-    RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH, SYS_TRACE_WIDTH, ZERO,
+    AdviceInjector, CodeBlockTable, Decorator, DecoratorIterator, Felt, FieldElement, Kernel,
+    Operation, StackTopState, StarkField, Word, CHIPLETS_WIDTH, DECODER_TRACE_WIDTH, MIN_TRACE_LEN,
+    ONE, RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH, SYS_TRACE_WIDTH, ZERO,
 };
 
 mod decorators;
@@ -160,7 +160,7 @@ impl Process {
             0,
             "a program has already been executed in this process"
         );
-        self.execute_code_block(program.root(), program.cb_table())?;
+        self.execute_code_block(program.root(), program.kernel(), program.cb_table())?;
 
         Ok(self.stack.get_outputs())
     }
@@ -175,13 +175,14 @@ impl Process {
     fn execute_code_block(
         &mut self,
         block: &CodeBlock,
+        kernel: &Kernel,
         cb_table: &CodeBlockTable,
     ) -> Result<(), ExecutionError> {
         match block {
-            CodeBlock::Join(block) => self.execute_join_block(block, cb_table),
-            CodeBlock::Split(block) => self.execute_split_block(block, cb_table),
-            CodeBlock::Loop(block) => self.execute_loop_block(block, cb_table),
-            CodeBlock::Call(block) => self.execute_call_block(block, cb_table),
+            CodeBlock::Join(block) => self.execute_join_block(block, kernel, cb_table),
+            CodeBlock::Split(block) => self.execute_split_block(block, kernel, cb_table),
+            CodeBlock::Loop(block) => self.execute_loop_block(block, kernel, cb_table),
+            CodeBlock::Call(block) => self.execute_call_block(block, kernel, cb_table),
             CodeBlock::Span(block) => self.execute_span_block(block),
             CodeBlock::Proxy(_) => Err(ExecutionError::UnexecutableCodeBlock(block.clone())),
         }
@@ -192,13 +193,14 @@ impl Process {
     fn execute_join_block(
         &mut self,
         block: &Join,
+        kernel: &Kernel,
         cb_table: &CodeBlockTable,
     ) -> Result<(), ExecutionError> {
         self.start_join_block(block)?;
 
         // execute first and then second child of the join block
-        self.execute_code_block(block.first(), cb_table)?;
-        self.execute_code_block(block.second(), cb_table)?;
+        self.execute_code_block(block.first(), kernel, cb_table)?;
+        self.execute_code_block(block.second(), kernel, cb_table)?;
 
         self.end_join_block(block)
     }
@@ -208,6 +210,7 @@ impl Process {
     fn execute_split_block(
         &mut self,
         block: &Split,
+        kernel: &Kernel,
         cb_table: &CodeBlockTable,
     ) -> Result<(), ExecutionError> {
         // start the SPLIT block; this also pops the stack and returns the popped element
@@ -215,9 +218,9 @@ impl Process {
 
         // execute either the true or the false branch of the split block based on the condition
         if condition == ONE {
-            self.execute_code_block(block.on_true(), cb_table)?;
+            self.execute_code_block(block.on_true(), kernel, cb_table)?;
         } else if condition == ZERO {
-            self.execute_code_block(block.on_false(), cb_table)?;
+            self.execute_code_block(block.on_false(), kernel, cb_table)?;
         } else {
             return Err(ExecutionError::NotBinaryValue(condition));
         }
@@ -230,6 +233,7 @@ impl Process {
     fn execute_loop_block(
         &mut self,
         block: &Loop,
+        kernel: &Kernel,
         cb_table: &CodeBlockTable,
     ) -> Result<(), ExecutionError> {
         // start the LOOP block; this also pops the stack and returns the popped element
@@ -238,7 +242,7 @@ impl Process {
         // if the top of the stack is ONE, execute the loop body; otherwise skip the loop body
         if condition == ONE {
             // execute the loop body at least once
-            self.execute_code_block(block.body(), cb_table)?;
+            self.execute_code_block(block.body(), kernel, cb_table)?;
 
             // keep executing the loop body until the condition on the top of the stack is no
             // longer ONE; each iteration of the loop is preceded by executing REPEAT operation
@@ -246,7 +250,7 @@ impl Process {
             while self.stack.peek() == ONE {
                 self.decoder.repeat();
                 self.execute_op(Operation::Drop)?;
-                self.execute_code_block(block.body(), cb_table)?;
+                self.execute_code_block(block.body(), kernel, cb_table)?;
             }
 
             // end the LOOP block and drop the condition from the stack
@@ -265,15 +269,21 @@ impl Process {
     fn execute_call_block(
         &mut self,
         block: &Call,
+        kernel: &Kernel,
         cb_table: &CodeBlockTable,
     ) -> Result<(), ExecutionError> {
+        // if this is a syscall, make sure the call target exists in the kernel
+        if block.is_syscall() && !kernel.contains_proc(block.fn_hash()) {
+            return Err(ExecutionError::SyscallTargetNotInKernel(block.fn_hash()));
+        }
+
         self.start_call_block(block)?;
 
         // get function body from the code block table and execute it
         let fn_body = cb_table
             .get(block.fn_hash())
             .ok_or_else(|| ExecutionError::CodeBlockNotFound(block.fn_hash()))?;
-        self.execute_code_block(fn_body, cb_table)?;
+        self.execute_code_block(fn_body, kernel, cb_table)?;
 
         self.end_call_block(block)
     }

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -30,6 +30,7 @@ impl Process {
             Operation::Split => unreachable!("control flow operation"),
             Operation::Loop => unreachable!("control flow operation"),
             Operation::Call => unreachable!("control flow operation"),
+            Operation::SysCall => unreachable!("control flow operation"),
             Operation::Span => unreachable!("control flow operation"),
             Operation::Repeat => unreachable!("control flow operation"),
             Operation::Respan => unreachable!("control flow operation"),

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -1,8 +1,8 @@
 use super::{ExecutionTrace, Felt, FieldElement, LookupTableRow, Process, Trace, NUM_RAND_ROWS};
 use rand_utils::rand_array;
 use vm_core::{
-    code_blocks::CodeBlock, CodeBlockTable, Operation, ProgramInputs, ProgramOutputs, Word, ONE,
-    ZERO,
+    code_blocks::CodeBlock, CodeBlockTable, Kernel, Operation, ProgramInputs, ProgramOutputs, Word,
+    ONE, ZERO,
 };
 
 mod chiplets;
@@ -18,7 +18,7 @@ pub fn build_trace_from_block(program: &CodeBlock, stack: &[u64]) -> ExecutionTr
     let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
     let mut process = Process::new(inputs);
     process
-        .execute_code_block(program, &CodeBlockTable::default())
+        .execute_code_block(program, &Kernel::default(), &CodeBlockTable::default())
         .unwrap();
     ExecutionTrace::new(process, ProgramOutputs::default())
 }
@@ -40,7 +40,7 @@ pub fn build_trace_from_ops_with_inputs(
     let mut process = Process::new(inputs);
     let program = CodeBlock::new_span(operations);
     process
-        .execute_code_block(&program, &CodeBlockTable::default())
+        .execute_code_block(&program, &Kernel::default(), &CodeBlockTable::default())
         .unwrap();
     ExecutionTrace::new(process, ProgramOutputs::default())
 }


### PR DESCRIPTION
This PR implements `SYSCALL` operation and the associated assembly instruction. Main changes are:

- Implement `Kernel` struct which is now included with every program.
- Update assembler to enable instantiation with a given kernel source and parsing programs in the context of the specified kernel.
- Update processor to execute programs in the context of a given kernel.

This PR does not include:
- Updates to the decoder required to enforce syscall semantics
- Updates to chiplets component to enforce verification of kernel calls
- Updates to the documentation