### PR TITLE
Stack io u32 operations

### DIFF
--- a/air/benches/enforce_stack_constraint.rs
+++ b/air/benches/enforce_stack_constraint.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use miden_air::{
     stack::{
-        enforce_constraints, field_ops, op_flags::generate_evaluation_frame, stack_manipulation,
-        system_ops, NUM_GENERAL_CONSTRAINTS,
+        enforce_constraints, field_ops, io_ops, op_flags::generate_evaluation_frame,
+        stack_manipulation, system_ops, u32_ops, NUM_GENERAL_CONSTRAINTS,
     },
     Felt, FieldElement,
 };
@@ -15,8 +15,10 @@ fn enforce_stack_constraint(c: &mut Criterion) {
 
     group.bench_function("enforce_stack", |bench| {
         const NUM_CONSTRAINTS: usize = system_ops::NUM_CONSTRAINTS
+            + u32_ops::NUM_CONSTRAINTS
             + field_ops::NUM_CONSTRAINTS
             + stack_manipulation::NUM_CONSTRAINTS
+            + io_ops::NUM_CONSTRAINTS
             + NUM_GENERAL_CONSTRAINTS;
 
         let mut frame = generate_evaluation_frame(Operation::Inv.op_code() as usize);

--- a/air/src/stack/io_ops/mod.rs
+++ b/air/src/stack/io_ops/mod.rs
@@ -1,0 +1,63 @@
+use super::{op_flags::OpFlags, EvaluationFrame, Vec};
+use crate::{stack::EvaluationFrameExt, utils::are_equal};
+use vm_core::FieldElement;
+use winter_air::TransitionConstraintDegree;
+
+#[cfg(test)]
+pub mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The number of unique transition constraints in the input/output operations.
+pub const NUM_CONSTRAINTS: usize = 1;
+
+/// The degrees of constraints in the individual constraints of the input/output ops.
+pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
+    // Given it is a degree 7 operation, 7 is added to all the individual constraints
+    // degree.
+    8, // constraint for SDEPTH operation.
+];
+
+// INPUT/OUTPUT OPERATIONS TRANSITION CONSTRAINTS
+// ================================================================================================
+
+/// Builds the transition constraint degrees for the input/output operations.
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    CONSTRAINT_DEGREES
+        .iter()
+        .map(|&degree| TransitionConstraintDegree::new(degree))
+        .collect()
+}
+
+/// Returns the number of transition constraints for the input/output operations.
+pub fn get_transition_constraint_count() -> usize {
+    NUM_CONSTRAINTS
+}
+
+/// Enforces constraints for the input/output operations.
+pub fn enforce_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: &OpFlags<E>,
+) -> usize {
+    let mut index = 0;
+
+    index += enforce_sdepth_constraint(frame, result, op_flag.sdepth());
+
+    index
+}
+
+/// Enforces constraints of the SDEPTH operation. The SDEPTH operation pushes the depth of
+/// the stack onto the stack. Therefore, the following constraints are enforced:
+/// - The depth of the stack should be equal to the top element in the next frame.
+pub fn enforce_sdepth_constraint<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+) -> usize {
+    // Enforces the depth of the stack is equal to the top element in the next frame.
+    result[0] = op_flag * are_equal(frame.stack_item_next(0), frame.depth());
+
+    1
+}

--- a/air/src/stack/io_ops/tests.rs
+++ b/air/src/stack/io_ops/tests.rs
@@ -1,6 +1,10 @@
 use super::{enforce_constraints, EvaluationFrame, NUM_CONSTRAINTS};
-use crate::stack::op_flags::{generate_evaluation_frame, OpFlags};
-use vm_core::{stack::B0_COL_IDX, Felt, FieldElement, Operation, STACK_TRACE_OFFSET};
+use crate::stack::{
+    op_flags::{generate_evaluation_frame, OpFlags},
+    B0_COL_IDX,
+};
+use rand_utils::rand_value;
+use vm_core::{Felt, FieldElement, Operation, STACK_TRACE_OFFSET};
 
 // UNIT TESTS
 // ================================================================================================
