### PR TITLE
Remove lookups from Hasher struct

### DIFF
--- a/processor/src/chiplets/hasher/lookups.rs
+++ b/processor/src/chiplets/hasher/lookups.rs
@@ -56,10 +56,10 @@ impl HasherLookup {
     }
 
     /// The cycle at which the lookup is provided by the hasher.
-    pub(super) fn cycle(&self) -> usize {
+    pub fn cycle(&self) -> u32 {
         // the hasher's addresses start from one instead of zero, so the cycle at which each lookup
         // is provided is one less than its address
-        self.addr as usize - 1
+        self.addr - 1
     }
 
     /// Returns the common header value which describes this hash operation. It is a combination of

--- a/processor/src/chiplets/hasher/mod.rs
+++ b/processor/src/chiplets/hasher/mod.rs
@@ -257,7 +257,7 @@ impl Hasher {
         } else if num_batches == 1 {
             self.trace.copy_trace(&mut state, start_row..end_row);
         } else {
-            for i in 1..num_batches - 1 {
+            for i in 1..num_batches {
                 // add the lookup for absorbing the next operation batch. Here we add the
                 // lookups before actually copying the memoized trace.
                 let lookup_addr = self.trace_len() + i * HASH_CYCLE_LEN;
@@ -271,10 +271,6 @@ impl Hasher {
             }
 
             self.trace.copy_trace(&mut state, start_row..end_row);
-
-            // add the lookup for absorbing the final operation batch.
-            let lookup = self.get_lookup(ABSORB_LABEL, ZERO, HasherLookupContext::Absorb);
-            lookups.push(lookup);
         }
 
         // add the lookup for the hash result.

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -1,3 +1,5 @@
+use crate::chiplets::hasher::{lookups::HasherLookupContext, HasherLookup};
+
 use super::{
     init_state_from_words, AuxTraceBuilder, Digest, Felt, Hasher, HasherState, Selectors,
     SiblingTableRow, SiblingTableUpdate, TraceFragment, Word, LINEAR_HASH, MP_VERIFY,
@@ -6,7 +8,9 @@ use super::{
 use rand_utils::rand_array;
 use vm_core::{
     chiplets::hasher::{
-        self, DIGEST_LEN, HASH_CYCLE_LEN, NUM_ROUNDS, NUM_SELECTORS, STATE_COL_RANGE,
+        self, DIGEST_LEN, HASH_CYCLE_LEN, LINEAR_HASH_LABEL, MP_VERIFY_LABEL, MR_UPDATE_NEW_LABEL,
+        MR_UPDATE_OLD_LABEL, NUM_ROUNDS, NUM_SELECTORS, RETURN_HASH_LABEL, RETURN_STATE_LABEL,
+        STATE_COL_RANGE,
     },
     code_blocks::{get_span_op_group_count, CodeBlock},
     AdviceSet, Operation, StarkField, ONE, ZERO,
@@ -24,6 +28,23 @@ fn hasher_permute() {
     let init_state: HasherState = rand_array();
     let mut lookups = Vec::new();
     let (addr, final_state) = hasher.permute(init_state, &mut lookups);
+
+    // there should be two lookups for start and end rows of hasher operation
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookup_start =
+        HasherLookup::new(LINEAR_HASH_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let expected_lookup_end = HasherLookup::new(
+        RETURN_STATE_LABEL,
+        1 + HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![expected_lookup_start, expected_lookup_end],
+    );
 
     // address of the permutation should be ONE (as hasher address starts at ONE)
     assert_eq!(ONE, addr);
@@ -100,8 +121,44 @@ fn hasher_build_merkle_root() {
     let path0 = tree.get_path(1, 0).unwrap();
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[0], &path0, ZERO, &mut lookups);
+
+    // there should be two lookups for start and end rows of hasher operation
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookup_start =
+        HasherLookup::new(MP_VERIFY_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let expected_lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        1 + HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![expected_lookup_start, expected_lookup_end],
+    );
+
     let path1 = tree.get_path(1, 1).unwrap();
+    let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[1], &path1, ONE, &mut lookups);
+
+    // there should be two lookups for start and end rows of hasher operation
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookup_start =
+        HasherLookup::new(MP_VERIFY_LABEL, 9, ONE, HasherLookupContext::Start);
+    let expected_lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        9 + HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![expected_lookup_start, expected_lookup_end],
+    );
 
     // build the trace
     let (trace, aux_hints) = build_trace(hasher, 16);
@@ -133,6 +190,23 @@ fn hasher_build_merkle_root() {
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[5], &path, Felt::new(5), &mut lookups);
 
+    // there should be two lookups for start and end rows of hasher operation
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookup_start =
+        HasherLookup::new(MP_VERIFY_LABEL, 1, Felt::new(5), HasherLookupContext::Start);
+    let expected_lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        1 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![expected_lookup_start, expected_lookup_end],
+    );
+
     // build and check the trace for validity
     let (trace, aux_hints) = build_trace(hasher, 24);
     check_merkle_path(&trace, 0, leaves[5], &path, 5, MP_VERIFY);
@@ -150,17 +224,97 @@ fn hasher_build_merkle_root() {
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[0], &path0, ZERO, &mut lookups);
 
+    // there should be two lookups for start and end rows of hasher operation
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookup_start =
+        HasherLookup::new(MP_VERIFY_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let expected_lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        1 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![expected_lookup_start, expected_lookup_end],
+    );
+
     let path3 = tree.get_path(3, 3).unwrap();
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[3], &path3, Felt::new(3), &mut lookups);
+
+    // there should be two lookups for start and end rows of hasher operation
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookup_start = HasherLookup::new(
+        MP_VERIFY_LABEL,
+        25,
+        Felt::new(3),
+        HasherLookupContext::Start,
+    );
+    let expected_lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        25 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![expected_lookup_start, expected_lookup_end],
+    );
 
     let path7 = tree.get_path(3, 7).unwrap();
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[7], &path7, Felt::new(7), &mut lookups);
 
+    // there should be two lookups for start and end rows of hasher operation
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookup_start = HasherLookup::new(
+        MP_VERIFY_LABEL,
+        49,
+        Felt::new(7),
+        HasherLookupContext::Start,
+    );
+    let expected_lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        49 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![expected_lookup_start, expected_lookup_end],
+    );
+
     // path3 again
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[3], &path3, Felt::new(3), &mut lookups);
+
+    // there should be two lookups for start and end rows of hasher operation
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookup_start = HasherLookup::new(
+        MP_VERIFY_LABEL,
+        73,
+        Felt::new(3),
+        HasherLookupContext::Start,
+    );
+    let expected_lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        73 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![expected_lookup_start, expected_lookup_end],
+    );
 
     // build and check the trace for validity
     let (trace, aux_hints) = build_trace(hasher, 96);
