### PR TITLE
Implement Kernel ROM

### DIFF
--- a/core/src/chiplets/bitwise.rs
+++ b/core/src/chiplets/bitwise.rs
@@ -6,7 +6,7 @@ use super::{create_range, Felt, Range, ONE, ZERO};
 /// Number of selector columns in the trace.
 pub const NUM_SELECTORS: usize = 1;
 
-/// Number of columns needed to record an execution trace of the bitwise helper.
+/// Number of columns needed to record an execution trace of the bitwise chiplet.
 pub const TRACE_WIDTH: usize = NUM_SELECTORS + 12;
 
 /// The number of rows required to compute an operation in the Bitwise chiplet.

--- a/core/src/chiplets/kernel_rom.rs
+++ b/core/src/chiplets/kernel_rom.rs
@@ -1,0 +1,5 @@
+// CONSTANTS
+// ================================================================================================
+
+/// Number of columns needed to record an execution trace of the kernel ROM chiplet.
+pub const TRACE_WIDTH: usize = 6;

--- a/core/src/chiplets/memory.rs
+++ b/core/src/chiplets/memory.rs
@@ -3,6 +3,9 @@ use super::{create_range, Felt, Range, ONE, ZERO};
 // CONSTANTS
 // ================================================================================================
 
+/// Number of columns needed to record an execution trace of the memory chiplet.
+pub const TRACE_WIDTH: usize = 12;
+
 /// Number of selector columns in the trace.
 pub const NUM_SELECTORS: usize = 2;
 

--- a/core/src/chiplets/mod.rs
+++ b/core/src/chiplets/mod.rs
@@ -17,6 +17,8 @@ pub const NUM_HASHER_SELECTORS: usize = 1;
 pub const NUM_BITWISE_SELECTORS: usize = 2;
 /// The number of columns in the chiplets which are used as selectors for the memory chiplet.
 pub const NUM_MEMORY_SELECTORS: usize = 3;
+/// The number of columns in the chiplets which are used as selectors for the kernel ROM chiplet.
+pub const NUM_KERNEL_ROM_SELECTORS: usize = 4;
 
 /// The first column of the hash chiplet.
 pub const HASHER_TRACE_OFFSET: usize = CHIPLETS_OFFSET + NUM_HASHER_SELECTORS;

--- a/core/src/chiplets/mod.rs
+++ b/core/src/chiplets/mod.rs
@@ -5,6 +5,7 @@ use core::ops::Range;
 
 pub mod bitwise;
 pub mod hasher;
+pub mod kernel_rom;
 pub mod memory;
 
 // CONSTANTS

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -89,9 +89,6 @@ pub const CHIPLETS_OFFSET: usize = RANGE_CHECK_TRACE_RANGE.end;
 pub const CHIPLETS_WIDTH: usize = 18;
 pub const CHIPLETS_RANGE: Range<usize> = range(CHIPLETS_OFFSET, CHIPLETS_WIDTH);
 
-// Chiplets components
-pub const MEMORY_TRACE_WIDTH: usize = 12;
-
 pub const TRACE_WIDTH: usize = CHIPLETS_OFFSET + CHIPLETS_WIDTH;
 
 // AUXILIARY COLUMNS LAYOUT

--- a/core/src/program/mod.rs
+++ b/core/src/program/mod.rs
@@ -146,7 +146,7 @@ impl Kernel {
     }
 
     /// Returns a list of procedure hashes contained in this kernel.
-    pub fn get_proc_hashes(&self) -> &[Digest] {
+    pub fn proc_hashes(&self) -> &[Digest] {
         &self.0
     }
 }

