### PR TITLE
Hasher execution trace memoization

### DIFF
--- a/core/src/chiplets/hasher.rs
+++ b/core/src/chiplets/hasher.rs
@@ -1,6 +1,6 @@
 //! TODO: add docs
 
-use super::{Felt, FieldElement, Word, HASHER_AUX_TRACE_OFFSET};
+use super::{create_range, Felt, FieldElement, Word, HASHER_AUX_TRACE_OFFSET};
 use core::ops::Range;
 use crypto::{ElementHasher, Hasher as HashFn};
 
@@ -30,6 +30,12 @@ pub type HasherState = [Felt; STATE_WIDTH];
 /// reserved for capacity. This configuration enables computation of 2-to-1 hash in a single
 /// permutation.
 pub const STATE_WIDTH: usize = Hasher::STATE_WIDTH;
+
+/// Index of the column holding row addresses in the trace.
+pub const ROW_COL_IDX: usize = NUM_SELECTORS;
+
+/// The hasher state portion of the execution trace, located in 4 .. 16 columns.
+pub const STATE_COL_RANGE: Range<usize> = create_range(ROW_COL_IDX + 1, STATE_WIDTH);
 
 /// Number of field elements in the rate portion of the hasher's state.
 pub const RATE_LEN: usize = 8;

--- a/core/src/chiplets/mod.rs
+++ b/core/src/chiplets/mod.rs
@@ -31,10 +31,12 @@ pub const MEMORY_TRACE_OFFSET: usize = CHIPLETS_OFFSET + NUM_MEMORY_SELECTORS;
 pub const HASHER_SELECTOR_COL_RANGE: Range<usize> =
     create_range(HASHER_TRACE_OFFSET, hasher::NUM_SELECTORS);
 /// The index of the hasher's row column in the execution trace.
-pub const HASHER_ROW_COL_IDX: usize = HASHER_SELECTOR_COL_RANGE.end;
+pub const HASHER_ROW_COL_IDX: usize = HASHER_TRACE_OFFSET + hasher::ROW_COL_IDX;
 /// The range of columns in the execution trace that contain the hasher's state.
-pub const HASHER_STATE_COL_RANGE: Range<usize> =
-    create_range(HASHER_ROW_COL_IDX + 1, hasher::STATE_WIDTH);
+pub const HASHER_STATE_COL_RANGE: Range<usize> = Range {
+    start: HASHER_TRACE_OFFSET + hasher::STATE_COL_RANGE.start,
+    end: HASHER_TRACE_OFFSET + hasher::STATE_COL_RANGE.end,
+};
 /// The index of the hasher's node index column in the execution trace.
 pub const HASHER_NODE_INDEX_COL_IDX: usize = HASHER_STATE_COL_RANGE.end;
 

--- a/processor/src/chiplets/hasher/trace.rs
+++ b/processor/src/chiplets/hasher/trace.rs
@@ -1,6 +1,6 @@
 use super::{Felt, HasherState, Selectors, TraceFragment, Vec, STATE_WIDTH, TRACE_WIDTH, ZERO};
-use vm_core::chiplets::hasher::{apply_round, NUM_ROUNDS};
-
+use core::ops::Range;
+use vm_core::chiplets::hasher::{apply_round, NUM_ROUNDS, NUM_SELECTORS};
 // HASHER TRACE
 // ================================================================================================
 
@@ -101,6 +101,32 @@ impl HasherTrace {
             trace_col.push(state_val);
         }
         self.node_index.push(index);
+    }
+
+    /// Copies section of trace from the given range of start and end rows at the end of the trace.
+    /// The hasher state of the last row is copied to the provided state input.
+    pub fn copy_trace(&mut self, state: &mut [Felt; STATE_WIDTH], range: Range<usize>) {
+        let mut hasher_state: [Felt; STATE_WIDTH] = Default::default();
+        let mut selectors: [Felt; NUM_SELECTORS] = Default::default();
+
+        for row in range {
+            for (col, selector) in selectors.iter_mut().enumerate() {
+                *selector = self.selectors[col][row];
+            }
+
+            for (col, state) in hasher_state.iter_mut().enumerate() {
+                *state = self.hasher_state[col][row];
+            }
+
+            let node_index = self.node_index[row];
+            self.append_row(selectors, &hasher_state, node_index);
+        }
+
+        // TODO: remove this after the state is removed from the HasherLookup struct
+        // copy the latest hasher state to the provided state slice
+        for (state_col, hasher_col) in state.iter_mut().zip(hasher_state.iter()) {
+            *state_col = *hasher_col
+        }
     }
 
     // EXECUTION TRACE GENERATION

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -151,11 +151,11 @@ impl Chiplets {
     /// hash(h1, h2) against the provided `expected_result`.
     ///
     /// It returns the row address of the execution trace at which the hash computation started.
-    pub fn hash_control_block(&mut self, h1: Word, h2: Word, expected_result: Digest) -> Felt {
-        let (addr, result, lookups) = self.hasher.merge(h1, h2);
+    pub fn hash_control_block(&mut self, h1: Word, h2: Word, expected_hash: Digest) -> Felt {
+        let (addr, result, lookups) = self.hasher.hash_control_block(h1, h2, expected_hash);
 
         // make sure the result computed by the hasher is the same as the expected block hash
-        debug_assert_eq!(expected_result, result.into());
+        debug_assert_eq!(expected_hash, result.into());
 
         // send the request for the hash initialization
         self.bus.request_hasher_lookup(lookups[0], self.clk);
@@ -174,12 +174,14 @@ impl Chiplets {
         &mut self,
         op_batches: &[OpBatch],
         num_op_groups: usize,
-        expected_result: Digest,
+        expected_hash: Digest,
     ) -> Felt {
-        let (addr, result, lookups) = self.hasher.hash_span_block(op_batches, num_op_groups);
+        let (addr, result, lookups) =
+            self.hasher
+                .hash_span_block(op_batches, num_op_groups, expected_hash);
 
         // make sure the result computed by the hasher is the same as the expected block hash
-        debug_assert_eq!(expected_result, result.into());
+        debug_assert_eq!(expected_hash, result.into());
 
         // send the request for the hash initialization
         self.bus.request_hasher_lookup(lookups[0], self.clk);

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -143,13 +143,7 @@ impl BlockInfo {
         match self.block_type {
             BlockType::Join(_) => 2,
             BlockType::Split => 1,
-            BlockType::Loop(is_entered) => {
-                if is_entered {
-                    1
-                } else {
-                    0
-                }
-            }
+            BlockType::Loop(is_entered) => u32::from(is_entered),
             BlockType::Call => 1,
             BlockType::Span => 0,
         }


### PR DESCRIPTION
## Describe your changes
Partly addressing #103.
Adds memoization of hash execution traces for program blocks so that we don't need to build the trace every time the same program block is encountered.

Benchmark (Execution times):
| Program | Without memoization  | With memoization  | Improvement (%)  |
|-------------|-------------------------------|--------------------------|--------------------|
| sha256   | 18.54 ms | 18.41  | Insignificant  |
| keccak256 | 99.91 ms  | 96.89 ms  | ~ 3% |
| blake3  | 5.68ms | 5.62 ms  | Insignificant  |

Just to have an idea of maximum improvement possible with memoization, we can consider programs that have highly repeated small program blocks. Consider the following program:
```
repeat.200
    push.10 drop
    while.true neq.0 end
end
 ```
Here we see the execution time reduce from 11.34 ms to 3.61 ms, a ~68% improvement.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.