### PR TITLE
Provide stdlib via module provider to assembler

### DIFF
--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -27,7 +27,6 @@ std = ["vm-core/std"]
 crypto = { package = "winter-crypto", version = "0.4", default-features = false }
 num_enum = "0.5.7"
 vm-core = { package = "miden-core", path = "../core", version = "0.3", default-features = false }
-vm-stdlib = { package = "miden-stdlib", path = "../stdlib", version = "0.2", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -1,3 +1,5 @@
+use crate::ModuleProvider;
+
 // SIMPLE PROGRAMS
 // ================================================================================================
 #[test]
@@ -177,14 +179,38 @@ fn program_with_exported_procedure() {
 
 #[test]
 fn program_with_one_import() {
-    let assembler = super::Assembler::default();
-    let source = "\
-        use.std::math::u256
-        begin \
-            push.4 push.3 \
-            exec.u256::iszero_unsafe \
-        end";
-    let program = assembler.compile(source).unwrap();
+    const MODULE: &str = "dummy::math::u256";
+
+    #[derive(Default)]
+    struct DummyProvider;
+
+    impl ModuleProvider for DummyProvider {
+        fn get_source(&self, path: &str) -> Option<&str> {
+            (path == MODULE).then_some(
+                r#"
+                export.iszero_unsafe
+                    eq.0
+                    repeat.7
+                        swap
+                        eq.0
+                        and
+                    end
+                end"#,
+            )
+        }
+    }
+
+    let assembler = super::Assembler::new().with_module_provider(DummyProvider::default());
+    let source = format!(
+        r#"
+        use.{}
+        begin
+            push.4 push.3
+            exec.u256::iszero_unsafe
+        end"#,
+        MODULE
+    );
+    let program = assembler.compile(&source).unwrap();
     let expected = "\
         begin \
             span \

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -42,6 +42,7 @@ prover = { package = "miden-prover", path = "../prover", version = "0.3", defaul
 serde = {version = "1.0.117", optional = true }
 serde_derive = {version = "1.0.117", optional = true }
 serde_json = {version = "1.0.59", optional = true }
+stdlib = { package = "miden-stdlib", path = "../stdlib", version = "0.2", default-features = false }
 structopt = { version = "0.3", default-features = false, optional = true }
 verifier = { package = "miden-verifier", path = "../verifier", version = "0.3", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.4", optional = true }

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -1,8 +1,9 @@
-use assembly::Assembler;
+use miden::Assembler;
 use prover::StarkProof;
 use serde_derive::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::{fs, io::Write, time::Instant};
+use stdlib::StdLibrary;
 use vm_core::ProgramOutputs;
 use vm_core::{chiplets::hasher::Digest, Program, ProgramInputs};
 use winter_utils::{Deserializable, SliceReader};
@@ -179,7 +180,8 @@ impl ProgramFile {
         let now = Instant::now();
 
         // compile program
-        let program = Assembler::default()
+        let program = Assembler::new()
+            .with_module_provider(StdLibrary::default())
             .compile(&program_file)
             .map_err(|err| format!("Failed to compile program - {}", err))?;
 

--- a/miden/src/examples/fibonacci.rs
+++ b/miden/src/examples/fibonacci.rs
@@ -1,5 +1,6 @@
 use super::Example;
 use miden::{Assembler, Program, ProgramInputs};
+use stdlib::StdLibrary;
 use vm_core::{Felt, FieldElement, StarkField};
 
 // EXAMPLE BUILDER
@@ -40,8 +41,10 @@ fn generate_fibonacci_program(n: usize) -> Program {
         n - 1
     );
 
-    let assembler = Assembler::default();
-    assembler.compile(&program).unwrap()
+    Assembler::new()
+        .with_module_provider(StdLibrary::default())
+        .compile(&program)
+        .unwrap()
 }
 
 /// Computes the `n`-th term of Fibonacci sequence

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -1,8 +1,10 @@
 use super::cli::InputFile;
-use assembly::{Assembler, AssemblyError};
+use assembly::AssemblyError;
 use core::fmt;
+use miden::Assembler;
 use processor::{AsmOpInfo, ExecutionError};
 use std::path::PathBuf;
+use stdlib::StdLibrary;
 use structopt::StructOpt;
 use vm_core::{utils::collections::Vec, Operation, ProgramInputs};
 
@@ -139,8 +141,9 @@ impl fmt::Display for ProgramInfo {
 
 /// Returns program analysis of a given program.
 pub fn analyze(program: &str, inputs: ProgramInputs) -> Result<ProgramInfo, ProgramError> {
-    let assembler = Assembler::new(true);
-    let program = assembler
+    let program = Assembler::new()
+        .with_debug_mode(true)
+        .with_module_provider(StdLibrary::default())
         .compile(program)
         .map_err(ProgramError::AssemblyError)?;
     let vm_state_iterator = processor::execute_iter(&program, &inputs);

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -17,3 +17,4 @@ doctest = false
 
 [dependencies]
 vm-core = { package = "miden-core", default-features = false, path = "../core", version = "0.3" }
+vm-assembly = { package = "miden-assembly", default-features = false, path = "../assembly", version = "0.3" }

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use vm_assembly::ModuleProvider;
 use vm_core::{
     errors::LibraryError,
     utils::{collections::BTreeMap, string::ToString},
@@ -25,6 +26,12 @@ type ModuleMap = BTreeMap<&'static str, &'static str>;
 /// TODO: add docs
 pub struct StdLibrary {
     modules: ModuleMap,
+}
+
+impl ModuleProvider for StdLibrary {
+    fn get_source(&self, path: &str) -> Option<&str> {
+        self.get_module_source(path).ok()
+    }
 }
 
 impl Library for StdLibrary {


### PR DESCRIPTION
## Describe your changes

This initial step for the solution of #298 removes stdlibrary as dependency of assembler.

This decoupling will increase the assembler module extraction flexibility. As next step, an efficient lookup of hasher module+label will be introduced in order to fetch parsed/compiled procedures.