@@ -191,11 +345,61 @@ fn hasher_update_merkle_root() {
     hasher.update_merkle_root(leaves[0], new_leaf0, &path0, ZERO, &mut lookups);
     tree.update_leaf(0, new_leaf0).unwrap();
 
+    let expected_lookups_len = 4;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookups = vec![
+        HasherLookup::new(MR_UPDATE_OLD_LABEL, 1, ZERO, HasherLookupContext::Start),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            1 + HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+        HasherLookup::new(
+            MR_UPDATE_NEW_LABEL,
+            1 + HASH_CYCLE_LEN as u32,
+            ZERO,
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            1 + 2 * HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+    ];
+    check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
+
     let path1 = tree.get_path(1, 1).unwrap();
     let new_leaf1 = init_leaf(4);
     let mut lookups = Vec::new();
     hasher.update_merkle_root(leaves[1], new_leaf1, &path1, ONE, &mut lookups);
     tree.update_leaf(1, new_leaf1).unwrap();
+
+    let expected_lookups_len = 4;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookups = vec![
+        HasherLookup::new(MR_UPDATE_OLD_LABEL, 17, ONE, HasherLookupContext::Start),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            17 + HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+        HasherLookup::new(
+            MR_UPDATE_NEW_LABEL,
+            17 + HASH_CYCLE_LEN as u32,
+            ONE,
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            17 + 2 * HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+    ];
+    check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
 
     // build the trace
     let (trace, aux_hints) = build_trace(hasher, 32);
@@ -249,11 +453,66 @@ fn hasher_update_merkle_root() {
     hasher.update_merkle_root(leaves[3], new_leaf3, &path3, Felt::new(3), &mut lookups);
     tree.update_leaf(3, new_leaf3).unwrap();
 
+    let expected_lookups_len = 4;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookups = vec![
+        HasherLookup::new(
+            MR_UPDATE_OLD_LABEL,
+            1,
+            Felt::new(3),
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            1 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+        HasherLookup::new(
+            MR_UPDATE_NEW_LABEL,
+            1 + 3 * HASH_CYCLE_LEN as u32,
+            Felt::new(3),
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(RETURN_HASH_LABEL, 48, ZERO, HasherLookupContext::Return),
+    ];
+    check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
+
     let path6 = tree.get_path(3, 6).unwrap();
     let new_leaf6 = init_leaf(25);
     let mut lookups = Vec::new();
     hasher.update_merkle_root(leaves[6], new_leaf6, &path6, Felt::new(6), &mut lookups);
     tree.update_leaf(6, new_leaf6).unwrap();
+
+    let expected_lookups_len = 4;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookups = vec![
+        HasherLookup::new(
+            MR_UPDATE_OLD_LABEL,
+            49,
+            Felt::new(6),
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            49 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+        HasherLookup::new(
+            MR_UPDATE_NEW_LABEL,
+            49 + 3 * HASH_CYCLE_LEN as u32,
+            Felt::new(6),
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            49 + 3 * HASH_CYCLE_LEN as u32 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+    ];
+    check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
 
     // update leaf 3 again
     let path3_2 = tree.get_path(3, 3).unwrap();
@@ -262,6 +521,36 @@ fn hasher_update_merkle_root() {
     hasher.update_merkle_root(new_leaf3, new_leaf3_2, &path3_2, Felt::new(3), &mut lookups);
     tree.update_leaf(3, new_leaf3_2).unwrap();
     assert_ne!(path3, path3_2);
+
+    let expected_lookups_len = 4;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookups = vec![
+        HasherLookup::new(
+            MR_UPDATE_OLD_LABEL,
+            97,
+            Felt::new(3),
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            97 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+        HasherLookup::new(
+            MR_UPDATE_NEW_LABEL,
+            97 + 3 * HASH_CYCLE_LEN as u32,
+            Felt::new(3),
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            97 + 3 * HASH_CYCLE_LEN as u32 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+    ];
+    check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
 
     // build and check the trace for validity
     let (trace, aux_hints) = build_trace(hasher, 144);
@@ -327,8 +616,8 @@ fn hash_memoization_control_blocks() {
     //        /      \
     //      Split1     Split2 (memoized)
 
-    let t_branch = CodeBlock::new_span(vec![Operation::Push(Felt::new(1))]);
-    let f_branch = CodeBlock::new_span(vec![Operation::Push(Felt::new(0))]);
+    let t_branch = CodeBlock::new_span(vec![Operation::Push(ZERO)]);
+    let f_branch = CodeBlock::new_span(vec![Operation::Push(ONE)]);
     let split1_block = CodeBlock::new_split(t_branch.clone(), f_branch.clone());
     let split2_block = CodeBlock::new_split(t_branch.clone(), f_branch.clone());
     let join_block = CodeBlock::new_join([split1_block.clone(), split2_block.clone()]);
@@ -351,6 +640,21 @@ fn hash_memoization_control_blocks() {
     // builds the trace of the join block.
     let (_, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
 
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        1 + HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![lookup_start, lookup_end],
+    );
+
     // make sure the hash of the final state is the same as the expected hash.
     assert_eq!(Digest::new(final_state), expected_hash);
 
@@ -370,6 +674,22 @@ fn hash_memoization_control_blocks() {
     let mut lookups = Vec::new();
     // builds the hash execution trace of the first split block from scratch.
     let (addr, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 9, ZERO, HasherLookupContext::Start);
+    let lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        9 + HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![lookup_start, lookup_end],
+    );
+
     let first_block_final_state = final_state;
 
     // make sure the hash of the final state of the first split block is the same as the expected
@@ -395,6 +715,21 @@ fn hash_memoization_control_blocks() {
     // builds the hash execution trace of the second split block by copying it from the trace of
     // the first split block.
     let (addr, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 17, ZERO, HasherLookupContext::Start);
+    let lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        17 + HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![lookup_start, lookup_end],
+    );
 
     // make sure the hash of the final state of the second split block is the same as the expected
     // hash.
@@ -509,6 +844,21 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
     let mut lookups = Vec::new();
     // builds the trace of the Join1 block.
     let (_, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        1 + HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![lookup_start, lookup_end],
+    );
     // make sure the hash of the final state of Join1 is the same as the expected hash.
     assert_eq!(Digest::new(final_state), expected_hash);
 
@@ -526,6 +876,22 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
 
     let mut lookups = Vec::new();
     let (_, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+
+    let expected_lookups_len = 2;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 9, ZERO, HasherLookupContext::Start);
+    let lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        9 + HASH_CYCLE_LEN as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    check_lookups_validity(
+        lookups,
+        expected_lookups_len,
+        vec![lookup_start, lookup_end],
+    );
+
     // make sure the hash of the final state of Join2 is the same as the expected hash.
     assert_eq!(Digest::new(final_state), expected_hash);
 
@@ -543,6 +909,50 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
         span1_block.hash(),
         &mut lookups,
     );
+
+    let num_batches = if let CodeBlock::Span(span) = &span1_block {
+        span.op_batches().len()
+    } else {
+        unreachable!()
+    };
+
+    let expected_lookups_len = 2 + num_batches - 1;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookups = if num_batches == 1 {
+        vec![
+            HasherLookup::new(LINEAR_HASH_LABEL, 17, ZERO, HasherLookupContext::Start),
+            HasherLookup::new(
+                RETURN_HASH_LABEL,
+                17 + HASH_CYCLE_LEN as u32 - 1,
+                ZERO,
+                HasherLookupContext::Return,
+            ),
+        ]
+    } else {
+        vec![
+            HasherLookup::new(LINEAR_HASH_LABEL, 17, ZERO, HasherLookupContext::Start),
+            HasherLookup::new(
+                LINEAR_HASH_LABEL,
+                17 + HASH_CYCLE_LEN as u32 - 1,
+                ZERO,
+                HasherLookupContext::Absorb,
+            ),
+            HasherLookup::new(
+                LINEAR_HASH_LABEL,
+                17 + 2 * HASH_CYCLE_LEN as u32 - 1,
+                ZERO,
+                HasherLookupContext::Absorb,
+            ),
+            HasherLookup::new(
+                RETURN_HASH_LABEL,
+                17 + 3 * HASH_CYCLE_LEN as u32 - 1,
+                ZERO,
+                HasherLookupContext::Return,
+            ),
+        ]
+    };
+    check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
+
     let first_span_block_final_state = final_state;
 
     // make sure the hash of the final state of Span1 block is the same as the expected hash.
@@ -567,6 +977,51 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
         span2_block.hash(),
         &mut lookups,
     );
+
+    let num_batches = if let CodeBlock::Span(span) = &span2_block {
+        span.op_batches().len()
+    } else {
+        unreachable!()
+    };
+
+    let expected_lookups_len = 2 + num_batches - 1;
+    // make sure the lookups have correct labels, addresses, indices and contexts.
+    let expected_lookups = if num_batches == 1 {
+        vec![
+            HasherLookup::new(LINEAR_HASH_LABEL, 25, ZERO, HasherLookupContext::Start),
+            HasherLookup::new(
+                RETURN_HASH_LABEL,
+                25 + HASH_CYCLE_LEN as u32 - 1,
+                ZERO,
+                HasherLookupContext::Return,
+            ),
+        ]
+    } else {
+        // the start row is 41 here instead of 25 since the hash execution trace of the last
+        // (memoized) span block ends at row 40 in case of span with multiple batches.
+        vec![
+            HasherLookup::new(LINEAR_HASH_LABEL, 41, ZERO, HasherLookupContext::Start),
+            HasherLookup::new(
+                LINEAR_HASH_LABEL,
+                41 + HASH_CYCLE_LEN as u32 - 1,
+                ZERO,
+                HasherLookupContext::Absorb,
+            ),
+            HasherLookup::new(
+                LINEAR_HASH_LABEL,
+                41 + 2 * HASH_CYCLE_LEN as u32 - 1,
+                ZERO,
+                HasherLookupContext::Absorb,
+            ),
+            HasherLookup::new(
+                RETURN_HASH_LABEL,
+                41 + 3 * HASH_CYCLE_LEN as u32 - 1,
+                ZERO,
+                HasherLookupContext::Return,
+            ),
+        ]
+    };
+    check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
 
     let expected_hash = span2_block.hash();
     // make sure the hash of the final state of Span2 block is the same as the expected hash.
@@ -720,6 +1175,24 @@ fn check_memoized_trace(
             column[start_row..end_row],
             column[copied_start_row..copied_end_row]
         )
+    }
+}
+
+/// Makes sure the lookups are built correctly.
+fn check_lookups_validity(
+    lookups: Vec<HasherLookup>,
+    expected_lookups_length: usize,
+    expected_lookups: Vec<HasherLookup>,
+) {
+    // make sure the length of the lookups is what we expect.
+    assert_eq!(expected_lookups_length, lookups.len());
+
+    // make sure the length of lookups and expected lookups is same.
+    assert_eq!(expected_lookups.len(), lookups.len());
+
+    for (lookup, expected_lookup) in lookups.iter().zip(expected_lookups) {
+        // make sure the lookups match with what we expect.
+        assert_eq!(expected_lookup, *lookup);
     }
 }
 

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -29,14 +29,20 @@ fn hasher_permute() {
     let mut lookups = Vec::new();
     let (addr, final_state) = hasher.permute(init_state, &mut lookups);
 
+    let lookup_start_addr = 1;
     // there should be two lookups for start and end rows of hasher operation
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let expected_lookup_start =
-        HasherLookup::new(LINEAR_HASH_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let expected_lookup_start = HasherLookup::new(
+        LINEAR_HASH_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
+
     let expected_lookup_end = HasherLookup::new(
         RETURN_STATE_LABEL,
-        1 + HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -125,11 +131,16 @@ fn hasher_build_merkle_root() {
     // there should be two lookups for start and end rows of hasher operation
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let expected_lookup_start =
-        HasherLookup::new(MP_VERIFY_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let lookup_start_addr = 1;
+    let expected_lookup_start = HasherLookup::new(
+        MP_VERIFY_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
     let expected_lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        1 + HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -143,14 +154,19 @@ fn hasher_build_merkle_root() {
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[1], &path1, ONE, &mut lookups);
 
+    let lookup_start_addr = 9;
     // there should be two lookups for start and end rows of hasher operation
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let expected_lookup_start =
-        HasherLookup::new(MP_VERIFY_LABEL, 9, ONE, HasherLookupContext::Start);
+    let expected_lookup_start = HasherLookup::new(
+        MP_VERIFY_LABEL,
+        lookup_start_addr,
+        ONE,
+        HasherLookupContext::Start,
+    );
     let expected_lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        9 + HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -190,14 +206,19 @@ fn hasher_build_merkle_root() {
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[5], &path, Felt::new(5), &mut lookups);
 
+    let lookup_start_addr = 1;
     // there should be two lookups for start and end rows of hasher operation
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let expected_lookup_start =
-        HasherLookup::new(MP_VERIFY_LABEL, 1, Felt::new(5), HasherLookupContext::Start);
+    let expected_lookup_start = HasherLookup::new(
+        MP_VERIFY_LABEL,
+        lookup_start_addr,
+        Felt::new(5),
+        HasherLookupContext::Start,
+    );
     let expected_lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        1 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -224,14 +245,19 @@ fn hasher_build_merkle_root() {
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[0], &path0, ZERO, &mut lookups);
 
+    let lookup_start_addr = 1;
     // there should be two lookups for start and end rows of hasher operation
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let expected_lookup_start =
-        HasherLookup::new(MP_VERIFY_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let expected_lookup_start = HasherLookup::new(
+        MP_VERIFY_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
     let expected_lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        1 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -245,18 +271,19 @@ fn hasher_build_merkle_root() {
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[3], &path3, Felt::new(3), &mut lookups);
 
+    let lookup_start_addr = 25;
     // there should be two lookups for start and end rows of hasher operation
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
     let expected_lookup_start = HasherLookup::new(
         MP_VERIFY_LABEL,
-        25,
+        lookup_start_addr,
         Felt::new(3),
         HasherLookupContext::Start,
     );
     let expected_lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        25 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -270,18 +297,19 @@ fn hasher_build_merkle_root() {
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[7], &path7, Felt::new(7), &mut lookups);
 
+    let lookup_start_addr = 49;
     // there should be two lookups for start and end rows of hasher operation
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
     let expected_lookup_start = HasherLookup::new(
         MP_VERIFY_LABEL,
-        49,
+        lookup_start_addr,
         Felt::new(7),
         HasherLookupContext::Start,
     );
     let expected_lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        49 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -295,18 +323,19 @@ fn hasher_build_merkle_root() {
     let mut lookups = Vec::new();
     hasher.build_merkle_root(leaves[3], &path3, Felt::new(3), &mut lookups);
 
+    let lookup_start_addr = 73;
     // there should be two lookups for start and end rows of hasher operation
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
     let expected_lookup_start = HasherLookup::new(
         MP_VERIFY_LABEL,
-        73,
+        lookup_start_addr,
         Felt::new(3),
         HasherLookupContext::Start,
     );
     let expected_lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        73 + 3 * HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -342,28 +371,34 @@ fn hasher_update_merkle_root() {
     let path0 = tree.get_path(1, 0).unwrap();
     let new_leaf0 = init_leaf(3);
     let mut lookups = Vec::new();
+    let lookup_start_addr = 1;
     hasher.update_merkle_root(leaves[0], new_leaf0, &path0, ZERO, &mut lookups);
     tree.update_leaf(0, new_leaf0).unwrap();
 
     let expected_lookups_len = 4;
     // make sure the lookups have correct labels, addresses, indices and contexts.
     let expected_lookups = vec![
-        HasherLookup::new(MR_UPDATE_OLD_LABEL, 1, ZERO, HasherLookupContext::Start),
         HasherLookup::new(
-            RETURN_HASH_LABEL,
-            1 + HASH_CYCLE_LEN as u32 - 1,
-            ZERO,
-            HasherLookupContext::Return,
-        ),
-        HasherLookup::new(
-            MR_UPDATE_NEW_LABEL,
-            1 + HASH_CYCLE_LEN as u32,
+            MR_UPDATE_OLD_LABEL,
+            lookup_start_addr,
             ZERO,
             HasherLookupContext::Start,
         ),
         HasherLookup::new(
             RETURN_HASH_LABEL,
-            1 + 2 * HASH_CYCLE_LEN as u32 - 1,
+            lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+        HasherLookup::new(
+            MR_UPDATE_NEW_LABEL,
+            lookup_start_addr + HASH_CYCLE_LEN as u32,
+            ZERO,
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            lookup_start_addr + 2 * HASH_CYCLE_LEN as u32 - 1,
             ZERO,
             HasherLookupContext::Return,
         ),
@@ -373,28 +408,35 @@ fn hasher_update_merkle_root() {
     let path1 = tree.get_path(1, 1).unwrap();
     let new_leaf1 = init_leaf(4);
     let mut lookups = Vec::new();
+
     hasher.update_merkle_root(leaves[1], new_leaf1, &path1, ONE, &mut lookups);
     tree.update_leaf(1, new_leaf1).unwrap();
 
+    let lookup_start_addr = 17;
     let expected_lookups_len = 4;
     // make sure the lookups have correct labels, addresses, indices and contexts.
     let expected_lookups = vec![
-        HasherLookup::new(MR_UPDATE_OLD_LABEL, 17, ONE, HasherLookupContext::Start),
         HasherLookup::new(
-            RETURN_HASH_LABEL,
-            17 + HASH_CYCLE_LEN as u32 - 1,
-            ZERO,
-            HasherLookupContext::Return,
-        ),
-        HasherLookup::new(
-            MR_UPDATE_NEW_LABEL,
-            17 + HASH_CYCLE_LEN as u32,
+            MR_UPDATE_OLD_LABEL,
+            lookup_start_addr,
             ONE,
             HasherLookupContext::Start,
         ),
         HasherLookup::new(
             RETURN_HASH_LABEL,
-            17 + 2 * HASH_CYCLE_LEN as u32 - 1,
+            lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
+        HasherLookup::new(
+            MR_UPDATE_NEW_LABEL,
+            lookup_start_addr + HASH_CYCLE_LEN as u32,
+            ONE,
+            HasherLookupContext::Start,
+        ),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            lookup_start_addr + 2 * HASH_CYCLE_LEN as u32 - 1,
             ZERO,
             HasherLookupContext::Return,
         ),
@@ -453,28 +495,34 @@ fn hasher_update_merkle_root() {
     hasher.update_merkle_root(leaves[3], new_leaf3, &path3, Felt::new(3), &mut lookups);
     tree.update_leaf(3, new_leaf3).unwrap();
 
+    let lookup_start_addr = 1;
     let expected_lookups_len = 4;
     // make sure the lookups have correct labels, addresses, indices and contexts.
     let expected_lookups = vec![
         HasherLookup::new(
             MR_UPDATE_OLD_LABEL,
-            1,
+            lookup_start_addr,
             Felt::new(3),
             HasherLookupContext::Start,
         ),
         HasherLookup::new(
             RETURN_HASH_LABEL,
-            1 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 - 1,
             ZERO,
             HasherLookupContext::Return,
         ),
         HasherLookup::new(
             MR_UPDATE_NEW_LABEL,
-            1 + 3 * HASH_CYCLE_LEN as u32,
+            lookup_start_addr + 3 * HASH_CYCLE_LEN as u32,
             Felt::new(3),
             HasherLookupContext::Start,
         ),
-        HasherLookup::new(RETURN_HASH_LABEL, 48, ZERO, HasherLookupContext::Return),
+        HasherLookup::new(
+            RETURN_HASH_LABEL,
+            lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            ZERO,
+            HasherLookupContext::Return,
+        ),
     ];
     check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
 
@@ -484,30 +532,31 @@ fn hasher_update_merkle_root() {
     hasher.update_merkle_root(leaves[6], new_leaf6, &path6, Felt::new(6), &mut lookups);
     tree.update_leaf(6, new_leaf6).unwrap();
 
+    let lookup_start_addr = 49;
     let expected_lookups_len = 4;
     // make sure the lookups have correct labels, addresses, indices and contexts.
     let expected_lookups = vec![
         HasherLookup::new(
             MR_UPDATE_OLD_LABEL,
-            49,
+            lookup_start_addr,
             Felt::new(6),
             HasherLookupContext::Start,
         ),
         HasherLookup::new(
             RETURN_HASH_LABEL,
-            49 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 - 1,
             ZERO,
             HasherLookupContext::Return,
         ),
         HasherLookup::new(
             MR_UPDATE_NEW_LABEL,
-            49 + 3 * HASH_CYCLE_LEN as u32,
+            lookup_start_addr + 3 * HASH_CYCLE_LEN as u32,
             Felt::new(6),
             HasherLookupContext::Start,
         ),
         HasherLookup::new(
             RETURN_HASH_LABEL,
-            49 + 3 * HASH_CYCLE_LEN as u32 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 + 3 * HASH_CYCLE_LEN as u32 - 1,
             ZERO,
             HasherLookupContext::Return,
         ),
@@ -522,30 +571,31 @@ fn hasher_update_merkle_root() {
     tree.update_leaf(3, new_leaf3_2).unwrap();
     assert_ne!(path3, path3_2);
 
+    let lookup_start_addr = 97;
     let expected_lookups_len = 4;
     // make sure the lookups have correct labels, addresses, indices and contexts.
     let expected_lookups = vec![
         HasherLookup::new(
             MR_UPDATE_OLD_LABEL,
-            97,
+            lookup_start_addr,
             Felt::new(3),
             HasherLookupContext::Start,
         ),
         HasherLookup::new(
             RETURN_HASH_LABEL,
-            97 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 - 1,
             ZERO,
             HasherLookupContext::Return,
         ),
         HasherLookup::new(
             MR_UPDATE_NEW_LABEL,
-            97 + 3 * HASH_CYCLE_LEN as u32,
+            lookup_start_addr + 3 * HASH_CYCLE_LEN as u32,
             Felt::new(3),
             HasherLookupContext::Start,
         ),
         HasherLookup::new(
             RETURN_HASH_LABEL,
-            97 + 3 * HASH_CYCLE_LEN as u32 + 3 * HASH_CYCLE_LEN as u32 - 1,
+            lookup_start_addr + 3 * HASH_CYCLE_LEN as u32 + 3 * HASH_CYCLE_LEN as u32 - 1,
             ZERO,
             HasherLookupContext::Return,
         ),
@@ -640,12 +690,18 @@ fn hash_memoization_control_blocks() {
     // builds the trace of the join block.
     let (_, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
 
+    let lookup_start_addr = 1;
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let lookup_start = HasherLookup::new(
+        LINEAR_HASH_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
     let lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        1 + HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -675,12 +731,18 @@ fn hash_memoization_control_blocks() {
     // builds the hash execution trace of the first split block from scratch.
     let (addr, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
 
+    let lookup_start_addr = 9;
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 9, ZERO, HasherLookupContext::Start);
+    let lookup_start = HasherLookup::new(
+        LINEAR_HASH_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
     let lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        9 + HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -716,12 +778,18 @@ fn hash_memoization_control_blocks() {
     // the first split block.
     let (addr, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
 
+    let lookup_start_addr = 17;
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 17, ZERO, HasherLookupContext::Start);
+    let lookup_start = HasherLookup::new(
+        LINEAR_HASH_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
     let lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        17 + HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -845,12 +913,18 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
     // builds the trace of the Join1 block.
     let (_, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
 
+    let lookup_start_addr = 1;
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 1, ZERO, HasherLookupContext::Start);
+    let lookup_start = HasherLookup::new(
+        LINEAR_HASH_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
     let lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        1 + HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -877,12 +951,18 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
     let mut lookups = Vec::new();
     let (_, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
 
+    let lookup_start_addr = 9;
     let expected_lookups_len = 2;
     // make sure the lookups have correct labels, addresses, indices and contexts.
-    let lookup_start = HasherLookup::new(LINEAR_HASH_LABEL, 9, ZERO, HasherLookupContext::Start);
+    let lookup_start = HasherLookup::new(
+        LINEAR_HASH_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
     let lookup_end = HasherLookup::new(
         RETURN_HASH_LABEL,
-        9 + HASH_CYCLE_LEN as u32 - 1,
+        lookup_start_addr + HASH_CYCLE_LEN as u32 - 1,
         ZERO,
         HasherLookupContext::Return,
     );
@@ -910,47 +990,45 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
         &mut lookups,
     );
 
-    let num_batches = if let CodeBlock::Span(span) = &span1_block {
-        span.op_batches().len()
-    } else {
-        unreachable!()
-    };
+    let num_batches = span1_block_val.op_batches().len();
+    let lookup_start_addr = 17;
 
     let expected_lookups_len = 2 + num_batches - 1;
-    // make sure the lookups have correct labels, addresses, indices and contexts.
-    let expected_lookups = if num_batches == 1 {
-        vec![
-            HasherLookup::new(LINEAR_HASH_LABEL, 17, ZERO, HasherLookupContext::Start),
-            HasherLookup::new(
-                RETURN_HASH_LABEL,
-                17 + HASH_CYCLE_LEN as u32 - 1,
-                ZERO,
-                HasherLookupContext::Return,
-            ),
-        ]
-    } else {
-        vec![
-            HasherLookup::new(LINEAR_HASH_LABEL, 17, ZERO, HasherLookupContext::Start),
-            HasherLookup::new(
-                LINEAR_HASH_LABEL,
-                17 + HASH_CYCLE_LEN as u32 - 1,
-                ZERO,
-                HasherLookupContext::Absorb,
-            ),
-            HasherLookup::new(
-                LINEAR_HASH_LABEL,
-                17 + 2 * HASH_CYCLE_LEN as u32 - 1,
-                ZERO,
-                HasherLookupContext::Absorb,
-            ),
-            HasherLookup::new(
-                RETURN_HASH_LABEL,
-                17 + 3 * HASH_CYCLE_LEN as u32 - 1,
-                ZERO,
-                HasherLookupContext::Return,
-            ),
-        ]
-    };
+
+    let mut expected_lookups = Vec::new();
+
+    // add lookup for start of span block
+    let lookup_start = HasherLookup::new(
+        LINEAR_HASH_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
+    expected_lookups.push(lookup_start);
+
+    // add lookups for absorbed batches
+    for i in 1..num_batches {
+        let lookup = HasherLookup::new(
+            LINEAR_HASH_LABEL,
+            lookup_start_addr + (i * HASH_CYCLE_LEN) as u32 - 1,
+            ZERO,
+            HasherLookupContext::Absorb,
+        );
+        expected_lookups.push(lookup);
+    }
+
+    let last_lookup_addr_memoized_block =
+        lookup_start_addr + (num_batches * HASH_CYCLE_LEN) as u32 - 1;
+
+    // add lookup for end of span block
+    let lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        last_lookup_addr_memoized_block,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    expected_lookups.push(lookup_end);
+
     check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
 
     let first_span_block_final_state = final_state;
@@ -978,49 +1056,42 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
         &mut lookups,
     );
 
-    let num_batches = if let CodeBlock::Span(span) = &span2_block {
-        span.op_batches().len()
-    } else {
-        unreachable!()
-    };
+    let num_batches = span2_block_val.op_batches().len();
+    let lookup_start_addr = last_lookup_addr_memoized_block + 1;
 
     let expected_lookups_len = 2 + num_batches - 1;
-    // make sure the lookups have correct labels, addresses, indices and contexts.
-    let expected_lookups = if num_batches == 1 {
-        vec![
-            HasherLookup::new(LINEAR_HASH_LABEL, 25, ZERO, HasherLookupContext::Start),
-            HasherLookup::new(
-                RETURN_HASH_LABEL,
-                25 + HASH_CYCLE_LEN as u32 - 1,
-                ZERO,
-                HasherLookupContext::Return,
-            ),
-        ]
-    } else {
-        // the start row is 41 here instead of 25 since the hash execution trace of the last
-        // (memoized) span block ends at row 40 in case of span with multiple batches.
-        vec![
-            HasherLookup::new(LINEAR_HASH_LABEL, 41, ZERO, HasherLookupContext::Start),
-            HasherLookup::new(
-                LINEAR_HASH_LABEL,
-                41 + HASH_CYCLE_LEN as u32 - 1,
-                ZERO,
-                HasherLookupContext::Absorb,
-            ),
-            HasherLookup::new(
-                LINEAR_HASH_LABEL,
-                41 + 2 * HASH_CYCLE_LEN as u32 - 1,
-                ZERO,
-                HasherLookupContext::Absorb,
-            ),
-            HasherLookup::new(
-                RETURN_HASH_LABEL,
-                41 + 3 * HASH_CYCLE_LEN as u32 - 1,
-                ZERO,
-                HasherLookupContext::Return,
-            ),
-        ]
-    };
+
+    let mut expected_lookups = Vec::new();
+
+    // add lookup for start of span block
+    let lookup_start = HasherLookup::new(
+        LINEAR_HASH_LABEL,
+        lookup_start_addr,
+        ZERO,
+        HasherLookupContext::Start,
+    );
+    expected_lookups.push(lookup_start);
+
+    // add lookups for absorbed batches
+    for i in 1..num_batches {
+        let lookup = HasherLookup::new(
+            LINEAR_HASH_LABEL,
+            lookup_start_addr + (i * HASH_CYCLE_LEN) as u32 - 1,
+            ZERO,
+            HasherLookupContext::Absorb,
+        );
+        expected_lookups.push(lookup);
+    }
+
+    // add lookup for end of span block
+    let lookup_end = HasherLookup::new(
+        RETURN_HASH_LABEL,
+        lookup_start_addr + (num_batches * HASH_CYCLE_LEN) as u32 - 1,
+        ZERO,
+        HasherLookupContext::Return,
+    );
+    expected_lookups.push(lookup_end);
+
     check_lookups_validity(lookups, expected_lookups_len, expected_lookups);
 
     let expected_hash = span2_block.hash();


### PR DESCRIPTION
## Describe your changes
Partly addressing #360.
Removes `lookups` from the `Hasher` struct and refactors sending responses to the Chiplet Bus so that the responses are provided to the bus at the same time as the requests.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.