@@ -8,11 +12,11 @@ use vm_core::{stack::B0_COL_IDX, Felt, FieldElement, Operation, STACK_TRACE_OFFS
 #[test]
 fn test_sdepth_operation() {
     let expected = [Felt::ZERO; NUM_CONSTRAINTS];
-    for i in 0..15 {
-        let frame = get_sdepth_test_frame(i);
-        let result = get_constraint_evaluation(frame);
-        assert_eq!(expected, result);
-    }
+    let depth = rand_value::<u32>() as u64;
+
+    let frame = get_sdepth_test_frame(depth);
+    let result = get_constraint_evaluation(frame);
+    assert_eq!(expected, result);
 }
 
 // TEST HELPERS
@@ -39,7 +43,6 @@ pub fn get_sdepth_test_frame(depth: u64) -> EvaluationFrame<Felt> {
     // element in the next frame.
     frame.current_mut()[B0_COL_IDX] = Felt::new(depth);
     frame.next_mut()[STACK_TRACE_OFFSET] = Felt::new(depth);
-    frame.next_mut()[B0_COL_IDX] = Felt::new(depth + 1);
 
     frame
 }

--- a/air/src/stack/io_ops/tests.rs
+++ b/air/src/stack/io_ops/tests.rs
@@ -1,0 +1,45 @@
+use super::{enforce_constraints, EvaluationFrame, NUM_CONSTRAINTS};
+use crate::stack::op_flags::{generate_evaluation_frame, OpFlags};
+use vm_core::{stack::B0_COL_IDX, Felt, FieldElement, Operation, STACK_TRACE_OFFSET};
+
+// UNIT TESTS
+// ================================================================================================
+
+#[test]
+fn test_sdepth_operation() {
+    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    for i in 0..15 {
+        let frame = get_sdepth_test_frame(i);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Returns the result of stack operation constraint evaluations on the provided frame.
+fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
+    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    let op_flag = &OpFlags::new(&frame);
+
+    enforce_constraints(&frame, &mut result, op_flag);
+
+    result
+}
+
+/// Generates the correct current and next rows for the SDEPTH operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_sdepth_test_frame(depth: u64) -> EvaluationFrame<Felt> {
+    // frame initialised with a u32split operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::SDepth.op_code() as usize);
+
+    // Set the output. The depth of the stack in the current trace should be the top
+    // element in the next frame.
+    frame.current_mut()[B0_COL_IDX] = Felt::new(depth);
+    frame.next_mut()[STACK_TRACE_OFFSET] = Felt::new(depth);
+    frame.next_mut()[B0_COL_IDX] = Felt::new(depth + 1);
+
+    frame
+}

--- a/air/src/stack/u32_ops/mod.rs
+++ b/air/src/stack/u32_ops/mod.rs
@@ -1,0 +1,367 @@
+use super::{op_flags::OpFlags, EvaluationFrame, Vec};
+use crate::{
+    stack::EvaluationFrameExt,
+    utils::{are_equal, is_binary},
+};
+use vm_core::FieldElement;
+use winter_air::TransitionConstraintDegree;
+
+#[cfg(test)]
+pub mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+/// The number of unique transition constraints in stack manipulation operations.
+pub const NUM_CONSTRAINTS: usize = 13;
+
+// The co-efficient of the most significant 16-bit limb in the helper register during aggregation.
+pub const TWO_48: u64 = 2u64.pow(48);
+
+// The co-efficient of the 2nd most significant 16-bit limb in the helper register during aggregation.
+pub const TWO_32: u64 = 2u64.pow(32);
+
+// The co-efficient of the 3rd significant 16-bit limb in the helper register during aggregation.
+pub const TWO_16: u64 = 2u64.pow(16);
+
+// The co-efficient of the least significant 16-bit bit in the helper register during aggregation.
+pub const TWO_0: u64 = 1;
+
+/// The degrees of constraints in individual u32 operations.
+pub const CONSTRAINT_DEGREES: [usize; NUM_CONSTRAINTS] = [
+    // Given it is a degree 6 operation, 6 is added to all the individual constraints
+    // degree.
+    9, // constraint for element validity check
+    7, 7, // 2 constraints in the agg of lower and upper limbs
+    7, // constraint for U32SPLIT operation
+    7, // constraint for U32ADD  operation
+    7, // constraint for U32ADD3 operation
+    7, 8, // 2 constraints for U32SUB operation
+    8, // constraint for U32MUL operation
+    8, // constraint for U32MADD operation
+    8, 7, 7, // constraint for U32DIV operation
+];
+
+// U32 OPERATIONS TRANSITION CONSTRAINTS
+// ================================================================================================
+
+/// Builds the transition constraint degrees for the u32 operations.
+pub fn get_transition_constraint_degrees() -> Vec<TransitionConstraintDegree> {
+    CONSTRAINT_DEGREES
+        .iter()
+        .map(|&degree| TransitionConstraintDegree::new(degree))
+        .collect()
+}
+
+/// Returns the number of transition constraints for the u32 operations.
+pub fn get_transition_constraint_count() -> usize {
+    NUM_CONSTRAINTS
+}
+
+/// Enforces constraints for the u32 operations.
+pub fn enforce_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: &OpFlags<E>,
+) -> usize {
+    let mut index = 0;
+
+    let limbs = LimbCompositions::new(frame);
+
+    index += enforce_check_element_validity(frame, result, op_flag, &limbs);
+
+    // Enforce general constaints of the u32 arithmetic operations.
+    index += enforce_limbs_agg(frame, &mut result[index..], op_flag, &limbs);
+
+    // Enforce constaints of the U32SPLIT operations.
+    index += enforce_u32split_constraints(frame, &mut result[index..], op_flag.u32split(), &limbs);
+
+    // Enforce constaints of the U32ADD operations.
+    index += enforce_u32add_constraints(frame, &mut result[index..], op_flag.u32add(), &limbs);
+
+    // Enforce constaints of the U32ADD3 operations.
+    index += enforce_u32add3_constraints(frame, &mut result[index..], op_flag.u32add3(), &limbs);
+
+    // Enforce constaints of the U32SUB operations.
+    index += enforce_u32sub_constraints(frame, &mut result[index..], op_flag.u32sub());
+
+    // Enforce constaints of the U32MUL operations.
+    index += enforce_u32mul_constraints(frame, &mut result[index..], op_flag.u32mul(), &limbs);
+
+    // Enforce constaints of the U32MADD operations.
+    index += enforce_u32madd_constraints(frame, &mut result[index..], op_flag.u32madd(), &limbs);
+
+    // Enforce constaints of the U32DIV operations.
+    index += enforce_u32div_constraints(frame, &mut result[index..], op_flag.u32div(), &limbs);
+
+    index
+}
+
+// TRANSITION CONSTRAINT HELPERS
+// ================================================================================================
+
+/// Enforces constraints of the U32SPLIT operation. The U32SPLIT operation splits the top element into
+/// two 32-bit numbers. Therefore, the following constraints are enforced:
+/// - The aggregation of limbs from the helper registers forms the top element in the stack.
+pub fn enforce_u32split_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+    limbs: &LimbCompositions<E>,
+) -> usize {
+    // Enforces the aggregation of limbs from the helper registers forms the top element in the current trace.
+    result[0] = op_flag * are_equal(frame.stack_item(0), limbs.v64());
+
+    1
+}
+
+/// Enforces constraints of the U32ADD operation. The U32ADD operation adds the top two
+/// elements in the current trace of the stack. Therefore, the following constraints are
+/// enforced:
+/// - The aggregation of limbs from the helper registers is equal to the sum of the top two
+/// element in the stack.
+pub fn enforce_u32add_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+    limbs: &LimbCompositions<E>,
+) -> usize {
+    let a = frame.stack_item(0);
+    let b = frame.stack_item(1);
+
+    // Enforces the aggregation of the least three significant limbs from the helper registers forms
+    // the sum of a and b.
+    result[0] = op_flag * are_equal(a + b, limbs.v48());
+
+    1
+}
+
+/// Enforces constraints of the U32ADD3 operation. The U32ADD3 operation adds the top three
+/// elements in the current trace of the stack. Therefore, the following constraints are
+/// enforced:
+/// - The aggregation of limbs from the helper registers is equal to the sum of the top three
+/// elements in the stack.
+pub fn enforce_u32add3_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+    limbs: &LimbCompositions<E>,
+) -> usize {
+    let a = frame.stack_item(0);
+    let b = frame.stack_item(1);
+    let c = frame.stack_item(2);
+
+    // Enforces the aggregation of the least three significant limbs from the helper registers forms
+    // the combined sum of a, b and c.
+    result[0] = op_flag * are_equal(a + b + c, limbs.v48());
+
+    1
+}
+
+/// Enforces constraints of the U32SUB operation. The U32SUB operation subtracts the first
+/// element from the second in the current trace of the stack. Therefore, the following
+/// constraints are enforced:
+/// - The aggregation of limbs from helper registers is equal to the difference of the top
+///   two elements in the stack.
+/// - The first element in the next trace should be a binary.
+pub fn enforce_u32sub_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+) -> usize {
+    let a = frame.stack_item(0);
+    let b = frame.stack_item(1);
+    let c = frame.stack_item_next(0);
+    let d = frame.stack_item_next(1);
+
+    let sub_limb_aggregation = a + d - E::from(TWO_32) * c;
+
+    // Enforces the aggregation of the limbs from the helper registers is equal to the difference
+    // of b and a.
+    result[0] = op_flag * are_equal(b, sub_limb_aggregation);
+
+    // Enforces that c is a binary.
+    result[1] = op_flag * is_binary(c);
+
+    2
+}
+
+/// Enforces constraints of the U32MUL operation. The U32MUL operation multiplies the top two
+/// elements in the current trace of the stack. Therefore, the following constraints are
+/// enforced:
+/// - The aggregation of all the limbs in the helper registers is equal to the product of the
+///   top two elements in the stack.
+pub fn enforce_u32mul_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+    limbs: &LimbCompositions<E>,
+) -> usize {
+    let a = frame.stack_item(0);
+    let b = frame.stack_item(1);
+
+    // Enforces the aggregation of all the limbs in the helper registers is the product of
+    // a and b.
+    result[0] = op_flag * are_equal(a * b, limbs.v64());
+
+    1
+}
+
+/// Enforces constraints of the U32MADD operation. The U32MADD operation adds the third
+/// element to the product of the first two elements in the current trace. Therefore, the
+/// following constraints are enforced:
+/// - The aggregation of all the limbs in the helper registers is equal to the sum of the
+///   third element with the product of the first two elements in the current trace.
+pub fn enforce_u32madd_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+    limbs: &LimbCompositions<E>,
+) -> usize {
+    let a = frame.stack_item(0);
+    let b = frame.stack_item(1);
+    let c = frame.stack_item(2);
+
+    // Enforces the aggregation of all the limbs in the helper registers is equal to the
+    // addition of c with the product of a and b.
+    result[0] = op_flag * are_equal(a * b + c, limbs.v64());
+
+    1
+}
+
+/// Enforces constraints of the U32DIV operation. The U32DIV operation divides the second element
+/// with the first element in the current trace. Therefore, the following constraints are enforced:
+/// - The second element in the current trace should be equal to the sum of the first element in the
+///   next trace with the product of the first element in the current trace and second element in the
+///   next trace.
+/// - The difference between the second elements in the current and next trace should be equal to the
+///   aggregation of the lower 16-bits limbs.
+/// - The difference between the second elements in the current and next trace and one should be equal
+///   to the aggregation of the upper 16-bits limbs.
+pub fn enforce_u32div_constraints<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: E,
+    limbs: &LimbCompositions<E>,
+) -> usize {
+    let a = frame.stack_item(0);
+    let b = frame.stack_item(1);
+    let c = frame.stack_item_next(0);
+    let d = frame.stack_item_next(1);
+
+    // Enforces that adding c with the product of a and d is equal to b.
+    result[0] = op_flag * are_equal(a * d + c, b);
+
+    // Enforces the aggregation of the lower limbs is equal to the difference between b and d.
+    result[1] = op_flag * are_equal(b - d, limbs.v_lo());
+
+    // Enforces the aggregation of the upper limbs is equal to the difference between a and c + 1.
+    result[2] = op_flag * are_equal(a - c, limbs.v_hi() + E::ONE);
+
+    3
+}
+
+// GENERAL U32 OPERATION CONSTRAINTS
+// ===============================================================================================================
+
+/// The constraint checks if the top four element in the trace on aggregating forms a valid field element.
+/// no not. This constraint is applicable in `U32SPLIT`, `U32MADD` and `U32MUL`.
+pub fn enforce_check_element_validity<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: &OpFlags<E>,
+    limbs: &LimbCompositions<E>,
+) -> usize {
+    let m = frame.user_op_helper(4);
+
+    // composite flag for u32split, u32madd and u32mul.
+    let u32_split_mul_madd = op_flag.u32mul() + op_flag.u32split() + op_flag.u32madd();
+
+    let v_hi_comp = E::ONE - m * (E::from(TWO_32) - E::ONE - limbs.v_hi());
+
+    // Enforces that the agggregation of the limbs forms a valid field element.
+    result[0] = u32_split_mul_madd * are_equal(v_hi_comp * limbs.v_lo(), E::ZERO);
+
+    1
+}
+
+/// Enforces constraints of the general operation. The constaints checks if the lower 16-bits limbs
+/// are aggregated correctly or not. Therefore, the following constraints are enforced:
+/// - The aggregation of lower two lower 16-bits limbs in the helper registers is equal to the second
+/// element in the next row.
+/// - The aggregation of lower two upper 16-bits limbs in the helper registers is equal to the first
+/// element in the next row.
+pub fn enforce_limbs_agg<E: FieldElement>(
+    frame: &EvaluationFrame<E>,
+    result: &mut [E],
+    op_flag: &OpFlags<E>,
+    limbs: &LimbCompositions<E>,
+) -> usize {
+    // flag of u32 arithmetic operation excluding the `U32DIV` operation.
+    let u32op_ex_div_assert2 = op_flag.u32_rc_op() - op_flag.u32div() - op_flag.u32assert2();
+
+    let u32op_ex_div_assert2_sub = u32op_ex_div_assert2 - op_flag.u32sub();
+
+    // Enforces that aggregation of the two lower 16-bits limbs is equal to the second stack element
+    // in the next row.
+    result[0] = u32op_ex_div_assert2 * are_equal(frame.stack_item_next(1), limbs.v_lo());
+
+    // Enforces that aggregation of the two upper 16-bits limbs is equal to the first stack element
+    // in the next row.
+    result[1] = u32op_ex_div_assert2_sub * are_equal(frame.stack_item_next(0), limbs.v_hi());
+
+    2
+}
+
+// U32 HELPERS
+// ================================================================================================
+
+/// Contains intermediate limbs values required in u32 constraint checks.
+pub struct LimbCompositions<E: FieldElement> {
+    v_hi: E,
+    v_lo: E,
+    v48: E,
+    v64: E,
+}
+
+impl<E: FieldElement> LimbCompositions<E> {
+    // Returns a new instance of [LimbCompositions] instantiated with all the intermediate limbs values.
+    pub fn new(frame: &EvaluationFrame<E>) -> Self {
+        let v_lo =
+            E::from(TWO_16) * frame.user_op_helper(1) + E::from(TWO_0) * frame.user_op_helper(0);
+
+        let v_hi =
+            E::from(TWO_16) * frame.user_op_helper(3) + E::from(TWO_0) * frame.user_op_helper(2);
+
+        let v48 = E::from(TWO_32) * frame.user_op_helper(2) + v_lo;
+
+        let v64 = E::from(TWO_48) * frame.user_op_helper(3) + v48;
+
+        Self {
+            v_hi,
+            v_lo,
+            v48,
+            v64,
+        }
+    }
+
+    /// Returns v_hi intermediate flag value.
+    fn v_hi(&self) -> E {
+        self.v_hi
+    }
+
+    /// Returns v_lo intermediate flag value.
+    fn v_lo(&self) -> E {
+        self.v_lo
+    }
+
+    /// Returns v48 intermediate flag value.
+    fn v48(&self) -> E {
+        self.v48
+    }
+
+    /// Returns v64 intermediate flag value.
+    fn v64(&self) -> E {
+        self.v64
+    }
+}

