### PR TITLE
docs(assembly): change examples for while, assertz

### DIFF
--- a/docs/src/user_docs/assembly/field_operations.md
+++ b/docs/src/user_docs/assembly/field_operations.md
@@ -10,7 +10,7 @@ For instructions where one or more operands can be provided as immediate paramet
 | Instruction      | Stack_input | Stack_output  | Notes                         |
 | ---------------- | ----------- | ------------- | ----------------------------- |
 | assert  <br> - *(1 cycle)*          | [a, ...]    | [...]         | If $a = 1$, removes it from the stack. <br> Fails if $a \ne 1$ |
-| assertz <br> - *(2 cycles)*       | [ a, ...] | [...]              | if $a = 0$, removes it from the stack, <br> Fails if $a \ne b$ |
+| assertz <br> - *(2 cycles)*       | [ a, ...] | [...]              | if $a = 0$, removes it from the stack, <br> Fails if $a \ne 0$ |
 | assert_eq <br> - *(2 cycles)*        | [b, a, ...] | [...]         | If $a = b$, removes them from the stack. <br> Fails if $a \ne b$ |
 
 

--- a/docs/src/user_docs/assembly/flow_control.md
+++ b/docs/src/user_docs/assembly/flow_control.md
@@ -51,3 +51,16 @@ where `instructions` can be a sequence of any instructions, including nested con
     c. If the popped value is not binary, the execution fails.
 3. If the value of the item is $0$, execution of loop body is skipped.
 4. If the value is not binary, the execution fails.
+
+Example:
+
+```
+# push the boolean true to the stack
+push.1
+
+# pop the top element of the stack and loop while it is true
+while.true
+    # push the boolean false to the stack, finishing the loop for the next iteration
+    push.0
+end
+```


### PR DESCRIPTION
## Describe your changes

This commit updates the documentation for `while` and `assertz` of the assembly documentation.

An example was added for `while` to clarify its expectation of having a boolean on top of the stack, instead of using a constant `true` as argument.

The `assertz` directive was updated from a nit that suggested there was a `b` to be evaluated, when in fact it is a constant `0`.

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [ ] Tests added for new functionality. (N/A; docs upd only)
- [x] Documentation/comments updated according to changes.