### PR TITLE
fix: multiple constants in push operation

### DIFF
--- a/assembly/src/parsers/ast/io_ops.rs
+++ b/assembly/src/parsers/ast/io_ops.rs
@@ -6,6 +6,9 @@ use vm_core::Felt;
 // CONSTANTS
 // ================================================================================================
 
+/// The maximum number of constant inputs allowed by `push` operation.
+const MAX_CONST_INPUTS: usize = 16;
+
 // Push constant
 
 /// The required length of the hexadecimal representation for an input value when more than one hex
@@ -44,7 +47,7 @@ pub fn parse_push_constants(op: &Token, constants: &mut Vec<Felt>) -> Result<(),
 }
 
 pub fn parse_push(op: &Token) -> Result<Node, AssemblyError> {
-    validate_operation!(op, "push", 1);
+    validate_operation!(op, "push", 1..MAX_CONST_INPUTS);
 
     let mut constants = Vec::<Felt>::new();
     parse_push_constants(op, &mut constants)?;

--- a/assembly/src/parsers/ast/tests.rs
+++ b/assembly/src/parsers/ast/tests.rs
@@ -107,7 +107,7 @@ fn test_ast_parsing_use() {
 
 #[test]
 fn test_ast_program_serde_simple() {
-    let source = "begin push.0 assertz end";
+    let source = "begin push.0xabc234 push.0 assertz end";
     let program = parse_program(source).unwrap();
     let program_serialized = program.to_bytes();
     let program_deserialized = ProgramAst::from_bytes(&mut program_serialized.as_slice()).unwrap();
@@ -157,8 +157,7 @@ fn test_ast_program_serde_control_flow() {
     begin
         repeat.3
             push.1
-            push.0
-            push.1
+            push.0.1
         end 
 
         if.true
@@ -169,8 +168,7 @@ fn test_ast_program_serde_control_flow() {
         end
         
         while.true
-            push.5
-            push.7
+            push.5.7
             u32checked_add
             loc_store.1
             push.0


### PR DESCRIPTION
Small bug fix: now `push` operation with multiple constants are available for use in AST parsing module