--- a/air/src/stack/u32_ops/tests.rs
+++ b/air/src/stack/u32_ops/tests.rs
@@ -1,0 +1,339 @@
+use super::{enforce_constraints, EvaluationFrame, NUM_CONSTRAINTS};
+use crate::stack::op_flags::{generate_evaluation_frame, OpFlags};
+use vm_core::{
+    decoder::USER_OP_HELPERS_OFFSET, Felt, FieldElement, Operation, StarkField,
+    DECODER_TRACE_OFFSET, STACK_TRACE_OFFSET, ZERO,
+};
+
+use proptest::prelude::*;
+
+// RANDOMIZED TESTS
+// ================================================================================================
+
+proptest! {
+
+    // -------------------------------- U32SPLIT test -----------------------------------------------
+
+    #[test]
+    fn test_u32split_operation(a in any::<u64>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_u32split_test_frame(a);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+
+    // -------------------------------- U32ADD test --------------------------------------------------
+
+    #[test]
+    fn test_u32add_operation(a in any::<u32>(), b in any::<u32>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_u32add_test_frame(a, b);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+
+    // -------------------------------- U32ADD3 test --------------------------------------------------
+
+    #[test]
+    fn test_u32add3_operation(a in any::<u32>(), b in any::<u32>(), c in any::<u32>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_u32add3_test_frame(a, b, c);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+
+    // -------------------------------- U32MUL test --------------------------------------------------
+
+    #[test]
+    fn test_u32mul_operation(a in any::<u32>(), b in any::<u32>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_u32mul_test_frame(a, b);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+
+    // -------------------------------- U32MADD test --------------------------------------------------
+
+    #[test]
+    #[allow(arithmetic_overflow)]
+    fn test_u32madd_operation(a in any::<u32>(), b in any::<u32>(), c in any::<u32>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_u32madd_test_frame(a, b, c);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+
+    // -------------------------------- U32SUB test --------------------------------------------------
+
+    #[test]
+    fn test_u32sub_operation(a in any::<u32>(), b in any::<u32>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let frame = get_u32sub_test_frame(a, b);
+        let result = get_constraint_evaluation(frame);
+        assert_eq!(expected, result);
+    }
+
+    // -------------------------------- U32DIV test --------------------------------------------------
+
+    #[test]
+    fn test_u32div_operation(a in any::<u32>(), b in any::<u32>()) {
+        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        if a != 0 {
+            let frame = get_u32div_test_frame(a, b);
+            let result = get_constraint_evaluation(frame);
+            assert_eq!(expected, result);
+        }
+
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Returns the result of stack operation constraint evaluations on the provided frame.
+fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
+    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    let op_flag = &OpFlags::new(&frame);
+
+    enforce_constraints(&frame, &mut result, op_flag);
+
+    result
+}
+
+/// Generates the correct current and next rows for the U32SPLIT operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_u32split_test_frame(a: u64) -> EvaluationFrame<Felt> {
+    // frame initialised with a u32split operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::U32split.op_code() as usize);
+
+    // element splitted into two 32-bit limbs.
+    let (c, b) = split_element(Felt::new(a));
+
+    // Set the output. First and second element in the next frame should be the
+    // upper and lower 32-bit limb of the first element in the current trace.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a);
+    frame.next_mut()[STACK_TRACE_OFFSET] = c;
+    frame.next_mut()[STACK_TRACE_OFFSET + 1] = b;
+
+    let (t1, t0) = split_u32_into_u16(b.as_int());
+    let (t3, t2) = split_u32_into_u16(c.as_int());
+    let m = (Felt::from(u32::MAX) - c).inv();
+
+    // set the helper registers in the decoder.
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET] = Felt::new(t0 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 1] = Felt::new(t1 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 2] = Felt::new(t2 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 3] = Felt::new(t3 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4] = m;
+
+    frame
+}
+
+/// Generates the correct current and next rows for the U32ADD operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_u32add_test_frame(a: u32, b: u32) -> EvaluationFrame<Felt> {
+    // frame initialised with a u32add operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::U32add.op_code() as usize);
+
+    // the sum of a and b is splitted into two 32-bit limbs.
+    let (hi, lo) = split_element(Felt::new(a.into()) + Felt::new(b.into()));
+
+    // Set the output. First and second element in the next frame should be the
+    // upper and lower 32-bit limb of the sum of the first two elements in the current trace.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a.into());
+    frame.current_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(b.into());
+    frame.next_mut()[STACK_TRACE_OFFSET] = hi;
+    frame.next_mut()[STACK_TRACE_OFFSET + 1] = lo;
+
+    let (t1, t0) = split_u32_into_u16(lo.as_int());
+
+    // set the helper registers in the decoder.
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET] = Felt::new(t0 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 1] = Felt::new(t1 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 2] = hi;
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 3] = ZERO;
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4] = ZERO;
+
+    frame
+}
+
+/// Generates the correct current and next rows for the U32ADD3 operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_u32add3_test_frame(a: u32, b: u32, c: u32) -> EvaluationFrame<Felt> {
+    // frame initialised with a u32add3 operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::U32add3.op_code() as usize);
+
+    // the combined sum of a, b and c is splitted into two 32-bit limbs.
+    let (hi, lo) = split_element(Felt::new(a.into()) + Felt::new(b.into()) + Felt::new(c.into()));
+
+    // Set the output. First and second element in the next frame should be the
+    // upper and lower 32-bit limb of the sum of the first three elements in the current trace.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a.into());
+    frame.current_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(b.into());
+    frame.current_mut()[STACK_TRACE_OFFSET + 2] = Felt::new(c.into());
+    frame.next_mut()[STACK_TRACE_OFFSET] = hi;
+    frame.next_mut()[STACK_TRACE_OFFSET + 1] = lo;
+
+    let (t1, t0) = split_u32_into_u16(lo.as_int());
+
+    // set the helper registers in the decoder.
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET] = Felt::new(t0 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 1] = Felt::new(t1 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 2] = hi;
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 3] = ZERO;
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4] = ZERO;
+
+    frame
+}
+
+/// Generates the correct current and next rows for the U32MUL operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_u32mul_test_frame(a: u32, b: u32) -> EvaluationFrame<Felt> {
+    // frame initialised with a u32mul operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::U32mul.op_code() as usize);
+
+    // element splitted into two 32-bit limbs.
+    let (hi, lo) = split_element(Felt::new(a.into()) * Felt::new(b.into()));
+
+    // Set the output. First and second element in the next frame should be the
+    // upper and lower 32-bit limb of the product of the first two elements in the current trace.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a.into());
+    frame.current_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(b.into());
+    frame.next_mut()[STACK_TRACE_OFFSET] = hi;
+    frame.next_mut()[STACK_TRACE_OFFSET + 1] = lo;
+
+    let (t1, t0) = split_u32_into_u16(lo.as_int());
+    let (t3, t2) = split_u32_into_u16(hi.as_int());
+    let m = (Felt::from(u32::MAX) - hi).inv();
+
+    // set the helper registers in the decoder.
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET] = Felt::new(t0 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 1] = Felt::new(t1 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 2] = Felt::new(t2 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 3] = Felt::new(t3 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4] = m;
+
+    frame
+}
+
+/// Generates the correct current and next rows for the U32MADD operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_u32madd_test_frame(a: u32, b: u32, c: u32) -> EvaluationFrame<Felt> {
+    // frame initialised with a u32madd operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::U32madd.op_code() as usize);
+
+    // element splitted into two 32-bit limbs.
+    let (hi, lo) = split_element(Felt::new((a as u64) * (b as u64) + (c as u64)));
+
+    // Set the output. First and second element in the next frame should be the upper and
+    // lower 32-bit limb of the addition of the third element with the product of the first
+    //  two elements in the current trace.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a.into());
+    frame.current_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(b.into());
+    frame.current_mut()[STACK_TRACE_OFFSET + 2] = Felt::new(c.into());
+    frame.next_mut()[STACK_TRACE_OFFSET] = hi;
+    frame.next_mut()[STACK_TRACE_OFFSET + 1] = lo;
+
+    let (t1, t0) = split_u32_into_u16(lo.as_int());
+    let (t3, t2) = split_u32_into_u16(hi.as_int());
+    let m = (Felt::from(u32::MAX) - hi).inv();
+
+    // set the helper registers in the decoder.
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET] = Felt::new(t0 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 1] = Felt::new(t1 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 2] = Felt::new(t2 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 3] = Felt::new(t3 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4] = m;
+
+    frame
+}
+
+/// Generates the correct current and next rows for the U32SUB operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_u32sub_test_frame(a: u32, b: u32) -> EvaluationFrame<Felt> {
+    // frame initialised with a u32sub operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::U32sub.op_code() as usize);
+
+    // the sum of a and b is splitted into two 32-bit limbs.
+    let (result, under) = b.overflowing_sub(a);
+
+    // Set the output.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a.into());
+    frame.current_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(b.into());
+    frame.next_mut()[STACK_TRACE_OFFSET] = Felt::new(under.into());
+    frame.next_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(result.into());
+
+    let (t1, t0) = split_u32_into_u16(result.into());
+
+    // set the helper registers in the decoder.
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET] = Felt::new(t0 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 1] = Felt::new(t1 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 2] = ZERO;
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 3] = ZERO;
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4] = ZERO;
+
+    frame
+}
+
+/// Generates the correct current and next rows for the U32DIV operation and inputs and
+/// returns an EvaluationFrame for testing.
+pub fn get_u32div_test_frame(a: u32, b: u32) -> EvaluationFrame<Felt> {
+    // frame initialised with a u32div operation using it's unique opcode.
+    let mut frame = generate_evaluation_frame(Operation::U32div.op_code() as usize);
+
+    let q = b / a;
+    let r = b - q * a;
+
+    // These range checks help enforce that q <= b.
+    let lo = b - q;
+    // These range checks help enforce that r < a.
+    let hi = a - r - 1;
+
+    // Set the output.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a.into());
+    frame.current_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(b.into());
+    frame.next_mut()[STACK_TRACE_OFFSET] = Felt::new(r.into());
+    frame.next_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(q.into());
+
+    let (t1, t0) = split_u32_into_u16(lo.into());
+    let (t3, t2) = split_u32_into_u16(hi.into());
+
+    // set the helper registers in the decoder.
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET] = Felt::new(t0 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 1] = Felt::new(t1 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 2] = Felt::new(t2 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 3] = Felt::new(t3 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4] = ZERO;
+
+    frame
+}
+
+/// Splits an element into two field elements containing 32-bit integer values
+pub fn split_element(value: Felt) -> (Felt, Felt) {
+    let value = value.as_int();
+    let lo = (value as u32) as u64;
+    let hi = value >> 32;
+    (Felt::new(hi), Felt::new(lo))
+}
+
+/// Splits an element into two 16 bit integer limbs. It assumes that the field element contains a
+/// valid 32-bit integer value.
+pub fn split_element_u32_into_u16(value: Felt) -> (Felt, Felt) {
+    let (hi, lo) = split_u32_into_u16(value.as_int());
+    (Felt::new(hi as u64), Felt::new(lo as u64))
+}
+
+/// Splits a u64 integer assumed to contain a 32-bit value into two u16 integers.
+///
+/// # Errors
+/// Fails in debug mode if the provided value is not a 32-bit value.
+pub fn split_u32_into_u16(value: u64) -> (u16, u16) {
+    const U32MAX: u64 = u32::MAX as u64;
+    debug_assert!(value <= U32MAX, "not a 32-bit value");
+
+    let lo = value as u16;
+    let hi = (value >> 16) as u16;
+
+    (hi, lo)
+}


### PR DESCRIPTION
## Describe your changes
This PR introduces u32 and input/output air constraints. 

On running the benchmark test with u32 and io constraints included, the following numbers have been observed:

```
enforce_stack_constraint/enforce_stack                                                                             
     time:   [1.0001 µs 1.0008 µs 1.0017 µs]
     change: [+78.924% +79.160% +79.435%] (p = 0.00 < 0.05)
     Performance has regressed.
```


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.