### PR TITLE
AST exec and call nodes refactoring

### DIFF
--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -24,9 +24,10 @@ default = ["std"]
 std = ["vm-core/std"]
 
 [dependencies]
+crypto = { package = "winter-crypto", version = "0.4", default-features = false }
+num_enum = "0.5.7"
 vm-core = { package = "miden-core", path = "../core", version = "0.3", default-features = false }
 vm-stdlib = { package = "miden-stdlib", path = "../stdlib", version = "0.2", default-features = false }
-num_enum = "0.5.7"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/assembly/src/parsers/ast/context.rs
+++ b/assembly/src/parsers/ast/context.rs
@@ -1,10 +1,14 @@
 use super::{
     io_ops, stack_ops, u32_ops, AssemblyError, Instruction, Node, ProcMap, ProcedureAst, Token,
-    TokenStream, MODULE_PATH_DELIM,
+    TokenStream, MODULE_PATH_DELIM, PROC_DIGEST_SIZE,
 };
-use vm_core::utils::{
-    collections::{BTreeMap, Vec},
-    string::{String, ToString},
+use crypto::{hashers::Blake3_192, Digest, Hasher};
+use vm_core::{
+    utils::{
+        collections::{BTreeMap, Vec},
+        string::{String, ToString},
+    },
+    Felt,
 };
 
 // Context
@@ -151,7 +155,8 @@ impl ParserContext {
 
         if label.contains(MODULE_PATH_DELIM) {
             let full_proc_name = self.get_full_imported_proc_name(label);
-            Ok(Node::Instruction(Instruction::ExecImported(full_proc_name)))
+            let proc_name_hash = self.get_proc_name_hash(full_proc_name);
+            Ok(Node::Instruction(Instruction::ExecImported(proc_name_hash)))
         } else {
             let index = self.procedures.get(&label).unwrap().index;
             Ok(Node::Instruction(Instruction::ExecLocal(index)))
@@ -163,7 +168,8 @@ impl ParserContext {
         tokens.advance();
         if label.contains(MODULE_PATH_DELIM) {
             let full_proc_name = self.get_full_imported_proc_name(label);
-            Ok(Node::Instruction(Instruction::CallImported(full_proc_name)))
+            let proc_name_hash = self.get_proc_name_hash(full_proc_name);
+            Ok(Node::Instruction(Instruction::CallImported(proc_name_hash)))
         } else {
             let index = self.procedures.get(&label).unwrap().index;
             Ok(Node::Instruction(Instruction::CallLocal(index)))
@@ -294,6 +300,13 @@ impl ParserContext {
         let (module_name, proc_name) = short_name.split_once(MODULE_PATH_DELIM).unwrap();
         let full_module_name = self.imports.get(module_name).unwrap();
         format!("{}{}{}", full_module_name, MODULE_PATH_DELIM, proc_name)
+    }
+
+    fn get_proc_name_hash(&self, proc_name: String) -> [u8; PROC_DIGEST_SIZE] {
+        let proc_name_digest = Blake3_192::<Felt>::hash(proc_name.as_bytes());
+        let mut proc_name_hash = [0; PROC_DIGEST_SIZE];
+        proc_name_hash.copy_from_slice(&proc_name_digest.as_bytes()[..PROC_DIGEST_SIZE]);
+        proc_name_hash
     }
 }
 

--- a/assembly/src/parsers/ast/mod.rs
+++ b/assembly/src/parsers/ast/mod.rs
@@ -19,6 +19,8 @@ mod u32_ops;
 #[cfg(test)]
 pub mod tests;
 
+const PROC_DIGEST_SIZE: usize = 24;
+
 // TYPE ALIASES
 // ================================================================================================
 type ProcMap = BTreeMap<String, ProcedureAst>;

--- a/assembly/src/parsers/ast/nodes.rs
+++ b/assembly/src/parsers/ast/nodes.rs
@@ -1,4 +1,4 @@
-use vm_core::utils::{collections::Vec, string::String};
+use vm_core::utils::collections::Vec;
 use vm_core::Felt;
 
 // Nodes
@@ -237,7 +237,7 @@ pub enum Instruction {
 
     // ----- exec / call ----------------------------------------------------------------------
     ExecLocal(u32),
-    ExecImported(String),
+    ExecImported([u8; 24]),
     CallLocal(u32),
-    CallImported(String),
+    CallImported([u8; 24]),
 }

--- a/assembly/src/parsers/ast/serde/serialization.rs
+++ b/assembly/src/parsers/ast/serde/serialization.rs
@@ -51,6 +51,10 @@ impl ByteWriter {
         Ok(())
     }
 
+    pub fn write_proc_hash(&mut self, val: &[u8; 24]) {
+        self.0.append(&mut val.to_vec());
+    }
+
     pub fn write_felt(&mut self, val: Felt) {
         self.write_u64(val.as_int());
     }
@@ -474,9 +478,7 @@ impl Serializable for Instruction {
             }
             Self::ExecImported(imported) => {
                 target.write_opcode(OpCode::ExecImported);
-                target
-                    .write_string(imported)
-                    .expect("String serialization failure");
+                target.write_proc_hash(imported);
             }
             Self::CallLocal(v) => {
                 target.write_opcode(OpCode::CallLocal);
@@ -484,9 +486,7 @@ impl Serializable for Instruction {
             }
             Self::CallImported(imported) => {
                 target.write_opcode(OpCode::CallImported);
-                target
-                    .write_string(imported)
-                    .expect("String serialization failure");
+                target.write_proc_hash(imported);
             }
         }
     }

--- a/assembly/src/parsers/ast/tests.rs
+++ b/assembly/src/parsers/ast/tests.rs
@@ -1,5 +1,6 @@
 use super::{parse_module, parse_program, BTreeMap, Instruction, Node, ProcMap, ProcedureAst};
 use crate::parsers::ast::{ModuleAst, ProgramAst};
+use crypto::{hashers::Blake3_192, Digest, Hasher};
 use vm_core::{Felt, FieldElement};
 
 // UNIT TESTS
@@ -96,9 +97,10 @@ fn test_ast_parsing_use() {
         exec.foo::bar
     end";
     let procedures: ProcMap = BTreeMap::new();
-    let nodes: Vec<Node> = vec![Node::Instruction(Instruction::ExecImported(String::from(
-        "std::abc::foo::bar",
-    )))];
+    let proc_name_digest = Blake3_192::<Felt>::hash(String::from("std::abc::foo::bar").as_bytes());
+    let mut proc_name_hash = [0; 24];
+    proc_name_hash.copy_from_slice(&proc_name_digest.as_bytes()[..24]);
+    let nodes: Vec<Node> = vec![Node::Instruction(Instruction::ExecImported(proc_name_hash))];
     assert_program_output(source, procedures, nodes);
 }
 


### PR DESCRIPTION
`exec` and `call` AST nodes now take hash of the path instead of path itself
