### PR TITLE
Implement SYSCALL block processing in decoder

### DIFF
--- a/core/src/decoder/mod.rs
+++ b/core/src/decoder/mod.rs
@@ -67,6 +67,9 @@ pub const OP_BATCH_1_GROUPS: [Felt; NUM_OP_BATCH_FLAGS] = [ZERO, ONE, ONE];
 /// Index of the op bits extra column in the decoder trace.
 pub const OP_BIT_EXTRA_COL_IDX: usize = OP_BATCH_FLAGS_RANGE.end;
 
+/// Index of the in_syscall column in the decoder trace.
+pub const IN_SYSCALL_COL_IDX: usize = OP_BIT_EXTRA_COL_IDX + 1;
+
 /// Index of a flag column which indicates whether an ending block is a body of a loop.
 pub const IS_LOOP_BODY_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 4;
 
@@ -75,6 +78,9 @@ pub const IS_LOOP_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 5;
 
 /// Index of a flag column which indicates whether an ending block is a CALL block.
 pub const IS_CALL_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 6;
+
+/// Index of a flag column which indicates whether an ending block is a SYSCALL block.
+pub const IS_SYSCALL_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 7;
 
 // --- Column accessors in the auxiliary columns --------------------------------------------------
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -57,7 +57,7 @@ pub const MIN_TRACE_LEN: usize = 1024;
 // ------------------------------------------------------------------------------------------------
 
 //      system          decoder           stack      range checks       chiplets
-//    (3 columns)     (23 columns)    (19 columns)    (4 columns)     (18 columns)
+//    (3 columns)     (24 columns)    (19 columns)    (4 columns)     (18 columns)
 // ├───────────────┴───────────────┴───────────────┴───────────────┴─────────────────┤
 
 pub const SYS_TRACE_OFFSET: usize = 0;
@@ -70,7 +70,7 @@ pub const CTX_COL_IDX: usize = SYS_TRACE_OFFSET + 2;
 
 // decoder trace
 pub const DECODER_TRACE_OFFSET: usize = SYS_TRACE_RANGE.end;
