### PR TITLE
chore(ci): add release to tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,11 @@ jobs:
           override: true
       - name: Test
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -C debug-assertions
         with:
           command: test
+          args: --release
 
   clippy:
     name: Clippy

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -100,3 +100,16 @@ pub fn new_array_vec<T: Debug, const N: usize>(capacity: usize) -> [Vec<T>; N] {
         .try_into()
         .expect("failed to convert vector to array")
 }
+
+#[test]
+#[should_panic]
+fn debug_assert_is_checked() {
+    // enforce the release checks to always have `RUSTFLAGS="-C debug-assertions".
+    //
+    // some upstream tests are performed with `debug_assert`, and we want to assert its correctness
+    // downstream.
+    //
+    // for reference, check
+    // https://github.com/maticnetwork/miden/issues/433
+    debug_assert!(false);
+}


### PR DESCRIPTION
## Describe your changes

This commit introduces the --release flag for the tests. It will sacrifice some build time to greatly improve the tests execution.

One concern to add `release` is that `debug_assert` checks will no longer be performed. These are used in `miden` and upstream dependencies. To fix that, the `debug-assertions` compiler flag was added so these assertions will be executed.

To ensure the CI always executes the debug assertions, a test `debug_assert_is_checked_in_ci` was added. It will expect a panic and will fail by default, unless the `CI` environment variable is set. If it is set, then it will panic only if `debug_assert` is evaluated.

The CI variable is always set to `true` in github CI environments. For more info:
https://docs.github.com/en/actions/learn-github-actions/environment-variables

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.