--- a/miden/tests/integration/helpers/mod.rs
+++ b/miden/tests/integration/helpers/mod.rs
@@ -102,10 +102,11 @@ impl Test {
         mem_addr: u64,
         expected_mem: &[u64],
     ) {
-        let mut process = Process::new(self.inputs.clone());
+        // compile the program
+        let program = self.compile();
 
         // execute the test
-        let program = self.compile();
+        let mut process = Process::new(program.kernel(), self.inputs.clone());
         process.execute(&program).unwrap();
 
         // validate the memory state

--- a/processor/src/chiplets/kernel_rom/mod.rs
+++ b/processor/src/chiplets/kernel_rom/mod.rs
@@ -1,0 +1,134 @@
+use super::{BTreeMap, Digest, ExecutionError, Felt, Kernel, TraceFragment, Word, ONE, ZERO};
+
+// KERNEL ROM
+// ================================================================================================
+
+/// Kernel ROM chiplet for the VM.
+///
+/// This component is responsible for validating that kernel calls requested by the executing
+/// program are made against procedures which are contained within the specified kernel. It also
+/// tacks all calls to kernel procedures and this info is used to construct an execution trace of
+/// all kernel accesses.
+///
+/// # Execution trace
+/// The layout of the execution trace of kernel procedure accesses is shown below:
+///
+///   s0   idx   h0   h1   h2   h3
+/// ├────┴─────┴────┴────┴────┴────┤
+///
+/// In the above, the meaning of columns is as follows:
+/// - `s0` is a selector column which indicates whether a procedure in a given row should count
+///   toward kernel access. ONE indicates that a procedure should be counted as a single access,
+///   and ZERO indicates that it shouldn't.
+/// - `idx` is a procedure index in the kernel. Values in this column start at ZERO and are
+///   incremented by ONE for every new procedure. Said another way, if `idx` does not change,
+///   values in `h0` - `h3` must remain the same, but when `idx` is incremented values in `h0` -
+///   `h3` can change.
+/// - `h0` - `h3` columns contain roots of procedures in a given kernel. Together with `idx`
+///   column, these form tuples (index, procedure root) for all procedures in the kernel.
+pub struct KernelRom {
+    access_map: BTreeMap<[u8; 32], ProcAccessInfo>,
+    trace_len: usize,
+}
+
+impl KernelRom {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new [KernelRom] instantiated from the specified Kernel.
+    ///
+    /// The kernel ROM is populated with all procedures from the provided kernel. For each
+    /// procedure access count is set to 0.
+    pub fn new(kernel: &Kernel) -> Self {
+        let mut access_map = BTreeMap::new();
+        for &proc_hash in kernel.proc_hashes() {
+            access_map.insert(proc_hash.into(), ProcAccessInfo::new(proc_hash));
+        }
+
+        Self {
+            access_map,
+            trace_len: kernel.proc_hashes().len(),
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns length of execution trace required to describe kernel ROM.
+    pub fn trace_len(&self) -> usize {
+        self.trace_len
+    }
+
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Marks the specified procedure as accessed from the program.
+    ///
+    /// # Errors
+    /// If the specified procedure does not exist in this kernel ROM, and error is returned.
+    pub fn access_proc(&mut self, proc_hash: Digest) -> Result<(), ExecutionError> {
+        let proc_hash_bytes: [u8; 32] = proc_hash.into();
+        let access_info = self
+            .access_map
+            .get_mut(&proc_hash_bytes)
+            .ok_or(ExecutionError::SyscallTargetNotInKernel(proc_hash))?;
+        // when access count is going from 0 to 1 we don't increment trace length as both 0 and 1
+        // accesses require a single row in the trace
+        if access_info.num_accesses > 0 {
+            self.trace_len += 1;
+        }
+        access_info.num_accesses += 1;
+        Ok(())
+    }
+
+    // EXECUTION TRACE GENERATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Populates the provided execution trace fragment with execution trace of this kernel ROM.
+    pub fn fill_trace(self, trace: &mut TraceFragment) {
+        let mut row = 0;
+        for (idx, access_info) in self.access_map.values().enumerate() {
+            let idx = Felt::from(idx as u16);
+
+            // write at least one row into the trace for each kernel procedure
+            access_info.write_into_trace(trace, row, idx);
+            row += 1;
+
+            // if the procedure was accessed more than once, we need write a row per additional
+            // access
+            for _ in 1..access_info.num_accesses {
+                access_info.write_into_trace(trace, row, idx);
+                row += 1;
+            }
+        }
+    }
+}
+
+// PROCEDURE ACCESS INFO
+// ================================================================================================
+
+/// Procedure access information for a given kernel procedure.
+struct ProcAccessInfo {
+    proc_hash: Word,
+    num_accesses: usize,
+}
+
+impl ProcAccessInfo {
+    /// Returns a new [ProcAccessInfo] for the specified procedure with `num_accesses` set to 0.
+    pub fn new(proc_hash: Digest) -> Self {
+        Self {
+            proc_hash: proc_hash.into(),
+            num_accesses: 0,
+        }
+    }
+
+    /// Writes a single row into the provided trace fragment for this procedure access entry.
+    pub fn write_into_trace(&self, trace: &mut TraceFragment, row: usize, idx: Felt) {
+        let s0 = if self.num_accesses == 0 { ZERO } else { ONE };
+        trace.set(row, 0, s0);
+        trace.set(row, 1, idx);
+        trace.set(row, 2, self.proc_hash[0]);
+        trace.set(row, 3, self.proc_hash[1]);
+        trace.set(row, 4, self.proc_hash[2]);
+        trace.set(row, 5, self.proc_hash[3]);
+    }
+}

--- a/processor/src/chiplets/kernel_rom/tests.rs
+++ b/processor/src/chiplets/kernel_rom/tests.rs
@@ -1,0 +1,120 @@
+use super::{Felt, Kernel, KernelRom, TraceFragment, Word, ONE, TRACE_WIDTH, ZERO};
+
+// CONSTANTS
+// ================================================================================================
+
+const PROC1_HASH: Word = [ONE, ZERO, ONE, ZERO];
+const PROC2_HASH: Word = [ONE, ONE, ONE, ONE];
+
+// TESTS
+// ================================================================================================
+
+#[test]
+fn kernel_rom_empty() {
+    let kernel = Kernel::default();
+    let rom = KernelRom::new(&kernel);
+    assert_eq!(0, rom.trace_len());
+}
+
+#[test]
+fn kernel_rom_invalid_access() {
+    let kernel = build_kernel();
+    let mut rom = KernelRom::new(&kernel);
+
+    // accessing procedure which is in the kernel should be fine
+    assert!(rom.access_proc(PROC1_HASH.into()).is_ok());
+
+    // accessing procedure which is not in the kernel should return an error
+    assert!(rom.access_proc([ZERO, ONE, ZERO, ONE].into()).is_err());
+}
+
+#[test]
+fn kernel_rom_no_access() {
+    let kernel = build_kernel();
+    let rom = KernelRom::new(&kernel);
+
+    let expected_trace_len = 2;
+    assert_eq!(expected_trace_len, rom.trace_len());
+
+    // generate trace
+    let trace = build_trace(rom, expected_trace_len);
+
+    // first row of the trace should correspond to the first procedure
+    let row = 0;
+
+    assert_eq!(trace[0][row], ZERO); // s0
+    assert_eq!(trace[1][row], ZERO); // idx
+    assert_eq!(trace[2][row], PROC1_HASH[0]);
+    assert_eq!(trace[3][row], PROC1_HASH[1]);
+    assert_eq!(trace[4][row], PROC1_HASH[2]);
+    assert_eq!(trace[5][row], PROC1_HASH[3]);
+
+    // second row of the trace should correspond to the second procedure
+    let row = 1;
+
+    assert_eq!(trace[0][row], ZERO); // s0
+    assert_eq!(trace[1][row], ONE); // idx
+    assert_eq!(trace[2][row], PROC2_HASH[0]);
+    assert_eq!(trace[3][row], PROC2_HASH[1]);
+    assert_eq!(trace[4][row], PROC2_HASH[2]);
+    assert_eq!(trace[5][row], PROC2_HASH[3]);
+}
+
+#[test]
+fn kernel_rom_with_access() {
+    let kernel = build_kernel();
+    let mut rom = KernelRom::new(&kernel);
+
+    // generate 5 access: 3 for proc1 and 2 for proc2
+    rom.access_proc(PROC1_HASH.into()).unwrap();
+    rom.access_proc(PROC2_HASH.into()).unwrap();
+    rom.access_proc(PROC1_HASH.into()).unwrap();
+    rom.access_proc(PROC1_HASH.into()).unwrap();
+    rom.access_proc(PROC2_HASH.into()).unwrap();
+
+    let expected_trace_len = 5;
+    assert_eq!(expected_trace_len, rom.trace_len());
+
+    // generate trace
+    let trace = build_trace(rom, expected_trace_len);
+
+    // first 3 rows of the trace should correspond to the first procedure
+    for row in 0..3 {
+        assert_eq!(trace[0][row], ONE); // s0
+        assert_eq!(trace[1][row], ZERO); // idx
+        assert_eq!(trace[2][row], PROC1_HASH[0]);
+        assert_eq!(trace[3][row], PROC1_HASH[1]);
+        assert_eq!(trace[4][row], PROC1_HASH[2]);
+        assert_eq!(trace[5][row], PROC1_HASH[3]);
+    }
+
+    // the remaining 2 rows of the trace should correspond to the second procedure
+    for row in 3..5 {
+        assert_eq!(trace[0][row], ONE); // s0
+        assert_eq!(trace[1][row], ONE); // idx
+        assert_eq!(trace[2][row], PROC2_HASH[0]);
+        assert_eq!(trace[3][row], PROC2_HASH[1]);
+        assert_eq!(trace[4][row], PROC2_HASH[2]);
+        assert_eq!(trace[5][row], PROC2_HASH[3]);
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Creates a kernel with two dummy procedures
+fn build_kernel() -> Kernel {
+    Kernel::new(&[PROC1_HASH.into(), PROC2_HASH.into()])
+}
+
+/// Builds a trace of the specified length and fills it with data from the provided KernelRom
+/// instance.
+fn build_trace(kernel_rom: KernelRom, num_rows: usize) -> Vec<Vec<Felt>> {
+    let mut trace = (0..TRACE_WIDTH)
+        .map(|_| vec![ZERO; num_rows])
+        .collect::<Vec<_>>();
+    let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
+    kernel_rom.fill_trace(&mut fragment);
+
+    trace
+}

--- a/processor/src/chiplets/memory/tests.rs
+++ b/processor/src/chiplets/memory/tests.rs
@@ -3,12 +3,9 @@ use super::{
     ChipletsBus, Felt, FieldElement, Memory, MemoryLookup, StarkField, TraceFragment, ADDR_COL_IDX,
     CLK_COL_IDX, CTX_COL_IDX, D0_COL_IDX, D1_COL_IDX, D_INV_COL_IDX, ONE, V_COL_RANGE, ZERO,
 };
-use vm_core::{
-    chiplets::memory::{
-        Selectors, MEMORY_COPY_READ, MEMORY_INIT_READ, MEMORY_READ_LABEL, MEMORY_WRITE,
-        MEMORY_WRITE_LABEL,
-    },
-    MEMORY_TRACE_WIDTH,
+use vm_core::chiplets::memory::{
+    Selectors, MEMORY_COPY_READ, MEMORY_INIT_READ, MEMORY_READ_LABEL, MEMORY_WRITE,
+    MEMORY_WRITE_LABEL, TRACE_WIDTH as MEMORY_TRACE_WIDTH,
 };
 
 #[test]

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -61,7 +61,7 @@ mod tests;
 /// - columns 3-14: execution trace of memory chiplet
 /// - columns 15-17: unused column padded with ZERO
 ///
-/// /// * Kernel ROM segment: contains the trace and selectors for the kernel ROM chiplet *
+/// * Kernel ROM segment: contains the trace and selectors for the kernel ROM chiplet *
 /// This segment begins at the end of the memory segment and fills the next rows of the trace for
 /// the `trace_len` of the kernel ROM chiplet.
 /// - column 0-2: selector columns with values set to ONE
@@ -88,6 +88,7 @@ pub struct Chiplets {
 impl Chiplets {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
+    /// Returns a new [Chiplets] component instantiated with the provided Kernel.
     pub fn new(kernel: &Kernel) -> Self {
         Self {
             clk: 0,
@@ -109,8 +110,8 @@ impl Chiplets {
         self.hasher.trace_len()
             + self.bitwise.trace_len()
             + self.memory.trace_len()
-            + 1
             + self.kernel_rom.trace_len()
+            + 1
     }
 
     /// Returns the index of the first row of [Bitwise] execution trace.
@@ -394,6 +395,8 @@ impl Chiplets {
     /// with which the kernel ROM was instantiated.
     pub fn access_kernel_proc(&mut self, proc_hash: Digest) -> Result<(), ExecutionError> {
         self.kernel_rom.access_proc(proc_hash)
+
+        // TODO: record the access in the chiplet bus
     }
 
     // CONTEXT MANAGEMENT
@@ -482,8 +485,8 @@ impl Chiplets {
         let mut memory_fragment = TraceFragment::new(CHIPLETS_WIDTH);
         let mut kernel_rom_fragment = TraceFragment::new(CHIPLETS_WIDTH);
 
-        // and add the hasher, bitwise, memory, and kernel ROM segments to their respective
-        // fragments so they can be filled with the chiplet traces
+        // add the hasher, bitwise, memory, and kernel ROM segments to their respective fragments
+        // so they can be filled with the chiplet traces
         for (column_num, column) in trace.iter_mut().enumerate().skip(1) {
             match column_num {
                 1 | 15..=17 => {

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -3,7 +3,6 @@ use super::{
     Word, CHIPLETS_WIDTH, ONE, ZERO,
 };
 use crate::{trace::LookupTableRow, ExecutionError};
-
 use vm_core::{
     chiplets::bitwise::{BITWISE_AND_LABEL, BITWISE_XOR_LABEL},
     chiplets::{
@@ -11,6 +10,7 @@ use vm_core::{
         memory::{MEMORY_READ_LABEL, MEMORY_WRITE_LABEL},
     },
     code_blocks::OpBatch,
+    Kernel,
 };
 
 mod bitwise;
@@ -23,19 +23,23 @@ pub use hasher::{AuxTraceBuilder as HasherAuxTraceBuilder, SiblingTableRow};
 mod memory;
 use memory::{Memory, MemoryLookup};
 
+mod kernel_rom;
+use kernel_rom::KernelRom;
+
 mod bus;
 pub use bus::{AuxTraceBuilder, ChipletsBus};
 
 #[cfg(test)]
 mod tests;
 
-// CHIPLETS MODULE OF HASHER, BITWISE, AND MEMORY CHIPLETS
+// CHIPLETS MODULE OF HASHER, BITWISE, MEMORY, AND KERNEL ROM CHIPLETS
 // ================================================================================================
 
-/// This module manages the VM's hasher, bitwise, and memory chiplets and is responsible for
-/// building a final execution trace from their stacked execution traces and chiplet selectors.
+/// This module manages the VM's hasher, bitwise, memory, and kernel ROM chiplets and is
+/// responsible for building a final execution trace from their stacked execution traces and
+/// chiplet selectors.
 ///
-/// The module's trace can be thought of as 4 stacked chiplet segments in the following form:
+/// The module's trace can be thought of as 5 stacked chiplet segments in the following form:
 /// * Hasher segment: contains the trace and selector for the hasher chiplet *
 /// This segment fills the first rows of the trace up to the length of the hasher `trace_len`.
 /// - column 0: selector column with values set to ZERO
@@ -46,35 +50,55 @@ mod tests;
 /// the `trace_len` of the bitwise chiplet.
 /// - column 0: selector column with values set to ONE
 /// - column 1: selector column with values set to ZERO
-/// - columns 2-15: execution trace of bitwise chiplet
-/// - column 16-17: unused columns padded with ZERO
+/// - columns 2-14: execution trace of bitwise chiplet
+/// - columns 15-17: unused columns padded with ZERO
 ///
 /// * Memory segment: contains the trace and selectors for the memory chiplet *
 /// This segment begins at the end of the bitwise segment and fills the next rows of the trace for
 /// the `trace_len` of the memory chiplet.
 /// - column 0-1: selector columns with values set to ONE
 /// - column 2: selector column with values set to ZERO
-/// - columns 3-16: execution trace of memory chiplet
-/// - column 17: unused column padded with ZERO
+/// - columns 3-14: execution trace of memory chiplet
+/// - columns 15-17: unused column padded with ZERO
+///
+/// /// * Kernel ROM segment: contains the trace and selectors for the kernel ROM chiplet *
+/// This segment begins at the end of the memory segment and fills the next rows of the trace for
+/// the `trace_len` of the kernel ROM chiplet.
+/// - column 0-2: selector columns with values set to ONE
+/// - column 3: selector column with values set to ZERO
+/// - columns 4-9: execution trace of kernel ROM chiplet
+/// - columns 10-17: unused column padded with ZERO
 ///
 /// * Padding segment: unused *
-/// This segment begins at the end of the memory segment and fills the rest of the execution trace
-/// minus the number of random rows. When it finishes, the execution trace should have exactly
-/// enough rows remaining for the specified number of random rows.
-/// - columns 0-2: selector columns with values set to ONE
+/// This segment begins at the end of the kernel ROM segment and fills the rest of the execution
+/// trace minus the number of random rows. When it finishes, the execution trace should have
+/// exactly enough rows remaining for the specified number of random rows.
+/// - columns 0-3: selector columns with values set to ONE
 /// - columns 3-17: unused columns padded with ZERO
-///
-#[derive(Default)]
 pub struct Chiplets {
     /// Current clock cycle of the VM.
     clk: u32,
     hasher: Hasher,
     bitwise: Bitwise,
     memory: Memory,
+    kernel_rom: KernelRom,
     bus: ChipletsBus,
 }
 
 impl Chiplets {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    pub fn new(kernel: &Kernel) -> Self {
+        Self {
+            clk: 0,
+            hasher: Hasher::default(),
+            bitwise: Bitwise::default(),
+            memory: Memory::default(),
+            kernel_rom: KernelRom::new(kernel),
+            bus: ChipletsBus::default(),
+        }
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
@@ -82,12 +106,31 @@ impl Chiplets {
     /// mandatory padding row required for ensuring sufficient trace length for auxiliary connector
     /// columns that rely on the memory chiplet.
     pub fn trace_len(&self) -> usize {
-        self.hasher.trace_len() + self.bitwise.trace_len() + self.memory.trace_len() + 1
+        self.hasher.trace_len()
+            + self.bitwise.trace_len()
+            + self.memory.trace_len()
+            + 1
+            + self.kernel_rom.trace_len()
+    }
+
+    /// Returns the index of the first row of [Bitwise] execution trace.
+    pub fn bitwise_start(&self) -> usize {
+        self.hasher.trace_len()
     }
 
     /// Returns the index of the first row of the [Memory] execution trace.
     pub fn memory_start(&self) -> usize {
-        self.hasher.trace_len() + self.bitwise.trace_len()
+        self.bitwise_start() + self.bitwise.trace_len()
+    }
+
+    /// Returns the index of the first row of [KernelRom] execution trace.
+    pub fn kernel_rom_start(&self) -> usize {
+        self.memory_start() + self.memory.trace_len()
+    }
+
+    /// Returns the index of the first row of the padding section of the execution trace.
+    pub fn padding_start(&self) -> usize {
+        self.kernel_rom_start() + self.kernel_rom.trace_len()
     }
 
     // HASH CHIPLET ACCESSORS FOR OPERATIONS
@@ -341,6 +384,18 @@ impl Chiplets {
         self.memory.size()
     }
 
+    // KERNEL ROM ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Increments access counter for the specified kernel procedure.
+    ///
+    /// # Errors
+    /// Returns an error if the procedure with the specified hash does not exist in the kernel
+    /// with which the kernel ROM was instantiated.
+    pub fn access_kernel_proc(&mut self, proc_hash: Digest) -> Result<(), ExecutionError> {
+        self.kernel_rom.access_proc(proc_hash)
+    }
+
     // CONTEXT MANAGEMENT
     // --------------------------------------------------------------------------------------------
 
@@ -372,16 +427,13 @@ impl Chiplets {
         );
 
         // Allocate columns for the trace of the chiplets.
-        // note: it may be possible to optimize this by initializing with Felt::zeroed_vector,
-        // depending on how the compiler reduces Felt(0) and whether initializing here + iterating
-        // to update selector values is faster than using resize to initialize all values
         let mut trace = (0..CHIPLETS_WIDTH)
-            .map(|_| Vec::<Felt>::with_capacity(trace_len))
+            .map(|_| Felt::zeroed_vector(trace_len))
             .collect::<Vec<_>>()
             .try_into()
             .expect("failed to convert vector to array");
 
-        let (hasher_aux_builder, aux_builder) = self.fill_trace(&mut trace, trace_len);
+        let (hasher_aux_builder, aux_builder) = self.fill_trace(&mut trace);
 
         ChipletsTrace {
             trace,
@@ -397,91 +449,66 @@ impl Chiplets {
     /// Hasher, Bitwise, and Memory chiplets, along with selector columns to identify each chiplet
     /// trace and padding to fill the rest of the trace.
     ///
-    /// It returns the auxiilary trace builders for generating auxiliary trace columns that depend
+    /// It returns the auxiliary trace builders for generating auxiliary trace columns that depend
     /// on data from [Chiplets].
     fn fill_trace(
         self,
         trace: &mut [Vec<Felt>; CHIPLETS_WIDTH],
-        trace_len: usize,
     ) -> (HasherAuxTraceBuilder, AuxTraceBuilder) {
         // get the rows where chiplets begin.
-        let bitwise_start = self.hasher.trace_len();
+        let bitwise_start = self.bitwise_start();
         let memory_start = self.memory_start();
+        let kernel_rom_start = self.kernel_rom_start();
+        let padding_start = self.padding_start();
+
         let Chiplets {
             clk: _,
             hasher,
             bitwise,
             memory,
+            kernel_rom,
             mut bus,
         } = self;
+
+        // populate external selector columns for all chiplets
+        trace[0][bitwise_start..].fill(ONE);
+        trace[1][memory_start..].fill(ONE);
+        trace[2][kernel_rom_start..].fill(ONE);
+        trace[3][padding_start..].fill(ONE);
 
         // allocate fragments to be filled with the respective execution traces of each chiplet
         let mut hasher_fragment = TraceFragment::new(CHIPLETS_WIDTH);
         let mut bitwise_fragment = TraceFragment::new(CHIPLETS_WIDTH);
         let mut memory_fragment = TraceFragment::new(CHIPLETS_WIDTH);
+        let mut kernel_rom_fragment = TraceFragment::new(CHIPLETS_WIDTH);
 
-        // set the selectors and padding as required by each column and segment
-        // and add the hasher, bitwise, and memory segments to their respective fragments
-        // so they can be filled with the chiplet traces
-        for (column_num, column) in trace.iter_mut().enumerate() {
+        // and add the hasher, bitwise, memory, and kernel ROM segments to their respective
+        // fragments so they can be filled with the chiplet traces
+        for (column_num, column) in trace.iter_mut().enumerate().skip(1) {
             match column_num {
-                0 => {
-                    // set the selector value for the hasher segment to ZERO
-                    column.resize(hasher.trace_len(), Felt::ZERO);
-                    // set the selector value for all other segments ONE
-                    column.resize(trace_len, Felt::ONE);
-                }
-                1 => {
-                    // initialize hasher segment and set bitwise segment selector value to ZERO
-                    column.resize(hasher.trace_len() + bitwise.trace_len(), Felt::ZERO);
-                    // set selector value for all other segments to ONE
-                    column.resize(trace_len, Felt::ONE);
-                    // add hasher segment to the hasher fragment to be filled from the hasher trace
+                1 | 15..=17 => {
+                    // columns 1 and 15 - 17 are relevant only for the hasher
                     hasher_fragment.push_column_slice(column, hasher.trace_len());
                 }
                 2 => {
-                    // initialize hasher and bitwise segments and set memory segment selector to ZERO
-                    column.resize(
-                        hasher.trace_len() + bitwise.trace_len() + memory.trace_len(),
-                        Felt::ZERO,
-                    );
-                    // set selector value for the final segment to ONE
-                    column.resize(trace_len, Felt::ONE);
-                    // add hasher segment to the hasher fragment to be filled from the hasher trace
-                    let rest_of_column =
-                        hasher_fragment.push_column_slice(column, hasher.trace_len());
-                    // add bitwise segment to the bitwise fragment to be filled from the bitwise trace
-                    bitwise_fragment.push_column_slice(rest_of_column, bitwise.trace_len());
+                    // column 2 is relevant to the hasher and to bitwise chiplet
+                    let rest = hasher_fragment.push_column_slice(column, hasher.trace_len());
+                    bitwise_fragment.push_column_slice(rest, bitwise.trace_len());
                 }
-                15 | 16 => {
-                    // initialize hasher & memory segments and bitwise, padding segments with ZERO
-                    column.resize(trace_len, Felt::ZERO);
-                    // add hasher segment to the hasher fragment to be filled from the hasher trace
-                    let rest_of_column =
-                        hasher_fragment.push_column_slice(column, hasher.trace_len());
-                    // split the column to skip bitwise which have already been padded.
-                    let (_, rest_of_column) = rest_of_column.split_at_mut(bitwise.trace_len());
-                    // add memory segment to the memory fragment to be filled from the memory trace
-                    memory_fragment.push_column_slice(rest_of_column, memory.trace_len());
+                3 | 10..=14 => {
+                    // columns 3 and 10 - 14 are relevant for hasher, bitwise, and memory chiplets
+                    let rest = hasher_fragment.push_column_slice(column, hasher.trace_len());
+                    let rest = bitwise_fragment.push_column_slice(rest, bitwise.trace_len());
+                    memory_fragment.push_column_slice(rest, memory.trace_len());
                 }
-                17 => {
-                    // initialize hasher segment and pad bitwise, memory, padding segments with ZERO
-                    column.resize(trace_len, Felt::ZERO);
-                    // add hasher segment to the hasher fragment to be filled from the hasher trace
-                    hasher_fragment.push_column_slice(column, hasher.trace_len());
+                4..=9 => {
+                    // columns 4 - 9 are relevant to all chiplets
+                    let rest = hasher_fragment.push_column_slice(column, hasher.trace_len());
+                    let rest = bitwise_fragment.push_column_slice(rest, bitwise.trace_len());
+                    let rest = memory_fragment.push_column_slice(rest, memory.trace_len());
+                    kernel_rom_fragment.push_column_slice(rest, kernel_rom.trace_len());
                 }
-                _ => {
-                    // initialize hasher, bitwise, memory segments and pad the rest with ZERO
-                    column.resize(trace_len, Felt::ZERO);
-                    // add hasher segment to the hasher fragment to be filled from the hasher trace
-                    let rest_of_column =
-                        hasher_fragment.push_column_slice(column, hasher.trace_len());
-                    // add bitwise segment to the bitwise fragment to be filled from the bitwise trace
-                    let rest_of_column =
-                        bitwise_fragment.push_column_slice(rest_of_column, bitwise.trace_len());
-                    // add memory segment to the memory fragment to be filled from the memory trace
-                    memory_fragment.push_column_slice(rest_of_column, memory.trace_len());
-                }
+                _ => panic!("invalid column index"),
             }
         }
 
@@ -490,6 +517,7 @@ impl Chiplets {
         let hasher_aux_builder = hasher.fill_trace(&mut hasher_fragment);
         bitwise.fill_trace(&mut bitwise_fragment, &mut bus, bitwise_start);
         memory.fill_trace(&mut memory_fragment, &mut bus, memory_start);
+        kernel_rom.fill_trace(&mut kernel_rom_fragment);
 
         (hasher_aux_builder, bus.into_aux_builder())
     }

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -5,6 +5,7 @@ use vm_core::{
         hasher::{Digest, HASH_CYCLE_LEN, LINEAR_HASH, RETURN_STATE},
         kernel_rom::TRACE_WIDTH as KERNEL_ROM_TRACE_WIDTH,
         memory::TRACE_WIDTH as MEMORY_TRACE_WIDTH,
+        NUM_BITWISE_SELECTORS, NUM_KERNEL_ROM_SELECTORS, NUM_MEMORY_SELECTORS,
     },
     CodeBlockTable, Felt, ProgramInputs, CHIPLETS_RANGE, CHIPLETS_WIDTH, ONE, ZERO,
 };
@@ -172,7 +173,10 @@ fn validate_bitwise_trace(trace: &ChipletsTrace, start: usize, end: usize) {
         assert_eq!(BITWISE_XOR, trace[2][row]);
 
         // the final columns should be padded
-        for column in trace.iter().skip(BITWISE_TRACE_WIDTH + 2) {
+        for column in trace
+            .iter()
+            .skip(BITWISE_TRACE_WIDTH + NUM_BITWISE_SELECTORS)
+        {
             assert_eq!(ZERO, column[row]);
         }
     }
@@ -189,18 +193,18 @@ fn validate_memory_trace(trace: &ChipletsTrace, start: usize, end: usize) {
         assert_eq!(ZERO, trace[2][row]);
 
         // the final columns should be padded
-        for column in trace.iter().skip(MEMORY_TRACE_WIDTH + 3) {
+        for column in trace.iter().skip(MEMORY_TRACE_WIDTH + NUM_MEMORY_SELECTORS) {
             assert_eq!(ZERO, column[row]);
         }
     }
 }
 
-/// Validate the kernel ROM trace output a kernel with two procedures and no access calls. The
+/// Validate the kernel ROM trace output for a kernel with two procedures and no access calls. The
 /// full kernel ROM trace is tested in the KernelRom module, so this just tests the ChipletsTrace
-/// selectors, the first column of the trace, and the final columns after the kernel ROm trace.
+/// selectors, the first column of the trace, and the final columns after the kernel ROM trace.
 fn validate_kernel_rom_trace(trace: &ChipletsTrace, start: usize, end: usize) {
     for row in start..end {
-        // The selectors should match the memory selectors
+        // The selectors should match the kernel selectors
         assert_eq!(ONE, trace[0][row]);
         assert_eq!(ONE, trace[1][row]);
         assert_eq!(ONE, trace[2][row]);
@@ -210,13 +214,16 @@ fn validate_kernel_rom_trace(trace: &ChipletsTrace, start: usize, end: usize) {
         assert_eq!(ZERO, trace[4][row]);
 
         // the final columns should be padded
-        for column in trace.iter().skip(KERNEL_ROM_TRACE_WIDTH + 4) {
+        for column in trace
+            .iter()
+            .skip(KERNEL_ROM_TRACE_WIDTH + NUM_KERNEL_ROM_SELECTORS)
+        {
             assert_eq!(ZERO, column[row]);
         }
     }
 }
 
-/// Checks that the final section of the chiplets module's trace after the memory chiplet is
+/// Checks that the final section of the chiplets module's trace after the kernel ROM chiplet is
 /// padded and has the correct selectors.
 fn validate_padding(trace: &ChipletsTrace, start: usize, end: usize) {
     for row in start..end {

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -1,21 +1,22 @@
 use crate::{utils::get_trace_len, CodeBlock, ExecutionTrace, Kernel, Operation, Process};
 use vm_core::{
     chiplets::{
-        bitwise::{BITWISE_XOR, OP_CYCLE_LEN},
-        hasher::{HASH_CYCLE_LEN, LINEAR_HASH, RETURN_STATE},
+        bitwise::{BITWISE_XOR, OP_CYCLE_LEN, TRACE_WIDTH as BITWISE_TRACE_WIDTH},
+        hasher::{Digest, HASH_CYCLE_LEN, LINEAR_HASH, RETURN_STATE},
+        kernel_rom::TRACE_WIDTH as KERNEL_ROM_TRACE_WIDTH,
+        memory::TRACE_WIDTH as MEMORY_TRACE_WIDTH,
     },
-    CodeBlockTable, Felt, FieldElement, ProgramInputs, CHIPLETS_RANGE, CHIPLETS_WIDTH,
-    MEMORY_TRACE_WIDTH,
+    CodeBlockTable, Felt, ProgramInputs, CHIPLETS_RANGE, CHIPLETS_WIDTH, ONE, ZERO,
 };
 
 type ChipletsTrace = [Vec<Felt>; CHIPLETS_WIDTH];
 
 #[test]
-fn hasher_aux_trace() {
+fn hasher_chiplet_trace() {
     // --- single hasher permutation with no stack manipulation -----------------------------------
     let stack = [2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0];
     let operations = vec![Operation::RpPerm];
-    let (chiplets_trace, trace_len) = build_trace(&stack, operations);
+    let (chiplets_trace, trace_len) = build_trace(&stack, operations, Kernel::default());
 
     // Skip the hash of the span block generated while building the trace to check only the RpPerm.
     let hasher_start = HASH_CYCLE_LEN;
@@ -27,11 +28,11 @@ fn hasher_aux_trace() {
 }
 
 #[test]
-fn bitwise_aux_trace() {
+fn bitwise_chiplet_trace() {
     // --- single bitwise operation with no stack manipulation ------------------------------------
     let stack = [4, 8];
     let operations = vec![Operation::U32xor];
-    let (chiplets_trace, trace_len) = build_trace(&stack, operations);
+    let (chiplets_trace, trace_len) = build_trace(&stack, operations, Kernel::default());
 
     let bitwise_end = HASH_CYCLE_LEN + OP_CYCLE_LEN;
     validate_bitwise_trace(&chiplets_trace, HASH_CYCLE_LEN, bitwise_end);
@@ -41,11 +42,11 @@ fn bitwise_aux_trace() {
 }
 
 #[test]
-fn memory_aux_trace() {
+fn memory_chiplet_trace() {
     // --- single memory operation with no stack manipulation -------------------------------------
     let stack = [1, 2, 3, 4];
     let operations = vec![Operation::Push(Felt::new(2)), Operation::MStoreW];
-    let (chiplets_trace, trace_len) = build_trace(&stack, operations);
+    let (chiplets_trace, trace_len) = build_trace(&stack, operations, Kernel::default());
     let memory_trace_len = 1;
 
     // Skip the hash cycle created by the span block when building the trace.
@@ -58,17 +59,19 @@ fn memory_aux_trace() {
 }
 
 #[test]
-fn stacked_aux_trace() {
+fn stacked_chiplet_trace() {
     // --- operations in hasher, bitwise, and memory processors without stack manipulation --------
     let stack = [8, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 1];
-    let operations = vec![
+    let ops = vec![
         Operation::U32xor,
-        Operation::Push(Felt::ZERO),
+        Operation::Push(ZERO),
         Operation::MStoreW,
         Operation::RpPerm,
     ];
-    let (chiplets_trace, trace_len) = build_trace(&stack, operations);
+    let kernel = build_kernel();
+    let (chiplets_trace, trace_len) = build_trace(&stack, ops, kernel);
     let memory_len = 1;
+    let kernel_rom_len = 2;
 
     // Skip the hash of the span block generated while building the trace to check only the RpPerm.
     let hasher_start = HASH_CYCLE_LEN;
@@ -83,18 +86,32 @@ fn stacked_aux_trace() {
     let memory_end = bitwise_end + memory_len;
     validate_memory_trace(&chiplets_trace, bitwise_end, memory_end);
 
+    let kernel_rom_end = memory_end + kernel_rom_len;
+    validate_kernel_rom_trace(&chiplets_trace, memory_end, kernel_rom_end);
+
     // Validate that the trace was padded correctly.
-    validate_padding(&chiplets_trace, memory_end, trace_len);
+    validate_padding(&chiplets_trace, kernel_rom_end, trace_len);
 }
 
 // HELPER FUNCTIONS
 // ================================================================================================
 
+/// Creates a kernel with two dummy procedures
+fn build_kernel() -> Kernel {
+    let proc_hash1: Digest = [ONE, ZERO, ONE, ZERO].into();
+    let proc_hash2: Digest = [ONE, ONE, ONE, ONE].into();
+    Kernel::new(&[proc_hash1, proc_hash2])
+}
+
 /// Builds a sample trace by executing a span block containing the specified operations. This
 /// results in 1 additional hash cycle (8 rows) at the beginning of the hash chiplet.
-fn build_trace(stack: &[u64], operations: Vec<Operation>) -> (ChipletsTrace, usize) {
+fn build_trace(
+    stack: &[u64],
+    operations: Vec<Operation>,
+    kernel: Kernel,
+) -> (ChipletsTrace, usize) {
     let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
-    let mut process = Process::new(&Kernel::default(), inputs);
+    let mut process = Process::new(&kernel, inputs);
     let program = CodeBlock::new_span(operations);
     process
         .execute_code_block(&program, &CodeBlockTable::default())
@@ -115,32 +132,26 @@ fn build_trace(stack: &[u64], operations: Vec<Operation>) -> (ChipletsTrace, usi
 /// Validate the hasher trace output by the rpperm operation. The full hasher trace is tested in
 /// the Hasher module, so this just tests the ChipletsTrace selectors and the initial columns
 /// of the hasher trace.
-fn validate_hasher_trace(chiplets: &ChipletsTrace, start: usize, end: usize) {
+fn validate_hasher_trace(trace: &ChipletsTrace, start: usize, end: usize) {
     // The selectors should match the hasher selectors
     for row in start..end {
         // The selectors should match the selectors for the hasher segment
-        assert_eq!(Felt::ZERO, chiplets[0][row]);
+        assert_eq!(ZERO, trace[0][row]);
 
         match row % HASH_CYCLE_LEN {
             0 => {
                 // in the first row, the expected start of the trace should hold the initial selectors
-                assert_eq!(
-                    LINEAR_HASH,
-                    [chiplets[1][row], chiplets[2][row], chiplets[3][row]]
-                );
+                assert_eq!(LINEAR_HASH, [trace[1][row], trace[2][row], trace[3][row]]);
             }
             7 => {
                 // in the last row, the expected start of the trace should hold the final selectors
-                assert_eq!(
-                    RETURN_STATE,
-                    [chiplets[1][row], chiplets[2][row], chiplets[3][row]]
-                );
+                assert_eq!(RETURN_STATE, [trace[1][row], trace[2][row], trace[3][row]]);
             }
             _ => {
                 // in the other rows, the expected start of the trace should hold the mid selectors
                 assert_eq!(
-                    [Felt::ZERO, LINEAR_HASH[1], LINEAR_HASH[2]],
-                    [chiplets[1][row], chiplets[2][row], chiplets[3][row]]
+                    [ZERO, LINEAR_HASH[1], LINEAR_HASH[2]],
+                    [trace[1][row], trace[2][row], trace[3][row]]
                 );
             }
         }
@@ -150,52 +161,74 @@ fn validate_hasher_trace(chiplets: &ChipletsTrace, start: usize, end: usize) {
 /// Validate the bitwise trace output by the u32xor operation. The full bitwise trace is tested in
 /// the Bitwise module, so this just tests the ChipletsTrace selectors, the initial columns
 /// of the bitwise trace, and the final columns after the bitwise trace.
-fn validate_bitwise_trace(chiplets: &ChipletsTrace, start: usize, end: usize) {
+fn validate_bitwise_trace(trace: &ChipletsTrace, start: usize, end: usize) {
     // The selectors should match the bitwise selectors
     for row in start..end {
         // The selectors should match the selectors for the bitwise segment
-        assert_eq!(Felt::ONE, chiplets[0][row]);
-        assert_eq!(Felt::ZERO, chiplets[1][row]);
+        assert_eq!(ONE, trace[0][row]);
+        assert_eq!(ZERO, trace[1][row]);
 
         // the expected start of the bitwise trace should hold the expected bitwise op selectors
-        assert_eq!(BITWISE_XOR, chiplets[2][row]);
+        assert_eq!(BITWISE_XOR, trace[2][row]);
 
         // the final columns should be padded
-        assert_eq!(Felt::ZERO, chiplets[16][row]);
-        assert_eq!(Felt::ZERO, chiplets[17][row]);
+        for column in trace.iter().skip(BITWISE_TRACE_WIDTH + 2) {
+            assert_eq!(ZERO, column[row]);
+        }
     }
 }
 
 /// Validate the bitwise trace output by the storew operation. The full memory trace is tested in
 /// the Memory module, so this just tests the ChipletsTrace selectors and the final columns after
 /// the memory trace.
-fn validate_memory_trace(chiplets: &ChipletsTrace, start: usize, end: usize) {
+fn validate_memory_trace(trace: &ChipletsTrace, start: usize, end: usize) {
     for row in start..end {
         // The selectors should match the memory selectors
-        assert_eq!(Felt::ONE, chiplets[0][row]);
-        assert_eq!(Felt::ONE, chiplets[1][row]);
-        assert_eq!(Felt::ZERO, chiplets[2][row]);
+        assert_eq!(ONE, trace[0][row]);
+        assert_eq!(ONE, trace[1][row]);
+        assert_eq!(ZERO, trace[2][row]);
 
         // the final columns should be padded
-        for column in chiplets.iter().skip(MEMORY_TRACE_WIDTH) {
-            assert_eq!(Felt::ZERO, column[row]);
+        for column in trace.iter().skip(MEMORY_TRACE_WIDTH + 3) {
+            assert_eq!(ZERO, column[row]);
+        }
+    }
+}
+
+/// Validate the kernel ROM trace output a kernel with two procedures and no access calls. The
+/// full kernel ROM trace is tested in the KernelRom module, so this just tests the ChipletsTrace
+/// selectors, the first column of the trace, and the final columns after the kernel ROm trace.
+fn validate_kernel_rom_trace(trace: &ChipletsTrace, start: usize, end: usize) {
+    for row in start..end {
+        // The selectors should match the memory selectors
+        assert_eq!(ONE, trace[0][row]);
+        assert_eq!(ONE, trace[1][row]);
+        assert_eq!(ONE, trace[2][row]);
+        assert_eq!(ZERO, trace[3][row]);
+
+        // the s0 column of kernel ROM must be set to ZERO as there were no kernel accesses
+        assert_eq!(ZERO, trace[4][row]);
+
+        // the final columns should be padded
+        for column in trace.iter().skip(KERNEL_ROM_TRACE_WIDTH + 4) {
+            assert_eq!(ZERO, column[row]);
         }
     }
 }
 
 /// Checks that the final section of the chiplets module's trace after the memory chiplet is
 /// padded and has the correct selectors.
-fn validate_padding(chiplets: &ChipletsTrace, start: usize, end: usize) {
+fn validate_padding(trace: &ChipletsTrace, start: usize, end: usize) {
     for row in start..end {
         // selectors
-        assert_eq!(Felt::ONE, chiplets[0][row]);
-        assert_eq!(Felt::ONE, chiplets[1][row]);
-        assert_eq!(Felt::ONE, chiplets[2][row]);
-        assert_eq!(Felt::ONE, chiplets[3][row]);
+        assert_eq!(ONE, trace[0][row]);
+        assert_eq!(ONE, trace[1][row]);
+        assert_eq!(ONE, trace[2][row]);
+        assert_eq!(ONE, trace[3][row]);
 
         // padding
-        chiplets.iter().skip(4).for_each(|column| {
-            assert_eq!(Felt::ZERO, column[row]);
+        trace.iter().skip(4).for_each(|column| {
+            assert_eq!(ZERO, column[row]);
         });
     }
 }

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -94,10 +94,10 @@ fn stacked_aux_trace() {
 /// results in 1 additional hash cycle (8 rows) at the beginning of the hash chiplet.
 fn build_trace(stack: &[u64], operations: Vec<Operation>) -> (ChipletsTrace, usize) {
     let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
-    let mut process = Process::new(inputs);
+    let mut process = Process::new(&Kernel::default(), inputs);
     let program = CodeBlock::new_span(operations);
     process
-        .execute_code_block(&program, &Kernel::default(), &CodeBlockTable::default())
+        .execute_code_block(&program, &CodeBlockTable::default())
         .unwrap();
 
     let (trace, _) = ExecutionTrace::test_finalize_trace(process);
@@ -191,9 +191,10 @@ fn validate_padding(chiplets: &ChipletsTrace, start: usize, end: usize) {
         assert_eq!(Felt::ONE, chiplets[0][row]);
         assert_eq!(Felt::ONE, chiplets[1][row]);
         assert_eq!(Felt::ONE, chiplets[2][row]);
+        assert_eq!(Felt::ONE, chiplets[3][row]);
 
         // padding
-        chiplets.iter().skip(3).for_each(|column| {
+        chiplets.iter().skip(4).for_each(|column| {
             assert_eq!(Felt::ZERO, column[row]);
         });
     }

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1121,9 +1121,9 @@ fn set_user_op_helpers_many() {
 
 fn build_trace(stack: &[u64], program: &CodeBlock) -> (DecoderTrace, AuxTraceHints, usize) {
     let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
-    let mut process = Process::new(inputs);
+    let mut process = Process::new(&Kernel::default(), inputs);
     process
-        .execute_code_block(program, &Kernel::default(), &CodeBlockTable::default())
+        .execute_code_block(program, &CodeBlockTable::default())
         .unwrap();
 
     let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
@@ -1144,15 +1144,13 @@ fn build_call_trace(
     fn_block: CodeBlock,
 ) -> (SystemTrace, DecoderTrace, AuxTraceHints, usize) {
     let inputs = ProgramInputs::new(&[], &[], vec![]).unwrap();
-    let mut process = Process::new(inputs);
+    let mut process = Process::new(&Kernel::default(), inputs);
 
     // build code block table
     let mut cb_table = CodeBlockTable::default();
     cb_table.insert(fn_block);
 
-    process
-        .execute_code_block(program, &Kernel::default(), &cb_table)
-        .unwrap();
+    process.execute_code_block(program, &cb_table).unwrap();
 
     let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
     let trace_len = get_trace_len(&trace) - ExecutionTrace::NUM_RAND_ROWS;

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -138,7 +138,7 @@ fn u64_to_u32_elements(value: u64) -> (Felt, Felt) {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{Felt, FieldElement, Operation, StarkField},
+        super::{Felt, FieldElement, Kernel, Operation, StarkField},
         Process,
     };
     use crate::Word;
@@ -160,7 +160,7 @@ mod tests {
         ];
 
         let inputs = ProgramInputs::new(&stack_inputs, &[], vec![tree.clone()]).unwrap();
-        let mut process = Process::new(inputs);
+        let mut process = Process::new(&Kernel::default(), inputs);
         process.execute_op(Operation::Noop).unwrap();
 
         // inject the node into the advice tape

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -9,6 +9,9 @@ mod sys_ops;
 mod u32_ops;
 mod utils;
 
+#[cfg(test)]
+use super::Kernel;
+
 // OPERATION DISPATCHER
 // ================================================================================================
 
@@ -158,7 +161,7 @@ impl Process {
     #[cfg(test)]
     fn new_dummy(stack_inputs: &[u64]) -> Self {
         let inputs = super::ProgramInputs::new(stack_inputs, &[], vec![]);
-        let mut process = Self::new(inputs.unwrap());
+        let mut process = Self::new(&Kernel::default(), inputs.unwrap());
         process.execute_op(Operation::Noop).unwrap();
         process
     }
@@ -167,7 +170,7 @@ impl Process {
     #[cfg(test)]
     fn new_dummy_with_advice_tape(advice_tape: &[u64]) -> Self {
         let inputs = super::ProgramInputs::new(&[], advice_tape, vec![]).unwrap();
-        let mut process = Self::new(inputs);
+        let mut process = Self::new(&Kernel::default(), inputs);
         process.execute_op(Operation::Noop).unwrap();
         process
     }
@@ -186,7 +189,7 @@ impl Process {
     /// for testing purposes.
     #[cfg(test)]
     fn new_dummy_with_inputs_and_decoder_helpers(input: super::ProgramInputs) -> Self {
-        let mut process = Self::new(input);
+        let mut process = Self::new(&Kernel::default(), input);
         process.decoder.add_dummy_trace_row();
         process.execute_op(Operation::Noop).unwrap();
         process

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -16,9 +16,9 @@ mod stack;
 /// Builds a sample trace by executing the provided code block against the provided stack inputs.
 pub fn build_trace_from_block(program: &CodeBlock, stack: &[u64]) -> ExecutionTrace {
     let inputs = ProgramInputs::new(stack, &[], vec![]).unwrap();
-    let mut process = Process::new(inputs);
+    let mut process = Process::new(&Kernel::default(), inputs);
     process
-        .execute_code_block(program, &Kernel::default(), &CodeBlockTable::default())
+        .execute_code_block(program, &CodeBlockTable::default())
         .unwrap();
     ExecutionTrace::new(process, ProgramOutputs::default())
 }
@@ -37,10 +37,10 @@ pub fn build_trace_from_ops_with_inputs(
     operations: Vec<Operation>,
     inputs: ProgramInputs,
 ) -> ExecutionTrace {
-    let mut process = Process::new(inputs);
+    let mut process = Process::new(&Kernel::default(), inputs);
     let program = CodeBlock::new_span(operations);
     process
-        .execute_code_block(&program, &Kernel::default(), &CodeBlockTable::default())
+        .execute_code_block(&program, &CodeBlockTable::default())
         .unwrap();
     ExecutionTrace::new(process, ProgramOutputs::default())
 }


### PR DESCRIPTION
This PR implements Kernel ROM chiplet within the `processor` crate. This includes:

* Implementing Kernel ROM chiplet.
* Updating the Decoder to rely on Kernel ROM chiplet to check `syscall` validity.

Things left for future PRs:
* Updating mdBook docs to describe the new structure of chiplets.
* Implementing additional `syscall` semantics:
  - Setting `fmp` to $2^{31}$ when for inside `syscall`s.
  - Adding trace columns to enable checks preventing `syscall`s from within kernel context.
* Update aux trace column needed for enforcing correctness of kernel ROM (this includes updates to chiplet bus).
  - Setting boundary constraints for the kernel against which a program was executed. 