### PR TITLE
refactor(verifier): add `Eq` derive to verifier

### DIFF
--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -57,7 +57,7 @@ pub fn verify(
 // ================================================================================================
 
 /// TODO: add docs, implement Display
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum VerificationError {
     VerifierError(VerifierError),
     InputNotFieldElement(u64),


### PR DESCRIPTION
## Describe your changes

clippy introduced a new lint that requires `Eq` to be derived when `PartialEq` is present