-pub const DECODER_TRACE_WIDTH: usize = 23;
+pub const DECODER_TRACE_WIDTH: usize = 24;
 pub const DECODER_TRACE_RANGE: Range<usize> = range(DECODER_TRACE_OFFSET, DECODER_TRACE_WIDTH);
 
 // Stack trace

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -25,8 +25,8 @@ impl BlockStack {
         block_type: BlockType,
         ctx_info: Option<ExecutionContextInfo>,
     ) -> Felt {
-        // make sure execution context was provided when expected
-        if block_type == BlockType::Call {
+        // make sure execution context was provided for CALL and SYSCALL blocks
+        if block_type == BlockType::Call || block_type == BlockType::SysCall {
             debug_assert!(
                 ctx_info.is_some(),
                 "no execution context provided for a CALL block"
@@ -137,6 +137,14 @@ impl BlockInfo {
         }
     }
 
+    /// Returns ONE if this block is a SYSCALL block; otherwise returns ZERO.
+    pub fn is_syscall(&self) -> Felt {
+        match self.block_type {
+            BlockType::SysCall => ONE,
+            _ => ZERO,
+        }
+    }
+
     /// Returns the number of children a block has. This is an integer between 0 and 2 (both
     /// inclusive).
     pub fn num_children(&self) -> u32 {
@@ -145,6 +153,7 @@ impl BlockInfo {
             BlockType::Split => 1,
             BlockType::Loop(is_entered) => u32::from(is_entered),
             BlockType::Call => 1,
+            BlockType::SysCall => 1,
             BlockType::Span => 0,
         }
     }
@@ -194,5 +203,6 @@ pub enum BlockType {
     Split,
     Loop(bool), // internal value set to false if the loop is never entered
     Call,
+    SysCall,
     Span,
 }

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -121,7 +121,7 @@ impl BlockInfo {
     }
 
     /// Returns ONE if this block is a body of a LOOP block; otherwise returns ZERO.
-    pub fn is_loop_body(&self) -> Felt {
+    pub const fn is_loop_body(&self) -> Felt {
         if self.is_loop_body {
             ONE
         } else {
@@ -130,7 +130,7 @@ impl BlockInfo {
     }
 
     /// Returns ONE if this block is a CALL block; otherwise returns ZERO.
-    pub fn is_call(&self) -> Felt {
+    pub const fn is_call(&self) -> Felt {
         match self.block_type {
             BlockType::Call => ONE,
             _ => ZERO,
@@ -138,7 +138,7 @@ impl BlockInfo {
     }
 
     /// Returns ONE if this block is a SYSCALL block; otherwise returns ZERO.
-    pub fn is_syscall(&self) -> Felt {
+    pub const fn is_syscall(&self) -> Felt {
         match self.block_type {
             BlockType::SysCall => ONE,
             _ => ZERO,

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -139,6 +139,7 @@ impl DecoderTrace {
         is_loop_body: Felt,
         is_loop: Felt,
         is_call: Felt,
+        is_syscall: Felt,
     ) {
         debug_assert!(is_loop_body.as_int() <= 1, "invalid loop body");
         debug_assert!(is_loop.as_int() <= 1, "invalid is loop");
@@ -154,7 +155,7 @@ impl DecoderTrace {
         self.hasher_trace[4].push(is_loop_body);
         self.hasher_trace[5].push(is_loop);
         self.hasher_trace[6].push(is_call);
-        self.hasher_trace[7].push(ZERO);
+        self.hasher_trace[7].push(is_syscall);
 
         self.in_span_trace.push(ZERO);
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -26,7 +26,7 @@ mod operations;
 
 mod system;
 use system::System;
-pub use system::FMP_MIN;
+pub use system::{FMP_MIN, SYSCALL_FMP_MIN};
 
 mod decoder;
 use decoder::Decoder;

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -37,7 +37,7 @@ impl Process {
     /// Pops an element off the stack and adds it to the current value of `fmp` register.
     ///
     /// # Errors
-    /// Returns an error if the new value of `fmp` register is greater than or equal to 2^32.
+    /// Returns an error if the new value of `fmp` register is greater than or equal to 3 * 2^30.
     pub(super) fn op_fmpupdate(&mut self) -> Result<(), ExecutionError> {
         let offset = self.stack.get(0);
         let fmp = self.system.fmp();

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -61,6 +61,8 @@ impl Process {
 mod tests {
     use super::{super::Operation, Felt, FieldElement, Process, FMP_MAX, FMP_MIN};
 
+    const MAX_PROC_LOCALS: u64 = 2_u64.pow(31) - 1;
+
     #[test]
     fn op_assert() {
         // calling assert with a minimum stack should be an ok, as long as the top value is ONE
@@ -99,12 +101,12 @@ mod tests {
         assert!(process.execute_op(Operation::FmpUpdate).is_err());
 
         // going up to the max fmp value should be OK
-        let mut process = Process::new_dummy(&[u32::MAX as u64]);
+        let mut process = Process::new_dummy(&[MAX_PROC_LOCALS]);
         process.execute_op(Operation::FmpUpdate).unwrap();
         assert_eq!(Felt::new(FMP_MAX), process.system.fmp());
 
         // but going beyond that should be an error
-        let mut process = Process::new_dummy(&[u32::MAX as u64 + 1]);
+        let mut process = Process::new_dummy(&[MAX_PROC_LOCALS + 1]);
         assert!(process.execute_op(Operation::FmpUpdate).is_err());
 
         // should not affect the rest of the stack state

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -5,10 +5,21 @@ use super::{Felt, FieldElement, SysTrace, Vec, ZERO};
 // CONSTANTS
 // ================================================================================================
 
-// Memory addresses for procedure locals should start at 2^30 and not go below.
+// We assign the following special meanings to memory segments in each context:
+// - First 2^30 addresses (0 to 2^30 - 1) are reserved for global memory.
+// - The next 2^30 addresses (2^30 to 2^31 - 1) are reserved for procedure locals.
+// - The next 2^30 addresses (2^31 to 3 * 2^30 - 1) are reserved for procedure locals of SYSCALLs.
+// - All remaining addresses do not have any special meaning.
+//
+// Note that the above assignment is purely conventional: a program can read from and write to any
+// address in a given context, regardless of which memory segment it belongs to.
+
+/// Memory addresses for procedure locals start at 2^30.
 pub const FMP_MIN: u64 = 2_u64.pow(30);
-// The total number of locals available to all procedures at runtime must be smaller than 2^32.
-pub const FMP_MAX: u64 = FMP_MIN + u32::MAX as u64;
+/// Memory address for procedure locals within a SYSCALL starts at 2^31.
+pub const SYSCALL_FMP_MIN: u64 = 2_u64.pow(31);
+/// Value of FMP register should not exceed 3 * 2^30 - 1.
+pub const FMP_MAX: u64 = 3 * 2_u64.pow(30) - 1;
 
 // SYSTEM INFO
 // ================================================================================================

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -1,6 +1,4 @@
-use vm_core::StarkField;
-
-use super::{Felt, FieldElement, SysTrace, Vec, ZERO};
+use super::{Felt, FieldElement, StarkField, SysTrace, Vec, ZERO};
 
 // CONSTANTS
 // ================================================================================================


### PR DESCRIPTION
This PR updates the decoder to correctly process SYSCALL blocks. This includes:

- Adding an `in_syscall` column to the decoder trace. Values in this column are set to 1 when we are inside a SYSCALL block and to 0 otherwise. We will use this column in constraints to make sure that executing a `SYSCALL` operation within a SYSCALL block is not possible.
- Setting the `h7` register to 1 when we are exiting a SYSCALL block (i.e., when `END` operation is executed). This means that we now make use of all helper registers when `END` operation is executed. Specifically, registers `h4` - `h7` are now set to the following flags: `[is_loop_body, is_loop, is_call, is_syscall]`.
- Updating logic for how `fmp` values are set. Specifically, the logic remains the same for regular procedure and function calls (i.e., `fmp` register is initialized to $2^{30}$), but for `SYSCALL`'s we initialize the `fmp` register to $2^{31}$. This way, when we make a `SYSCALL`, procedure locals of procedures executed within a SYSCALL block will not conflict with procedure locals of the original root context.

While working on this PR, I've also found a way to speed up trace generation by about 15% by refactoring our approach to the decoder trace generation. I'll write this up in a separate issue.