### PR TITLE
Memory layout of procedure locals

### DIFF
--- a/assembly/src/parsers/io_ops/env_ops.rs
+++ b/assembly/src/parsers/io_ops/env_ops.rs
@@ -29,8 +29,7 @@ pub fn parse_locaddr(
         2 => parse_u32_param(op, 1, 0, num_proc_locals - 1)?,
         _ => return Err(AssemblyError::extra_param(op)),
     };
-
-    push_value(span_ops, -Felt::from(index));
+    push_value(span_ops, -Felt::from(num_proc_locals - 1 - index));
     span_ops.push(Operation::FmpAdd);
 
     Ok(())

--- a/assembly/src/parsers/io_ops/mem_ops.rs
+++ b/assembly/src/parsers/io_ops/mem_ops.rs
@@ -129,7 +129,8 @@ fn push_local_addr(
     // put the absolute memory address on the stack
     // negate the value to use it as an offset from the fmp
     // since the fmp value was incremented when locals were allocated
-    push_value(span_ops, -Felt::from(index));
+    // As the index increases, so does the memory address
+    push_value(span_ops, -Felt::from(num_proc_locals - 1 - index));
     span_ops.push(Operation::FmpAdd);
 
     Ok(())

--- a/miden/tests/integration/operations/io_ops/env_ops.rs
+++ b/miden/tests/integration/operations/io_ops/env_ops.rs
@@ -37,7 +37,7 @@ fn locaddr() {
         end";
 
     let test = build_test!(source, &[10]);
-    test.expect_stack(&[FMP_MIN + 1, FMP_MIN + 2, 10]);
+    test.expect_stack(&[FMP_MIN + 2, FMP_MIN + 1, 10]);
 
     // --- accessing mem via locaddr updates the correct variables --------------------------------
     let source = "
@@ -78,14 +78,14 @@ fn locaddr() {
 
     let test = build_test!(source, &[10]);
     test.expect_stack(&[
+        FMP_MIN + 3,
+        FMP_MIN + 2,
         FMP_MIN + 1,
         FMP_MIN + 2,
-        FMP_MIN + 3,
-        FMP_MIN + 1,
-        FMP_MIN + 3,
-        FMP_MIN + 4,
         FMP_MIN + 5,
-        FMP_MIN + 2,
+        FMP_MIN + 4,
+        FMP_MIN + 3,
+        FMP_MIN + 1,
         10,
     ]);
 


### PR DESCRIPTION
Memory layout has been reversed to be in increasing order as it mentioned in issue #417 
