### PR TITLE
Update stdlib build to ast

### DIFF
--- a/assembly/src/parsers/ast/mod.rs
+++ b/assembly/src/parsers/ast/mod.rs
@@ -99,7 +99,7 @@ impl ModuleAst {
     }
 
     /// Returns a `ModuleAst` struct by its byte representation.
-    pub fn from_bytes(bytes: &mut &[u8]) -> Result<Self, SerializationError> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
         let mut byte_reader = ByteReader::new(bytes.to_vec());
 
         let mut procedures = ProcMap::new();

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -17,6 +17,7 @@ mod stack_ops;
 mod u32_ops;
 
 mod ast;
+pub use ast::{parse_module, ModuleAst};
 
 // OP PARSER
 // ================================================================================================

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::ModuleProvider;
+use crate::{ModuleAst, ModuleProvider, ProcedureId};
 
 // SIMPLE PROGRAMS
 // ================================================================================================
@@ -197,6 +197,11 @@ fn program_with_one_import() {
                     end
                 end"#,
             )
+        }
+
+        fn get_module(&self, id: &ProcedureId) -> Option<&ModuleAst> {
+            // this test is checking the source as string
+            None
         }
     }
 

--- a/core/src/program/library.rs
+++ b/core/src/program/library.rs
@@ -2,15 +2,17 @@ use crate::errors::LibraryError;
 
 /// TODO: add docs
 pub trait Library {
+    type Module;
+
     /// Returns the root namespace of this library.
     fn root_ns(&self) -> &str;
 
     /// Returns the version number of this library.
     fn version(&self) -> &str;
 
-    /// Returns the source code of the module located at the specified path.
+    /// Returns the module located at the specified path.
     ///
     /// # Errors
     /// Returns an error if the modules for the specified path does not exist in this library.
-    fn get_module_source(&self, module_path: &str) -> Result<&str, LibraryError>;
+    fn get_module(&self, module_path: &str) -> Result<&Self::Module, LibraryError>;
 }

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -18,3 +18,6 @@ doctest = false
 [dependencies]
 vm-core = { package = "miden-core", default-features = false, path = "../core", version = "0.3" }
 vm-assembly = { package = "miden-assembly", default-features = false, path = "../assembly", version = "0.3" }
+
+[build-dependencies]
+vm-assembly = { package = "miden-assembly", default-features = false, path = "../assembly", version = "0.3" }

--- a/stdlib/src/asm.rs
+++ b/stdlib/src/asm.rs
@@ -2,1050 +2,1593 @@
 
 /// An array of modules defined in Miden standard library.
 ///
-/// Entries in the array are tuples containing module namespace and module source code.
+/// Entries in the array are tuples containing module namespace and module parsed+serialized.
 #[rustfmt::skip]
-pub const MODULES: [(&str, &str); 13] = [
-// ----- std::crypto::dsa::falcon -----------------------------------------------------------------
-("std::crypto::dsa::falcon", r#"use.std::math::poly512
-
-#! Given an element on stack top, this routine normalizes that element in 
-#! interval (-q/2, q/2] | q = 12289
-#!
-#! Imagine, a is the provided element, which needs to be normalized
-#!
-#! b = normalize(a)
-#!   = (a + (q >> 1)) % q - (q >> 1) | a ∈ [0, q), q = 12289
-#!
-#! Note, normalization requires that we can represent the number as signed integer,
-#! which is not allowed inside Miden VM stack. But we can ignore the sign of integer and only
-#! store the absolute value as field element. This can be safely done because after normalization
-#! anyway `b` will be squared ( for computing norm of a vector i.e. polynomial, where b is a coefficient ).
-#! That means we can just drop the sign, and that's what is done in this routine.
-#!
-#! To be more concrete, normalization of 12166 ( = a ) should result into -123, but absolute value 
-#! 123 will be kept on stack. While normalization of 21, should result into 21, which has absolute
-#! value 21 --- that's what is kept on stack.
-#!
-#! Expected stack state :
-#!
-#! [a, ...]
-#!
-#! After normalization ( represented using unsigned integer i.e. Miden field element ) stack looks like
-#!
-#! [b, ...]
-proc.normalize
-    dup
-    push.6144
-    gt
-
-    if.true
-        push.6144
-        add
-
-        exec.poly512::mod_12289
-
-        dup
-        push.6144
-        gte
-
-        if.true
-            push.6144
-            sub
-        else
-            push.6144
-            swap
-            sub
-        end
-    end
-end
-
-#! Given four elements from Falcon prime field, on stack top, this routine 
-#! normalizes each of them, using above defined `normalize()` routine.
-#!
-#! Expected stack state :
-#!
-#! [a0, a1, a2, a3, ...]
-#!
-#! Output stack state :
-#!
-#! [b0, b1, b2, b3, ...]
-#!
-#! b`i` = normalize(a`i`) | i ∈ [0..4)
-proc.normalize_word
-    exec.normalize
-
-    swap
-    exec.normalize
-    swap
-
-    movup.2
-    exec.normalize
-    movdn.2
-
-    movup.3
-    exec.normalize
-    movdn.3
-end
-
-#! Given a degree 512 polynomial on stack, using its starting (absolute) memory address, 
-#! this routine normalizes each coefficient of the polynomial, using above defined 
-#! `normalize()` routine
-#!
-#! Imagine, f is the given polynomial of degree 512. It can be normalized using
-#!
-#! g = [normalize(f[i]) for i in range(512)]
-#!
-#! Expected stack state :
-#!
-#! [f_start_addr, g_start_addr, ...] | next 127 absolute addresses can be computed using `INCR` instruction
-#!
-#! Post normalization stack state looks like
-#!
-#! [ ... ]
-#!
-#! Note, input polynomial which is provided using memory addresses, is not mutated.
-export.normalize_poly512
-    push.0.0.0.0
-
-    repeat.128
-        dup.4
-        mem_loadw
-
-        exec.normalize_word
-
-        dup.5
-        mem_storew
-
-        movup.5
-        add.1
-        movdn.5
-
-        movup.4
-        add.1
-        movdn.4
-    end
-
-    dropw
-    drop
-    drop
-end
-
-#! Given four elements on stack top, this routine computes squared norm of that
-#! vector ( read polynomial ) with four coefficients.
-#!
-#! Imagine, given vector is f, which is described as
-#!
-#! f = [a0, a1, a2, a3]
-#!
-#! Norm of that vector is
-#!
-#! √(a0 ^ 2 + a1 ^ 2 + a2 ^ 2 + a3 ^ 2)
-#!
-#! But we need squared norm, which is just skipping the final square root operation.
-#!
-#! Expected stack state :
-#!
-#! [a0, a1, a2, a3, ...]
-#!
-#! Final stack state :
-#!
-#! [b, ...] | b = a0 ^ 2 + a1 ^ 2 + a2 ^ 2 + a3 ^ 2
-proc.squared_norm_word
-    dup
-    mul
-
-    swap
-    dup
-    mul
-
-    add
-
-    swap
-    dup
-    mul
-
-    add
-
-    swap
-    dup
-    mul
-
-    add
-end
-
-#! Given a degree 512 polynomial in coefficient form, as starting (absolute) memory address 
-#! on stack, this routine computes squared norm of that vector, using following formula
-#!
-#! Say, f = [a0, a1, a2, ..., a510, a511]
-#!      g = sq_norm(f) = a0 ^ 2 + a1 ^ 2 + ... + a510 ^ 2 + a511 ^ 2
-#!
-#! Expected input stack state :
-#!
-#! [f_start_addr, ...] | f_addr`i` holds f[(i << 2) .. ((i+1) << 2)]
-#!
-#! Consecutive 127 addresses on stack can be computed using `INCR` instruction, because memory 
-#! addresses are consecutive i.e. monotonically increasing by 1.
-#!
-#! Final stack state :
-#!
-#! [g, ...] | g = sq_norm(f)
-export.squared_norm_poly512
-    push.0.0.0.0.0
-
-    repeat.128
-        dup.5
-        mem_loadw
-
-        exec.squared_norm_word
-        add
-
-        swap
-        add.1
-        swap
-
-        push.0.0.0.0
-    end
-
-    dropw
-    swap
-    drop
-end
-
-#! Falcon-512 Digital Signature Verification routine
-#!
-#! Given four degree-511 polynomials, using initial absolute memory addresses on stack, 
-#! this routine checks whether it's a valid Falcon signature or not.
-#!
-#! Four degree-511 polynomials, which are provided ( in order )
-#!
-#! f = [f0, f1, ..., f510, f511] -> decompressed Falcon-512 signature
-#! g = [g0, g1, ..., g510, g511] -> public key used for signing input message
-#! h = [h0, h1, ..., h510, h511] -> input message hashed using SHAKE256 XOF and converted to polynomial
-#! k = [k0, k1, ..., k510, k511] -> [abs(i) for i in f] | abs(a) = a < 0 ? 0 - a : a
-#!
-#! Each of these polynomials are represented using starting absolute memory address. Contiguous 127 
-#! memory addresses can be computed by repeated application of INCR instruction ( read add.1 ) on previous
-#! absolute memory address.
-#!
-#! f`i` holds f[(i << 2) .. ((i+1) << 2)] | i ∈ [0..128)
-#! g`i` holds g[(i << 2) .. ((i+1) << 2)] | i ∈ [0..128)
-#! h`i` holds h[(i << 2) .. ((i+1) << 2)] | i ∈ [0..128)
-#! k`i` holds k[(i << 2) .. ((i+1) << 2)] | i ∈ [0..128)
-#!
-#! Expected stack state :
-#!
-#! [f_start_addr, g_start_addr, h_start_addr, k_start_addr, ...]
-#!
-#! After execution of verification routine, stack looks like
-#!
-#! [ ... ]
-#!
-#! If verification fails, program panics, due to failure in assertion !
-#!
-#! Note, input memory addresses are considered to be immutable.
-export.verify.257
-    locaddr.0
-    movdn.2
-    exec.poly512::mul_zq
-
-    locaddr.128
-    locaddr.0
-    exec.poly512::neg_zq
-
-    locaddr.0
-    swap
-    locaddr.128
-    exec.poly512::add_zq
-
-    locaddr.128
-    locaddr.0
-    exec.normalize_poly512
-
-    # compute squared norm of s0
-
-    locaddr.128
-    exec.squared_norm_poly512
-
-    locaddr.256
-    mem_store
-    drop
-
-    # compute squared norm of s1 ( where s1 is provided as polynomial
-    # with coefficients represented using absolute value i.e. signs are ignored )
-
-    exec.squared_norm_poly512
-
-    locaddr.256
-    mem_load
-    add
-
-    # check that norm of the signature is small enough
-
-    push.34034726 # constant sig_bound for Falcon-512 signature
-    lte
-    assert
-end
-"#),
-// ----- std::crypto::hashes::blake3 --------------------------------------------------------------
-("std::crypto::hashes::blake3", r#"#! Initializes four memory addresses, provided for storing initial 4x4 blake3 
-#! state matrix ( i.e. 16 elements each of 32 -bit ), for computing blake3 2-to-1 hash
-#!
-#! Expected stack state:
-#!
-#! [state_0_3_addr, state_4_7_addr, state_8_11_addr, state_12_15_addr]
-#!
-#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
-#!
-#! Final stack state:
-#!
-#! [...]
-#!
-#! Initialized stack state is written back to provided memory addresses.
-#!
-#! Functionally this routine is equivalent to https://github.com/itzmeanjan/blake3/blob/f07d32e/include/blake3.hpp#!L1709-L1713
-proc.initialize
-    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
-    movup.4
-    mem_storew
-    dropw
-
-    push.0x5BE0CD19.0x1F83D9AB.0x9B05688C.0x510E527F
-    movup.4
-    mem_storew
-    dropw
-
-    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
-    movup.4
-    mem_storew
-    dropw
-
-    push.11.64.0.0
-    movup.4
-    mem_storew
-    dropw
-end
-
-#! Permutes ordered message words, kept on stack top ( = sixteen 32 -bit BLAKE3 words )
-#!
-#! Expected stack top: 
-#!
-#! [s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]
-#!
-#! After permutation, stack top:
-#!
-#! [s2, s6, s3, s10, s7, s0, s4, s13, s1, s11, s12, s5, s9, s14, s15, s8]
-#!
-#! See https://github.com/itzmeanjan/blake3/blob/f07d32ec10cbc8a10663b7e6539e0b1dab3e453b/include/blake3.hpp#!L1623-L1639
-#! and https://github.com/maticnetwork/miden/pull/313#!discussion_r922627984
-proc.permute_msg_words
-    movdn.7
-    movup.5
-    movdn.2
-    movup.4
-    movdn.7
-    swapw.3
-    swap
-    movdn.7
-    swapdw
-    movup.2
-    movdn.7
-    swapw
-    swapw.2
-    movup.3
-    movdn.6
-    movdn.5
-    movup.3
-    swapw
-    movup.3
-    swapdw
-end
-
-#! Given blake3 state matrix on stack top ( in order ) as 16 elements ( each of 32 -bit ),
-#! this routine computes output chaining value i.e. 2-to-1 hashing digest.
-#!
-#! Expected stack state:
-#!
-#! [state0, state1, state2, state3, state4, state5, state6, state7, state8, state9, state10, state11, state12, state13, state14, state15]
-#!
-#! After finalizing, stack should look like
-#!
-#! [dig0, dig1, dig2, dig3, dig4, dig5, dig6, dig7]
-#!
-#! See https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L116-L119 ,
-#! you'll notice I've skipped executing second statement in loop body of above hyperlinked implementation,
-#! that's because it doesn't dictate what output of 2-to-1 hash will be.
-proc.finalize
-    movup.8
-    u32checked_xor
-
-    swap
-    movup.8
-    u32checked_xor
-    swap
-
-    movup.2
-    movup.8
-    u32checked_xor
-    movdn.2
-
-    movup.3
-    movup.8
-    u32checked_xor
-    movdn.3
-
-    movup.4
-    movup.8
-    u32checked_xor
-    movdn.4
-
-    movup.5
-    movup.8
-    u32checked_xor
-    movdn.5
-
-    movup.6
-    movup.8
-    u32checked_xor
-    movdn.6
-
-    movup.7
-    movup.8
-    u32checked_xor
-    movdn.7
-end
-
-#! Given blake3 state matrix ( total 16 elements, each of 32 -bit ) and 
-#! 8 message words ( each of 32 -bit ), this routine performs column-wise mixing
-#! of message words into blake3 hash state.
-#!
-#! Functionality wise this routine is equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L55-L59
-#!
-#! Expected stack state:
-#!
-#! [state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr, m0, m1, m2, m3, m4, m5, m6, m7]
-#!
-#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
-#!
-#! Meaning four consecutive blake3 state words can be read from memory easily.
-#!
-#! Final stack state:
-#!
-#! [state0, state1, state2, state3, state4, state5, state6, state7, state8, state9, state10, state11, state12, state13, state14, state15]
-#!
-#! i.e. whole blake3 state is placed on stack ( in order ).
-proc.columnar_mixing.1
-    swapw.2
-    swapw
-
-    movup.7
-    movup.6
-    movup.5
-    movup.4
-
+pub const MODULES: [(&str, vm_assembly::ProcedureId, &str, &[u8]); 13] = [
+("std::sys",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 115, 121, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),"#! Removes elements deep in the stack until the depth of the stack is exactly 16. The elements
+#! are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack
+#! would otherwise contain more than 16 elements at the end of execution, then adding a call to this 
+#! function at the end will reduce the size of the public inputs that are shared with the verifier.
+#! Input: Stack with 16 or more elements.
+#! Output: Stack with only the original top 16 elements.
+export.truncate_stack.4
     loc_storew.0
-
-    movup.9
-    mem_loadw
-    movup.8
-    push.0.0.0.0
-    movup.4
-    mem_loadw
-
-    movup.8
-    dup.5
-    u32overflowing_add3
-    drop
-
-    swap
-    movup.8
-    dup.6
-    u32overflowing_add3
-    drop
-    swap
-
-    movup.2
-    dup.6
-    movup.9
-    u32overflowing_add3
-    drop
-    movdn.2
-
-    movup.3
-    dup.7
-    movup.9
-    u32overflowing_add3
-    drop
-    movdn.3
-
-    movup.9
-    push.0.0.0.0
-    movup.4
-    mem_loadw
-
-    dup.4
-    u32checked_xor
-    u32unchecked_rotr.16
-    
-    swap
-    dup.5
-    u32checked_xor
-    u32unchecked_rotr.16
-    swap
-
-    movup.2
-    dup.6
-    u32checked_xor
-    u32unchecked_rotr.16
-    movdn.2
-
-    movup.3
-    dup.7
-    u32checked_xor
-    u32unchecked_rotr.16
-    movdn.3
-
-    movup.12
-    push.0.0.0.0
-    movup.4
-    mem_loadw
-
-    dup.4
-    u32wrapping_add
-
-    swap
-    dup.5
-    u32wrapping_add
-    swap
-
-    movup.2
-    dup.6
-    u32wrapping_add
-    movdn.2
-
-    movup.3
-    dup.7
-    u32wrapping_add
-    movdn.3
-
-    movupw.3
-
-    dup.4
-    u32checked_xor
-    u32unchecked_rotr.12
-    
-    swap
-    dup.5
-    u32checked_xor
-    u32unchecked_rotr.12
-    swap
-
-    movup.2
-    dup.6
-    u32checked_xor
-    u32unchecked_rotr.12
-    movdn.2
-
-    movup.3
-    dup.7
-    u32checked_xor
-    u32unchecked_rotr.12
-    movdn.3
-
-    movupw.3
-    push.0.0.0.0
-    loc_loadw.0
-    swapw
-
-    movup.4
-    dup.8
-    u32overflowing_add3
-    drop
-
-    swap
-    movup.4
-    dup.8
-    u32overflowing_add3
-    drop
-    swap
-
-    movup.2
-    movup.4
-    dup.8
-    u32overflowing_add3
-    drop
-    movdn.2
-
-    movup.3
-    movup.4
-    dup.8
-    u32overflowing_add3
-    drop
-    movdn.3
-
-    movupw.3
-
-    dup.4
-    u32checked_xor
-    u32unchecked_rotr.8
-    
-    swap
-    dup.5
-    u32checked_xor
-    u32unchecked_rotr.8
-    swap
-
-    movup.2
-    dup.6
-    u32checked_xor
-    u32unchecked_rotr.8
-    movdn.2
-
-    movup.3
-    dup.7
-    u32checked_xor
-    u32unchecked_rotr.8
-    movdn.3
-
-    movupw.3
-
-    dup.4
-    u32wrapping_add
-
-    swap
-    dup.5
-    u32wrapping_add
-    swap
-
-    movup.2
-    dup.6
-    u32wrapping_add
-    movdn.2
-
-    movup.3
-    dup.7
-    u32wrapping_add
-    movdn.3
-
-    movupw.3
-
-    dup.4
-    u32checked_xor
-    u32unchecked_rotr.7
-
-    swap
-    dup.5
-    u32checked_xor
-    u32unchecked_rotr.7
-    swap
-
-    movup.2
-    dup.6
-    u32checked_xor
-    u32unchecked_rotr.7
-    movdn.2
-
-    movup.3
-    dup.7
-    u32checked_xor
-    u32unchecked_rotr.7
-    movdn.3
-
-    movupw.3
-end
-
-#! Given blake3 state matrix ( total 16 elements, each of 32 -bit ) and 
-#! 8 message words ( each of 32 -bit ), this routine performs diagonal-wise mixing
-#! of message words into blake3 hash state.
-#!
-#! Functionality wise this routine is equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L61-L64
-#!
-#! Expected stack state:
-#!
-#! [state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr, m0, m1, m2, m3, m4, m5, m6, m7]
-#!
-#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
-#!
-#! Meaning four consecutive blake3 state words can be read from memory easily.
-#!
-#! Final stack state:
-#!
-#! [state0, state1, state2, state3, state4, state5, state6, state7, state8, state9, state10, state11, state12, state13, state14, state15]
-#!
-#! i.e. whole blake3 state is placed on stack ( in order ).
-proc.diagonal_mixing.1
-    swapw.2
-    swapw
-
-    movup.7
-    movup.6
-    movup.5
-    movup.4
-
-    loc_storew.0
-
-    movup.9
-    mem_loadw
-    movup.8
-    push.0.0.0.0
-    movup.4
-    mem_loadw
-
-    movup.8
-    dup.6
-    u32overflowing_add3
-    drop
-
-    swap
-    movup.8
-    dup.7
-    u32overflowing_add3
-    drop
-    swap
-
-    movup.2
-    movup.8
-    dup.8
-    u32overflowing_add3
-    drop
-    movdn.2
-
-    movup.3
-    movup.8
-    dup.5
-    u32overflowing_add3
-    drop
-    movdn.3
-
-    movup.9
-    push.0.0.0.0
-    movup.4
-    mem_loadw
-
-    movup.3
-    dup.4
-    u32checked_xor
-    u32unchecked_rotr.16
-    movdn.3
-
-    dup.5
-    u32checked_xor
-    u32unchecked_rotr.16
-
-    swap
-    dup.6
-    u32checked_xor
-    u32unchecked_rotr.16
-    swap
-
-    movup.2
-    dup.7
-    u32checked_xor
-    u32unchecked_rotr.16
-    movdn.2
-
-    movup.12
-    push.0.0.0.0
-    movup.4
-    mem_loadw
-
-    movup.2
-    dup.7
-    u32wrapping_add
-    movdn.2
-
-    movup.3
-    dup.4
-    u32wrapping_add
-    movdn.3
-
-    dup.5
-    u32wrapping_add
-
-    swap
-    dup.6
-    u32wrapping_add
-    swap
-
-    movupw.3
-
-    swap
-    dup.6
-    u32checked_xor
-    u32unchecked_rotr.12
-    swap
-
-    movup.2
-    dup.7
-    u32checked_xor
-    u32unchecked_rotr.12
-    movdn.2
-
-    movup.3
-    dup.4
-    u32checked_xor
-    u32unchecked_rotr.12
-    movdn.3
-
-    dup.5
-    u32checked_xor
-    u32unchecked_rotr.12
-
-    movupw.3
-    push.0.0.0.0
-    loc_loadw.0
-    swapw
-
-    movup.4
-    dup.9
-    u32overflowing_add3
-    drop
-
-    swap
-    movup.4
-    dup.9
-    u32overflowing_add3
-    drop
-    swap
-
-    movup.2
-    movup.4
-    dup.9
-    u32overflowing_add3
-    drop
-    movdn.2
-
-    movup.3
-    movup.4
-    dup.5
-    u32overflowing_add3
-    drop
-    movdn.3
-
-    movupw.3
-
-    movup.3
-    dup.4
-    u32checked_xor
-    u32unchecked_rotr.8
-    movdn.3
-
-    dup.5
-    u32checked_xor
-    u32unchecked_rotr.8
-
-    swap
-    dup.6
-    u32checked_xor
-    u32unchecked_rotr.8
-    swap
-
-    movup.2
-    dup.7
-    u32checked_xor
-    u32unchecked_rotr.8
-    movdn.2
-
-    movupw.3
-
-    movup.2
-    dup.7
-    u32wrapping_add
-    movdn.2
-
-    movup.3
-    dup.4
-    u32wrapping_add
-    movdn.3
-
-    dup.5
-    u32wrapping_add
-
-    swap
-    dup.6
-    u32wrapping_add
-    swap
-
-    movupw.3
-
-    swap
-    dup.6
-    u32checked_xor
-    u32unchecked_rotr.7
-    swap
-
-    movup.2
-    dup.7
-    u32checked_xor
-    u32unchecked_rotr.7
-    movdn.2
-
-    movup.3
-    dup.4
-    u32checked_xor
-    u32unchecked_rotr.7
-    movdn.3
-
-    dup.5
-    u32checked_xor
-    u32unchecked_rotr.7
-
-    movupw.3
-end
-
-#! Given blake3 state matrix ( total 16 elements, each of 32 -bit ) and 
-#! 16 message words ( each of 32 -bit ), this routine applies single round of mixing
-#! of message words into hash state i.e. msg_word[0..8] are mixed into hash state using
-#! columnar mixing while remaining message words ( msg_word[8..16] ) are mixed into hash state
-#! using diagonal mixing.
-#!
-#! Functionality wise this routine is equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L54-L65
-#!
-#! Expected stack state:
-#!
-#! [state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr, m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15]
-#!
-#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
-#!
-#! Meaning four consecutive blake3 state words can be read from memory easily.
-#!
-#! Final stack state:
-#!
-#! [...]
-#!
-#! i.e. mixed state matrix lives in memory addresses {state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr}, 
-#! which were provided, on stack top, while invoking this routine.
-proc.round.5
-    loc_storew.0
-
-    exec.columnar_mixing
-
+    dropw
     loc_storew.1
     dropw
     loc_storew.2
     dropw
     loc_storew.3
     dropw
-    loc_storew.4
-    dropw
-
-    locaddr.4
-    locaddr.3
-    locaddr.2
-    locaddr.1
-
-    exec.diagonal_mixing
-
-    push.0.0.0.0
-    loc_loadw.0
-    swapw
-    movup.4
-    mem_storew
-    dropw
-
-    repeat.3
-        push.0
-        movdn.3
-        swapw
-        movup.4
-        mem_storew
+    sdepth
+    neq.16
+    while.true
         dropw
+        sdepth
+        neq.16
     end
+    loc_loadw.3
+    swapw.3
+    loc_loadw.2
+    swapw.2
+    loc_loadw.1
+    swapw.1
+    loc_loadw.0
+end
+",&[1, 0, 14, 116, 114, 117, 110, 99, 97, 116, 101, 95, 115, 116, 97, 99, 107, 0, 0, 14, 116, 114, 117, 110, 99, 97, 116, 101, 95, 115, 116, 97, 99, 107, 1, 4, 0, 18, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 196, 3, 0, 0, 0, 0, 0, 0, 0, 105, 184, 21, 255, 3, 0, 105, 184, 21, 190, 3, 0, 0, 0, 0, 0, 0, 0, 144, 190, 2, 0, 0, 0, 0, 0, 0, 0, 143, 190, 1, 0, 0, 0, 0, 0, 0, 0, 142, 190, 0, 0, 0, 0, 0, 0, 0, 0]),
+("std::crypto::hashes::sha256",vm_assembly::ProcedureId([65, 65, 82, 58, 58, 99, 114, 121, 112, 116, 111, 58, 58, 104, 97, 115, 104, 101, 115, 58, 58, 115, 104, 97]),"#! Given [x, ...] on stack top, this routine computes [y, ...]
+#! such that y = σ_0(x), as defined in SHA specification
+#!
+#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L73-L79
+proc.small_sigma_0
+    dup
+    u32unchecked_rotr.7
 
-    repeat.3
-        drop
-    end
+    swap
+
+    dup
+    u32unchecked_rotr.18
+
+    swap
+
+    u32unchecked_shr.3
+
+    u32checked_xor
+    u32checked_xor
 end
 
-#! Given blake3 state matrix ( total 16 elements, each of 32 -bit ) and a message block
-#! i.e. 16 message words ( each of 32 -bit ), this routine applies 7 rounds of mixing
-#! of (permuted) message words into hash state.
+#! Given [x, ...] on stack top, this routine computes [y, ...]
+#! such that y = σ_1(x), as defined in SHA specification
 #!
-#! Functionality wise this routine is equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L75-L114
+#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L81-L87
+proc.small_sigma_1
+    dup
+    u32unchecked_rotr.17
+
+    swap
+
+    dup
+    u32unchecked_rotr.19
+
+    swap
+
+    u32unchecked_shr.10
+
+    u32checked_xor
+    u32checked_xor
+end
+
+#! Given [x, ...] on stack top, this routine computes [y, ...]
+#! such that y = Σ_0(x), as defined in SHA specification
+#!
+#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L57-L63
+proc.cap_sigma_0
+    dup
+    u32unchecked_rotr.2
+
+    swap
+
+    dup
+    u32unchecked_rotr.13
+
+    swap
+
+    u32unchecked_rotr.22
+
+    u32checked_xor
+    u32checked_xor
+end
+
+#! Given [x, ...] on stack top, this routine computes [y, ...]
+#! such that y = Σ_1(x), as defined in SHA specification
+#!
+#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L65-L71
+proc.cap_sigma_1
+    dup
+    u32unchecked_rotr.6
+
+    swap
+
+    dup
+    u32unchecked_rotr.11
+
+    swap
+
+    u32unchecked_rotr.25
+
+    u32checked_xor
+    u32checked_xor
+end
+
+#! Given [x, y, z, ...] on stack top, this routine computes [o, ...]
+#! such that o = ch(x, y, z), as defined in SHA specification
+#!
+#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L37-L45
+proc.ch
+    swap
+    dup.1
+    u32checked_and
+
+    swap
+    u32checked_not
+
+    movup.2
+    u32checked_and
+
+    u32checked_xor
+end
+
+#! Given [x, y, z, ...] on stack top, this routine computes [o, ...]
+#! such that o = maj(x, y, z), as defined in SHA specification
+#!
+#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L47-L55
+proc.maj
+    dup.1
+    dup.1
+    u32checked_and
+
+    swap
+    dup.3
+    u32checked_and
+
+    movup.2
+    movup.3
+    u32checked_and
+
+    u32checked_xor
+    u32checked_xor
+end
+
+#! Given [a, b, c, d, ...] on stack top, this routine reverses order of first 
+#! four elements on stack top such that final stack state looks like [d, c, b, a, ...]
+proc.rev_element_order
+    swap
+    movup.2
+    movup.3
+end
+
+#! Given [a, b, c, d, ...] on stack top, this routine computes next message schedule word
+#! using following formula
+#!
+#! t0 = small_sigma_1(a) + b
+#! t1 = small_sigma_0(c) + d
+#! return t0 + t1
+#!
+#! If to be computed message schedule word has index i ∈ [16, 64), then 
+#! a, b, c, d will have following indices in message schedule
+#!
+#! a = msg[i - 2]
+#! b = msg[i - 7]
+#! c = msg[i - 15]
+#! d = msg[i - 16]
+proc.compute_message_schedule_word
+    exec.small_sigma_1
+    movup.2
+    exec.small_sigma_0
+
+    u32overflowing_add3
+    drop
+    u32wrapping_add
+end
+
+#! Given eight working variables of SHA256 ( i.e. hash state ), a 32 -bit round constant & 
+#! 32 -bit message word on stack top, this routine consumes constant & message word into 
+#! hash state.
+#!
+#! Expected stack state looks like
+#!
+#! [a, b, c, d, e, f, g, h, CONST_i, WORD_i] | i ∈ [0, 64)
+#!
+#! After finishing execution, stack looks like
+#!
+#! [a', b', c', d', e', f', g', h']
+#!
+#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2_256.hpp#L165-L175
+proc.consume_message_word
+    dup.6
+    dup.6
+    dup.6
+    exec.ch
+
+    movup.9
+    movup.10
+
+    u32overflowing_add3
+    drop
+
+    dup.5
+    exec.cap_sigma_1
+
+    movup.9
+    u32overflowing_add3
+    drop
+
+    dup.3
+    dup.3
+    dup.3
+    exec.maj
+
+    dup.2
+    exec.cap_sigma_0
+
+    u32wrapping_add
+
+    movup.5
+    dup.2
+    u32wrapping_add
+    movdn.5
+
+    u32wrapping_add
+end
+
+#! Given 32 -bytes hash state ( in terms of 8 SHA256 words ) and 64 -bytes input 
+#! message ( in terms of 16 SHA256 words ) on stack top, this routine computes
+#! whole message schedule of 64 message words and consumes them into hash state.
 #!
 #! Expected stack state:
 #!
-#! [state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr, m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15]
+#! [state0, state1, state2, state3, state4, state5, state6, state7, msg0, msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8, msg9, msg10, msg11, msg12, msg13, msg14, msg15]
 #!
-#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
+#! Final stack state after completion of execution
 #!
-#! Meaning four consecutive blake3 state words can be read from memory easily.
+#! [state0', state1', state2', state3', state4', state5', state6', state7']
 #!
-#! Final stack state:
+#! Note, each SHA256 word is 32 -bit wide
 #!
-#! [...]
-#!
-#! i.e. 7 -round mixed state matrix lives in memory addresses {state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr}, 
-#! which were provided, on stack top, while invoking this routine. So updated state matrix can be read by caller routine, by reading
-#! the content of memory addresses where state was provided as routine input.
-proc.compress.1
+#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L89-L113
+#! & https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2_256.hpp#L148-L187 ( loop body execution when i = 0 )
+proc.prepare_message_schedule_and_consume.2
     loc_storew.0
     dropw
+    loc_storew.1
+    dropw
 
-    # apply first 6 rounds of mixing
-    repeat.6
-        # round `i` | i ∈ [1..7)
-        repeat.4
-            dupw.3
-        end
+    dup.15
+    dup.15
 
-        push.0.0.0.0
-        loc_loadw.0
-        exec.round
-        exec.permute_msg_words
-    end
+    dup.11
+    swap
+    dup.4
+    dup.4
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[16]
 
-    # round 7 ( last round, so no message word permutation required )
-    push.0.0.0.0
-    loc_loadw.0
-    exec.round
-end
+    swap
+    dup.12
+    swap
+    dup.5
+    dup.5
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[17]
 
-#! Blake3 2-to-1 hash function, which takes 64 -bytes input and produces 32 -bytes output digest
-#!
-#! Expected stack state:
-#!
-#! [msg0, msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8, msg9, msg10, msg11, msg12, msg13, msg14, msg15]
-#!
-#! msg`i` -> 32 -bit message word | i ∈ [0, 16)
-#!
-#! Output stack state:
-#!
-#! [dig0, dig1, dig2, dig3, dig4, dig5, dig6, dig7]
-#!
-#! dig`i` -> 32 -bit digest word | i ∈ [0, 8)
-export.hash.4
-    locaddr.3
-    locaddr.2
-    locaddr.1
-    locaddr.0
+    dup.1
+    dup.14
+    swap
+    dup.7
+    dup.7
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[18]
 
-    exec.initialize
+    dup.15
+    dup.2
+    dup.9
+    dup.9
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[19]
 
-    # Note, chunk compression routine needs to compress only one chunk with one message 
-    # block ( = 64 -bytes ) because what we're doing here is 2-to-1 hashing i.e. 64 -bytes 
-    # input being converted to 32 -bytes output
+    swapw
 
-    locaddr.3
-    locaddr.2
-    locaddr.1
-    locaddr.0
-
-    exec.compress
-
-    push.0.0.0.0
-    loc_loadw.3
-    push.0.0.0.0
-    loc_loadw.2
+    push.0x428a2f98
     push.0.0.0.0
     loc_loadw.1
     push.0.0.0.0
     loc_loadw.0
+    exec.consume_message_word # consume msg[0]
 
-    exec.finalize
+    push.0x71374491
+    movdn.8
+    exec.consume_message_word # consume msg[1]
+
+    push.0xb5c0fbcf
+    movdn.8
+    exec.consume_message_word # consume msg[2]
+
+    push.0xe9b5dba5
+    movdn.8
+    exec.consume_message_word # consume msg[3]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    dup.15
+    dup.15
+    dup.15
+
+    dup.4
+    dup.9
+    dup.9
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[20]
+
+    swap
+    dup.3
+    dup.10
+    dup.10
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[21]
+
+    movup.2
+    dup.2
+    dup.11
+    dup.11
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[22]
+
+    dup.6
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[23]
+
+    movupw.2
+
+    push.0x3956c25b
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[4]
+
+    push.0x59f111f1
+    movdn.8
+    exec.consume_message_word # consume msg[5]
+
+    push.0x923f82a4
+    movdn.8
+    exec.consume_message_word # consume msg[6]
+
+    push.0xab1c5ed5
+    movdn.8
+    exec.consume_message_word # consume msg[7]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    dup.6
+    dup.2
+    dup.11
+    dup.11
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[24]
+
+    dup.6
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[25]
+
+    dup.6
+    dup.2
+    dup.15
+    dup.15
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[26]
+
+    dup.15
+    dup.15
+    swap
+    dup.8
+    dup.4
+    exec.compute_message_schedule_word # computed msg[27]
+
+    movupw.3
+
+    push.0xd807aa98
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[8]
+
+    push.0x12835b01
+    movdn.8
+    exec.consume_message_word # consume msg[9]
+
+    push.0x243185be
+    movdn.8
+    exec.consume_message_word # consume msg[10]
+
+    push.0x550c7dc3
+    movdn.8
+    exec.consume_message_word # consume msg[11]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.3
+    movupw.3
+
+    dup.14
+    dup.10
+    dup.7
+    dup.7
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[28]
+
+    dup.14
+    dup.10
+    dup.9
+    dup.9
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[29]
+
+    dup.14
+    dup.2
+    dup.11
+    dup.11
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[30]
+
+    dup.14
+    dup.2
+    dup.8
+    dup.13
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[31]
+
+    movupw.2
+
+    push.0x72be5d74
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[12]
+
+    push.0x80deb1fe
+    movdn.8
+    exec.consume_message_word # consume msg[13]
+
+    push.0x9bdc06a7
+    movdn.8
+    exec.consume_message_word # consume msg[14]
+
+    push.0xc19bf174
+    movdn.8
+    exec.consume_message_word # consume msg[15]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.3
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[32]
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[33]
+
+    dup.14
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[34]
+
+    dup.10
+    dup.2
+    dup.8
+    dup.14
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[35]
+
+    movupw.3
+    exec.rev_element_order
+
+    push.0xe49b69c1
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[16]
+
+    push.0xefbe4786
+    movdn.8
+    exec.consume_message_word # consume msg[17]
+
+    push.0x0fc19dc6
+    movdn.8
+    exec.consume_message_word # consume msg[18]
+
+    push.0x240ca1cc
+    movdn.8
+    exec.consume_message_word # consume msg[19]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.3
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[36]
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[37]
+
+    dup.14
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[38]
+
+    dup.10
+    dup.2
+    dup.8
+    dup.14
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[39]
+
+    movupw.3
+    exec.rev_element_order
+
+    push.0x2de92c6f
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[20]
+
+    push.0x4a7484aa
+    movdn.8
+    exec.consume_message_word # consume msg[21]
+
+    push.0x5cb0a9dc
+    movdn.8
+    exec.consume_message_word # consume msg[22]
+
+    push.0x76f988da
+    movdn.8
+    exec.consume_message_word # consume msg[23]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.3
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[40]
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[41]
+
+    dup.14
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[42]
+
+    dup.10
+    dup.2
+    dup.13
+    dup.9
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[43]
+
+    movupw.3
+    exec.rev_element_order
+
+    push.0x983e5152
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[24]
+
+    push.0xa831c66d
+    movdn.8
+    exec.consume_message_word # consume msg[25]
+
+    push.0xb00327c8
+    movdn.8
+    exec.consume_message_word # consume msg[26]
+
+    push.0xbf597fc7
+    movdn.8
+    exec.consume_message_word # consume msg[27]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.3
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[44]
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[45]
+
+    dup.14
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[46]
+
+    dup.10
+    dup.2
+    dup.8
+    dup.14
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[47]
+
+    movupw.3
+    exec.rev_element_order
+
+    push.0xc6e00bf3
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[28]
+
+    push.0xd5a79147
+    movdn.8
+    exec.consume_message_word # consume msg[29]
+
+    push.0x06ca6351
+    movdn.8
+    exec.consume_message_word # consume msg[30]
+
+    push.0x14292967
+    movdn.8
+    exec.consume_message_word # consume msg[31]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.3
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[48]
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[49]
+
+    dup.14
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[50]
+
+    dup.10
+    dup.2
+    dup.8
+    dup.14
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[51]
+
+    movupw.3
+    exec.rev_element_order
+
+    push.0x27b70a85
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[32]
+
+    push.0x2e1b2138
+    movdn.8
+    exec.consume_message_word # consume msg[33]
+
+    push.0x4d2c6dfc
+    movdn.8
+    exec.consume_message_word # consume msg[34]
+
+    push.0x53380d13
+    movdn.8
+    exec.consume_message_word # consume msg[35]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.3
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[52]
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[53]
+
+    dup.14
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[54]
+
+    dup.10
+    dup.2
+    dup.8
+    dup.14
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[55]
+
+    movupw.3
+    exec.rev_element_order
+
+    push.0x650a7354
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[36]
+
+    push.0x766a0abb
+    movdn.8
+    exec.consume_message_word # consume msg[37]
+
+    push.0x81c2c92e
+    movdn.8
+    exec.consume_message_word # consume msg[38]
+
+    push.0x92722c85
+    movdn.8
+    exec.consume_message_word # consume msg[39]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.3
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[56]
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[57]
+
+    dup.14
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[58]
+
+    dup.10
+    dup.2
+    dup.8
+    dup.14
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[59]
+
+    movupw.3
+    exec.rev_element_order
+
+    push.0xa2bfe8a1
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[40]
+
+    push.0xa81a664b
+    movdn.8
+    exec.consume_message_word # consume msg[41]
+
+    push.0xc24b8b70
+    movdn.8
+    exec.consume_message_word # consume msg[42]
+
+    push.0xc76c51a3
+    movdn.8
+    exec.consume_message_word # consume msg[43]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.3
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[60]
+
+    dup.14
+    dup.6
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[61]
+
+    dup.14
+    dup.2
+    dup.13
+    dup.13
+    movdn.3
+    movdn.3
+    exec.compute_message_schedule_word # computed msg[62]
+
+    dup.10
+    dup.2
+    dup.8
+    dup.14
+    movdn.3
+    movdn.2
+    exec.compute_message_schedule_word # computed msg[63]
+
+    movupw.3
+    exec.rev_element_order
+
+    push.0xd192e819
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[44]
+
+    push.0xd6990624
+    movdn.8
+    exec.consume_message_word # consume msg[45]
+
+    push.0xf40e3585
+    movdn.8
+    exec.consume_message_word # consume msg[46]
+
+    push.0x106aa070
+    movdn.8
+    exec.consume_message_word # consume msg[47]
+
+    loc_storew.0
+    dropw
+    loc_storew.1
+    dropw
+
+    movupw.2
+    movupw.3
+    movupw.3
+
+    exec.rev_element_order
+
+    push.0x19a4c116
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
+    exec.consume_message_word # consume msg[48]
+
+    push.0x1e376c08
+    movdn.8
+    exec.consume_message_word # consume msg[49]
+
+    push.0x2748774c
+    movdn.8
+    exec.consume_message_word # consume msg[50]
+
+    push.0x34b0bcb5
+    movdn.8
+    exec.consume_message_word # consume msg[51]
+
+    movupw.2
+    exec.rev_element_order
+    movdnw.2
+
+    push.0x391c0cb3
+    movdn.8
+    exec.consume_message_word # consume msg[52]
+
+    push.0x4ed8aa4a
+    movdn.8
+    exec.consume_message_word # consume msg[53]
+
+    push.0x5b9cca4f
+    movdn.8
+    exec.consume_message_word # consume msg[54]
+
+    push.0x682e6ff3
+    movdn.8
+    exec.consume_message_word # consume msg[55]
+
+    movupw.2
+    exec.rev_element_order
+    movdnw.2
+
+    push.0x748f82ee
+    movdn.8
+    exec.consume_message_word # consume msg[56]
+
+    push.0x78a5636f
+    movdn.8
+    exec.consume_message_word # consume msg[57]
+
+    push.0x84c87814
+    movdn.8
+    exec.consume_message_word # consume msg[58]
+
+    push.0x8cc70208
+    movdn.8
+    exec.consume_message_word # consume msg[59]
+
+    movupw.2
+    exec.rev_element_order
+    movdnw.2
+
+    push.0x90befffa
+    movdn.8
+    exec.consume_message_word # consume msg[60]
+
+    push.0xa4506ceb
+    movdn.8
+    exec.consume_message_word # consume msg[61]
+
+    push.0xbef9a3f7
+    movdn.8
+    exec.consume_message_word # consume msg[62]
+
+    push.0xc67178f2
+    movdn.8
+    exec.consume_message_word # consume msg[63]
+
+    push.0x6a09e667
+    u32wrapping_add
+
+    swap
+    push.0xbb67ae85
+    u32wrapping_add
+    swap
+
+    movup.2
+    push.0x3c6ef372
+    u32wrapping_add
+    movdn.2
+
+    movup.3
+    push.0xa54ff53a
+    u32wrapping_add
+    movdn.3
+
+    movup.4
+    push.0x510e527f
+    u32wrapping_add
+    movdn.4
+
+    movup.5
+    push.0x9b05688c
+    u32wrapping_add
+    movdn.5
+
+    movup.6
+    push.0x1f83d9ab
+    u32wrapping_add
+    movdn.6
+
+    movup.7
+    push.0x5be0cd19
+    u32wrapping_add
+    movdn.7
 end
-"#),
-// ----- std::crypto::hashes::keccak256 -----------------------------------------------------------
-("std::crypto::hashes::keccak256", r#"#! Keccak-p[1600, 24] permutation's θ step mapping function, which is implemented 
+
+#! Given 32 -bytes hash state ( in terms of 8 SHA256 words ) and precomputed message 
+#! schedule of padding bytes ( in terms of 64 message words ), this routine consumes
+#! that into hash state, leaving final hash state, which is 32 -bytes SHA256 digest.
+#!
+#! Note, in SHA256 2-to-1 hashing, 64 -bytes are padded, which is processed as second message
+#! block ( each SHA256 message block is 64 -bytes wide ). That message block is used for generating 
+#! message schedule of 64 SHA256 words. That's exactly what can be precomputed & is consumed here 
+#! ( in this routine ) into provided hash state.
+#!
+#! Expected stack state:
+#!
+#! [state0, state1, state2, state3, state4, state5, state6, state7, ...]
+#!
+#! Final stack state after completion of execution
+#!
+#! [state0', state1', state2', state3', state4', state5', state6', state7']
+#!
+#! Note, each SHA256 word is 32 -bit wide
+#!
+#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2_256.hpp#L148-L187 ( loop 
+#! body execution when i = 1 i.e. consuming padding bytes )
+proc.consume_padding_message_schedule
+    dupw.1
+    dupw.1
+
+    push.2147483648
+    movdn.8
+    push.0x428a2f98
+    movdn.8
+    exec.consume_message_word # consume msg[0]
+
+    push.0
+    movdn.8
+    push.0x71374491
+    movdn.8
+    exec.consume_message_word # consume msg[1]
+
+    push.0
+    movdn.8
+    push.0xb5c0fbcf
+    movdn.8
+    exec.consume_message_word # consume msg[2]
+
+    push.0
+    movdn.8
+    push.0xe9b5dba5
+    movdn.8
+    exec.consume_message_word # consume msg[3]
+
+    push.0
+    movdn.8
+    push.0x3956c25b
+    movdn.8
+    exec.consume_message_word # consume msg[4]
+
+    push.0
+    movdn.8
+    push.0x59f111f1
+    movdn.8
+    exec.consume_message_word # consume msg[5]
+
+    push.0
+    movdn.8
+    push.0x923f82a4
+    movdn.8
+    exec.consume_message_word # consume msg[6]
+
+    push.0
+    movdn.8
+    push.0xab1c5ed5
+    movdn.8
+    exec.consume_message_word # consume msg[7]
+
+    push.0
+    movdn.8
+    push.0xd807aa98
+    movdn.8
+    exec.consume_message_word # consume msg[8]
+
+    push.0
+    movdn.8
+    push.0x12835b01
+    movdn.8
+    exec.consume_message_word # consume msg[9]
+
+    push.0
+    movdn.8
+    push.0x243185be
+    movdn.8
+    exec.consume_message_word # consume msg[10]
+
+    push.0
+    movdn.8
+    push.0x550c7dc3
+    movdn.8
+    exec.consume_message_word # consume msg[11]
+
+    push.0
+    movdn.8
+    push.0x72be5d74
+    movdn.8
+    exec.consume_message_word # consume msg[12]
+
+    push.0
+    movdn.8
+    push.0x80deb1fe
+    movdn.8
+    exec.consume_message_word # consume msg[13]
+
+    push.0
+    movdn.8
+    push.0x9bdc06a7
+    movdn.8
+    exec.consume_message_word # consume msg[14]
+
+    push.512
+    movdn.8
+    push.0xc19bf174
+    movdn.8
+    exec.consume_message_word # consume msg[15]
+
+    push.2147483648
+    movdn.8
+    push.0xe49b69c1
+    movdn.8
+    exec.consume_message_word # consume msg[16]
+
+    push.20971520
+    movdn.8
+    push.0xefbe4786
+    movdn.8
+    exec.consume_message_word # consume msg[17]
+
+    push.2117632
+    movdn.8
+    push.0x0fc19dc6
+    movdn.8
+    exec.consume_message_word # consume msg[18]
+
+    push.20616
+    movdn.8
+    push.0x240ca1cc
+    movdn.8
+    exec.consume_message_word # consume msg[19]
+
+    push.570427392
+    movdn.8
+    push.0x2de92c6f
+    movdn.8
+    exec.consume_message_word # consume msg[20]
+
+    push.575995924
+    movdn.8
+    push.0x4a7484aa
+    movdn.8
+    exec.consume_message_word # consume msg[21]
+
+    push.84449090
+    movdn.8
+    push.0x5cb0a9dc
+    movdn.8
+    exec.consume_message_word # consume msg[22]
+
+    push.2684354592
+    movdn.8
+    push.0x76f988da
+    movdn.8
+    exec.consume_message_word # consume msg[23]
+
+    push.1518862336
+    movdn.8
+    push.0x983e5152
+    movdn.8
+    exec.consume_message_word # consume msg[24]
+
+    push.6067200
+    movdn.8
+    push.0xa831c66d
+    movdn.8
+    exec.consume_message_word # consume msg[25]
+
+    push.1496221
+    movdn.8
+    push.0xb00327c8
+    movdn.8
+    exec.consume_message_word # consume msg[26]
+
+    push.4202700544
+    movdn.8
+    push.0xbf597fc7
+    movdn.8
+    exec.consume_message_word # consume msg[27]
+
+    push.3543279056
+    movdn.8
+    push.0xc6e00bf3
+    movdn.8
+    exec.consume_message_word # consume msg[28]
+
+    push.291985753
+    movdn.8
+    push.0xd5a79147
+    movdn.8
+    exec.consume_message_word # consume msg[29]
+
+    push.4142317530
+    movdn.8
+    push.0x06ca6351
+    movdn.8
+    exec.consume_message_word # consume msg[30]
+
+    push.3003913545
+    movdn.8
+    push.0x14292967
+    movdn.8
+    exec.consume_message_word # consume msg[31]
+
+    push.145928272
+    movdn.8
+    push.0x27b70a85
+    movdn.8
+    exec.consume_message_word # consume msg[32]
+
+    push.2642168871
+    movdn.8
+    push.0x2e1b2138
+    movdn.8
+    exec.consume_message_word # consume msg[33]
+
+    push.216179603
+    movdn.8
+    push.0x4d2c6dfc
+    movdn.8
+    exec.consume_message_word # consume msg[34]
+
+    push.2296832490
+    movdn.8
+    push.0x53380d13
+    movdn.8
+    exec.consume_message_word # consume msg[35]
+
+    push.2771075893
+    movdn.8
+    push.0x650a7354
+    movdn.8
+    exec.consume_message_word # consume msg[36]
+
+    push.1738633033
+    movdn.8
+    push.0x766a0abb
+    movdn.8
+    exec.consume_message_word # consume msg[37]
+
+    push.3610378607
+    movdn.8
+    push.0x81c2c92e
+    movdn.8
+    exec.consume_message_word # consume msg[38]
+
+    push.1324035729
+    movdn.8
+    push.0x92722c85
+    movdn.8
+    exec.consume_message_word # consume msg[39]
+
+    push.1572820453
+    movdn.8
+    push.0xa2bfe8a1
+    movdn.8
+    exec.consume_message_word # consume msg[40]
+
+    push.2397971253
+    movdn.8
+    push.0xa81a664b
+    movdn.8
+    exec.consume_message_word # consume msg[41]
+
+    push.3803995842
+    movdn.8
+    push.0xc24b8b70
+    movdn.8
+    exec.consume_message_word # consume msg[42]
+
+    push.2822718356
+    movdn.8
+    push.0xc76c51a3
+    movdn.8
+    exec.consume_message_word # consume msg[43]
+
+    push.1168996599
+    movdn.8
+    push.0xd192e819
+    movdn.8
+    exec.consume_message_word # consume msg[44]
+
+    push.921948365
+    movdn.8
+    push.0xd6990624
+    movdn.8
+    exec.consume_message_word # consume msg[45]
+
+    push.3650881000
+    movdn.8
+    push.0xf40e3585
+    movdn.8
+    exec.consume_message_word # consume msg[46]
+
+    push.2958106055
+    movdn.8
+    push.0x106aa070
+    movdn.8
+    exec.consume_message_word # consume msg[47]
+
+    push.1773959876
+    movdn.8
+    push.0x19a4c116
+    movdn.8
+    exec.consume_message_word # consume msg[48]
+
+    push.3172022107
+    movdn.8
+    push.0x1e376c08
+    movdn.8
+    exec.consume_message_word # consume msg[49]
+
+    push.3820646885
+    movdn.8
+    push.0x2748774c
+    movdn.8
+    exec.consume_message_word # consume msg[50]
+
+    push.991993842
+    movdn.8
+    push.0x34b0bcb5
+    movdn.8
+    exec.consume_message_word # consume msg[51]
+
+    push.419360279
+    movdn.8
+    push.0x391c0cb3
+    movdn.8
+    exec.consume_message_word # consume msg[52]
+
+    push.3797604839
+    movdn.8
+    push.0x4ed8aa4a
+    movdn.8
+    exec.consume_message_word # consume msg[53]
+
+    push.322392134
+    movdn.8
+    push.0x5b9cca4f
+    movdn.8
+    exec.consume_message_word # consume msg[54]
+
+    push.85264541
+    movdn.8
+    push.0x682e6ff3
+    movdn.8
+    exec.consume_message_word # consume msg[55]
+
+    push.1326255876
+    movdn.8
+    push.0x748f82ee
+    movdn.8
+    exec.consume_message_word # consume msg[56]
+
+    push.640108622
+    movdn.8
+    push.0x78a5636f
+    movdn.8
+    exec.consume_message_word # consume msg[57]
+
+    push.822159570
+    movdn.8
+    push.0x84c87814
+    movdn.8
+    exec.consume_message_word # consume msg[58]
+
+    push.3328750644
+    movdn.8
+    push.0x8cc70208
+    movdn.8
+    exec.consume_message_word # consume msg[59]
+
+    push.1107837388
+    movdn.8
+    push.0x90befffa
+    movdn.8
+    exec.consume_message_word # consume msg[60]
+
+    push.1657999800
+    movdn.8
+    push.0xa4506ceb
+    movdn.8
+    exec.consume_message_word # consume msg[61]
+
+    push.3852183409
+    movdn.8
+    push.0xbef9a3f7
+    movdn.8
+    exec.consume_message_word # consume msg[62]
+
+    push.2242356356
+    movdn.8
+    push.0xc67178f2
+    movdn.8
+    exec.consume_message_word # consume msg[63]
+
+    movup.8
+    u32wrapping_add
+
+    swap
+    movup.8
+    u32wrapping_add
+    swap
+
+    movup.2
+    movup.8
+    u32wrapping_add
+    movdn.2
+
+    movup.3
+    movup.8
+    u32wrapping_add
+    movdn.3
+
+    movup.4
+    movup.8
+    u32wrapping_add
+    movdn.4
+
+    movup.5
+    movup.8
+    u32wrapping_add
+    movdn.5
+
+    movup.6
+    movup.8
+    u32wrapping_add
+    movdn.6
+
+    movup.7
+    movup.8
+    u32wrapping_add
+    movdn.7
+end
+
+#! Given 64 -bytes input, this routine computes 32 -bytes SAH256 digest
+#!
+#! Expected stack state:
+#!
+#! [m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15] | m[0,16) = 32 -bit word
+#!
+#! Note, each SHA256 word is 32 -bit wide, so that's how input is expected.
+#! If you've 64 -bytes, consider packing 4 consecutive bytes into single word, 
+#! maintaining big endian byte order.
+#!
+#! Final stack state:
+#!
+#! [dig0, dig1, dig2, dig3, dig4, dig5, dig6, dig7]
+#!
+#! SHA256 digest is represented in terms of eight 32 -bit words ( big endian byte order ).
+export.hash
+    push.0x5be0cd19.0x1f83d9ab.0x9b05688c.0x510e527f
+    push.0xa54ff53a.0x3c6ef372.0xbb67ae85.0x6a09e667
+
+    exec.prepare_message_schedule_and_consume
+    exec.consume_padding_message_schedule
+end
+",&[12, 0, 11, 99, 97, 112, 95, 115, 105, 103, 109, 97, 95, 48, 2, 0, 11, 99, 97, 112, 95, 115, 105, 103, 109, 97, 95, 48, 0, 0, 0, 9, 0, 107, 83, 2, 127, 107, 83, 13, 127, 83, 22, 70, 70, 11, 99, 97, 112, 95, 115, 105, 103, 109, 97, 95, 49, 3, 0, 11, 99, 97, 112, 95, 115, 105, 103, 109, 97, 95, 49, 0, 0, 0, 9, 0, 107, 83, 6, 127, 107, 83, 11, 127, 83, 25, 70, 70, 2, 99, 104, 4, 0, 2, 99, 104, 0, 0, 0, 8, 0, 127, 108, 68, 127, 71, 146, 68, 70, 29, 99, 111, 109, 112, 117, 116, 101, 95, 109, 101, 115, 115, 97, 103, 101, 95, 115, 99, 104, 101, 100, 117, 108, 101, 95, 119, 111, 114, 100, 7, 0, 29, 99, 111, 109, 112, 117, 116, 101, 95, 109, 101, 115, 115, 97, 103, 101, 95, 115, 99, 104, 101, 100, 117, 108, 101, 95, 119, 111, 114, 100, 0, 0, 0, 6, 0, 207, 1, 0, 0, 0, 146, 207, 0, 0, 0, 0, 40, 104, 36, 20, 99, 111, 110, 115, 117, 109, 101, 95, 109, 101, 115, 115, 97, 103, 101, 95, 119, 111, 114, 100, 8, 0, 20, 99, 111, 110, 115, 117, 109, 101, 95, 109, 101, 115, 115, 97, 103, 101, 95, 119, 111, 114, 100, 0, 0, 0, 25, 0, 113, 113, 113, 207, 4, 0, 0, 0, 153, 154, 40, 104, 112, 207, 3, 0, 0, 0, 153, 40, 104, 110, 110, 110, 207, 5, 0, 0, 0, 109, 207, 2, 0, 0, 0, 36, 149, 109, 36, 165, 36, 32, 99, 111, 110, 115, 117, 109, 101, 95, 112, 97, 100, 100, 105, 110, 103, 95, 109, 101, 115, 115, 97, 103, 101, 95, 115, 99, 104, 101, 100, 117, 108, 101, 10, 0, 32, 99, 111, 110, 115, 117, 109, 101, 95, 112, 97, 100, 100, 105, 110, 103, 95, 109, 101, 115, 115, 97, 103, 101, 95, 115, 99, 104, 101, 100, 117, 108, 101, 0, 0, 0, 96, 1, 124, 124, 198, 1, 0, 0, 0, 128, 0, 0, 0, 0, 168, 198, 1, 152, 47, 138, 66, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 145, 68, 55, 113, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 207, 251, 192, 181, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 165, 219, 181, 233, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 91, 194, 86, 57, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 241, 17, 241, 89, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 164, 130, 63, 146, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 213, 94, 28, 171, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 152, 170, 7, 216, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 1, 91, 131, 18, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 190, 133, 49, 36, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 195, 125, 12, 85, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 116, 93, 190, 114, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 254, 177, 222, 128, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 168, 198, 1, 167, 6, 220, 155, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 2, 0, 0, 0, 0, 0, 0, 168, 198, 1, 116, 241, 155, 193, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 0, 128, 0, 0, 0, 0, 168, 198, 1, 193, 105, 155, 228, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 64, 1, 0, 0, 0, 0, 168, 198, 1, 134, 71, 190, 239, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 80, 32, 0, 0, 0, 0, 0, 168, 198, 1, 198, 157, 193, 15, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 136, 80, 0, 0, 0, 0, 0, 0, 168, 198, 1, 204, 161, 12, 36, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 8, 0, 34, 0, 0, 0, 0, 168, 198, 1, 111, 44, 233, 45, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 20, 0, 85, 34, 0, 0, 0, 0, 168, 198, 1, 170, 132, 116, 74, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 66, 151, 8, 5, 0, 0, 0, 0, 168, 198, 1, 220, 169, 176, 92, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 32, 0, 0, 160, 0, 0, 0, 0, 168, 198, 1, 218, 136, 249, 118, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 0, 136, 90, 0, 0, 0, 0, 168, 198, 1, 82, 81, 62, 152, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 148, 92, 0, 0, 0, 0, 0, 168, 198, 1, 109, 198, 49, 168, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 157, 212, 22, 0, 0, 0, 0, 0, 168, 198, 1, 200, 39, 3, 176, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 0, 31, 128, 250, 0, 0, 0, 0, 168, 198, 1, 199, 127, 89, 191, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 208, 37, 50, 211, 0, 0, 0, 0, 168, 198, 1, 243, 11, 224, 198, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 89, 89, 103, 17, 0, 0, 0, 0, 168, 198, 1, 71, 145, 167, 213, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 218, 191, 230, 246, 0, 0, 0, 0, 168, 198, 1, 81, 99, 202, 6, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 73, 21, 12, 179, 0, 0, 0, 0, 168, 198, 1, 103, 41, 41, 20, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 80, 176, 178, 8, 0, 0, 0, 0, 168, 198, 1, 133, 10, 183, 39, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 39, 76, 124, 157, 0, 0, 0, 0, 168, 198, 1, 56, 33, 27, 46, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 147, 163, 226, 12, 0, 0, 0, 0, 168, 198, 1, 252, 109, 44, 77, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 234, 225, 230, 136, 0, 0, 0, 0, 168, 198, 1, 19, 13, 56, 83, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 53, 67, 43, 165, 0, 0, 0, 0, 168, 198, 1, 84, 115, 10, 101, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 73, 111, 161, 103, 0, 0, 0, 0, 168, 198, 1, 187, 10, 106, 118, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 111, 1, 50, 215, 0, 0, 0, 0, 168, 198, 1, 46, 201, 194, 129, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 145, 46, 235, 78, 0, 0, 0, 0, 168, 198, 1, 133, 44, 114, 146, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 229, 85, 191, 93, 0, 0, 0, 0, 168, 198, 1, 161, 232, 191, 162, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 53, 35, 238, 142, 0, 0, 0, 0, 168, 198, 1, 75, 102, 26, 168, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 194, 94, 188, 226, 0, 0, 0, 0, 168, 198, 1, 112, 139, 75, 194, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 148, 67, 63, 168, 0, 0, 0, 0, 168, 198, 1, 163, 81, 108, 199, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 247, 120, 173, 69, 0, 0, 0, 0, 168, 198, 1, 25, 232, 146, 209, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 205, 208, 243, 54, 0, 0, 0, 0, 168, 198, 1, 36, 6, 153, 214, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 232, 5, 156, 217, 0, 0, 0, 0, 168, 198, 1, 133, 53, 14, 244, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 199, 29, 81, 176, 0, 0, 0, 0, 168, 198, 1, 112, 160, 106, 16, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 196, 122, 188, 105, 0, 0, 0, 0, 168, 198, 1, 22, 193, 164, 25, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 91, 55, 17, 189, 0, 0, 0, 0, 168, 198, 1, 8, 108, 55, 30, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 229, 113, 186, 227, 0, 0, 0, 0, 168, 198, 1, 76, 119, 72, 39, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 242, 159, 32, 59, 0, 0, 0, 0, 168, 198, 1, 181, 188, 176, 52, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 23, 238, 254, 24, 0, 0, 0, 0, 168, 198, 1, 179, 12, 28, 57, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 231, 217, 90, 226, 0, 0, 0, 0, 168, 198, 1, 74, 170, 216, 78, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 70, 80, 55, 19, 0, 0, 0, 0, 168, 198, 1, 79, 202, 156, 91, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 157, 8, 21, 5, 0, 0, 0, 0, 168, 198, 1, 243, 111, 46, 104, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 4, 15, 13, 79, 0, 0, 0, 0, 168, 198, 1, 238, 130, 143, 116, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 78, 72, 39, 38, 0, 0, 0, 0, 168, 198, 1, 111, 99, 165, 120, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 210, 40, 1, 49, 0, 0, 0, 0, 168, 198, 1, 20, 120, 200, 132, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 52, 180, 104, 198, 0, 0, 0, 0, 168, 198, 1, 8, 2, 199, 140, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 204, 65, 8, 66, 0, 0, 0, 0, 168, 198, 1, 250, 255, 190, 144, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 184, 17, 211, 98, 0, 0, 0, 0, 168, 198, 1, 235, 108, 80, 164, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 113, 167, 155, 229, 0, 0, 0, 0, 168, 198, 1, 247, 163, 249, 190, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 132, 164, 167, 133, 0, 0, 0, 0, 168, 198, 1, 242, 120, 113, 198, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 152, 36, 127, 152, 36, 127, 146, 152, 36, 162, 147, 152, 36, 163, 148, 152, 36, 164, 149, 152, 36, 165, 150, 152, 36, 166, 151, 152, 36, 167, 4, 104, 97, 115, 104, 11, 0, 4, 104, 97, 115, 104, 1, 0, 0, 4, 0, 198, 4, 25, 205, 224, 91, 0, 0, 0, 0, 171, 217, 131, 31, 0, 0, 0, 0, 140, 104, 5, 155, 0, 0, 0, 0, 127, 82, 14, 81, 0, 0, 0, 0, 198, 4, 58, 245, 79, 165, 0, 0, 0, 0, 114, 243, 110, 60, 0, 0, 0, 0, 133, 174, 103, 187, 0, 0, 0, 0, 103, 230, 9, 106, 0, 0, 0, 0, 207, 9, 0, 0, 0, 207, 10, 0, 0, 0, 3, 109, 97, 106, 5, 0, 3, 109, 97, 106, 0, 0, 0, 11, 0, 108, 108, 68, 127, 110, 68, 146, 147, 68, 70, 70, 36, 112, 114, 101, 112, 97, 114, 101, 95, 109, 101, 115, 115, 97, 103, 101, 95, 115, 99, 104, 101, 100, 117, 108, 101, 95, 97, 110, 100, 95, 99, 111, 110, 115, 117, 109, 101, 9, 0, 36, 112, 114, 101, 112, 97, 114, 101, 95, 109, 101, 115, 115, 97, 103, 101, 95, 115, 99, 104, 101, 100, 117, 108, 101, 95, 97, 110, 100, 95, 99, 111, 110, 115, 117, 109, 101, 0, 2, 0, 185, 2, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 122, 122, 118, 127, 111, 111, 163, 162, 207, 7, 0, 0, 0, 127, 119, 127, 112, 112, 163, 162, 207, 7, 0, 0, 0, 108, 121, 127, 114, 114, 163, 162, 207, 7, 0, 0, 0, 122, 109, 116, 116, 163, 162, 207, 7, 0, 0, 0, 142, 198, 1, 152, 47, 138, 66, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 145, 68, 55, 113, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 207, 251, 192, 181, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 165, 219, 181, 233, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 122, 122, 122, 111, 116, 116, 163, 162, 207, 7, 0, 0, 0, 127, 110, 117, 117, 163, 162, 207, 7, 0, 0, 0, 146, 109, 118, 118, 163, 162, 207, 7, 0, 0, 0, 113, 109, 120, 120, 163, 162, 207, 7, 0, 0, 0, 160, 198, 1, 91, 194, 86, 57, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 241, 17, 241, 89, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 164, 130, 63, 146, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 213, 94, 28, 171, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 113, 109, 118, 118, 163, 162, 207, 7, 0, 0, 0, 113, 109, 120, 120, 163, 162, 207, 7, 0, 0, 0, 113, 109, 122, 122, 163, 162, 207, 7, 0, 0, 0, 122, 122, 127, 115, 111, 207, 7, 0, 0, 0, 161, 198, 1, 152, 170, 7, 216, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 1, 91, 131, 18, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 190, 133, 49, 36, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 195, 125, 12, 85, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 161, 161, 121, 117, 114, 114, 163, 162, 207, 7, 0, 0, 0, 121, 117, 116, 116, 163, 162, 207, 7, 0, 0, 0, 121, 109, 118, 118, 163, 162, 207, 7, 0, 0, 0, 121, 109, 115, 120, 163, 162, 207, 7, 0, 0, 0, 160, 198, 1, 116, 93, 190, 114, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 254, 177, 222, 128, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 167, 6, 220, 155, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 116, 241, 155, 193, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 161, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 109, 120, 120, 163, 163, 207, 7, 0, 0, 0, 117, 109, 115, 121, 163, 162, 207, 7, 0, 0, 0, 161, 207, 6, 0, 0, 0, 198, 1, 193, 105, 155, 228, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 134, 71, 190, 239, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 198, 157, 193, 15, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 204, 161, 12, 36, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 161, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 109, 120, 120, 163, 163, 207, 7, 0, 0, 0, 117, 109, 115, 121, 163, 162, 207, 7, 0, 0, 0, 161, 207, 6, 0, 0, 0, 198, 1, 111, 44, 233, 45, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 170, 132, 116, 74, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 220, 169, 176, 92, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 218, 136, 249, 118, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 161, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 109, 120, 120, 163, 163, 207, 7, 0, 0, 0, 117, 109, 120, 116, 163, 163, 207, 7, 0, 0, 0, 161, 207, 6, 0, 0, 0, 198, 1, 82, 81, 62, 152, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 109, 198, 49, 168, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 200, 39, 3, 176, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 199, 127, 89, 191, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 161, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 109, 120, 120, 163, 163, 207, 7, 0, 0, 0, 117, 109, 115, 121, 163, 162, 207, 7, 0, 0, 0, 161, 207, 6, 0, 0, 0, 198, 1, 243, 11, 224, 198, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 71, 145, 167, 213, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 81, 99, 202, 6, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 103, 41, 41, 20, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 161, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 109, 120, 120, 163, 163, 207, 7, 0, 0, 0, 117, 109, 115, 121, 163, 162, 207, 7, 0, 0, 0, 161, 207, 6, 0, 0, 0, 198, 1, 133, 10, 183, 39, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 56, 33, 27, 46, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 252, 109, 44, 77, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 19, 13, 56, 83, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 161, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 109, 120, 120, 163, 163, 207, 7, 0, 0, 0, 117, 109, 115, 121, 163, 162, 207, 7, 0, 0, 0, 161, 207, 6, 0, 0, 0, 198, 1, 84, 115, 10, 101, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 187, 10, 106, 118, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 46, 201, 194, 129, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 133, 44, 114, 146, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 161, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 109, 120, 120, 163, 163, 207, 7, 0, 0, 0, 117, 109, 115, 121, 163, 162, 207, 7, 0, 0, 0, 161, 207, 6, 0, 0, 0, 198, 1, 161, 232, 191, 162, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 75, 102, 26, 168, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 112, 139, 75, 194, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 163, 81, 108, 199, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 161, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 113, 120, 120, 163, 163, 207, 7, 0, 0, 0, 121, 109, 120, 120, 163, 163, 207, 7, 0, 0, 0, 117, 109, 115, 121, 163, 162, 207, 7, 0, 0, 0, 161, 207, 6, 0, 0, 0, 198, 1, 25, 232, 146, 209, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 36, 6, 153, 214, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 133, 53, 14, 244, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 112, 160, 106, 16, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 160, 161, 161, 207, 6, 0, 0, 0, 198, 1, 22, 193, 164, 25, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 198, 1, 8, 108, 55, 30, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 76, 119, 72, 39, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 181, 188, 176, 52, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 160, 207, 6, 0, 0, 0, 176, 198, 1, 179, 12, 28, 57, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 74, 170, 216, 78, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 79, 202, 156, 91, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 243, 111, 46, 104, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 160, 207, 6, 0, 0, 0, 176, 198, 1, 238, 130, 143, 116, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 111, 99, 165, 120, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 20, 120, 200, 132, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 8, 2, 199, 140, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 160, 207, 6, 0, 0, 0, 176, 198, 1, 250, 255, 190, 144, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 235, 108, 80, 164, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 247, 163, 249, 190, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 242, 120, 113, 198, 0, 0, 0, 0, 168, 207, 8, 0, 0, 0, 198, 1, 103, 230, 9, 106, 0, 0, 0, 0, 36, 127, 198, 1, 133, 174, 103, 187, 0, 0, 0, 0, 36, 127, 146, 198, 1, 114, 243, 110, 60, 0, 0, 0, 0, 36, 162, 147, 198, 1, 58, 245, 79, 165, 0, 0, 0, 0, 36, 163, 148, 198, 1, 127, 82, 14, 81, 0, 0, 0, 0, 36, 164, 149, 198, 1, 140, 104, 5, 155, 0, 0, 0, 0, 36, 165, 150, 198, 1, 171, 217, 131, 31, 0, 0, 0, 0, 36, 166, 151, 198, 1, 25, 205, 224, 91, 0, 0, 0, 0, 36, 167, 17, 114, 101, 118, 95, 101, 108, 101, 109, 101, 110, 116, 95, 111, 114, 100, 101, 114, 6, 0, 17, 114, 101, 118, 95, 101, 108, 101, 109, 101, 110, 116, 95, 111, 114, 100, 101, 114, 0, 0, 0, 3, 0, 127, 146, 147, 13, 115, 109, 97, 108, 108, 95, 115, 105, 103, 109, 97, 95, 48, 0, 0, 13, 115, 109, 97, 108, 108, 95, 115, 105, 103, 109, 97, 95, 48, 0, 0, 0, 9, 0, 107, 83, 7, 127, 107, 83, 18, 127, 75, 3, 70, 70, 13, 115, 109, 97, 108, 108, 95, 115, 105, 103, 109, 97, 95, 49, 1, 0, 13, 115, 109, 97, 108, 108, 95, 115, 105, 103, 109, 97, 95, 49, 0, 0, 0, 9, 0, 107, 83, 17, 127, 107, 83, 19, 127, 75, 10, 70, 70]),
+("std::crypto::hashes::keccak256",vm_assembly::ProcedureId([16, 21, 15, 8, 15, 85, 114, 121, 112, 116, 111, 58, 58, 104, 97, 115, 104, 101, 115, 58, 58, 107, 101, 99]),"#! Keccak-p[1600, 24] permutation's θ step mapping function, which is implemented 
 #! in terms of 32 -bit word size ( bit interleaved representation )
 #!
 #! See https://github.com/itzmeanjan/merklize-sha/blob/1d35aae9da7fed20127489f362b4bc93242a516c/include/sha3.hpp#L55-L98 for original implementation
@@ -4551,4028 +5094,1045 @@ export.hash.13
     push.0.0.0.0
     loc_loadw.0
     exec.to_digest
-end"#),
-// ----- std::crypto::hashes::sha256 --------------------------------------------------------------
-("std::crypto::hashes::sha256", r#"#! Given [x, ...] on stack top, this routine computes [y, ...]
-#! such that y = σ_0(x), as defined in SHA specification
-#!
-#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L73-L79
-proc.small_sigma_0
-    dup
-    u32unchecked_rotr.7
-
-    swap
-
-    dup
-    u32unchecked_rotr.18
-
-    swap
-
-    u32unchecked_shr.3
-
-    u32checked_xor
-    u32checked_xor
-end
-
-#! Given [x, ...] on stack top, this routine computes [y, ...]
-#! such that y = σ_1(x), as defined in SHA specification
-#!
-#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L81-L87
-proc.small_sigma_1
-    dup
-    u32unchecked_rotr.17
-
-    swap
-
-    dup
-    u32unchecked_rotr.19
-
-    swap
-
-    u32unchecked_shr.10
-
-    u32checked_xor
-    u32checked_xor
-end
-
-#! Given [x, ...] on stack top, this routine computes [y, ...]
-#! such that y = Σ_0(x), as defined in SHA specification
-#!
-#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L57-L63
-proc.cap_sigma_0
-    dup
-    u32unchecked_rotr.2
-
-    swap
-
-    dup
-    u32unchecked_rotr.13
-
-    swap
-
-    u32unchecked_rotr.22
-
-    u32checked_xor
-    u32checked_xor
-end
-
-#! Given [x, ...] on stack top, this routine computes [y, ...]
-#! such that y = Σ_1(x), as defined in SHA specification
-#!
-#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L65-L71
-proc.cap_sigma_1
-    dup
-    u32unchecked_rotr.6
-
-    swap
-
-    dup
-    u32unchecked_rotr.11
-
-    swap
-
-    u32unchecked_rotr.25
-
-    u32checked_xor
-    u32checked_xor
-end
-
-#! Given [x, y, z, ...] on stack top, this routine computes [o, ...]
-#! such that o = ch(x, y, z), as defined in SHA specification
-#!
-#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L37-L45
-proc.ch
-    swap
-    dup.1
-    u32checked_and
-
-    swap
-    u32checked_not
-
-    movup.2
-    u32checked_and
-
-    u32checked_xor
-end
-
-#! Given [x, y, z, ...] on stack top, this routine computes [o, ...]
-#! such that o = maj(x, y, z), as defined in SHA specification
-#!
-#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L47-L55
-proc.maj
-    dup.1
-    dup.1
-    u32checked_and
-
-    swap
-    dup.3
-    u32checked_and
-
-    movup.2
-    movup.3
-    u32checked_and
-
-    u32checked_xor
-    u32checked_xor
-end
-
-#! Given [a, b, c, d, ...] on stack top, this routine reverses order of first 
-#! four elements on stack top such that final stack state looks like [d, c, b, a, ...]
-proc.rev_element_order
-    swap
-    movup.2
-    movup.3
-end
-
-#! Given [a, b, c, d, ...] on stack top, this routine computes next message schedule word
-#! using following formula
-#!
-#! t0 = small_sigma_1(a) + b
-#! t1 = small_sigma_0(c) + d
-#! return t0 + t1
-#!
-#! If to be computed message schedule word has index i ∈ [16, 64), then 
-#! a, b, c, d will have following indices in message schedule
-#!
-#! a = msg[i - 2]
-#! b = msg[i - 7]
-#! c = msg[i - 15]
-#! d = msg[i - 16]
-proc.compute_message_schedule_word
-    exec.small_sigma_1
-    movup.2
-    exec.small_sigma_0
-
-    u32overflowing_add3
-    drop
-    u32wrapping_add
-end
-
-#! Given eight working variables of SHA256 ( i.e. hash state ), a 32 -bit round constant & 
-#! 32 -bit message word on stack top, this routine consumes constant & message word into 
-#! hash state.
-#!
-#! Expected stack state looks like
-#!
-#! [a, b, c, d, e, f, g, h, CONST_i, WORD_i] | i ∈ [0, 64)
-#!
-#! After finishing execution, stack looks like
-#!
-#! [a', b', c', d', e', f', g', h']
-#!
-#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2_256.hpp#L165-L175
-proc.consume_message_word
-    dup.6
-    dup.6
-    dup.6
-    exec.ch
-
-    movup.9
-    movup.10
-
-    u32overflowing_add3
-    drop
-
-    dup.5
-    exec.cap_sigma_1
-
-    movup.9
-    u32overflowing_add3
-    drop
-
-    dup.3
-    dup.3
-    dup.3
-    exec.maj
-
-    dup.2
-    exec.cap_sigma_0
-
-    u32wrapping_add
-
-    movup.5
-    dup.2
-    u32wrapping_add
-    movdn.5
-
-    u32wrapping_add
-end
-
-#! Given 32 -bytes hash state ( in terms of 8 SHA256 words ) and 64 -bytes input 
-#! message ( in terms of 16 SHA256 words ) on stack top, this routine computes
-#! whole message schedule of 64 message words and consumes them into hash state.
+end",&[12, 0, 3, 99, 104, 105, 3, 0, 3, 99, 104, 105, 0, 4, 0, 82, 3, 107, 183, 0, 0, 0, 0, 0, 0, 0, 0, 191, 104, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 71, 127, 71, 127, 146, 3, 107, 163, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 108, 108, 150, 68, 127, 150, 68, 127, 147, 71, 147, 71, 148, 68, 127, 148, 68, 127, 147, 147, 183, 1, 0, 0, 0, 0, 0, 0, 0, 194, 111, 187, 104, 104, 71, 127, 71, 127, 146, 3, 107, 163, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 108, 108, 148, 68, 127, 148, 68, 127, 147, 147, 148, 5, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 149, 71, 149, 71, 109, 68, 127, 110, 68, 127, 151, 151, 183, 2, 0, 0, 0, 0, 0, 0, 0, 194, 105, 71, 127, 71, 127, 146, 68, 127, 146, 68, 127, 183, 0, 0, 0, 0, 0, 0, 0, 0, 185, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 187, 183, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 183, 2, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 149, 70, 127, 149, 70, 127, 111, 194, 148, 3, 164, 111, 187, 71, 127, 71, 127, 110, 110, 146, 68, 127, 146, 68, 127, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 183, 1, 0, 0, 0, 0, 0, 0, 0, 194, 150, 3, 107, 167, 187, 149, 149, 71, 127, 71, 127, 109, 68, 127, 110, 68, 127, 147, 147, 71, 127, 71, 127, 111, 68, 127, 112, 68, 127, 147, 147, 183, 2, 0, 0, 0, 0, 0, 0, 0, 194, 150, 5, 107, 167, 187, 104, 104, 108, 108, 148, 71, 149, 71, 127, 146, 68, 127, 146, 68, 127, 147, 147, 148, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 147, 147, 71, 127, 71, 127, 146, 68, 127, 146, 68, 127, 147, 147, 183, 3, 0, 0, 0, 0, 0, 0, 0, 194, 183, 0, 0, 0, 0, 0, 0, 0, 0, 185, 3, 107, 165, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 104, 104, 71, 127, 71, 127, 146, 3, 162, 109, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 108, 108, 150, 68, 127, 150, 68, 127, 147, 147, 71, 127, 71, 127, 111, 68, 127, 112, 68, 127, 147, 147, 196, 1, 0, 0, 0, 0, 0, 0, 0, 150, 3, 166, 113, 187, 146, 104, 146, 104, 108, 108, 149, 149, 71, 127, 71, 127, 146, 68, 127, 146, 68, 127, 148, 5, 164, 111, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 151, 151, 71, 127, 71, 127, 110, 110, 146, 68, 127, 146, 68, 127, 151, 151, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 71, 127, 71, 127, 146, 68, 127, 146, 68, 127, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 163, 163, 196, 3, 0, 0, 0, 0, 0, 0, 0, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 71, 127, 71, 127, 110, 110, 146, 68, 127, 146, 68, 127, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 1, 0, 0, 0, 0, 0, 0, 0, 150, 3, 166, 113, 187, 149, 149, 71, 127, 71, 127, 110, 110, 146, 68, 127, 146, 68, 127, 147, 147, 71, 127, 71, 127, 112, 112, 146, 68, 127, 146, 68, 127, 147, 147, 196, 2, 0, 0, 0, 0, 0, 0, 0, 150, 5, 166, 113, 187, 104, 104, 147, 147, 71, 127, 71, 127, 110, 110, 146, 68, 127, 146, 68, 127, 148, 3, 164, 111, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 149, 149, 71, 127, 71, 127, 146, 68, 127, 146, 68, 127, 147, 147, 196, 3, 0, 0, 0, 0, 0, 0, 0, 148, 5, 164, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 104, 104, 146, 3, 162, 109, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 149, 149, 71, 127, 71, 127, 110, 110, 146, 68, 127, 146, 68, 127, 147, 147, 71, 127, 71, 127, 112, 112, 146, 68, 127, 146, 68, 127, 147, 147, 196, 1, 0, 0, 0, 0, 0, 0, 0, 150, 3, 166, 113, 187, 146, 104, 146, 104, 147, 147, 71, 127, 71, 127, 110, 110, 146, 68, 127, 146, 68, 127, 148, 5, 164, 111, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 151, 151, 71, 127, 71, 127, 110, 110, 146, 68, 127, 146, 68, 127, 151, 151, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 71, 127, 71, 127, 146, 68, 127, 146, 68, 127, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 163, 163, 196, 3, 0, 0, 0, 0, 0, 0, 0, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 148, 3, 164, 111, 187, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 148, 70, 127, 148, 70, 127, 146, 148, 70, 162, 147, 148, 70, 163, 111, 194, 105, 104, 20, 102, 114, 111, 109, 95, 98, 105, 116, 95, 105, 110, 116, 101, 114, 108, 101, 97, 118, 101, 100, 8, 0, 20, 102, 114, 111, 109, 95, 98, 105, 116, 95, 105, 110, 116, 101, 114, 108, 101, 97, 118, 101, 100, 1, 0, 0, 6, 0, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 189, 8, 36, 0, 75, 2, 127, 75, 2, 127, 110, 110, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 68, 127, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 68, 79, 31, 127, 79, 30, 70, 146, 70, 127, 110, 110, 198, 1, 0, 0, 1, 0, 0, 0, 0, 0, 68, 127, 198, 1, 0, 0, 1, 0, 0, 0, 0, 0, 68, 79, 15, 127, 79, 14, 70, 70, 146, 75, 1, 162, 147, 75, 1, 163, 146, 104, 146, 104, 4, 104, 97, 115, 104, 11, 0, 4, 104, 97, 115, 104, 1, 13, 0, 9, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 207, 9, 0, 0, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 10, 0, 0, 0, 4, 105, 111, 116, 97, 4, 0, 4, 105, 111, 116, 97, 0, 0, 0, 13, 0, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 149, 70, 127, 149, 70, 127, 148, 194, 105, 8, 107, 101, 99, 99, 97, 107, 95, 112, 6, 0, 8, 107, 101, 99, 99, 97, 107, 95, 112, 0, 0, 0, 120, 0, 107, 207, 5, 0, 0, 0, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 137, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 139, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 128, 128, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 139, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 0, 128, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 136, 128, 0, 128, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 130, 0, 0, 128, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 130, 128, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 3, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 139, 128, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 11, 0, 0, 128, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 138, 0, 0, 128, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 129, 0, 0, 128, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 129, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 8, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 131, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 3, 128, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 136, 128, 0, 128, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 136, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 0, 128, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 109, 207, 4, 0, 0, 0, 107, 207, 5, 0, 0, 0, 198, 2, 130, 128, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 146, 207, 4, 0, 0, 0, 2, 112, 105, 2, 0, 2, 112, 105, 0, 14, 0, 25, 1, 107, 183, 0, 0, 0, 0, 0, 0, 0, 0, 191, 104, 183, 1, 0, 0, 0, 0, 0, 0, 0, 127, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 187, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 163, 163, 114, 194, 104, 104, 163, 163, 112, 3, 194, 148, 3, 164, 111, 187, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 163, 163, 114, 3, 194, 104, 104, 112, 3, 194, 148, 3, 164, 111, 187, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 114, 3, 194, 146, 104, 146, 104, 163, 163, 112, 3, 194, 148, 3, 164, 111, 187, 112, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 114, 194, 114, 3, 187, 146, 104, 146, 104, 112, 3, 194, 148, 3, 164, 111, 187, 112, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 114, 3, 194, 105, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 163, 163, 112, 3, 194, 148, 3, 164, 111, 187, 112, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 114, 3, 194, 114, 3, 187, 146, 104, 146, 104, 112, 3, 194, 148, 3, 164, 111, 187, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 163, 163, 114, 3, 194, 104, 104, 163, 163, 112, 3, 194, 148, 3, 164, 111, 187, 112, 3, 194, 148, 3, 164, 111, 187, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 163, 163, 114, 3, 194, 104, 104, 163, 163, 112, 3, 194, 148, 3, 164, 111, 187, 112, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 114, 3, 194, 114, 3, 187, 146, 104, 146, 104, 112, 3, 194, 148, 3, 164, 111, 187, 112, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 147, 147, 114, 3, 194, 105, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 163, 163, 112, 3, 194, 148, 3, 164, 111, 187, 112, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 114, 3, 194, 114, 3, 187, 146, 104, 146, 104, 112, 3, 194, 148, 3, 164, 111, 187, 112, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 163, 163, 114, 3, 194, 104, 104, 148, 104, 183, 0, 0, 0, 0, 0, 0, 0, 0, 185, 164, 254, 148, 4, 10, 0, 112, 187, 111, 194, 148, 3, 164, 149, 3, 165, 105, 104, 104, 3, 114, 104, 111, 1, 0, 3, 114, 104, 111, 0, 1, 0, 203, 0, 107, 183, 0, 0, 0, 0, 0, 0, 0, 0, 191, 104, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 187, 147, 87, 1, 162, 148, 107, 3, 165, 194, 111, 187, 87, 31, 127, 87, 31, 127, 146, 87, 14, 162, 147, 87, 14, 163, 148, 107, 3, 165, 194, 111, 187, 87, 13, 127, 87, 14, 146, 87, 18, 162, 147, 87, 18, 163, 148, 107, 3, 165, 194, 111, 187, 87, 22, 127, 87, 22, 127, 146, 87, 3, 162, 147, 87, 3, 163, 148, 107, 3, 165, 194, 111, 187, 87, 27, 127, 87, 28, 146, 87, 10, 162, 147, 87, 10, 163, 148, 107, 3, 165, 194, 111, 187, 87, 1, 127, 87, 2, 146, 87, 5, 162, 147, 87, 5, 163, 148, 107, 3, 165, 194, 111, 187, 87, 21, 127, 87, 22, 146, 87, 12, 163, 146, 87, 13, 162, 148, 107, 3, 165, 194, 111, 187, 87, 19, 127, 87, 20, 146, 87, 20, 163, 146, 87, 21, 162, 148, 107, 3, 165, 194, 111, 187, 87, 22, 127, 87, 23, 146, 87, 7, 163, 146, 87, 8, 162, 148, 107, 3, 165, 194, 111, 187, 87, 10, 127, 87, 11, 146, 87, 4, 162, 147, 87, 4, 163, 148, 107, 3, 165, 194, 111, 187, 87, 9, 127, 87, 9, 127, 146, 87, 1, 162, 147, 87, 1, 163, 148, 107, 3, 165, 194, 111, 187, 87, 30, 127, 87, 31, 146, 87, 28, 162, 147, 87, 28, 163, 148, 107, 3, 165, 194, 111, 187, 87, 7, 127, 87, 7, 127, 148, 194, 105, 5, 114, 111, 117, 110, 100, 5, 0, 5, 114, 111, 117, 110, 100, 0, 0, 0, 7, 0, 107, 207, 0, 0, 0, 0, 107, 207, 1, 0, 0, 0, 107, 207, 2, 0, 0, 0, 207, 3, 0, 0, 0, 5, 116, 104, 101, 116, 97, 0, 0, 5, 116, 104, 101, 116, 97, 0, 3, 0, 175, 2, 107, 183, 0, 0, 0, 0, 0, 0, 0, 0, 191, 104, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 147, 70, 127, 147, 70, 127, 146, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 146, 70, 127, 146, 70, 127, 183, 0, 0, 0, 0, 0, 0, 0, 0, 185, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 147, 70, 127, 147, 70, 127, 146, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 146, 70, 127, 146, 70, 127, 147, 147, 183, 1, 0, 0, 0, 0, 0, 0, 0, 194, 105, 183, 0, 0, 0, 0, 0, 0, 0, 0, 185, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 147, 70, 127, 147, 70, 127, 146, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 146, 70, 127, 146, 70, 127, 183, 0, 0, 0, 0, 0, 0, 0, 0, 185, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 147, 70, 127, 147, 70, 127, 146, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 146, 70, 127, 146, 70, 127, 147, 147, 183, 2, 0, 0, 0, 0, 0, 0, 0, 194, 105, 183, 0, 0, 0, 0, 0, 0, 0, 0, 185, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 147, 70, 127, 147, 70, 127, 146, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 104, 104, 147, 70, 127, 147, 70, 127, 146, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 104, 146, 104, 146, 70, 127, 146, 70, 127, 183, 2, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 183, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 115, 111, 87, 1, 70, 117, 111, 70, 109, 115, 87, 1, 70, 111, 115, 70, 150, 118, 87, 1, 70, 151, 117, 70, 152, 157, 87, 1, 70, 153, 156, 70, 154, 154, 87, 1, 70, 154, 154, 70, 127, 146, 147, 148, 149, 150, 151, 152, 153, 183, 0, 0, 0, 0, 0, 0, 0, 0, 185, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 112, 70, 127, 113, 70, 127, 146, 114, 70, 162, 147, 115, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 116, 70, 127, 117, 70, 127, 146, 118, 70, 162, 147, 119, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 120, 70, 127, 121, 70, 127, 146, 112, 70, 162, 147, 113, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 114, 70, 127, 115, 70, 127, 146, 116, 70, 162, 147, 117, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 118, 70, 127, 119, 70, 127, 146, 120, 70, 162, 147, 121, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 112, 70, 127, 113, 70, 127, 146, 114, 70, 162, 147, 115, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 116, 70, 127, 117, 70, 127, 146, 118, 70, 162, 147, 119, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 120, 70, 127, 121, 70, 127, 146, 112, 70, 162, 147, 113, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 114, 70, 127, 115, 70, 127, 146, 116, 70, 162, 147, 117, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 118, 70, 127, 119, 70, 127, 146, 120, 70, 162, 147, 121, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 149, 70, 127, 149, 70, 127, 146, 149, 70, 162, 147, 149, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 149, 70, 127, 149, 70, 127, 146, 149, 70, 162, 147, 149, 70, 163, 111, 194, 105, 3, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 149, 70, 127, 149, 70, 127, 148, 194, 105, 18, 116, 111, 95, 98, 105, 116, 95, 105, 110, 116, 101, 114, 108, 101, 97, 118, 101, 100, 7, 0, 18, 116, 111, 95, 98, 105, 116, 95, 105, 110, 116, 101, 114, 108, 101, 97, 118, 101, 100, 1, 0, 0, 6, 0, 198, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 140, 8, 40, 0, 75, 1, 127, 75, 1, 127, 110, 110, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 68, 127, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 68, 127, 79, 31, 127, 79, 15, 127, 70, 70, 110, 110, 198, 1, 2, 0, 0, 0, 0, 0, 0, 0, 68, 127, 198, 1, 2, 0, 0, 0, 0, 0, 0, 0, 68, 127, 79, 30, 127, 79, 14, 127, 147, 70, 70, 127, 146, 75, 2, 162, 147, 75, 2, 163, 146, 104, 146, 104, 9, 116, 111, 95, 100, 105, 103, 101, 115, 116, 10, 0, 9, 116, 111, 95, 100, 105, 103, 101, 115, 116, 0, 0, 0, 1, 0, 254, 36, 9, 3, 0, 151, 151, 207, 8, 0, 0, 0, 14, 116, 111, 95, 115, 116, 97, 116, 101, 95, 97, 114, 114, 97, 121, 9, 0, 14, 116, 111, 95, 115, 116, 97, 116, 101, 95, 97, 114, 114, 97, 121, 0, 0, 0, 45, 0, 254, 233, 8, 11, 0, 164, 207, 7, 0, 0, 0, 147, 147, 207, 7, 0, 0, 0, 147, 147, 111, 194, 105, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 111, 194, 105, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 194, 105, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 194, 105, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 194, 105, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 194, 105, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 194, 105, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 194, 105, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 194, 105, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105]),
+("std::crypto::hashes::blake3",vm_assembly::ProcedureId([24, 17, 87, 58, 58, 99, 114, 121, 112, 116, 111, 58, 58, 104, 97, 115, 104, 101, 115, 58, 58, 98, 108, 97]),"#! Initializes four memory addresses, provided for storing initial 4x4 blake3 
+#! state matrix ( i.e. 16 elements each of 32 -bit ), for computing blake3 2-to-1 hash
 #!
 #! Expected stack state:
 #!
-#! [state0, state1, state2, state3, state4, state5, state6, state7, msg0, msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8, msg9, msg10, msg11, msg12, msg13, msg14, msg15]
+#! [state_0_3_addr, state_4_7_addr, state_8_11_addr, state_12_15_addr]
 #!
-#! Final stack state after completion of execution
-#!
-#! [state0', state1', state2', state3', state4', state5', state6', state7']
-#!
-#! Note, each SHA256 word is 32 -bit wide
-#!
-#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L89-L113
-#! & https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2_256.hpp#L148-L187 ( loop body execution when i = 0 )
-proc.prepare_message_schedule_and_consume.2
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    dup.15
-    dup.15
-
-    dup.11
-    swap
-    dup.4
-    dup.4
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[16]
-
-    swap
-    dup.12
-    swap
-    dup.5
-    dup.5
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[17]
-
-    dup.1
-    dup.14
-    swap
-    dup.7
-    dup.7
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[18]
-
-    dup.15
-    dup.2
-    dup.9
-    dup.9
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[19]
-
-    swapw
-
-    push.0x428a2f98
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[0]
-
-    push.0x71374491
-    movdn.8
-    exec.consume_message_word # consume msg[1]
-
-    push.0xb5c0fbcf
-    movdn.8
-    exec.consume_message_word # consume msg[2]
-
-    push.0xe9b5dba5
-    movdn.8
-    exec.consume_message_word # consume msg[3]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    dup.15
-    dup.15
-    dup.15
-
-    dup.4
-    dup.9
-    dup.9
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[20]
-
-    swap
-    dup.3
-    dup.10
-    dup.10
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[21]
-
-    movup.2
-    dup.2
-    dup.11
-    dup.11
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[22]
-
-    dup.6
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[23]
-
-    movupw.2
-
-    push.0x3956c25b
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[4]
-
-    push.0x59f111f1
-    movdn.8
-    exec.consume_message_word # consume msg[5]
-
-    push.0x923f82a4
-    movdn.8
-    exec.consume_message_word # consume msg[6]
-
-    push.0xab1c5ed5
-    movdn.8
-    exec.consume_message_word # consume msg[7]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    dup.6
-    dup.2
-    dup.11
-    dup.11
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[24]
-
-    dup.6
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[25]
-
-    dup.6
-    dup.2
-    dup.15
-    dup.15
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[26]
-
-    dup.15
-    dup.15
-    swap
-    dup.8
-    dup.4
-    exec.compute_message_schedule_word # computed msg[27]
-
-    movupw.3
-
-    push.0xd807aa98
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[8]
-
-    push.0x12835b01
-    movdn.8
-    exec.consume_message_word # consume msg[9]
-
-    push.0x243185be
-    movdn.8
-    exec.consume_message_word # consume msg[10]
-
-    push.0x550c7dc3
-    movdn.8
-    exec.consume_message_word # consume msg[11]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.3
-    movupw.3
-
-    dup.14
-    dup.10
-    dup.7
-    dup.7
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[28]
-
-    dup.14
-    dup.10
-    dup.9
-    dup.9
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[29]
-
-    dup.14
-    dup.2
-    dup.11
-    dup.11
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[30]
-
-    dup.14
-    dup.2
-    dup.8
-    dup.13
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[31]
-
-    movupw.2
-
-    push.0x72be5d74
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[12]
-
-    push.0x80deb1fe
-    movdn.8
-    exec.consume_message_word # consume msg[13]
-
-    push.0x9bdc06a7
-    movdn.8
-    exec.consume_message_word # consume msg[14]
-
-    push.0xc19bf174
-    movdn.8
-    exec.consume_message_word # consume msg[15]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.3
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[32]
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[33]
-
-    dup.14
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[34]
-
-    dup.10
-    dup.2
-    dup.8
-    dup.14
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[35]
-
-    movupw.3
-    exec.rev_element_order
-
-    push.0xe49b69c1
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[16]
-
-    push.0xefbe4786
-    movdn.8
-    exec.consume_message_word # consume msg[17]
-
-    push.0x0fc19dc6
-    movdn.8
-    exec.consume_message_word # consume msg[18]
-
-    push.0x240ca1cc
-    movdn.8
-    exec.consume_message_word # consume msg[19]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.3
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[36]
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[37]
-
-    dup.14
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[38]
-
-    dup.10
-    dup.2
-    dup.8
-    dup.14
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[39]
-
-    movupw.3
-    exec.rev_element_order
-
-    push.0x2de92c6f
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[20]
-
-    push.0x4a7484aa
-    movdn.8
-    exec.consume_message_word # consume msg[21]
-
-    push.0x5cb0a9dc
-    movdn.8
-    exec.consume_message_word # consume msg[22]
-
-    push.0x76f988da
-    movdn.8
-    exec.consume_message_word # consume msg[23]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.3
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[40]
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[41]
-
-    dup.14
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[42]
-
-    dup.10
-    dup.2
-    dup.13
-    dup.9
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[43]
-
-    movupw.3
-    exec.rev_element_order
-
-    push.0x983e5152
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[24]
-
-    push.0xa831c66d
-    movdn.8
-    exec.consume_message_word # consume msg[25]
-
-    push.0xb00327c8
-    movdn.8
-    exec.consume_message_word # consume msg[26]
-
-    push.0xbf597fc7
-    movdn.8
-    exec.consume_message_word # consume msg[27]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.3
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[44]
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[45]
-
-    dup.14
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[46]
-
-    dup.10
-    dup.2
-    dup.8
-    dup.14
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[47]
-
-    movupw.3
-    exec.rev_element_order
-
-    push.0xc6e00bf3
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[28]
-
-    push.0xd5a79147
-    movdn.8
-    exec.consume_message_word # consume msg[29]
-
-    push.0x06ca6351
-    movdn.8
-    exec.consume_message_word # consume msg[30]
-
-    push.0x14292967
-    movdn.8
-    exec.consume_message_word # consume msg[31]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.3
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[48]
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[49]
-
-    dup.14
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[50]
-
-    dup.10
-    dup.2
-    dup.8
-    dup.14
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[51]
-
-    movupw.3
-    exec.rev_element_order
-
-    push.0x27b70a85
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[32]
-
-    push.0x2e1b2138
-    movdn.8
-    exec.consume_message_word # consume msg[33]
-
-    push.0x4d2c6dfc
-    movdn.8
-    exec.consume_message_word # consume msg[34]
-
-    push.0x53380d13
-    movdn.8
-    exec.consume_message_word # consume msg[35]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.3
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[52]
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[53]
-
-    dup.14
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[54]
-
-    dup.10
-    dup.2
-    dup.8
-    dup.14
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[55]
-
-    movupw.3
-    exec.rev_element_order
-
-    push.0x650a7354
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[36]
-
-    push.0x766a0abb
-    movdn.8
-    exec.consume_message_word # consume msg[37]
-
-    push.0x81c2c92e
-    movdn.8
-    exec.consume_message_word # consume msg[38]
-
-    push.0x92722c85
-    movdn.8
-    exec.consume_message_word # consume msg[39]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.3
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[56]
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[57]
-
-    dup.14
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[58]
-
-    dup.10
-    dup.2
-    dup.8
-    dup.14
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[59]
-
-    movupw.3
-    exec.rev_element_order
-
-    push.0xa2bfe8a1
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[40]
-
-    push.0xa81a664b
-    movdn.8
-    exec.consume_message_word # consume msg[41]
-
-    push.0xc24b8b70
-    movdn.8
-    exec.consume_message_word # consume msg[42]
-
-    push.0xc76c51a3
-    movdn.8
-    exec.consume_message_word # consume msg[43]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.3
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[60]
-
-    dup.14
-    dup.6
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[61]
-
-    dup.14
-    dup.2
-    dup.13
-    dup.13
-    movdn.3
-    movdn.3
-    exec.compute_message_schedule_word # computed msg[62]
-
-    dup.10
-    dup.2
-    dup.8
-    dup.14
-    movdn.3
-    movdn.2
-    exec.compute_message_schedule_word # computed msg[63]
-
-    movupw.3
-    exec.rev_element_order
-
-    push.0xd192e819
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[44]
-
-    push.0xd6990624
-    movdn.8
-    exec.consume_message_word # consume msg[45]
-
-    push.0xf40e3585
-    movdn.8
-    exec.consume_message_word # consume msg[46]
-
-    push.0x106aa070
-    movdn.8
-    exec.consume_message_word # consume msg[47]
-
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-
-    movupw.2
-    movupw.3
-    movupw.3
-
-    exec.rev_element_order
-
-    push.0x19a4c116
-    push.0.0.0.0
-    loc_loadw.1
-    push.0.0.0.0
-    loc_loadw.0
-    exec.consume_message_word # consume msg[48]
-
-    push.0x1e376c08
-    movdn.8
-    exec.consume_message_word # consume msg[49]
-
-    push.0x2748774c
-    movdn.8
-    exec.consume_message_word # consume msg[50]
-
-    push.0x34b0bcb5
-    movdn.8
-    exec.consume_message_word # consume msg[51]
-
-    movupw.2
-    exec.rev_element_order
-    movdnw.2
-
-    push.0x391c0cb3
-    movdn.8
-    exec.consume_message_word # consume msg[52]
-
-    push.0x4ed8aa4a
-    movdn.8
-    exec.consume_message_word # consume msg[53]
-
-    push.0x5b9cca4f
-    movdn.8
-    exec.consume_message_word # consume msg[54]
-
-    push.0x682e6ff3
-    movdn.8
-    exec.consume_message_word # consume msg[55]
-
-    movupw.2
-    exec.rev_element_order
-    movdnw.2
-
-    push.0x748f82ee
-    movdn.8
-    exec.consume_message_word # consume msg[56]
-
-    push.0x78a5636f
-    movdn.8
-    exec.consume_message_word # consume msg[57]
-
-    push.0x84c87814
-    movdn.8
-    exec.consume_message_word # consume msg[58]
-
-    push.0x8cc70208
-    movdn.8
-    exec.consume_message_word # consume msg[59]
-
-    movupw.2
-    exec.rev_element_order
-    movdnw.2
-
-    push.0x90befffa
-    movdn.8
-    exec.consume_message_word # consume msg[60]
-
-    push.0xa4506ceb
-    movdn.8
-    exec.consume_message_word # consume msg[61]
-
-    push.0xbef9a3f7
-    movdn.8
-    exec.consume_message_word # consume msg[62]
-
-    push.0xc67178f2
-    movdn.8
-    exec.consume_message_word # consume msg[63]
-
-    push.0x6a09e667
-    u32wrapping_add
-
-    swap
-    push.0xbb67ae85
-    u32wrapping_add
-    swap
-
-    movup.2
-    push.0x3c6ef372
-    u32wrapping_add
-    movdn.2
-
-    movup.3
-    push.0xa54ff53a
-    u32wrapping_add
-    movdn.3
-
-    movup.4
-    push.0x510e527f
-    u32wrapping_add
-    movdn.4
-
-    movup.5
-    push.0x9b05688c
-    u32wrapping_add
-    movdn.5
-
-    movup.6
-    push.0x1f83d9ab
-    u32wrapping_add
-    movdn.6
-
-    movup.7
-    push.0x5be0cd19
-    u32wrapping_add
-    movdn.7
-end
-
-#! Given 32 -bytes hash state ( in terms of 8 SHA256 words ) and precomputed message 
-#! schedule of padding bytes ( in terms of 64 message words ), this routine consumes
-#! that into hash state, leaving final hash state, which is 32 -bytes SHA256 digest.
-#!
-#! Note, in SHA256 2-to-1 hashing, 64 -bytes are padded, which is processed as second message
-#! block ( each SHA256 message block is 64 -bytes wide ). That message block is used for generating 
-#! message schedule of 64 SHA256 words. That's exactly what can be precomputed & is consumed here 
-#! ( in this routine ) into provided hash state.
-#!
-#! Expected stack state:
-#!
-#! [state0, state1, state2, state3, state4, state5, state6, state7, ...]
-#!
-#! Final stack state after completion of execution
-#!
-#! [state0', state1', state2', state3', state4', state5', state6', state7']
-#!
-#! Note, each SHA256 word is 32 -bit wide
-#!
-#! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2_256.hpp#L148-L187 ( loop 
-#! body execution when i = 1 i.e. consuming padding bytes )
-proc.consume_padding_message_schedule
-    dupw.1
-    dupw.1
-
-    push.2147483648
-    movdn.8
-    push.0x428a2f98
-    movdn.8
-    exec.consume_message_word # consume msg[0]
-
-    push.0
-    movdn.8
-    push.0x71374491
-    movdn.8
-    exec.consume_message_word # consume msg[1]
-
-    push.0
-    movdn.8
-    push.0xb5c0fbcf
-    movdn.8
-    exec.consume_message_word # consume msg[2]
-
-    push.0
-    movdn.8
-    push.0xe9b5dba5
-    movdn.8
-    exec.consume_message_word # consume msg[3]
-
-    push.0
-    movdn.8
-    push.0x3956c25b
-    movdn.8
-    exec.consume_message_word # consume msg[4]
-
-    push.0
-    movdn.8
-    push.0x59f111f1
-    movdn.8
-    exec.consume_message_word # consume msg[5]
-
-    push.0
-    movdn.8
-    push.0x923f82a4
-    movdn.8
-    exec.consume_message_word # consume msg[6]
-
-    push.0
-    movdn.8
-    push.0xab1c5ed5
-    movdn.8
-    exec.consume_message_word # consume msg[7]
-
-    push.0
-    movdn.8
-    push.0xd807aa98
-    movdn.8
-    exec.consume_message_word # consume msg[8]
-
-    push.0
-    movdn.8
-    push.0x12835b01
-    movdn.8
-    exec.consume_message_word # consume msg[9]
-
-    push.0
-    movdn.8
-    push.0x243185be
-    movdn.8
-    exec.consume_message_word # consume msg[10]
-
-    push.0
-    movdn.8
-    push.0x550c7dc3
-    movdn.8
-    exec.consume_message_word # consume msg[11]
-
-    push.0
-    movdn.8
-    push.0x72be5d74
-    movdn.8
-    exec.consume_message_word # consume msg[12]
-
-    push.0
-    movdn.8
-    push.0x80deb1fe
-    movdn.8
-    exec.consume_message_word # consume msg[13]
-
-    push.0
-    movdn.8
-    push.0x9bdc06a7
-    movdn.8
-    exec.consume_message_word # consume msg[14]
-
-    push.512
-    movdn.8
-    push.0xc19bf174
-    movdn.8
-    exec.consume_message_word # consume msg[15]
-
-    push.2147483648
-    movdn.8
-    push.0xe49b69c1
-    movdn.8
-    exec.consume_message_word # consume msg[16]
-
-    push.20971520
-    movdn.8
-    push.0xefbe4786
-    movdn.8
-    exec.consume_message_word # consume msg[17]
-
-    push.2117632
-    movdn.8
-    push.0x0fc19dc6
-    movdn.8
-    exec.consume_message_word # consume msg[18]
-
-    push.20616
-    movdn.8
-    push.0x240ca1cc
-    movdn.8
-    exec.consume_message_word # consume msg[19]
-
-    push.570427392
-    movdn.8
-    push.0x2de92c6f
-    movdn.8
-    exec.consume_message_word # consume msg[20]
-
-    push.575995924
-    movdn.8
-    push.0x4a7484aa
-    movdn.8
-    exec.consume_message_word # consume msg[21]
-
-    push.84449090
-    movdn.8
-    push.0x5cb0a9dc
-    movdn.8
-    exec.consume_message_word # consume msg[22]
-
-    push.2684354592
-    movdn.8
-    push.0x76f988da
-    movdn.8
-    exec.consume_message_word # consume msg[23]
-
-    push.1518862336
-    movdn.8
-    push.0x983e5152
-    movdn.8
-    exec.consume_message_word # consume msg[24]
-
-    push.6067200
-    movdn.8
-    push.0xa831c66d
-    movdn.8
-    exec.consume_message_word # consume msg[25]
-
-    push.1496221
-    movdn.8
-    push.0xb00327c8
-    movdn.8
-    exec.consume_message_word # consume msg[26]
-
-    push.4202700544
-    movdn.8
-    push.0xbf597fc7
-    movdn.8
-    exec.consume_message_word # consume msg[27]
-
-    push.3543279056
-    movdn.8
-    push.0xc6e00bf3
-    movdn.8
-    exec.consume_message_word # consume msg[28]
-
-    push.291985753
-    movdn.8
-    push.0xd5a79147
-    movdn.8
-    exec.consume_message_word # consume msg[29]
-
-    push.4142317530
-    movdn.8
-    push.0x06ca6351
-    movdn.8
-    exec.consume_message_word # consume msg[30]
-
-    push.3003913545
-    movdn.8
-    push.0x14292967
-    movdn.8
-    exec.consume_message_word # consume msg[31]
-
-    push.145928272
-    movdn.8
-    push.0x27b70a85
-    movdn.8
-    exec.consume_message_word # consume msg[32]
-
-    push.2642168871
-    movdn.8
-    push.0x2e1b2138
-    movdn.8
-    exec.consume_message_word # consume msg[33]
-
-    push.216179603
-    movdn.8
-    push.0x4d2c6dfc
-    movdn.8
-    exec.consume_message_word # consume msg[34]
-
-    push.2296832490
-    movdn.8
-    push.0x53380d13
-    movdn.8
-    exec.consume_message_word # consume msg[35]
-
-    push.2771075893
-    movdn.8
-    push.0x650a7354
-    movdn.8
-    exec.consume_message_word # consume msg[36]
-
-    push.1738633033
-    movdn.8
-    push.0x766a0abb
-    movdn.8
-    exec.consume_message_word # consume msg[37]
-
-    push.3610378607
-    movdn.8
-    push.0x81c2c92e
-    movdn.8
-    exec.consume_message_word # consume msg[38]
-
-    push.1324035729
-    movdn.8
-    push.0x92722c85
-    movdn.8
-    exec.consume_message_word # consume msg[39]
-
-    push.1572820453
-    movdn.8
-    push.0xa2bfe8a1
-    movdn.8
-    exec.consume_message_word # consume msg[40]
-
-    push.2397971253
-    movdn.8
-    push.0xa81a664b
-    movdn.8
-    exec.consume_message_word # consume msg[41]
-
-    push.3803995842
-    movdn.8
-    push.0xc24b8b70
-    movdn.8
-    exec.consume_message_word # consume msg[42]
-
-    push.2822718356
-    movdn.8
-    push.0xc76c51a3
-    movdn.8
-    exec.consume_message_word # consume msg[43]
-
-    push.1168996599
-    movdn.8
-    push.0xd192e819
-    movdn.8
-    exec.consume_message_word # consume msg[44]
-
-    push.921948365
-    movdn.8
-    push.0xd6990624
-    movdn.8
-    exec.consume_message_word # consume msg[45]
-
-    push.3650881000
-    movdn.8
-    push.0xf40e3585
-    movdn.8
-    exec.consume_message_word # consume msg[46]
-
-    push.2958106055
-    movdn.8
-    push.0x106aa070
-    movdn.8
-    exec.consume_message_word # consume msg[47]
-
-    push.1773959876
-    movdn.8
-    push.0x19a4c116
-    movdn.8
-    exec.consume_message_word # consume msg[48]
-
-    push.3172022107
-    movdn.8
-    push.0x1e376c08
-    movdn.8
-    exec.consume_message_word # consume msg[49]
-
-    push.3820646885
-    movdn.8
-    push.0x2748774c
-    movdn.8
-    exec.consume_message_word # consume msg[50]
-
-    push.991993842
-    movdn.8
-    push.0x34b0bcb5
-    movdn.8
-    exec.consume_message_word # consume msg[51]
-
-    push.419360279
-    movdn.8
-    push.0x391c0cb3
-    movdn.8
-    exec.consume_message_word # consume msg[52]
-
-    push.3797604839
-    movdn.8
-    push.0x4ed8aa4a
-    movdn.8
-    exec.consume_message_word # consume msg[53]
-
-    push.322392134
-    movdn.8
-    push.0x5b9cca4f
-    movdn.8
-    exec.consume_message_word # consume msg[54]
-
-    push.85264541
-    movdn.8
-    push.0x682e6ff3
-    movdn.8
-    exec.consume_message_word # consume msg[55]
-
-    push.1326255876
-    movdn.8
-    push.0x748f82ee
-    movdn.8
-    exec.consume_message_word # consume msg[56]
-
-    push.640108622
-    movdn.8
-    push.0x78a5636f
-    movdn.8
-    exec.consume_message_word # consume msg[57]
-
-    push.822159570
-    movdn.8
-    push.0x84c87814
-    movdn.8
-    exec.consume_message_word # consume msg[58]
-
-    push.3328750644
-    movdn.8
-    push.0x8cc70208
-    movdn.8
-    exec.consume_message_word # consume msg[59]
-
-    push.1107837388
-    movdn.8
-    push.0x90befffa
-    movdn.8
-    exec.consume_message_word # consume msg[60]
-
-    push.1657999800
-    movdn.8
-    push.0xa4506ceb
-    movdn.8
-    exec.consume_message_word # consume msg[61]
-
-    push.3852183409
-    movdn.8
-    push.0xbef9a3f7
-    movdn.8
-    exec.consume_message_word # consume msg[62]
-
-    push.2242356356
-    movdn.8
-    push.0xc67178f2
-    movdn.8
-    exec.consume_message_word # consume msg[63]
-
-    movup.8
-    u32wrapping_add
-
-    swap
-    movup.8
-    u32wrapping_add
-    swap
-
-    movup.2
-    movup.8
-    u32wrapping_add
-    movdn.2
-
-    movup.3
-    movup.8
-    u32wrapping_add
-    movdn.3
-
-    movup.4
-    movup.8
-    u32wrapping_add
-    movdn.4
-
-    movup.5
-    movup.8
-    u32wrapping_add
-    movdn.5
-
-    movup.6
-    movup.8
-    u32wrapping_add
-    movdn.6
-
-    movup.7
-    movup.8
-    u32wrapping_add
-    movdn.7
-end
-
-#! Given 64 -bytes input, this routine computes 32 -bytes SAH256 digest
-#!
-#! Expected stack state:
-#!
-#! [m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15] | m[0,16) = 32 -bit word
-#!
-#! Note, each SHA256 word is 32 -bit wide, so that's how input is expected.
-#! If you've 64 -bytes, consider packing 4 consecutive bytes into single word, 
-#! maintaining big endian byte order.
+#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
 #!
 #! Final stack state:
 #!
+#! [...]
+#!
+#! Initialized stack state is written back to provided memory addresses.
+#!
+#! Functionally this routine is equivalent to https://github.com/itzmeanjan/blake3/blob/f07d32e/include/blake3.hpp#!L1709-L1713
+proc.initialize
+    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
+    movup.4
+    mem_storew
+    dropw
+
+    push.0x5BE0CD19.0x1F83D9AB.0x9B05688C.0x510E527F
+    movup.4
+    mem_storew
+    dropw
+
+    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
+    movup.4
+    mem_storew
+    dropw
+
+    push.11.64.0.0
+    movup.4
+    mem_storew
+    dropw
+end
+
+#! Permutes ordered message words, kept on stack top ( = sixteen 32 -bit BLAKE3 words )
+#!
+#! Expected stack top: 
+#!
+#! [s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15]
+#!
+#! After permutation, stack top:
+#!
+#! [s2, s6, s3, s10, s7, s0, s4, s13, s1, s11, s12, s5, s9, s14, s15, s8]
+#!
+#! See https://github.com/itzmeanjan/blake3/blob/f07d32ec10cbc8a10663b7e6539e0b1dab3e453b/include/blake3.hpp#!L1623-L1639
+#! and https://github.com/maticnetwork/miden/pull/313#!discussion_r922627984
+proc.permute_msg_words
+    movdn.7
+    movup.5
+    movdn.2
+    movup.4
+    movdn.7
+    swapw.3
+    swap
+    movdn.7
+    swapdw
+    movup.2
+    movdn.7
+    swapw
+    swapw.2
+    movup.3
+    movdn.6
+    movdn.5
+    movup.3
+    swapw
+    movup.3
+    swapdw
+end
+
+#! Given blake3 state matrix on stack top ( in order ) as 16 elements ( each of 32 -bit ),
+#! this routine computes output chaining value i.e. 2-to-1 hashing digest.
+#!
+#! Expected stack state:
+#!
+#! [state0, state1, state2, state3, state4, state5, state6, state7, state8, state9, state10, state11, state12, state13, state14, state15]
+#!
+#! After finalizing, stack should look like
+#!
 #! [dig0, dig1, dig2, dig3, dig4, dig5, dig6, dig7]
 #!
-#! SHA256 digest is represented in terms of eight 32 -bit words ( big endian byte order ).
-export.hash
-    push.0x5be0cd19.0x1f83d9ab.0x9b05688c.0x510e527f
-    push.0xa54ff53a.0x3c6ef372.0xbb67ae85.0x6a09e667
-
-    exec.prepare_message_schedule_and_consume
-    exec.consume_padding_message_schedule
-end
-"#),
-// ----- std::math::ec_ext5 -----------------------------------------------------------------------
-("std::math::ec_ext5", r#"use.std::math::ext5
-
-#! Given an encoded elliptic curve point `w` s.t. it's expressed using
-#! an element ∈ GF(p^5) | p = 2^64 - 2^32 + 1, this routine verifies whether
-#! given point can be successfully decoded or not
-#!
-#! Expected stack state 
-#!
-#! [w0, w1, w2, w3, w4, ...]
-#!
-#! Final stack state 
-#!
-#! [flg, ...]
-#!
-#! If w can be decoded, flg = 1
-#! Else flg = 0
-#!
-#! Note, if w = (0, 0, 0, 0, 0), it can be successfully decoded to point 
-#! at infinity i.e. flg = 1, in that case.
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1043-L1052
-#! for reference implementation
-export.validate
-    repeat.5
-        dup.4
-    end
-
-    exec.ext5::square
-    sub.2 # = e
-
-    exec.ext5::square
-    swap
-    sub.1052
-    swap # = delta
-    
-    exec.ext5::legendre
-    eq.1
-    movdn.5
-
-    push.1
-    repeat.5
-        swap
-        eq.0
-        and
-    end
-
-    or
-end
-
-#! Given an encoded elliptic curve point `w` s.t. it's expressed using
-#! an element ∈ GF(p^5) | p = 2^64 - 2^32 + 1, this routine attempts to decode
-#! it into x, y coordinates, along with boolean field element denoting whether it's
-#! point-at-infinity or not.
-#!
-#! Expected stack state 
-#!
-#! [w0, w1, w2, w3, w4, ...]
-#!
-#! Final state state 
-#!
-#! [x0, x1, x2, x3, x4, y0, y1, y2, y3, y4, inf, flg, ...]
-#!
-#! If `w` has be decoded, flg = 1
-#! Else flg = 0 and x, y = (0, 0)
-#!
-#! Note, when w = (0, 0, 0, 0, 0), it will be successfully decoded to
-#! point-at-infinity i.e. x, y = (0, 0) and flg = 1
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1022-L1041
-#! for reference implementation
-export.decode
-    repeat.5
-        dup.4
-    end
-
-    exec.ext5::square
-    sub.2 # = e
-
-    repeat.5
-        dup.4
-    end
-
-    exec.ext5::square
-    swap
-    sub.1052
-    swap # = delta
-
-    exec.ext5::sqrt # = (r, c)
-
-    repeat.5
-        dup.10
-    end
-
-    repeat.5
-        dup.9
-    end
-
-    exec.ext5::add
-    push.0.0.0.0.9223372034707292161
-    exec.ext5::mul # = x1
-
-    repeat.5
-        movup.9
-    end
-
-    repeat.5
-        movup.15
-    end
-
-    exec.ext5::sub
-    push.0.0.0.0.9223372034707292161
-    exec.ext5::mul # = x2
-
-    repeat.5
-        movup.9
-    end
-
-    repeat.5
-        dup.4
-    end
-
-    exec.ext5::legendre
-    eq.1
-
-    if.true
-        repeat.5
-            movup.5
-            drop
-        end
-    else
-        repeat.5
-            drop
-        end
-    end # = x
-
-    repeat.5
-        dup.10
-    end
-
-    repeat.5
-        dup.9
-    end
-
-    exec.ext5::mul
-    repeat.5
-        movup.4
-        neg
-    end # = y
-
-    dup.10
-    not # = inf
-
-    push.1
-    repeat.5
-        movup.13
-        eq.0
-        and
-    end
-
-    movup.12
-    or # = c
+#! See https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L116-L119 ,
+#! you'll notice I've skipped executing second statement in loop body of above hyperlinked implementation,
+#! that's because it doesn't dictate what output of 2-to-1 hash will be.
+proc.finalize
+    movup.8
+    u32checked_xor
 
     swap
+    movup.8
+    u32checked_xor
+    swap
 
-    repeat.5
-        movup.6
-    end
+    movup.2
+    movup.8
+    u32checked_xor
+    movdn.2
 
-    repeat.5
-        movup.11
-    end
+    movup.3
+    movup.8
+    u32checked_xor
+    movdn.3
 
-    add.6148914689804861441 # = x
-end
-
-#! Given an elliptic curve point as Weierstraß coordinates (X, Y) along with
-#! boolean field element `inf`, denoting whether this is point-at-infinity or not, 
-#! this routine encodes it to a single element ∈ GF(p^5) | p = 2^64 - 2^32 + 1
-#!
-#! Expected stack state 
-#!
-#! [x0, x1, x2, x3, x4, y0, y1, y2, y3, y4, inf, ...]
-#!
-#! Final stack state 
-#!
-#! [w0, w1, w2, w3, w4, ...]
-#!
-#! Note, when inf = 1, encoded point w = (0, 0, 0, 0, 0)
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1214-L1216
-#! for reference implementation.
-export.encode
-    push.0.0.0.0.6148914689804861441 # = a/ 3
-
-    exec.ext5::sub # = (a/ 3) - x
-
-    repeat.5
-        movup.9
-    end
-
-    exec.ext5::div # = w = y/ ((a/ 3) - x)
+    movup.4
+    movup.8
+    u32checked_xor
+    movdn.4
 
     movup.5
-    if.true
-        repeat.5
-            drop
-        end
-
-        push.0.0.0.0.0
-    end
-end
-
-#! Given two elliptic curve points ( say a, b ) as Weierstraß coordinates (X, Y) on stack,
-#! this routine computes elliptic curve point c, resulting from a + b.
-#!
-#! Following point addition formula is complete and it works when two points are 
-#! same/ different or input operands are point-at-infinity.
-#!
-#! Expected stack state
-#!
-#! [x1_0, x1_1, x1_2, x1_3, x1_4, y1_0, y1_1, y1_2, y1_3, y1_4, inf1, x2_0, x2_1, x2_2, x2_3, x2_4, y2_0, y2_1, y2_2, y2_3, y2_4, inf2, ...]
-#!
-#! s.t. x1_{0..5} -> x1, y1_{0..5} -> y1 |> a = (x1, y1, inf1)
-#!      x2_{0..5} -> x2, y2_{0..5} -> y2 |> b = (x2, y2, inf2)
-#!
-#! Final stack state
-#!
-#! [x3_0, x3_1, x3_2, x3_3, x3_4, y3_0, y3_1, y3_2, y3_3, y3_4, inf3, ...]
-#!
-#! Read point addition section ( on page 8 ) of https://ia.cr/2022/274
-#! For reference implementation see https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1228-L1255
-export.add.10
-    loc_storew.0
-    dropw
-    loc_store.1 # cached x1
-    drop
-
-    loc_storew.2
-    dropw
-    loc_store.3 # cached y1
-    drop
-
-    loc_store.4 # cached inf1
-    drop
-
-    loc_storew.5
-    dropw
-    loc_store.6 # cached x2
-    drop
-
-    loc_storew.7
-    dropw
-    loc_store.8 # cached y2
-    drop
-
-    loc_store.9 # cached inf2
-    drop
-
-    loc_load.6
-    push.0.0.0.0
-    loc_loadw.5 # bring x2
-
-    loc_load.1
-    push.0.0.0.0
-    loc_loadw.0 # bring x1
-
-    exec.ext5::eq
-    dup
-
-    if.true
-        loc_load.1
-        push.0.0.0.0
-        loc_loadw.0 # bring x1
-
-        exec.ext5::square
-
-        repeat.5
-            movup.4
-            mul.3
-        end
-
-        add.6148914689804861439
-        swap
-        add.263
-        swap
-    else
-        loc_load.3
-        push.0.0.0.0
-        loc_loadw.2 # bring y1
-
-        loc_load.8
-        push.0.0.0.0
-        loc_loadw.7 # bring y2
-
-        exec.ext5::sub
-    end # = λ0
-
-    dup.5
-
-    if.true
-        loc_load.3
-        push.0.0.0.0
-        loc_loadw.2 # bring y1
-
-        repeat.5
-            movup.4
-            mul.2
-        end
-    else
-        loc_load.1
-        push.0.0.0.0
-        loc_loadw.0 # bring x1
-
-        loc_load.6
-        push.0.0.0.0
-        loc_loadw.5 # bring x2
-
-        exec.ext5::sub
-    end # = λ1
-
-    repeat.5
-        movup.9
-    end
-
-    exec.ext5::div # = λ
-
-    repeat.5
-        dup.4
-    end
-
-    exec.ext5::square # = λ^2
-
-    loc_load.6
-    push.0.0.0.0
-    loc_loadw.5 # bring x2
-
-    loc_load.1
-    push.0.0.0.0
-    loc_loadw.0 # bring x1
-
-    exec.ext5::add
-
-    repeat.5
-        movup.9
-    end
-
-    exec.ext5::sub # compute x3
-
-    repeat.5
-        dup.4
-    end
-
-    loc_load.1
-    push.0.0.0.0
-    loc_loadw.0 # bring x1
-
-    exec.ext5::sub
-
-    repeat.5
-        movup.14
-    end
-
-    exec.ext5::mul
-
-    loc_load.3
-    push.0.0.0.0
-    loc_loadw.2 # bring y1
-
-    repeat.5
-        movup.9
-    end
-
-    exec.ext5::sub # compute y3
-
-    movup.10
-
-    loc_load.3
-    push.0.0.0.0
-    loc_loadw.2 # bring y1
-
-    loc_load.8
-    push.0.0.0.0
-    loc_loadw.7 # bring y2
-
-    exec.ext5::neq
-
-    and # compute inf3
-
+    movup.8
+    u32checked_xor
     movdn.5
 
-    # finalize selection of y3
+    movup.6
+    movup.8
+    u32checked_xor
+    movdn.6
 
-    loc_load.8
-    push.0.0.0.0
-    loc_loadw.7 # bring y2
-
-    loc_load.4 # bring inf1
-
-    if.true
-        repeat.5
-            movup.5
-            drop
-        end
-    else
-        repeat.5
-            drop
-        end
-    end
-
-    loc_load.3
-    push.0.0.0.0
-    loc_loadw.2 # bring y1
-
-    loc_load.9 # bring inf2
-
-    if.true
-        repeat.5
-            movup.5
-            drop
-        end
-    else
-        repeat.5
-            drop
-        end
-    end
-
-    # finalize selection of x3
-
-    repeat.5
-        movup.10
-    end
-
-    loc_load.6
-    push.0.0.0.0
-    loc_loadw.5 # bring x2
-
-    loc_load.4 # bring inf1
-
-    if.true
-        repeat.5
-            movup.5
-            drop
-        end
-    else
-        repeat.5
-            drop
-        end
-    end
-
-    loc_load.1
-    push.0.0.0.0
-    loc_loadw.0 # bring x1
-
-    loc_load.9 # bring inf2
-
-    if.true
-        repeat.5
-            movup.5
-            drop
-        end
-    else
-        repeat.5
-            drop
-        end
-    end
-
-    # finalize selection of inf3
-
-    movup.10
-    loc_load.9 # bring inf2
-    loc_load.4 # bring inf1
-    cdrop
-
-    loc_load.4 # bring inf1
-    loc_load.9 # bring inf2
-    cdrop
-
-    movdn.10
+    movup.7
+    movup.8
+    u32checked_xor
+    movdn.7
 end
 
-#! Given one elliptic curve point ( say a ) as Weierstraß coordinates (X, Y) on stack,
-#! this routine computes elliptic curve point b s.t. b = 2 * a.
+#! Given blake3 state matrix ( total 16 elements, each of 32 -bit ) and 
+#! 8 message words ( each of 32 -bit ), this routine performs column-wise mixing
+#! of message words into blake3 hash state.
 #!
-#! Following point doubling formula is complete and it works only when input operand is
-#! a non-infinity point, then resulting point b should also be non-infinity.
+#! Functionality wise this routine is equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L55-L59
 #!
-#! Note, result of add(a, b) = double(a) | a = b
+#! Expected stack state:
 #!
-#! Expected stack state
+#! [state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr, m0, m1, m2, m3, m4, m5, m6, m7]
 #!
-#! [x0, x1, x2, x3, x4, y0, y1, y2, y3, y4, inf, ...]
+#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
 #!
-#! s.t. x{0..5} -> x, y{0..5} -> y |> a = (x, y, inf)
+#! Meaning four consecutive blake3 state words can be read from memory easily.
 #!
-#! Final stack state
+#! Final stack state:
 #!
-#! [x'0, x'1, x'2, x'3, x'4, y'0, y'1, y'2, y'3, y'4, inf, ...]
+#! [state0, state1, state2, state3, state4, state5, state6, state7, state8, state9, state10, state11, state12, state13, state14, state15]
 #!
-#! Read point addition section ( on page 8 ) of https://ia.cr/2022/274
-#! For reference implementation see https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1270-L1280
-export.double.5
+#! i.e. whole blake3 state is placed on stack ( in order ).
+proc.columnar_mixing.1
+    swapw.2
+    swapw
+
+    movup.7
+    movup.6
+    movup.5
+    movup.4
+
     loc_storew.0
-    dropw
-    loc_store.1 # cached x
-    drop
 
-    loc_storew.2
-    dropw
-    loc_store.3 # cached y
-    drop
-
-    loc_store.4 # cached inf
-    drop
-
-    loc_load.3
+    movup.9
+    mem_loadw
+    movup.8
     push.0.0.0.0
-    loc_loadw.2 # bring y
+    movup.4
+    mem_loadw
 
-    repeat.5
-        movup.4
-        mul.2
-    end # compute λ1
+    movup.8
+    dup.5
+    u32overflowing_add3
+    drop
 
-    loc_load.1
-    push.0.0.0.0
-    loc_loadw.0 # bring x
-
-    exec.ext5::square
-
-    repeat.5
-        movup.4
-        mul.3
-    end
-
-    add.6148914689804861439
     swap
-    add.263
-    swap # compute λ0
+    movup.8
+    dup.6
+    u32overflowing_add3
+    drop
+    swap
 
-    exec.ext5::div # compute λ
+    movup.2
+    dup.6
+    movup.9
+    u32overflowing_add3
+    drop
+    movdn.2
 
-    loc_load.1
+    movup.3
+    dup.7
+    movup.9
+    u32overflowing_add3
+    drop
+    movdn.3
+
+    movup.9
     push.0.0.0.0
-    loc_loadw.0 # bring x
+    movup.4
+    mem_loadw
 
-    repeat.5
-        movup.4
-        mul.2
-    end
+    dup.4
+    u32checked_xor
+    u32unchecked_rotr.16
+    
+    swap
+    dup.5
+    u32checked_xor
+    u32unchecked_rotr.16
+    swap
 
-    repeat.5
-        dup.9
-    end
+    movup.2
+    dup.6
+    u32checked_xor
+    u32unchecked_rotr.16
+    movdn.2
 
-    exec.ext5::square
-    exec.ext5::sub # compute x'
+    movup.3
+    dup.7
+    u32checked_xor
+    u32unchecked_rotr.16
+    movdn.3
 
-    repeat.5
-        dup.4
-    end
-
-    loc_load.1
+    movup.12
     push.0.0.0.0
-    loc_loadw.0 # bring x
+    movup.4
+    mem_loadw
 
-    exec.ext5::sub
+    dup.4
+    u32wrapping_add
 
-    repeat.5
-        movup.14
-    end
+    swap
+    dup.5
+    u32wrapping_add
+    swap
 
-    exec.ext5::mul
+    movup.2
+    dup.6
+    u32wrapping_add
+    movdn.2
 
-    loc_load.3
+    movup.3
+    dup.7
+    u32wrapping_add
+    movdn.3
+
+    movupw.3
+
+    dup.4
+    u32checked_xor
+    u32unchecked_rotr.12
+    
+    swap
+    dup.5
+    u32checked_xor
+    u32unchecked_rotr.12
+    swap
+
+    movup.2
+    dup.6
+    u32checked_xor
+    u32unchecked_rotr.12
+    movdn.2
+
+    movup.3
+    dup.7
+    u32checked_xor
+    u32unchecked_rotr.12
+    movdn.3
+
+    movupw.3
     push.0.0.0.0
-    loc_loadw.2 # bring y
+    loc_loadw.0
+    swapw
 
-    repeat.5
-        movup.9
-    end
+    movup.4
+    dup.8
+    u32overflowing_add3
+    drop
 
-    exec.ext5::sub # compute y'
+    swap
+    movup.4
+    dup.8
+    u32overflowing_add3
+    drop
+    swap
 
-    repeat.5
-        movup.9
-    end
+    movup.2
+    movup.4
+    dup.8
+    u32overflowing_add3
+    drop
+    movdn.2
 
-    loc_load.4
-    movdn.10
+    movup.3
+    movup.4
+    dup.8
+    u32overflowing_add3
+    drop
+    movdn.3
+
+    movupw.3
+
+    dup.4
+    u32checked_xor
+    u32unchecked_rotr.8
+    
+    swap
+    dup.5
+    u32checked_xor
+    u32unchecked_rotr.8
+    swap
+
+    movup.2
+    dup.6
+    u32checked_xor
+    u32unchecked_rotr.8
+    movdn.2
+
+    movup.3
+    dup.7
+    u32checked_xor
+    u32unchecked_rotr.8
+    movdn.3
+
+    movupw.3
+
+    dup.4
+    u32wrapping_add
+
+    swap
+    dup.5
+    u32wrapping_add
+    swap
+
+    movup.2
+    dup.6
+    u32wrapping_add
+    movdn.2
+
+    movup.3
+    dup.7
+    u32wrapping_add
+    movdn.3
+
+    movupw.3
+
+    dup.4
+    u32checked_xor
+    u32unchecked_rotr.7
+
+    swap
+    dup.5
+    u32checked_xor
+    u32unchecked_rotr.7
+    swap
+
+    movup.2
+    dup.6
+    u32checked_xor
+    u32unchecked_rotr.7
+    movdn.2
+
+    movup.3
+    dup.7
+    u32checked_xor
+    u32unchecked_rotr.7
+    movdn.3
+
+    movupw.3
 end
 
-#! Given an elliptic curve point ( say a ) as Weierstraß coordinates (X, Y) and a 319 -bit scalar ( say e )
-#! on stack, this routine computes elliptic curve point b s.t. b =  e * a, using double-and-add technique.
+#! Given blake3 state matrix ( total 16 elements, each of 32 -bit ) and 
+#! 8 message words ( each of 32 -bit ), this routine performs diagonal-wise mixing
+#! of message words into blake3 hash state.
 #!
-#! Scalar e should be lesser than 1067993516717146951041484916571792702745057740581727230159139685185762082554198619328292418486241 ( prime number ).
-#! Note, scalar e should be provided as 10 limbs on stack, each of 32 -bit ( in little endian byte order ).
-#! 
-#! Given a scalar e ( as arbitrary width big integer ), following python code snippet should convert it to desired input form
+#! Functionality wise this routine is equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L61-L64
 #!
-#! [(a >> (32*i)) & 0xffff_ffff for i in range(10)]
+#! Expected stack state:
 #!
-#! Expected stack state
+#! [state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr, m0, m1, m2, m3, m4, m5, m6, m7]
 #!
-#! [x0, x1, x2, x3, x4, y0, y1, y2, y3, y4, inf, e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, ...]
+#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
 #!
-#! Point a = (x, y, inf)
-#! Scalar e = (e0, e1, e2, e3, e4, e5, e6, e7, e8, e9)
+#! Meaning four consecutive blake3 state words can be read from memory easily.
 #!
-#! Final stack state
+#! Final stack state:
 #!
-#! [x'0, x'1, x'2, x'3, x'4, y'0, y'1, y'2, y'3, y'4, inf, ...]
+#! [state0, state1, state2, state3, state4, state5, state6, state7, state8, state9, state10, state11, state12, state13, state14, state15]
 #!
-#! Point b = (x', y' inf') | b = e * a
-#!
-#! See https://github.com/itzmeanjan/secp256k1/blob/cbbe199/point.py#L174-L186 for source of inpiration.
-export.mul.10
+#! i.e. whole blake3 state is placed on stack ( in order ).
+proc.diagonal_mixing.1
+    swapw.2
+    swapw
+
+    movup.7
+    movup.6
+    movup.5
+    movup.4
+
     loc_storew.0
-    dropw
-    loc_store.1 # cached base_x
+
+    movup.9
+    mem_loadw
+    movup.8
+    push.0.0.0.0
+    movup.4
+    mem_loadw
+
+    movup.8
+    dup.6
+    u32overflowing_add3
     drop
 
+    swap
+    movup.8
+    dup.7
+    u32overflowing_add3
+    drop
+    swap
+
+    movup.2
+    movup.8
+    dup.8
+    u32overflowing_add3
+    drop
+    movdn.2
+
+    movup.3
+    movup.8
+    dup.5
+    u32overflowing_add3
+    drop
+    movdn.3
+
+    movup.9
+    push.0.0.0.0
+    movup.4
+    mem_loadw
+
+    movup.3
+    dup.4
+    u32checked_xor
+    u32unchecked_rotr.16
+    movdn.3
+
+    dup.5
+    u32checked_xor
+    u32unchecked_rotr.16
+
+    swap
+    dup.6
+    u32checked_xor
+    u32unchecked_rotr.16
+    swap
+
+    movup.2
+    dup.7
+    u32checked_xor
+    u32unchecked_rotr.16
+    movdn.2
+
+    movup.12
+    push.0.0.0.0
+    movup.4
+    mem_loadw
+
+    movup.2
+    dup.7
+    u32wrapping_add
+    movdn.2
+
+    movup.3
+    dup.4
+    u32wrapping_add
+    movdn.3
+
+    dup.5
+    u32wrapping_add
+
+    swap
+    dup.6
+    u32wrapping_add
+    swap
+
+    movupw.3
+
+    swap
+    dup.6
+    u32checked_xor
+    u32unchecked_rotr.12
+    swap
+
+    movup.2
+    dup.7
+    u32checked_xor
+    u32unchecked_rotr.12
+    movdn.2
+
+    movup.3
+    dup.4
+    u32checked_xor
+    u32unchecked_rotr.12
+    movdn.3
+
+    dup.5
+    u32checked_xor
+    u32unchecked_rotr.12
+
+    movupw.3
+    push.0.0.0.0
+    loc_loadw.0
+    swapw
+
+    movup.4
+    dup.9
+    u32overflowing_add3
+    drop
+
+    swap
+    movup.4
+    dup.9
+    u32overflowing_add3
+    drop
+    swap
+
+    movup.2
+    movup.4
+    dup.9
+    u32overflowing_add3
+    drop
+    movdn.2
+
+    movup.3
+    movup.4
+    dup.5
+    u32overflowing_add3
+    drop
+    movdn.3
+
+    movupw.3
+
+    movup.3
+    dup.4
+    u32checked_xor
+    u32unchecked_rotr.8
+    movdn.3
+
+    dup.5
+    u32checked_xor
+    u32unchecked_rotr.8
+
+    swap
+    dup.6
+    u32checked_xor
+    u32unchecked_rotr.8
+    swap
+
+    movup.2
+    dup.7
+    u32checked_xor
+    u32unchecked_rotr.8
+    movdn.2
+
+    movupw.3
+
+    movup.2
+    dup.7
+    u32wrapping_add
+    movdn.2
+
+    movup.3
+    dup.4
+    u32wrapping_add
+    movdn.3
+
+    dup.5
+    u32wrapping_add
+
+    swap
+    dup.6
+    u32wrapping_add
+    swap
+
+    movupw.3
+
+    swap
+    dup.6
+    u32checked_xor
+    u32unchecked_rotr.7
+    swap
+
+    movup.2
+    dup.7
+    u32checked_xor
+    u32unchecked_rotr.7
+    movdn.2
+
+    movup.3
+    dup.4
+    u32checked_xor
+    u32unchecked_rotr.7
+    movdn.3
+
+    dup.5
+    u32checked_xor
+    u32unchecked_rotr.7
+
+    movupw.3
+end
+
+#! Given blake3 state matrix ( total 16 elements, each of 32 -bit ) and 
+#! 16 message words ( each of 32 -bit ), this routine applies single round of mixing
+#! of message words into hash state i.e. msg_word[0..8] are mixed into hash state using
+#! columnar mixing while remaining message words ( msg_word[8..16] ) are mixed into hash state
+#! using diagonal mixing.
+#!
+#! Functionality wise this routine is equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L54-L65
+#!
+#! Expected stack state:
+#!
+#! [state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr, m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15]
+#!
+#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
+#!
+#! Meaning four consecutive blake3 state words can be read from memory easily.
+#!
+#! Final stack state:
+#!
+#! [...]
+#!
+#! i.e. mixed state matrix lives in memory addresses {state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr}, 
+#! which were provided, on stack top, while invoking this routine.
+proc.round.5
+    loc_storew.0
+
+    exec.columnar_mixing
+
+    loc_storew.1
+    dropw
     loc_storew.2
     dropw
-    loc_store.3 # cached base_y
-    drop
+    loc_storew.3
+    dropw
+    loc_storew.4
+    dropw
 
-    loc_store.4 # cached base_inf
-    drop
+    locaddr.4
+    locaddr.3
+    locaddr.2
+    locaddr.1
+
+    exec.diagonal_mixing
 
     push.0.0.0.0
-    loc_storew.5
+    loc_loadw.0
+    swapw
+    movup.4
+    mem_storew
     dropw
-    push.0
-    loc_store.6 # initialize and cache res_x
-    drop
 
-    push.0.0.0.0
-    loc_storew.7
-    dropw
-    push.0
-    loc_store.8 # initialize and cache res_y
-    drop
+    repeat.3
+        push.0
+        movdn.3
+        swapw
+        movup.4
+        mem_storew
+        dropw
+    end
 
-    push.1
-    loc_store.9 # initialize and cache res_inf
-    drop
-
-    repeat.10
-        repeat.32
-            dup
-            push.1
-            u32checked_and
-
-            if.true
-                # bring base
-                loc_load.4
-
-                loc_load.3
-                push.0.0.0.0
-                loc_loadw.2
-
-                loc_load.1
-                push.0.0.0.0
-                loc_loadw.0
-
-                # bring res
-                loc_load.9
-
-                loc_load.8
-                push.0.0.0.0
-                loc_loadw.7
-
-                loc_load.6
-                push.0.0.0.0
-                loc_loadw.5
-
-                exec.add
-
-                # write back res
-                loc_storew.5
-                dropw
-                loc_store.6
-                drop
-
-                loc_storew.7
-                dropw
-                loc_store.8
-                drop
-
-                loc_store.9
-                drop
-            end
-
-            # bring base
-            loc_load.4
-
-            loc_load.3
-            push.0.0.0.0
-            loc_loadw.2
-
-            loc_load.1
-            push.0.0.0.0
-            loc_loadw.0
-
-            exec.double
-
-            # write back base
-            loc_storew.0
-            dropw
-            loc_store.1
-            drop
-
-            loc_storew.2
-            dropw
-            loc_store.3
-            drop
-
-            loc_store.4
-            drop
-
-            u32unchecked_shr.1
-        end
-
+    repeat.3
         drop
     end
+end
 
-    # bring res
-    loc_load.9
+#! Given blake3 state matrix ( total 16 elements, each of 32 -bit ) and a message block
+#! i.e. 16 message words ( each of 32 -bit ), this routine applies 7 rounds of mixing
+#! of (permuted) message words into hash state.
+#!
+#! Functionality wise this routine is equivalent to https://github.com/BLAKE3-team/BLAKE3/blob/da4c792/reference_impl/reference_impl.rs#!L75-L114
+#!
+#! Expected stack state:
+#!
+#! [state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr, m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15]
+#!
+#! Note, state_`i`_`j`_addr -> absolute address of {state[i], state[i+1], state[i+2], state[i+3]} in memory | j = i+3
+#!
+#! Meaning four consecutive blake3 state words can be read from memory easily.
+#!
+#! Final stack state:
+#!
+#! [...]
+#!
+#! i.e. 7 -round mixed state matrix lives in memory addresses {state0_3_addr, state4_7_addr, state8_11_addr, state12_15_addr}, 
+#! which were provided, on stack top, while invoking this routine. So updated state matrix can be read by caller routine, by reading
+#! the content of memory addresses where state was provided as routine input.
+proc.compress.1
+    loc_storew.0
+    dropw
 
-    loc_load.8
+    # apply first 6 rounds of mixing
+    repeat.6
+        # round `i` | i ∈ [1..7)
+        repeat.4
+            dupw.3
+        end
+
+        push.0.0.0.0
+        loc_loadw.0
+        exec.round
+        exec.permute_msg_words
+    end
+
+    # round 7 ( last round, so no message word permutation required )
     push.0.0.0.0
-    loc_loadw.7
+    loc_loadw.0
+    exec.round
+end
 
-    loc_load.6
+#! Blake3 2-to-1 hash function, which takes 64 -bytes input and produces 32 -bytes output digest
+#!
+#! Expected stack state:
+#!
+#! [msg0, msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8, msg9, msg10, msg11, msg12, msg13, msg14, msg15]
+#!
+#! msg`i` -> 32 -bit message word | i ∈ [0, 16)
+#!
+#! Output stack state:
+#!
+#! [dig0, dig1, dig2, dig3, dig4, dig5, dig6, dig7]
+#!
+#! dig`i` -> 32 -bit digest word | i ∈ [0, 8)
+export.hash.4
+    locaddr.3
+    locaddr.2
+    locaddr.1
+    locaddr.0
+
+    exec.initialize
+
+    # Note, chunk compression routine needs to compress only one chunk with one message 
+    # block ( = 64 -bytes ) because what we're doing here is 2-to-1 hashing i.e. 64 -bytes 
+    # input being converted to 32 -bytes output
+
+    locaddr.3
+    locaddr.2
+    locaddr.1
+    locaddr.0
+
+    exec.compress
+
     push.0.0.0.0
-    loc_loadw.5
-end
-"#),
-// ----- std::math::ext2 --------------------------------------------------------------------------
-("std::math::ext2", r#"#! Given a stack with initial configuration given by [a1,a0,b1,b0,...] where a = (a0,a1) and
-#! b = (b0,b1) represent elements in the extension field of degree 2, the procedure outputs the 
-#! product c = (c1,c0) where c0 = a0b0 - 2(a1b1) and c1 = (a0 + a1)(b0 + b1) - a0b0
-export.mul
-    dupw            #[a1,a0,b1,b0,a1,a0,b1,b0,...]
-    swap.3          #[b0,a0,b1,a1,a1,a0,b1,b0,...]
-    mul             #[b0a0,b1,a1,a1,a0,b1,b0,...]
-    dup             #[b0a0,b0a0,b1,a1,a1,a0,b1,b0,...]
-    movdn.7         #[b0a0,b1,a1,a1,a0,b1,b0,b0a0,...]
-    movdn.2         #[b1,a1,b0a0,a1,a0,b1,b0,b0a0,...]
-    mul.2           #[2b1,a1,b0a0,a1,a0,b1,b0,b0a0,...]
-    mul             #[2b1a1,b0a0,a1,a0,b1,b0,b0a0,...]
-    sub             #[b0a0-2b1a1,a1,a0,b1,b0,b0a0,...]
-    movdn.5         #[a1,a0,b1,b0,b0a0,b0a0-2b1a1,...]
-    add             #[a1+a0,b1,b0,b0a0,b0a0-2b1a1,...]
-    swap.2          #[b0,b1,a1+a0,b0a0,b0a0-2b1a1,...]
-    add             #[b0+b1,a1+a0,b0a0,b0a0-2b1a1,...]
-    mul             #[(b0+b1)(a1+a0),b0a0,b0a0-2b1a1,...]
-    swap            #[b0a0,(b0+b1)(a1+a0),b0a0-2b1a1,...]
-    sub             #[(b0+b1)(a1+a0)-b0a0,b0a0-2b1a1,...]
-end
+    loc_loadw.3
+    push.0.0.0.0
+    loc_loadw.2
+    push.0.0.0.0
+    loc_loadw.1
+    push.0.0.0.0
+    loc_loadw.0
 
-#! Given a stack with initial configuration given by [x,a1,a0,...] where a = (a0,a1) is an element
-#! in the field extension and x is an element of the base field, this procedure computes the multiplication
-#! of x, when looked at as (x,0), with a in the extension field. The output is [xa1,xa0,...]
-export.mul_base
-    dup         #[x,x,a1,a0,...]
-    movdn.3     #[x,a1,a0,x,...]
-    mul         #[xa1,a0,x,...]
-    movdn.2     #[a0,x,xa1,...]
-    mul         #[xa0,xa1,...]
-    swap        #[xa1,xa0,...]
+    exec.finalize
 end
+",&[8, 0, 15, 99, 111, 108, 117, 109, 110, 97, 114, 95, 109, 105, 120, 105, 110, 103, 3, 0, 15, 99, 111, 108, 117, 109, 110, 97, 114, 95, 109, 105, 120, 105, 110, 103, 0, 1, 0, 174, 0, 143, 142, 151, 150, 149, 148, 196, 0, 0, 0, 0, 0, 0, 0, 0, 153, 187, 152, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 152, 112, 40, 104, 127, 152, 113, 40, 104, 127, 146, 113, 153, 40, 104, 162, 147, 114, 153, 40, 104, 163, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 111, 70, 83, 16, 127, 112, 70, 83, 16, 127, 146, 113, 70, 83, 16, 162, 147, 114, 70, 83, 16, 163, 156, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 111, 36, 127, 112, 36, 127, 146, 113, 36, 162, 147, 114, 36, 163, 161, 111, 70, 83, 12, 127, 112, 70, 83, 12, 127, 146, 113, 70, 83, 12, 162, 147, 114, 70, 83, 12, 163, 161, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 142, 148, 115, 40, 104, 127, 148, 115, 40, 104, 127, 146, 148, 115, 40, 104, 162, 147, 148, 115, 40, 104, 163, 161, 111, 70, 83, 8, 127, 112, 70, 83, 8, 127, 146, 113, 70, 83, 8, 162, 147, 114, 70, 83, 8, 163, 161, 111, 36, 127, 112, 36, 127, 146, 113, 36, 162, 147, 114, 36, 163, 161, 111, 70, 83, 7, 127, 112, 70, 83, 7, 127, 146, 113, 70, 83, 7, 162, 147, 114, 70, 83, 7, 163, 161, 8, 99, 111, 109, 112, 114, 101, 115, 115, 6, 0, 8, 99, 111, 109, 112, 114, 101, 115, 115, 0, 1, 0, 6, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 254, 205, 1, 5, 0, 254, 206, 1, 1, 0, 126, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 207, 1, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 15, 100, 105, 97, 103, 111, 110, 97, 108, 95, 109, 105, 120, 105, 110, 103, 4, 0, 15, 100, 105, 97, 103, 111, 110, 97, 108, 95, 109, 105, 120, 105, 110, 103, 0, 1, 0, 174, 0, 143, 142, 151, 150, 149, 148, 196, 0, 0, 0, 0, 0, 0, 0, 0, 153, 187, 152, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 152, 113, 40, 104, 127, 152, 114, 40, 104, 127, 146, 152, 115, 40, 104, 162, 147, 152, 112, 40, 104, 163, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 147, 111, 70, 83, 16, 163, 112, 70, 83, 16, 127, 113, 70, 83, 16, 127, 146, 114, 70, 83, 16, 162, 156, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 146, 114, 36, 162, 147, 111, 36, 163, 112, 36, 127, 113, 36, 127, 161, 127, 113, 70, 83, 12, 127, 146, 114, 70, 83, 12, 162, 147, 111, 70, 83, 12, 163, 112, 70, 83, 12, 161, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 142, 148, 116, 40, 104, 127, 148, 116, 40, 104, 127, 146, 148, 116, 40, 104, 162, 147, 148, 112, 40, 104, 163, 161, 147, 111, 70, 83, 8, 163, 112, 70, 83, 8, 127, 113, 70, 83, 8, 127, 146, 114, 70, 83, 8, 162, 161, 146, 114, 36, 162, 147, 111, 36, 163, 112, 36, 127, 113, 36, 127, 161, 127, 113, 70, 83, 7, 127, 146, 114, 70, 83, 7, 162, 147, 111, 70, 83, 7, 163, 112, 70, 83, 7, 161, 8, 102, 105, 110, 97, 108, 105, 122, 101, 2, 0, 8, 102, 105, 110, 97, 108, 105, 122, 101, 0, 0, 0, 30, 0, 152, 70, 127, 152, 70, 127, 146, 152, 70, 162, 147, 152, 70, 163, 148, 152, 70, 164, 149, 152, 70, 165, 150, 152, 70, 166, 151, 152, 70, 167, 4, 104, 97, 115, 104, 7, 0, 4, 104, 97, 115, 104, 1, 4, 0, 19, 0, 183, 3, 0, 0, 0, 0, 0, 0, 0, 183, 2, 0, 0, 0, 0, 0, 0, 0, 183, 1, 0, 0, 0, 0, 0, 0, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 207, 0, 0, 0, 0, 183, 3, 0, 0, 0, 0, 0, 0, 0, 183, 2, 0, 0, 0, 0, 0, 0, 0, 183, 1, 0, 0, 0, 0, 0, 0, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 2, 0, 0, 0, 10, 105, 110, 105, 116, 105, 97, 108, 105, 122, 101, 0, 0, 10, 105, 110, 105, 116, 105, 97, 108, 105, 122, 101, 0, 0, 0, 16, 0, 198, 4, 58, 245, 79, 165, 0, 0, 0, 0, 114, 243, 110, 60, 0, 0, 0, 0, 133, 174, 103, 187, 0, 0, 0, 0, 103, 230, 9, 106, 0, 0, 0, 0, 148, 194, 105, 198, 4, 25, 205, 224, 91, 0, 0, 0, 0, 171, 217, 131, 31, 0, 0, 0, 0, 140, 104, 5, 155, 0, 0, 0, 0, 127, 82, 14, 81, 0, 0, 0, 0, 148, 194, 105, 198, 4, 58, 245, 79, 165, 0, 0, 0, 0, 114, 243, 110, 60, 0, 0, 0, 0, 133, 174, 103, 187, 0, 0, 0, 0, 103, 230, 9, 106, 0, 0, 0, 0, 148, 194, 105, 198, 4, 11, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 17, 112, 101, 114, 109, 117, 116, 101, 95, 109, 115, 103, 95, 119, 111, 114, 100, 115, 1, 0, 17, 112, 101, 114, 109, 117, 116, 101, 95, 109, 115, 103, 95, 119, 111, 114, 100, 115, 0, 0, 0, 20, 0, 167, 149, 162, 148, 167, 144, 127, 167, 145, 146, 167, 142, 143, 147, 166, 165, 147, 142, 147, 145, 5, 114, 111, 117, 110, 100, 5, 0, 5, 114, 111, 117, 110, 100, 0, 5, 0, 23, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 207, 3, 0, 0, 0, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 196, 3, 0, 0, 0, 0, 0, 0, 0, 105, 196, 4, 0, 0, 0, 0, 0, 0, 0, 105, 183, 4, 0, 0, 0, 0, 0, 0, 0, 183, 3, 0, 0, 0, 0, 0, 0, 0, 183, 2, 0, 0, 0, 0, 0, 0, 0, 183, 1, 0, 0, 0, 0, 0, 0, 0, 207, 4, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 142, 148, 194, 105, 254, 190, 1, 6, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 163, 142, 148, 194, 105, 254, 198, 1, 1, 0, 104]),
+("std::crypto::dsa::falcon",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 99, 114, 121, 112, 116, 111, 58, 58, 100, 115, 97, 58, 58, 102, 97, 108, 99, 111, 110]),"use.std::math::poly512
 
-#! Given a stack in the following initial configuration [a1,a0,b1,b0,...] the following
-#! procedure computes [a1+b1,a0+b0,...]
-export.add
-    swap        #[a0,a1,b1,b0,...]
-    movup.3     #[b0,a0,a1,b1,...]
-    add         #[b0+a0,a1,b1,...]
-    movdn.2     #[a1,b1,b0+a0,...]
-    add         #[a1+b1,b0+a0,...]
-end
-
-#! Given a stack in the following initial configuration [a1,a0,b1,b0,...] the following
-#! procedure computes [a1-b1,a0-b0,...]
-export.sub
-    swap        #[a0,a1,b1,b0,...]
-    movup.3     #[b0,a0,a1,b1,...]
-    sub         #[a0-b0,a1,b1,...]
-    movdn.2     #[a1,b1,a0-b0,...]
-    swap        #[b1,a1,a0-b0,...]
-    sub         #[a1-b1,a0-b0,...]
-end"#),
-// ----- std::math::ext5 --------------------------------------------------------------------------
-("std::math::ext5", r#"#! Given two GF(p^5) elements on stack, this routine computes modular
-#! addition over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
+#! Given an element on stack top, this routine normalizes that element in 
+#! interval (-q/2, q/2] | q = 12289
+#!
+#! Imagine, a is the provided element, which needs to be normalized
+#!
+#! b = normalize(a)
+#!   = (a + (q >> 1)) % q - (q >> 1) | a ∈ [0, q), q = 12289
+#!
+#! Note, normalization requires that we can represent the number as signed integer,
+#! which is not allowed inside Miden VM stack. But we can ignore the sign of integer and only
+#! store the absolute value as field element. This can be safely done because after normalization
+#! anyway `b` will be squared ( for computing norm of a vector i.e. polynomial, where b is a coefficient ).
+#! That means we can just drop the sign, and that's what is done in this routine.
+#!
+#! To be more concrete, normalization of 12166 ( = a ) should result into -123, but absolute value 
+#! 123 will be kept on stack. While normalization of 21, should result into 21, which has absolute
+#! value 21 --- that's what is kept on stack.
 #!
 #! Expected stack state :
 #!
-#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
+#! [a, ...]
 #!
-#! After application of routine stack :
+#! After normalization ( represented using unsigned integer i.e. Miden field element ) stack looks like
 #!
-#! [c0, c1, c2, c3, c4, ...] s.t. c = a + b
-#!
-#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
-#!
-#! For reference implementation in high level language, see 
-#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L607-L616
-export.add
-    repeat.5
-        movup.5
+#! [b, ...]
+proc.normalize
+    dup
+    push.6144
+    gt
+
+    if.true
+        push.6144
         add
-        movdn.4
+
+        exec.poly512::mod_12289
+
+        dup
+        push.6144
+        gte
+
+        if.true
+            push.6144
+            sub
+        else
+            push.6144
+            swap
+            sub
+        end
     end
 end
 
-#! Given two GF(p^5) elements on stack, this routine subtracts second
-#! element from first one, over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
+#! Given four elements from Falcon prime field, on stack top, this routine 
+#! normalizes each of them, using above defined `normalize()` routine.
 #!
 #! Expected stack state :
 #!
-#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
+#! [a0, a1, a2, a3, ...]
 #!
-#! After application of routine stack :
+#! Output stack state :
 #!
-#! [c0, c1, c2, c3, c4, ...] s.t. c = a - b
+#! [b0, b1, b2, b3, ...]
 #!
-#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
-#!
-#! For reference implementation in high level language, see 
-#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L629-L638
-export.sub
-    repeat.5
-        movup.5
-        sub
-        movdn.4
-    end
-end
+#! b`i` = normalize(a`i`) | i ∈ [0..4)
+proc.normalize_word
+    exec.normalize
 
-#! Given two GF(p^5) elements on stack, this routine computes modular
-#! multiplication ( including reduction by irreducible polynomial ) 
-#! over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
-#!
-#! Expected stack state :
-#!
-#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
-#!
-#! After application of routine stack :
-#!
-#! [c0, c1, c2, c3, c4, ...] s.t. c = a * b
-#!
-#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
-#!
-#! For reference implementation in high level language, see 
-#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L676-L689
-export.mul
-    # compute {c0, c1, c2, c3, c4} - five coefficients of resulting
-    # degree-4 polynomial
-    
-    # compute c4
-    dup.9
-    dup.1
-    mul
-
-    dup.9
-    dup.3
-    mul
-
-    add
-
-    dup.8
-    dup.4
-    mul
-
-    add
-
-    dup.7
-    dup.5
-    mul
-
-    add
-
-    dup.6
-    dup.6
-    mul
-    
-    add
-
-    # compute c3
-    dup.9
-    dup.2
-    mul
-
-    dup.9
-    dup.4
-    mul
-    
-    add
-
-    dup.8
-    dup.5
-    mul
-
-    add
-
-    dup.7
-    dup.6
-    mul
-
-    add
-
-    dup.11
-    dup.7
-    mul
-    mul.3
-
-    add
-
-    # compute c2
-    dup.9
-    dup.3
-    mul
-
-    dup.9
-    dup.5
-    mul
-
-    add
-
-    dup.8
-    dup.6
-    mul
-    
-    add
-
-    dup.12
-    dup.7
-    mul
-    mul.3
-
-    add
-
-    dup.11
-    dup.8
-    mul
-    mul.3
-
-    add
-
-    # compute c1
-    dup.9
-    dup.4
-    mul
-
-    dup.9
-    dup.6
-    mul
-
-    add
-
-    dup.13
-    dup.7
-    mul
-    mul.3
-
-    add
-
-    dup.12
-    dup.8
-    mul
-    mul.3
-
-    add
-
-    dup.11
-    dup.9
-    mul
-    mul.3
-
-    add
-
-    # compute c0
-    movup.9
-    movup.5
-    mul
-
-    movup.12
-    movup.6
-    mul
-    mul.3
-
-    add
-
-    movup.10
-    movup.6
-    mul
-    mul.3
-
-    add
-
-    movup.8
-    movup.6
-    mul
-    mul.3
-
-    add
-
-    movup.6
-    movup.6
-    mul
-    mul.3
-
-    add
-end
-
-#! Given one GF(p^5) element on stack, this routine computes modular
-#! squaring ( including reduction by irreducible polynomial ) 
-#! over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
-#!
-#! This routine has same effect as calling mul(a, a) | a ∈ GF(p^5)
-#!
-#! Expected stack state :
-#!
-#! [a0, a1, a2, a3, a4, ...]
-#!
-#! After application of routine stack :
-#!
-#! [b0, b1, b2, b3, b4, ...] s.t. b = a * a
-#!
-#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
-#!
-#! For reference implementation in high level language, see 
-#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L709-L715
-export.square
-    # compute {b0, b1, b2, b3, b4} - five coefficients of resulting
-    # degree-4 polynomial
-
-    # compute b4
-    dup.2
-    dup.3
-    mul
-
-    dup.5
-    dup.2
-    mul
-    mul.2
-
-    add
-
-    dup.4
-    dup.3
-    mul
-    mul.2
-
-    add
-
-    # compute b3
-    dup.4
-    dup.2
-    mul
-    mul.2
-
-    dup.4
-    dup.4
-    mul
-    mul.2
-
-    add
-
-    dup.6
-    dup.7
-    mul
-    mul.3
-
-    add
-
-    # compute b2
-    dup.3
-    dup.4
-    mul
-    
-    dup.5
-    dup.4
-    mul
-    mul.2
-
-    add
-
-    dup.7
-    dup.7
-    mul
-    mul.6
-
-    add
-
-    # compute b1
-    dup.4
-    dup.4
-    mul
-    mul.2
-
-    dup.7
-    dup.8
-    mul
-    mul.3
-
-    add
-
-    dup.8
-    dup.7
-    mul
-    mul.6
-
-    add
-
-    # compute b0
-    dup.4
-    movup.5
-    mul
-
-    movup.8
-    movup.6
-    mul
-    mul.6
-
-    add
-
-    movup.6
-    movup.6
-    mul
-    mul.6
-
-    add
-end
-
-#! Given an element a ∈ GF(p^5), this routine applies Frobenius operator
-#! once, raising the element to the power of p | p = 2^64 - 2^32 + 1.
-#!
-#! Expected stack state :
-#!
-#! [a0, a1, a2, a3, a4, ...]
-#!
-#! Final stack state :
-#!
-#! [b0, b1, b2, b3, b4, ...]
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L723-L737
-#! for reference implementation in high-level language.
-proc.frobenius_once
-    movup.4
-    mul.1373043270956696022
-
-    movup.4
-    mul.211587555138949697
-
-    movup.4
-    mul.15820824984080659046
-
-    movup.4
-    mul.1041288259238279555
-
-    movup.4
-end
-
-#! Given an element a ∈ GF(p^5), this routine applies Frobenius operator
-#! twice, raising the element to the power of p^2 | p = 2^64 - 2^32 + 1.
-#!
-#! Expected stack state :
-#!
-#! [a0, a1, a2, a3, a4, ...]
-#!
-#! Final stack state :
-#!
-#! [b0, b1, b2, b3, b4, ...]
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L739-L749
-#! for reference implementation in high-level language.
-proc.frobenius_twice
-    movup.4
-    mul.211587555138949697
-
-    movup.4
-    mul.1041288259238279555
-
-    movup.4
-    mul.1373043270956696022
-
-    movup.4
-    mul.15820824984080659046
-
-    movup.4
-end
-
-#! Given one GF(p^5) element on stack, this routine computes multiplicative
-#! inverse over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
-#!
-#! Expected stack state :
-#!
-#! [a0, a1, a2, a3, a4, ...]
-#!
-#! After application of routine stack :
-#!
-#! [b0, b1, b2, b3, b4, ...] s.t. b = 1 / a
-#!
-#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
-#!
-#! For reference implementation in high level language, see 
-#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L751-L775
-#!
-#! Note, this routine will not panic even when operand `a` is zero.
-export.inv
-    repeat.5
-        dup.4
-    end
-
-    exec.frobenius_once # = t0
-
-    repeat.5
-        dup.4
-    end
-
-    exec.frobenius_once # = t0.frobenius_once()
-    exec.mul            # = t1
-
-    repeat.5
-        dup.4
-    end
-
-    exec.frobenius_twice # = t1.frobenius_twice()
-    exec.mul             # = t2
-
-    movup.5
-    dup.1
-    mul
-
-    movup.6
-    dup.6
-    mul
-    mul.3
-
-    add
-
-    movup.6
-    dup.5
-    mul
-    mul.3
-
-    add
-
-    movup.6
-    dup.4
-    mul
-    mul.3
-
-    add
-
-    movup.6
-    dup.3
-    mul
-    mul.3
-
-    add                    # = t3
-
-    dup
-    push.0
-    eq
-    add
-    inv                    # = t4
-
-    movup.5
-    dup.1
-    mul
-
-    movup.5
-    dup.2
-    mul
-
-    movup.5
-    dup.3
-    mul
-
-    movup.5
-    dup.4
-    mul
-
-    movup.5
-    movup.5
-    mul
-end
-
-#! Given two GF(p^5) elements ( say a, b ) on stack, this routine computes
-#! modular division over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
-#!
-#! Expected stack state :
-#!
-#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
-#!
-#! After application of routine stack :
-#!
-#! [c0, c1, c2, c3, c4, ...] s.t. c = a / b
-#!
-#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
-#!
-#! For reference implementation in high level language, see 
-#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L777-L781
-export.div
-    repeat.5
-        movup.9
-    end
-
-    exec.inv
-    exec.mul
-end
-
-#! Given an element v ∈ Z_q | q = 2^64 - 2^32 + 1, and n on stack, this routine
-#! raises it to the power 2^n, by means of n successive squarings
-#!
-#! Expected stack stack
-#!
-#! [v, n, ...] | n >= 0
-#!
-#! After finishing execution stack
-#!
-#! [v', ...] s.t. v' = v ^ (2^n)
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L461-L469
-#! for reference implementation in higher level language
-proc.base_msquare
     swap
-    dup
-    neq.0
+    exec.normalize
+    swap
 
-    while.true
-        sub.1
-        swap
-        dup
-        mul
+    movup.2
+    exec.normalize
+    movdn.2
 
-        swap
-        dup
-        neq.0
+    movup.3
+    exec.normalize
+    movdn.3
+end
+
+#! Given a degree 512 polynomial on stack, using its starting (absolute) memory address, 
+#! this routine normalizes each coefficient of the polynomial, using above defined 
+#! `normalize()` routine
+#!
+#! Imagine, f is the given polynomial of degree 512. It can be normalized using
+#!
+#! g = [normalize(f[i]) for i in range(512)]
+#!
+#! Expected stack state :
+#!
+#! [f_start_addr, g_start_addr, ...] | next 127 absolute addresses can be computed using `INCR` instruction
+#!
+#! Post normalization stack state looks like
+#!
+#! [ ... ]
+#!
+#! Note, input polynomial which is provided using memory addresses, is not mutated.
+export.normalize_poly512
+    push.0.0.0.0
+
+    repeat.128
+        dup.4
+        mem_loadw
+
+        exec.normalize_word
+
+        dup.5
+        mem_storew
+
+        movup.5
+        add.1
+        movdn.5
+
+        movup.4
+        add.1
+        movdn.4
     end
 
+    dropw
+    drop
     drop
 end
 
-#! Given an element v ∈ Z_q | q = 2^64 - 2^32 + 1, this routine attempts to compute
-#! square root of v, if that number is a square.
+#! Given four elements on stack top, this routine computes squared norm of that
+#! vector ( read polynomial ) with four coefficients.
+#!
+#! Imagine, given vector is f, which is described as
+#!
+#! f = [a0, a1, a2, a3]
+#!
+#! Norm of that vector is
+#!
+#! √(a0 ^ 2 + a1 ^ 2 + a2 ^ 2 + a3 ^ 2)
+#!
+#! But we need squared norm, which is just skipping the final square root operation.
 #!
 #! Expected stack state :
 #!
-#! [v, ...]
+#! [a0, a1, a2, a3, ...]
 #!
-#! After finishing execution stack looks like :
+#! Final stack state :
 #!
-#! [v', flg, ...]
-#!
-#! If flg = 1, it denotes v' is square root of v i.e. v' * v' = v ( mod q )
-#! If flg = 0, then v' = 0, denoting v doesn't have a square root
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L349-L446
-#! for reference implementation in higher level language.
-proc.base_sqrt
-    dup # = x
+#! [b, ...] | b = a0 ^ 2 + a1 ^ 2 + a2 ^ 2 + a3 ^ 2
+proc.squared_norm_word
+    dup
+    mul
 
-    push.31
     swap
-    exec.base_msquare # = u
+    dup
+    mul
 
-    dup
-    dup
-    mul # = u^2
-
-    movup.2
-    dup
-    eq.0
     add
 
-    div # = v
-
-    # j = 1
-    # i = 32 - j = 31
+    swap
     dup
-    push.30
-    swap
-    exec.base_msquare # = w
+    mul
 
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.4614640910117430873
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.1753635133440165772
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
+    add
 
     swap
-
-    # j = 2
-    # i = 32 - j = 30
     dup
-    push.29
-    swap
-    exec.base_msquare # = w
+    mul
 
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.9123114210336311365
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.4614640910117430873
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 3
-    # i = 32 - j = 29
-    dup
-    push.28
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.16116352524544190054
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.9123114210336311365
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 4
-    # i = 32 - j = 28
-    dup
-    push.27
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.6414415596519834757
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.16116352524544190054
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 5
-    # i = 32 - j = 27
-    dup
-    push.26
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.1213594585890690845
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.6414415596519834757
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 6
-    # i = 32 - j = 26
-    dup
-    push.25
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.17096174751763063430
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.1213594585890690845
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 7
-    # i = 32 - j = 25
-    dup
-    push.24
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.5456943929260765144
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.17096174751763063430
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 8
-    # i = 32 - j = 24
-    dup
-    push.23
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.9713644485405565297
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.5456943929260765144
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 9
-    # i = 32 - j = 23
-    dup
-    push.22
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.16905767614792059275
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.9713644485405565297
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 10
-    # i = 32 - j = 22
-    dup
-    push.21
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.5416168637041100469
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.16905767614792059275
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 11
-    # i = 32 - j = 21
-    dup
-    push.20
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.17654865857378133588
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.5416168637041100469
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 12
-    # i = 32 - j = 20
-    dup
-    push.19
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.3511170319078647661
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.17654865857378133588
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 13
-    # i = 32 - j = 19
-    dup
-    push.18
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.18146160046829613826
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.3511170319078647661
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 14
-    # i = 32 - j = 18
-    dup
-    push.17
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.9306717745644682924
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.18146160046829613826
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 15
-    # i = 32 - j = 17
-    dup
-    push.16
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.12380578893860276750
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.9306717745644682924
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 16
-    # i = 32 - j = 16
-    dup
-    push.15
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.6115771955107415310
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.12380578893860276750
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 17
-    # i = 32 - j = 15
-    dup
-    push.14
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.17776499369601055404
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.6115771955107415310
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 18
-    # i = 32 - j = 14
-    dup
-    push.13
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.16207902636198568418
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.17776499369601055404
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 19
-    # i = 32 - j = 13
-    dup
-    push.12
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.1532612707718625687
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.16207902636198568418
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 20
-    # i = 32 - j = 12
-    dup
-    push.11
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.17492915097719143606
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.1532612707718625687
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 21
-    # i = 32 - j = 11
-    dup
-    push.10
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.455906449640507599
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.17492915097719143606
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 22
-    # i = 32 - j = 10
-    dup
-    push.9
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.11353340290879379826
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.455906449640507599
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 23
-    # i = 32 - j = 9
-    dup
-    push.8
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.1803076106186727246
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.11353340290879379826
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 24
-    # i = 32 - j = 8
-    dup
-    push.7
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.13797081185216407910
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.1803076106186727246
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 25
-    # i = 32 - j = 7
-    dup
-    push.6
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.17870292113338400769
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.13797081185216407910
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 26
-    # i = 32 - j = 6
-    dup
-    push.5
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.549755813888
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.17870292113338400769
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 27
-    # i = 32 - j = 5
-    dup
-    push.4
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.70368744161280
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.549755813888
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 28
-    # i = 32 - j = 4
-    dup
-    push.3
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.17293822564807737345
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.70368744161280
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 29
-    # i = 32 - j = 3
-    dup
-    push.2
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.18446744069397807105
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.17293822564807737345
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 30
-    # i = 32 - j = 2
-    dup
-    push.1
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.281474976710656
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.18446744069397807105
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap
-
-    # j = 31
-    # i = 32 - j = 1
-    dup
-    push.0
-    swap
-    exec.base_msquare # = w
-
-    eq.18446744069414584320 # = cc
-
-    dup.1
-    mul.18446744069414584320
-    movup.2
-    swap
-    dup.2
-    cdrop # = v'
-
-    dup.2
-    mul.281474976710656
-    movup.3
-    swap
-    movup.3
-    cdrop # = u'
-
-    swap # On stack [v, u, ...]
-
-    dup
-    eq.0
-    swap
-    eq.1
-    or # = cc
-
-    swap
-    dup.1
-    mul # On stack [u * cc, cc, ...]
+    add
 end
 
-#! Given an element v ∈ Z_q | q = 2^64 - 2^32 + 1, this routine computes
-#! legendre symbol, by raising that element to the power (p-1) / 2
+#! Given a degree 512 polynomial in coefficient form, as starting (absolute) memory address 
+#! on stack, this routine computes squared norm of that vector, using following formula
 #!
-#! Expected stack state :
+#! Say, f = [a0, a1, a2, ..., a510, a511]
+#!      g = sq_norm(f) = a0 ^ 2 + a1 ^ 2 + ... + a510 ^ 2 + a511 ^ 2
 #!
-#! [v, ...]
+#! Expected input stack state :
 #!
-#! After finishing execution stack looks like
+#! [f_start_addr, ...] | f_addr`i` holds f[(i << 2) .. ((i+1) << 2)]
 #!
-#! [v', ...] s.t. v' = legendre symbol of v
+#! Consecutive 127 addresses on stack can be computed using `INCR` instruction, because memory 
+#! addresses are consecutive i.e. monotonically increasing by 1.
 #!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L448-L459
-#! for reference implementation in higher level language.
-proc.base_legendre
-    repeat.31
-        dup
-        mul
-    end
-
-    dup
-
-    repeat.32
-        dup
-        mul
-    end
-
-    swap
-    dup
-    eq.0
-    add
-
-    div
-end
-
-#! Given an element v ∈ GF(p^5), this routine computes its legendre symbol,
-#! which is an element ∈ GF(p) | p = 2^64 - 2^32 + 1
+#! Final stack state :
 #!
-#! At beginning stack looks like
-#!
-#! [a0, a1, a2, a3, a4, ...]
-#!
-#! At end stack looks like
-#!
-#! [b, ...] s.t. b = legendre symbol of a
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L857-L877
-#! for reference implementation in higher level language.
-export.legendre
-    repeat.5
-        dup.4
-    end
+#! [g, ...] | g = sq_norm(f)
+export.squared_norm_poly512
+    push.0.0.0.0.0
 
-    exec.frobenius_once
-
-    repeat.5
-        dup.4
-    end
-
-    exec.frobenius_once
-    exec.mul
-
-    repeat.5
-        dup.4
-    end
-
-    exec.frobenius_twice
-    exec.mul
-
-    movup.5
-    mul
-
-    movup.5
-    movup.5
-    mul
-    mul.3
-    
-    add
-
-    movup.4
-    movup.4
-    mul
-    mul.3
-
-    add
-
-    movup.3
-    movup.3
-    mul
-    mul.3
-
-    add
-
-    movup.2
-    movup.2
-    mul
-    mul.3
-
-    add
-
-    exec.base_legendre
-end
-
-#! Given an element v ∈ GF(p^5), this routine attempts to compute square root of v, 
-#! if that number is a square.
-#!
-#! At beginning stack looks like
-#!
-#! [a0, a1, a2, a3, a4, ...]
-#!
-#! At end stack looks like
-#!
-#! [b0, b1, b2, b3, b4, flg, ...]
-#!
-#! If flg = 1, it denotes v' = {b0, b1, b2, b3, b4} is square root of v i.e. v' * v' = v ( mod GF(p^5) )
-#! If flg = 0, then v' = {0, 0, 0, 0, 0}, denoting v doesn't have a square root
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L879-L910
-#! for reference implementation in higher level language.
-export.sqrt
-    repeat.5
-        dup.4
-    end
-
-    repeat.31
-        repeat.5
-            dup.4
-        end
-
-        exec.mul
-    end # = v
-
-    repeat.5
-        dup.4
-    end
-
-    repeat.32
-        repeat.5
-            dup.4
-        end
-
-        exec.mul
-    end
-
-    exec.div
-
-    repeat.5
-        dup.9
-    end
-
-    exec.mul # = d
-
-    repeat.5
-        dup.4
-    end
-
-    exec.frobenius_twice
-    exec.mul
-    exec.frobenius_once # = e
-
-    repeat.5
-        dup.4
-    end
-
-    exec.square # = f
-
-    movup.10
-    mul
-
-    swap
-    movup.13
-    mul
-    mul.3
-    add
-
-    swap
-    movup.11
-    mul
-    mul.3
-    add
-
-    swap
-    movup.9
-    mul
-    mul.3
-    add
-
-    swap
-    movup.7
-    mul
-    mul.3
-    add # = g
-
-    exec.base_sqrt # On stack [s, c, e0, e1, e2, e3, e4, ...]
-
-    repeat.5
-        movup.6
-    end
-
-    exec.inv # = e'
-
-    repeat.5
-        movup.4
+    repeat.128
         dup.5
-        mul
+        mem_loadw
+
+        exec.squared_norm_word
+        add
+
+        swap
+        add.1
+        swap
+
+        push.0.0.0.0
     end
 
-    movup.5
-    drop # On stack [e0, e1, e2, e3, e4, c, ...]
+    dropw
+    swap
+    drop
 end
 
-#! Given two elements a, b ∈ GF(p^5), this routine produces single field element r,
-#! denoting whether a == b.
+#! Falcon-512 Digital Signature Verification routine
 #!
-#! Expected stack state 
+#! Given four degree-511 polynomials, using initial absolute memory addresses on stack, 
+#! this routine checks whether it's a valid Falcon signature or not.
 #!
-#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
+#! Four degree-511 polynomials, which are provided ( in order )
 #!
-#! Final stack state 
+#! f = [f0, f1, ..., f510, f511] -> decompressed Falcon-512 signature
+#! g = [g0, g1, ..., g510, g511] -> public key used for signing input message
+#! h = [h0, h1, ..., h510, h511] -> input message hashed using SHAKE256 XOF and converted to polynomial
+#! k = [k0, k1, ..., k510, k511] -> [abs(i) for i in f] | abs(a) = a < 0 ? 0 - a : a
 #!
-#! [r, ...]
+#! Each of these polynomials are represented using starting absolute memory address. Contiguous 127 
+#! memory addresses can be computed by repeated application of INCR instruction ( read add.1 ) on previous
+#! absolute memory address.
 #!
-#! If a == b { r = 1 } Else { r = 0 }
+#! f`i` holds f[(i << 2) .. ((i+1) << 2)] | i ∈ [0..128)
+#! g`i` holds g[(i << 2) .. ((i+1) << 2)] | i ∈ [0..128)
+#! h`i` holds h[(i << 2) .. ((i+1) << 2)] | i ∈ [0..128)
+#! k`i` holds k[(i << 2) .. ((i+1) << 2)] | i ∈ [0..128)
 #!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L797-L806
-#! for reference implementation.
-export.eq
-    push.1
+#! Expected stack state :
+#!
+#! [f_start_addr, g_start_addr, h_start_addr, k_start_addr, ...]
+#!
+#! After execution of verification routine, stack looks like
+#!
+#! [ ... ]
+#!
+#! If verification fails, program panics, due to failure in assertion !
+#!
+#! Note, input memory addresses are considered to be immutable.
+export.verify.257
+    locaddr.0
+    movdn.2
+    exec.poly512::mul_zq
 
-    swap
-    movup.6
-    eq
-    and
+    locaddr.128
+    locaddr.0
+    exec.poly512::neg_zq
 
+    locaddr.0
     swap
-    movup.5
-    eq
-    and
+    locaddr.128
+    exec.poly512::add_zq
 
-    swap
-    movup.4
-    eq
-    and
+    locaddr.128
+    locaddr.0
+    exec.normalize_poly512
 
-    swap
-    movup.3
-    eq
-    and
+    # compute squared norm of s0
 
-    swap
-    movup.2
-    eq
-    and
+    locaddr.128
+    exec.squared_norm_poly512
+
+    locaddr.256
+    mem_store
+    drop
+
+    # compute squared norm of s1 ( where s1 is provided as polynomial
+    # with coefficients represented using absolute value i.e. signs are ignored )
+
+    exec.squared_norm_poly512
+
+    locaddr.256
+    mem_load
+    add
+
+    # check that norm of the signature is small enough
+
+    push.34034726 # constant sig_bound for Falcon-512 signature
+    lte
+    assert
 end
-
-#! Given two elements a, b ∈ GF(p^5), this routine produces single field element r,
-#! denoting whether a != b.
-#!
-#! Expected stack state 
-#!
-#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
-#!
-#! Final stack state 
-#!
-#! [r, ...]
-#!
-#! If a != b { r = 1 } Else { r = 0 }
-#!
-#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L813-L822
-#! for reference implementation.
-export.neq
-    push.0
-
-    swap
-    movup.6
-    neq
-    or
-
-    swap
-    movup.5
-    neq
-    or
-
-    swap
-    movup.4
-    neq
-    or
-
-    swap
-    movup.3
-    neq
-    or
-
-    swap
-    movup.2
-    neq
-    or
-end
-"#),
-// ----- std::math::ntt512 ------------------------------------------------------------------------
-("std::math::ntt512", r#"#! Applies four NTT butterflies on four different indices, given following stack state
+",&[6, 0, 9, 110, 111, 114, 109, 97, 108, 105, 122, 101, 0, 0, 9, 110, 111, 114, 109, 97, 108, 105, 122, 101, 0, 0, 0, 4, 0, 107, 198, 1, 0, 24, 0, 0, 0, 0, 0, 0, 26, 253, 7, 0, 198, 1, 0, 24, 0, 0, 0, 0, 0, 0, 3, 208, 85, 132, 203, 155, 10, 43, 66, 153, 188, 247, 113, 182, 11, 149, 253, 89, 63, 20, 200, 120, 146, 57, 157, 137, 107, 198, 1, 0, 24, 0, 0, 0, 0, 0, 0, 27, 253, 2, 0, 198, 1, 0, 24, 0, 0, 0, 0, 0, 0, 5, 3, 0, 198, 1, 0, 24, 0, 0, 0, 0, 0, 0, 127, 5, 0, 0, 17, 110, 111, 114, 109, 97, 108, 105, 122, 101, 95, 112, 111, 108, 121, 53, 49, 50, 2, 0, 17, 110, 111, 114, 109, 97, 108, 105, 122, 101, 95, 112, 111, 108, 121, 53, 49, 50, 1, 0, 0, 5, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 36, 0, 11, 0, 111, 187, 207, 1, 0, 0, 0, 112, 194, 149, 3, 165, 148, 3, 164, 105, 104, 104, 14, 110, 111, 114, 109, 97, 108, 105, 122, 101, 95, 119, 111, 114, 100, 1, 0, 14, 110, 111, 114, 109, 97, 108, 105, 122, 101, 95, 119, 111, 114, 100, 0, 0, 0, 10, 0, 207, 0, 0, 0, 0, 127, 207, 0, 0, 0, 0, 127, 146, 207, 0, 0, 0, 0, 162, 147, 207, 0, 0, 0, 0, 163, 20, 115, 113, 117, 97, 114, 101, 100, 95, 110, 111, 114, 109, 95, 112, 111, 108, 121, 53, 49, 50, 4, 0, 20, 115, 113, 117, 97, 114, 101, 100, 95, 110, 111, 114, 109, 95, 112, 111, 108, 121, 53, 49, 50, 1, 0, 0, 5, 0, 198, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 71, 0, 8, 0, 112, 187, 207, 3, 0, 0, 0, 3, 127, 3, 127, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 105, 127, 104, 17, 115, 113, 117, 97, 114, 101, 100, 95, 110, 111, 114, 109, 95, 119, 111, 114, 100, 3, 0, 17, 115, 113, 117, 97, 114, 101, 100, 95, 110, 111, 114, 109, 95, 119, 111, 114, 100, 0, 0, 0, 14, 0, 107, 7, 127, 107, 7, 3, 127, 107, 7, 3, 127, 107, 7, 3, 6, 118, 101, 114, 105, 102, 121, 5, 0, 6, 118, 101, 114, 105, 102, 121, 1, 1, 1, 25, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 162, 208, 198, 4, 141, 102, 17, 204, 28, 154, 71, 189, 42, 106, 248, 32, 176, 63, 110, 187, 169, 166, 97, 67, 211, 29, 183, 128, 0, 0, 0, 0, 0, 0, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 208, 155, 180, 67, 30, 194, 168, 239, 166, 191, 42, 172, 120, 205, 218, 138, 159, 213, 146, 128, 132, 109, 111, 94, 112, 183, 0, 0, 0, 0, 0, 0, 0, 0, 127, 183, 128, 0, 0, 0, 0, 0, 0, 0, 208, 146, 126, 125, 245, 167, 6, 77, 144, 105, 242, 2, 197, 171, 93, 11, 100, 207, 223, 103, 221, 8, 17, 80, 124, 183, 128, 0, 0, 0, 0, 0, 0, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 207, 2, 0, 0, 0, 183, 128, 0, 0, 0, 0, 0, 0, 0, 207, 4, 0, 0, 0, 183, 0, 1, 0, 0, 0, 0, 0, 0, 191, 104, 207, 4, 0, 0, 0, 183, 0, 1, 0, 0, 0, 0, 0, 0, 185, 3, 198, 1, 38, 84, 7, 2, 0, 0, 0, 0, 25, 0]),
+("std::math::ntt512",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 109, 97, 116, 104, 58, 58, 110, 116, 116, 53, 49, 50, 0, 0, 0, 0, 0, 0, 0]),"#! Applies four NTT butterflies on four different indices, given following stack state
 #!
 #! [k0, k1, k2, k3, A0, B0, C0, D0, A1, B1, C1, D1]
 #! 
@@ -10830,9 +8390,2221 @@ export.backward.128
 
     locaddr.0
 end
-"#),
-// ----- std::math::poly512 -----------------------------------------------------------------------
-("std::math::poly512", r#"use.std::math::ntt512
+",&[5, 0, 8, 98, 97, 99, 107, 119, 97, 114, 100, 4, 0, 8, 98, 97, 99, 107, 119, 97, 114, 100, 1, 128, 0, 172, 1, 183, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 107, 3, 10, 0, 112, 187, 111, 194, 149, 3, 165, 148, 3, 164, 105, 104, 104, 198, 4, 114, 15, 216, 85, 131, 25, 188, 255, 149, 85, 132, 25, 39, 170, 10, 215, 171, 10, 215, 107, 255, 112, 15, 216, 231, 67, 0, 113, 40, 148, 85, 132, 198, 4, 70, 152, 193, 251, 169, 112, 189, 166, 128, 162, 170, 112, 61, 4, 16, 247, 5, 16, 247, 128, 88, 69, 152, 193, 144, 66, 89, 69, 8, 127, 162, 170, 198, 4, 43, 92, 175, 169, 195, 61, 96, 87, 16, 1, 196, 61, 80, 86, 17, 102, 87, 17, 102, 240, 167, 42, 92, 175, 195, 159, 168, 42, 153, 15, 1, 196, 198, 4, 65, 220, 3, 118, 20, 97, 6, 239, 11, 101, 21, 97, 251, 137, 170, 194, 138, 170, 194, 245, 16, 64, 220, 3, 159, 249, 16, 64, 61, 10, 101, 21, 198, 4, 9, 51, 120, 255, 20, 174, 215, 84, 80, 84, 21, 174, 135, 0, 226, 30, 1, 226, 30, 176, 170, 8, 51, 120, 82, 40, 171, 8, 225, 79, 84, 21, 198, 4, 86, 225, 122, 77, 31, 238, 1, 187, 125, 8, 32, 238, 132, 178, 138, 48, 179, 138, 48, 131, 68, 85, 225, 122, 18, 254, 68, 85, 207, 124, 8, 32, 198, 4, 137, 123, 192, 174, 33, 204, 224, 253, 162, 172, 34, 204, 62, 81, 85, 184, 82, 85, 184, 94, 1, 136, 123, 192, 52, 31, 2, 136, 71, 161, 172, 34, 198, 4, 43, 194, 12, 222, 84, 133, 235, 53, 249, 19, 85, 133, 242, 33, 128, 184, 34, 128, 184, 7, 202, 42, 194, 12, 123, 20, 202, 42, 71, 248, 19, 85, 198, 4, 155, 163, 144, 78, 60, 57, 41, 5, 186, 83, 60, 57, 111, 177, 40, 35, 178, 40, 35, 70, 250, 154, 163, 144, 199, 214, 250, 154, 220, 185, 83, 60, 198, 4, 198, 147, 147, 82, 138, 50, 98, 196, 246, 22, 139, 50, 108, 173, 175, 57, 174, 175, 57, 10, 59, 197, 147, 147, 206, 157, 59, 197, 197, 245, 22, 139, 198, 4, 163, 140, 24, 177, 107, 142, 66, 58, 92, 235, 107, 142, 230, 78, 241, 228, 79, 241, 228, 164, 197, 162, 140, 24, 114, 189, 197, 162, 26, 91, 235, 107, 198, 4, 191, 230, 40, 164, 20, 79, 78, 74, 120, 238, 20, 79, 214, 91, 44, 202, 92, 44, 202, 136, 181, 190, 230, 40, 177, 177, 181, 190, 53, 119, 238, 20, 198, 4, 121, 114, 82, 10, 81, 70, 140, 88, 223, 98, 81, 70, 173, 245, 53, 71, 246, 53, 71, 33, 167, 120, 114, 82, 186, 115, 167, 120, 184, 222, 98, 81, 198, 4, 23, 101, 196, 136, 94, 115, 20, 210, 217, 90, 95, 115, 59, 119, 138, 39, 120, 138, 39, 39, 45, 22, 101, 196, 141, 235, 45, 22, 216, 216, 90, 95, 198, 4, 216, 28, 133, 116, 226, 201, 73, 41, 207, 157, 226, 201, 122, 139, 69, 25, 140, 69, 25, 49, 214, 215, 28, 133, 55, 182, 214, 215, 229, 206, 157, 226, 198, 4, 42, 158, 156, 148, 88, 148, 17, 35, 175, 183, 88, 148, 98, 107, 125, 205, 108, 125, 205, 81, 220, 41, 158, 156, 108, 238, 220, 41, 50, 174, 183, 88, 198, 4, 63, 153, 94, 34, 118, 9, 205, 9, 44, 44, 118, 9, 161, 221, 74, 93, 222, 74, 93, 212, 245, 62, 153, 94, 247, 50, 246, 62, 162, 43, 44, 118, 198, 4, 99, 151, 208, 156, 173, 212, 69, 61, 23, 218, 173, 212, 46, 99, 239, 147, 100, 239, 147, 233, 193, 98, 151, 208, 44, 186, 194, 98, 107, 22, 218, 173, 198, 4, 44, 117, 81, 79, 251, 100, 122, 137, 204, 216, 251, 100, 174, 176, 216, 37, 177, 216, 37, 52, 118, 43, 117, 81, 156, 133, 118, 43, 217, 203, 216, 251, 198, 4, 190, 79, 166, 151, 138, 93, 66, 115, 233, 10, 139, 93, 89, 104, 183, 82, 105, 183, 82, 23, 140, 189, 79, 166, 163, 189, 140, 189, 172, 232, 10, 139, 198, 4, 237, 18, 154, 19, 149, 186, 168, 167, 67, 187, 149, 186, 101, 236, 125, 50, 237, 125, 50, 189, 87, 236, 18, 154, 70, 87, 88, 236, 204, 66, 187, 149, 198, 4, 92, 169, 139, 122, 222, 39, 211, 75, 95, 198, 222, 39, 116, 133, 197, 46, 134, 197, 46, 161, 179, 91, 169, 139, 217, 44, 180, 91, 208, 94, 198, 222, 198, 4, 248, 201, 244, 18, 177, 75, 104, 78, 94, 97, 177, 75, 10, 237, 86, 234, 238, 86, 234, 162, 176, 247, 201, 244, 181, 151, 177, 247, 20, 93, 97, 177, 198, 4, 23, 187, 132, 230, 109, 165, 46, 234, 180, 208, 110, 165, 122, 25, 123, 159, 26, 123, 159, 76, 21, 22, 187, 132, 91, 209, 21, 22, 96, 179, 208, 110, 198, 4, 59, 43, 212, 125, 24, 232, 152, 106, 110, 232, 24, 232, 42, 130, 172, 236, 131, 172, 236, 146, 148, 58, 43, 212, 24, 103, 149, 58, 19, 109, 232, 24, 198, 4, 143, 129, 142, 169, 199, 202, 46, 121, 190, 34, 200, 202, 112, 86, 169, 179, 87, 169, 179, 66, 134, 142, 129, 142, 54, 209, 134, 142, 75, 189, 34, 200, 198, 4, 179, 178, 75, 94, 233, 172, 80, 247, 157, 85, 234, 172, 179, 161, 99, 160, 162, 99, 160, 99, 8, 178, 178, 75, 84, 175, 8, 178, 94, 156, 85, 234, 198, 4, 166, 206, 10, 117, 57, 6, 58, 166, 69, 27, 58, 6, 245, 138, 32, 43, 139, 32, 43, 187, 89, 165, 206, 10, 250, 197, 89, 165, 212, 68, 27, 58, 198, 4, 50, 208, 49, 213, 88, 217, 37, 47, 88, 4, 89, 217, 205, 42, 117, 86, 43, 117, 86, 168, 208, 49, 208, 49, 39, 218, 208, 49, 169, 87, 4, 89, 198, 4, 145, 149, 93, 242, 81, 103, 133, 186, 227, 172, 82, 103, 162, 13, 29, 3, 14, 29, 3, 29, 69, 144, 149, 93, 153, 122, 69, 144, 252, 226, 172, 82, 198, 4, 213, 89, 161, 238, 198, 64, 199, 84, 105, 67, 199, 64, 94, 17, 100, 101, 18, 100, 101, 151, 170, 212, 89, 161, 192, 56, 171, 212, 153, 104, 67, 199, 198, 4, 117, 12, 116, 76, 64, 86, 118, 201, 235, 21, 65, 86, 139, 179, 74, 157, 180, 74, 157, 21, 54, 116, 12, 116, 170, 137, 54, 116, 98, 234, 21, 65, 198, 4, 22, 1, 250, 37, 134, 42, 85, 230, 80, 12, 135, 42, 5, 218, 99, 212, 219, 99, 212, 176, 24, 21, 1, 250, 214, 170, 25, 21, 43, 79, 12, 135, 198, 4, 113, 168, 82, 101, 61, 70, 13, 59, 96, 160, 61, 70, 173, 154, 81, 17, 155, 81, 17, 160, 196, 112, 168, 82, 186, 242, 196, 112, 238, 95, 160, 61, 198, 4, 144, 81, 195, 206, 83, 4, 232, 151, 172, 102, 84, 4, 60, 49, 28, 170, 50, 28, 170, 84, 103, 143, 81, 195, 252, 23, 104, 143, 85, 171, 102, 84, 198, 4, 71, 69, 128, 126, 194, 161, 74, 149, 203, 19, 195, 161, 127, 129, 246, 24, 130, 246, 24, 53, 106, 70, 69, 128, 95, 181, 106, 70, 230, 202, 19, 195, 198, 4, 15, 85, 170, 204, 198, 168, 97, 231, 12, 180, 199, 168, 85, 51, 42, 2, 52, 42, 2, 244, 23, 14, 85, 170, 88, 158, 24, 14, 253, 11, 180, 199, 198, 4, 124, 140, 26, 118, 162, 34, 64, 191, 91, 53, 163, 34, 229, 137, 225, 80, 138, 225, 80, 165, 64, 123, 140, 26, 222, 191, 64, 123, 174, 90, 53, 163, 198, 4, 169, 8, 208, 47, 56, 84, 169, 50, 122, 98, 56, 84, 47, 208, 30, 163, 209, 30, 163, 134, 204, 168, 8, 208, 172, 86, 205, 168, 92, 121, 98, 56, 198, 4, 135, 67, 149, 42, 236, 49, 106, 216, 0, 3, 237, 49, 106, 213, 140, 138, 214, 140, 138, 0, 39, 134, 67, 149, 207, 149, 39, 134, 116, 255, 2, 237, 198, 4, 243, 126, 175, 14, 251, 70, 69, 100, 245, 114, 251, 70, 80, 241, 17, 58, 242, 17, 58, 11, 155, 242, 126, 175, 186, 186, 155, 242, 196, 244, 114, 251, 198, 4, 184, 111, 84, 68, 30, 161, 179, 208, 9, 21, 31, 161, 170, 187, 41, 239, 188, 41, 239, 247, 46, 183, 111, 84, 95, 76, 47, 183, 16, 8, 21, 31, 198, 4, 72, 232, 44, 52, 202, 251, 189, 58, 235, 110, 202, 251, 210, 203, 237, 27, 204, 237, 27, 21, 197, 71, 232, 44, 5, 66, 197, 71, 227, 234, 110, 202, 198, 4, 167, 188, 223, 171, 220, 190, 81, 17, 50, 189, 220, 190, 31, 84, 124, 132, 85, 124, 132, 206, 237, 166, 188, 223, 66, 174, 238, 166, 122, 49, 189, 220, 198, 4, 247, 141, 138, 200, 35, 116, 22, 26, 162, 226, 35, 116, 116, 55, 229, 253, 56, 229, 253, 94, 229, 246, 141, 138, 140, 233, 229, 246, 1, 161, 226, 35, 198, 4, 63, 66, 103, 161, 82, 222, 239, 213, 88, 119, 83, 222, 151, 94, 110, 223, 95, 110, 223, 168, 41, 62, 66, 103, 34, 16, 42, 62, 32, 87, 119, 83, 198, 4, 149, 247, 123, 117, 219, 55, 42, 34, 167, 151, 219, 55, 131, 138, 143, 208, 139, 143, 208, 89, 221, 148, 247, 123, 201, 213, 221, 148, 46, 166, 151, 219, 198, 4, 186, 125, 163, 34, 248, 8, 157, 133, 65, 168, 248, 8, 92, 221, 77, 121, 222, 77, 121, 191, 121, 185, 125, 163, 248, 98, 122, 185, 133, 64, 168, 248, 198, 4, 0, 99, 18, 129, 99, 167, 163, 73, 183, 202, 99, 167, 236, 126, 156, 245, 127, 156, 245, 73, 182, 255, 98, 18, 89, 92, 182, 255, 9, 182, 202, 99, 198, 4, 61, 118, 58, 154, 199, 89, 159, 84, 218, 238, 199, 89, 197, 101, 251, 47, 102, 251, 47, 38, 171, 60, 118, 58, 167, 96, 171, 60, 207, 217, 238, 199, 198, 4, 114, 214, 39, 213, 254, 139, 73, 4, 114, 217, 254, 139, 215, 42, 143, 157, 43, 143, 157, 142, 251, 113, 214, 39, 117, 182, 251, 113, 97, 113, 217, 254, 198, 4, 238, 191, 152, 68, 242, 216, 233, 104, 131, 173, 242, 216, 102, 187, 31, 103, 188, 31, 103, 125, 150, 237, 191, 152, 40, 22, 151, 237, 151, 130, 173, 242, 198, 4, 200, 78, 71, 147, 56, 235, 147, 106, 220, 253, 56, 235, 183, 108, 255, 197, 109, 255, 197, 36, 149, 199, 78, 71, 21, 108, 149, 199, 57, 219, 253, 56, 198, 4, 144, 179, 62, 169, 246, 95, 76, 34, 140, 203, 246, 95, 192, 86, 121, 236, 87, 121, 236, 116, 221, 143, 179, 62, 161, 179, 221, 143, 18, 139, 203, 246, 198, 4, 254, 23, 147, 8, 30, 59, 29, 77, 177, 85, 30, 59, 108, 247, 227, 172, 248, 227, 172, 79, 178, 253, 23, 147, 197, 226, 178, 253, 82, 176, 85, 30, 198, 4, 230, 177, 211, 209, 62, 206, 250, 164, 207, 118, 63, 206, 43, 46, 219, 127, 47, 219, 127, 49, 90, 229, 177, 211, 50, 5, 91, 229, 127, 206, 118, 63, 198, 4, 211, 137, 215, 248, 216, 191, 192, 181, 153, 174, 217, 191, 39, 7, 84, 182, 8, 84, 182, 103, 73, 210, 137, 215, 65, 63, 74, 210, 72, 152, 174, 217, 198, 4, 155, 253, 11, 92, 64, 101, 123, 22, 136, 114, 64, 101, 243, 163, 36, 157, 164, 36, 157, 120, 233, 154, 253, 11, 155, 132, 233, 154, 98, 135, 114, 64, 198, 4, 81, 217, 158, 69, 72, 39, 94, 227, 254, 40, 73, 39, 96, 186, 102, 255, 187, 102, 255, 2, 28, 80, 217, 158, 217, 161, 28, 80, 0, 253, 40, 73, 198, 4, 147, 116, 226, 53, 107, 246, 47, 112, 19, 166, 107, 246, 28, 202, 1, 149, 203, 1, 149, 237, 142, 146, 116, 226, 10, 208, 143, 146, 106, 18, 166, 107, 198, 4, 180, 127, 129, 107, 167, 108, 207, 162, 81, 14, 168, 108, 126, 148, 164, 19, 149, 164, 19, 175, 92, 179, 127, 129, 148, 48, 93, 179, 235, 80, 14, 168, 198, 4, 129, 202, 246, 44, 73, 58, 241, 26, 233, 71, 73, 58, 8, 211, 53, 251, 212, 53, 251, 23, 228, 128, 202, 246, 198, 14, 229, 128, 4, 232, 71, 73, 198, 4, 147, 78, 188, 198, 204, 254, 5, 174, 195, 116, 205, 254, 66, 57, 160, 178, 58, 160, 178, 61, 81, 146, 78, 188, 2, 250, 81, 146, 76, 194, 116, 205, 198, 4, 216, 236, 95, 224, 2, 42, 219, 179, 60, 148, 3, 42, 159, 31, 37, 233, 32, 37, 233, 196, 75, 215, 236, 95, 214, 36, 76, 215, 22, 59, 148, 3, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 1, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 192, 3, 36, 0, 115, 187, 142, 116, 187, 146, 127, 150, 149, 149, 149, 151, 151, 157, 157, 157, 157, 207, 2, 0, 0, 0, 149, 127, 149, 149, 151, 150, 151, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 135, 36, 159, 90, 119, 78, 45, 233, 135, 36, 159, 90, 119, 78, 45, 233, 205, 67, 120, 78, 96, 165, 1, 141, 205, 67, 120, 78, 96, 165, 1, 141, 198, 4, 166, 1, 141, 51, 22, 134, 36, 159, 166, 1, 141, 51, 22, 134, 36, 159, 178, 210, 22, 134, 114, 204, 67, 120, 178, 210, 22, 134, 114, 204, 67, 120, 198, 4, 133, 231, 212, 146, 25, 208, 56, 195, 133, 231, 212, 146, 25, 208, 56, 195, 14, 86, 26, 208, 42, 109, 97, 72, 14, 86, 26, 208, 42, 109, 97, 72, 198, 4, 110, 97, 72, 242, 59, 132, 231, 212, 110, 97, 72, 242, 59, 132, 231, 212, 48, 199, 60, 132, 183, 13, 86, 26, 48, 199, 60, 132, 183, 13, 86, 26, 198, 4, 7, 52, 206, 240, 23, 146, 124, 106, 7, 52, 206, 240, 23, 146, 124, 106, 75, 91, 24, 146, 49, 15, 225, 57, 75, 91, 24, 146, 49, 15, 225, 57, 198, 4, 16, 225, 57, 181, 148, 6, 52, 206, 16, 225, 57, 181, 148, 6, 52, 206, 110, 131, 149, 6, 198, 74, 91, 24, 110, 131, 149, 6, 198, 74, 91, 24, 198, 4, 134, 33, 201, 167, 16, 158, 83, 75, 134, 33, 201, 167, 16, 158, 83, 75, 29, 243, 16, 158, 54, 88, 105, 64, 29, 243, 16, 158, 54, 88, 105, 64, 198, 4, 89, 105, 64, 227, 179, 133, 33, 201, 89, 105, 64, 227, 179, 133, 33, 201, 98, 172, 180, 133, 191, 28, 243, 16, 98, 172, 180, 133, 191, 28, 243, 16, 198, 4, 241, 156, 90, 210, 2, 26, 103, 120, 241, 156, 90, 210, 2, 26, 103, 120, 194, 74, 3, 26, 165, 45, 12, 73, 194, 74, 3, 26, 165, 45, 12, 73, 198, 4, 46, 12, 73, 62, 135, 240, 156, 90, 46, 12, 73, 62, 135, 240, 156, 90, 230, 152, 135, 240, 182, 193, 74, 3, 230, 152, 135, 240, 182, 193, 74, 3, 198, 4, 53, 160, 113, 134, 194, 144, 228, 83, 53, 160, 113, 134, 194, 144, 228, 83, 87, 218, 194, 144, 141, 121, 8, 207, 87, 218, 194, 144, 141, 121, 8, 207, 198, 4, 122, 8, 207, 169, 171, 52, 160, 113, 122, 8, 207, 169, 171, 52, 160, 113, 112, 27, 172, 52, 48, 86, 218, 194, 112, 27, 172, 52, 48, 86, 218, 194, 198, 4, 49, 36, 249, 212, 193, 115, 106, 73, 49, 36, 249, 212, 193, 115, 106, 73, 100, 30, 194, 115, 6, 43, 13, 104, 100, 30, 194, 115, 6, 43, 13, 104, 198, 4, 44, 13, 104, 156, 181, 48, 36, 249, 44, 13, 104, 156, 181, 48, 36, 249, 141, 149, 182, 48, 151, 99, 30, 194, 141, 149, 182, 48, 151, 99, 30, 194, 198, 4, 34, 60, 167, 150, 210, 128, 198, 25, 34, 60, 167, 150, 210, 128, 198, 25, 110, 176, 210, 128, 88, 105, 11, 67, 110, 176, 210, 128, 88, 105, 11, 67, 198, 4, 106, 11, 67, 146, 229, 33, 60, 167, 106, 11, 67, 146, 229, 33, 60, 167, 128, 57, 230, 33, 188, 109, 176, 210, 128, 57, 230, 33, 188, 109, 176, 210, 198, 4, 152, 232, 86, 212, 11, 209, 137, 82, 152, 232, 86, 212, 11, 209, 137, 82, 225, 38, 12, 209, 168, 43, 92, 70, 225, 38, 12, 209, 168, 43, 92, 70, 198, 4, 44, 92, 70, 31, 173, 151, 232, 86, 44, 92, 70, 31, 173, 151, 232, 86, 47, 118, 173, 151, 185, 224, 38, 12, 47, 118, 173, 151, 185, 224, 38, 12, 198, 4, 195, 16, 157, 40, 194, 101, 244, 145, 195, 16, 157, 40, 194, 101, 244, 145, 146, 186, 194, 101, 98, 215, 122, 137, 146, 186, 194, 101, 98, 215, 122, 137, 198, 4, 216, 122, 137, 110, 109, 194, 16, 157, 216, 122, 137, 110, 109, 194, 16, 157, 155, 11, 110, 194, 117, 145, 186, 194, 155, 11, 110, 194, 117, 145, 186, 194, 198, 4, 113, 25, 125, 100, 94, 162, 91, 81, 113, 25, 125, 100, 94, 162, 91, 81, 217, 181, 94, 162, 130, 155, 48, 68, 217, 181, 94, 162, 130, 155, 48, 68, 198, 4, 156, 48, 68, 39, 174, 112, 25, 125, 156, 48, 68, 39, 174, 112, 25, 125, 94, 164, 174, 112, 187, 216, 181, 94, 94, 164, 174, 112, 187, 216, 181, 94, 198, 4, 236, 37, 186, 21, 9, 67, 116, 162, 236, 37, 186, 21, 9, 67, 116, 162, 47, 184, 9, 67, 69, 234, 10, 151, 47, 184, 9, 67, 69, 234, 10, 151, 198, 4, 235, 10, 151, 209, 92, 235, 37, 186, 235, 10, 151, 209, 92, 235, 37, 186, 189, 139, 93, 235, 104, 46, 184, 9, 189, 139, 93, 235, 104, 46, 184, 9, 198, 4, 25, 162, 19, 165, 183, 140, 62, 178, 25, 162, 19, 165, 183, 140, 62, 178, 83, 87, 184, 140, 235, 90, 47, 209, 83, 87, 184, 140, 235, 90, 47, 209, 198, 4, 91, 47, 209, 173, 77, 24, 162, 19, 91, 47, 209, 173, 77, 24, 162, 19, 116, 193, 77, 24, 46, 82, 87, 184, 116, 193, 77, 24, 46, 82, 87, 184, 198, 4, 134, 203, 232, 35, 245, 18, 221, 138, 134, 203, 232, 35, 245, 18, 221, 138, 198, 174, 245, 18, 23, 220, 132, 33, 198, 174, 245, 18, 23, 220, 132, 33, 198, 4, 221, 132, 33, 58, 116, 133, 203, 232, 221, 132, 33, 58, 116, 133, 203, 232, 238, 34, 117, 133, 221, 197, 174, 245, 238, 34, 117, 133, 221, 197, 174, 245, 198, 4, 190, 68, 183, 162, 96, 136, 78, 148, 190, 68, 183, 162, 96, 136, 78, 148, 6, 55, 97, 136, 72, 93, 225, 50, 6, 55, 97, 136, 72, 93, 225, 50, 198, 4, 94, 225, 50, 250, 106, 189, 68, 183, 94, 225, 50, 250, 106, 189, 68, 183, 120, 177, 107, 189, 204, 5, 55, 97, 120, 177, 107, 189, 204, 5, 55, 97, 198, 4, 20, 134, 232, 68, 21, 46, 163, 143, 20, 134, 232, 68, 21, 46, 163, 143, 140, 212, 21, 46, 23, 187, 214, 75, 140, 212, 21, 46, 23, 187, 214, 75, 198, 4, 188, 214, 75, 116, 111, 19, 134, 232, 188, 214, 75, 116, 111, 19, 134, 232, 210, 92, 112, 19, 180, 139, 212, 21, 210, 92, 112, 19, 180, 139, 212, 21, 198, 4, 149, 179, 166, 164, 199, 175, 74, 159, 149, 179, 166, 164, 199, 175, 74, 159, 242, 67, 200, 175, 88, 91, 163, 156, 242, 67, 200, 175, 88, 91, 163, 156, 198, 4, 92, 163, 156, 14, 96, 148, 179, 166, 92, 163, 156, 14, 96, 148, 179, 166, 81, 181, 96, 148, 98, 241, 67, 200, 81, 181, 96, 148, 98, 241, 67, 200, 198, 4, 133, 252, 170, 244, 52, 202, 233, 192, 133, 252, 170, 244, 52, 202, 233, 192, 149, 181, 53, 202, 84, 11, 70, 57, 149, 181, 53, 202, 84, 11, 70, 57, 198, 4, 12, 70, 57, 107, 62, 132, 252, 170, 12, 70, 57, 107, 62, 132, 252, 170, 54, 22, 63, 132, 198, 148, 181, 53, 54, 22, 63, 132, 198, 148, 181, 53, 198, 4, 142, 114, 58, 240, 80, 206, 154, 146, 142, 114, 58, 240, 80, 206, 154, 146, 214, 130, 81, 206, 196, 15, 33, 191, 214, 130, 81, 206, 196, 15, 33, 191, 198, 4, 16, 33, 191, 42, 109, 141, 114, 58, 16, 33, 191, 42, 109, 141, 114, 58, 50, 101, 109, 141, 64, 213, 130, 81, 50, 101, 109, 141, 64, 213, 130, 81, 198, 4, 25, 229, 172, 41, 16, 242, 171, 210, 25, 229, 172, 41, 16, 242, 171, 210, 89, 252, 16, 242, 82, 214, 214, 40, 89, 252, 16, 242, 82, 214, 214, 40, 198, 4, 215, 214, 40, 167, 44, 24, 229, 172, 215, 214, 40, 167, 44, 24, 229, 172, 14, 84, 45, 24, 215, 88, 252, 16, 14, 84, 45, 24, 215, 88, 252, 16, 198, 4, 145, 95, 149, 62, 70, 57, 29, 120, 145, 95, 149, 62, 70, 57, 29, 120, 179, 182, 70, 57, 106, 193, 40, 103, 179, 182, 70, 57, 106, 193, 40, 103, 198, 4, 194, 40, 103, 77, 135, 144, 95, 149, 194, 40, 103, 77, 135, 144, 95, 149, 199, 226, 135, 144, 152, 178, 182, 70, 199, 226, 135, 144, 152, 178, 182, 70, 198, 4, 108, 148, 211, 129, 139, 114, 214, 148, 108, 148, 211, 129, 139, 114, 214, 148, 171, 22, 140, 114, 43, 126, 8, 249, 171, 22, 140, 114, 43, 126, 8, 249, 198, 4, 127, 8, 249, 85, 106, 107, 148, 211, 127, 8, 249, 85, 106, 107, 148, 211, 142, 41, 107, 107, 6, 170, 22, 140, 142, 41, 107, 107, 6, 170, 22, 140, 198, 4, 164, 156, 53, 37, 65, 126, 85, 250, 164, 156, 53, 37, 65, 126, 85, 250, 140, 31, 66, 126, 201, 218, 26, 229, 140, 31, 66, 126, 201, 218, 26, 229, 198, 4, 219, 26, 229, 116, 5, 163, 156, 53, 219, 26, 229, 116, 5, 163, 156, 53, 130, 170, 5, 163, 26, 139, 31, 66, 130, 170, 5, 163, 26, 139, 31, 66, 198, 4, 34, 228, 87, 165, 173, 81, 78, 7, 34, 228, 87, 165, 173, 81, 78, 7, 167, 172, 173, 81, 167, 90, 48, 202, 167, 172, 173, 81, 167, 90, 48, 202, 198, 4, 91, 48, 202, 89, 248, 33, 228, 87, 91, 48, 202, 89, 248, 33, 228, 87, 175, 177, 248, 33, 53, 166, 172, 173, 175, 177, 248, 33, 53, 166, 172, 173, 198, 4, 9, 145, 171, 88, 244, 17, 196, 133, 9, 145, 171, 88, 244, 17, 196, 133, 112, 222, 244, 17, 84, 167, 2, 93, 112, 222, 244, 17, 84, 167, 2, 93, 198, 4, 168, 2, 93, 144, 121, 8, 145, 171, 168, 2, 93, 144, 121, 8, 145, 171, 239, 59, 122, 8, 162, 111, 222, 244, 239, 59, 122, 8, 162, 111, 222, 244, 198, 4, 78, 31, 65, 92, 42, 208, 5, 25, 78, 31, 65, 92, 42, 208, 5, 25, 71, 117, 42, 208, 190, 163, 135, 16, 71, 117, 42, 208, 190, 163, 135, 16, 198, 4, 164, 135, 16, 185, 230, 77, 31, 65, 164, 135, 16, 185, 230, 77, 31, 65, 48, 250, 230, 77, 239, 70, 117, 42, 48, 250, 230, 77, 239, 70, 117, 42, 198, 4, 11, 116, 65, 134, 33, 68, 174, 98, 11, 116, 65, 134, 33, 68, 174, 98, 240, 232, 33, 68, 190, 121, 211, 71, 240, 232, 33, 68, 190, 121, 211, 71, 198, 4, 122, 211, 71, 16, 157, 10, 116, 65, 122, 211, 71, 16, 157, 10, 116, 65, 188, 81, 157, 10, 184, 239, 232, 33, 188, 81, 157, 10, 184, 239, 232, 33, 198, 4, 31, 66, 228, 42, 55, 125, 4, 113, 31, 66, 228, 42, 55, 125, 4, 113, 233, 155, 55, 125, 27, 213, 169, 64, 233, 155, 55, 125, 27, 213, 169, 64, 198, 4, 214, 169, 64, 23, 142, 30, 66, 228, 214, 169, 64, 23, 142, 30, 66, 228, 131, 251, 142, 30, 191, 232, 155, 55, 131, 251, 142, 30, 191, 232, 155, 55, 198, 4, 234, 35, 136, 11, 5, 186, 32, 67, 234, 35, 136, 11, 5, 186, 32, 67, 169, 78, 5, 186, 119, 244, 16, 34, 169, 78, 5, 186, 119, 244, 16, 34, 198, 4, 245, 16, 34, 87, 188, 233, 35, 136, 245, 16, 34, 87, 188, 233, 35, 136, 70, 223, 188, 233, 221, 168, 78, 5, 70, 223, 188, 233, 221, 168, 78, 5, 198, 4, 85, 160, 11, 50, 15, 33, 114, 21, 85, 160, 11, 50, 15, 33, 114, 21, 126, 71, 15, 33, 244, 205, 155, 62, 126, 71, 15, 33, 244, 205, 155, 62, 198, 4, 206, 155, 62, 130, 234, 84, 160, 11, 206, 155, 62, 130, 234, 84, 160, 11, 223, 141, 234, 84, 193, 125, 71, 15, 223, 141, 234, 84, 193, 125, 71, 15, 198, 4, 68, 136, 92, 197, 166, 143, 32, 46, 68, 136, 92, 197, 166, 143, 32, 46, 126, 243, 166, 143, 162, 58, 21, 232, 126, 243, 166, 143, 162, 58, 21, 232, 198, 4, 59, 21, 232, 130, 209, 67, 136, 92, 59, 21, 232, 130, 209, 67, 136, 92, 113, 223, 209, 67, 23, 125, 243, 166, 113, 223, 209, 67, 23, 125, 243, 166, 198, 4, 112, 250, 8, 226, 82, 129, 46, 200, 112, 250, 8, 226, 82, 129, 46, 200, 56, 170, 83, 129, 246, 29, 61, 132, 56, 170, 83, 129, 246, 29, 61, 132, 198, 4, 30, 61, 132, 200, 55, 111, 250, 8, 30, 61, 132, 200, 55, 111, 250, 8, 127, 209, 55, 111, 123, 55, 170, 83, 127, 209, 55, 111, 123, 55, 170, 83, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 1, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 48, 4, 29, 0, 115, 187, 142, 116, 187, 165, 165, 151, 151, 157, 157, 157, 157, 207, 2, 0, 0, 0, 165, 165, 151, 151, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 248, 192, 115, 116, 146, 254, 70, 31, 248, 192, 115, 116, 146, 254, 70, 31, 248, 192, 115, 116, 146, 254, 70, 31, 248, 192, 115, 116, 146, 254, 70, 31, 198, 4, 187, 147, 146, 254, 139, 139, 117, 64, 187, 147, 146, 254, 139, 139, 117, 64, 187, 147, 146, 254, 139, 139, 117, 64, 187, 147, 146, 254, 139, 139, 117, 64, 198, 4, 140, 117, 64, 69, 224, 247, 192, 115, 140, 117, 64, 69, 224, 247, 192, 115, 140, 117, 64, 69, 224, 247, 192, 115, 140, 117, 64, 69, 224, 247, 192, 115, 198, 4, 2, 185, 224, 247, 190, 186, 147, 146, 2, 185, 224, 247, 190, 186, 147, 146, 2, 185, 224, 247, 190, 186, 147, 146, 2, 185, 224, 247, 190, 186, 147, 146, 198, 4, 42, 233, 111, 244, 87, 7, 84, 196, 42, 233, 111, 244, 87, 7, 84, 196, 42, 233, 111, 244, 87, 7, 84, 196, 42, 233, 111, 244, 87, 7, 84, 196, 198, 4, 196, 184, 88, 7, 144, 11, 126, 15, 196, 184, 88, 7, 144, 11, 126, 15, 196, 184, 88, 7, 144, 11, 126, 15, 196, 184, 88, 7, 144, 11, 126, 15, 198, 4, 12, 126, 15, 60, 59, 41, 233, 111, 12, 126, 15, 60, 59, 41, 233, 111, 12, 126, 15, 60, 59, 41, 233, 111, 12, 126, 15, 60, 59, 41, 233, 111, 198, 4, 249, 171, 59, 41, 240, 195, 184, 88, 249, 171, 59, 41, 240, 195, 184, 88, 249, 171, 59, 41, 240, 195, 184, 88, 249, 171, 59, 41, 240, 195, 184, 88, 198, 4, 215, 1, 21, 177, 222, 3, 207, 209, 215, 1, 21, 177, 222, 3, 207, 209, 215, 1, 21, 177, 222, 3, 207, 209, 215, 1, 21, 177, 222, 3, 207, 209, 198, 4, 229, 130, 223, 3, 234, 78, 74, 250, 229, 130, 223, 3, 234, 78, 74, 250, 229, 130, 223, 3, 234, 78, 74, 250, 229, 130, 223, 3, 234, 78, 74, 250, 198, 4, 79, 74, 250, 27, 46, 214, 1, 21, 79, 74, 250, 27, 46, 214, 1, 21, 79, 74, 250, 27, 46, 214, 1, 21, 79, 74, 250, 27, 46, 214, 1, 21, 198, 4, 253, 48, 46, 214, 4, 228, 130, 223, 253, 48, 46, 214, 4, 228, 130, 223, 253, 48, 46, 214, 4, 228, 130, 223, 253, 48, 46, 214, 4, 228, 130, 223, 198, 4, 249, 61, 240, 28, 164, 164, 191, 209, 249, 61, 240, 28, 164, 164, 191, 209, 249, 61, 240, 28, 164, 164, 191, 209, 249, 61, 240, 28, 164, 164, 191, 209, 198, 4, 176, 238, 164, 164, 15, 227, 98, 29, 176, 238, 164, 164, 15, 227, 98, 29, 176, 238, 164, 164, 15, 227, 98, 29, 176, 238, 164, 164, 15, 227, 98, 29, 198, 4, 228, 98, 29, 80, 45, 248, 61, 240, 228, 98, 29, 80, 45, 248, 61, 240, 228, 98, 29, 80, 45, 248, 61, 240, 228, 98, 29, 80, 45, 248, 61, 240, 198, 4, 92, 64, 46, 248, 225, 175, 238, 164, 92, 64, 46, 248, 225, 175, 238, 164, 92, 64, 46, 248, 225, 175, 238, 164, 92, 64, 46, 248, 225, 175, 238, 164, 198, 4, 38, 253, 141, 62, 234, 128, 138, 216, 38, 253, 141, 62, 234, 128, 138, 216, 38, 253, 141, 62, 234, 128, 138, 216, 38, 253, 141, 62, 234, 128, 138, 216, 198, 4, 25, 23, 235, 128, 113, 193, 239, 129, 25, 23, 235, 128, 113, 193, 239, 129, 25, 23, 235, 128, 113, 193, 239, 129, 25, 23, 235, 128, 113, 193, 239, 129, 198, 4, 194, 239, 129, 231, 38, 37, 253, 141, 194, 239, 129, 231, 38, 37, 253, 141, 194, 239, 129, 231, 38, 37, 253, 141, 194, 239, 129, 231, 38, 37, 253, 141, 198, 4, 128, 117, 39, 37, 125, 24, 23, 235, 128, 117, 39, 37, 125, 24, 23, 235, 128, 117, 39, 37, 125, 24, 23, 235, 128, 117, 39, 37, 125, 24, 23, 235, 198, 4, 178, 14, 168, 136, 251, 30, 120, 142, 178, 14, 168, 136, 251, 30, 120, 142, 178, 14, 168, 136, 251, 30, 120, 142, 178, 14, 168, 136, 251, 30, 120, 142, 198, 4, 33, 23, 252, 30, 87, 119, 82, 210, 33, 23, 252, 30, 87, 119, 82, 210, 33, 23, 252, 30, 87, 119, 82, 210, 33, 23, 252, 30, 87, 119, 82, 210, 198, 4, 120, 82, 210, 223, 112, 177, 14, 168, 120, 82, 210, 223, 112, 177, 14, 168, 120, 82, 210, 223, 112, 177, 14, 168, 120, 82, 210, 223, 112, 177, 14, 168, 198, 4, 226, 135, 113, 177, 44, 32, 23, 252, 226, 135, 113, 177, 44, 32, 23, 252, 226, 135, 113, 177, 44, 32, 23, 252, 226, 135, 113, 177, 44, 32, 23, 252, 198, 4, 192, 7, 158, 163, 147, 244, 55, 250, 192, 7, 158, 163, 147, 244, 55, 250, 192, 7, 158, 163, 147, 244, 55, 250, 192, 7, 158, 163, 147, 244, 55, 250, 198, 4, 214, 157, 148, 244, 97, 92, 172, 3, 214, 157, 148, 244, 97, 92, 172, 3, 214, 157, 148, 244, 97, 92, 172, 3, 214, 157, 148, 244, 97, 92, 172, 3, 198, 4, 93, 172, 3, 42, 5, 191, 7, 158, 93, 172, 3, 42, 5, 191, 7, 158, 93, 172, 3, 42, 5, 191, 7, 158, 93, 172, 3, 42, 5, 191, 7, 158, 198, 4, 12, 200, 5, 191, 251, 213, 157, 148, 12, 200, 5, 191, 251, 213, 157, 148, 12, 200, 5, 191, 251, 213, 157, 148, 12, 200, 5, 191, 251, 213, 157, 148, 198, 4, 74, 73, 127, 163, 197, 58, 160, 34, 74, 73, 127, 163, 197, 58, 160, 34, 74, 73, 127, 163, 197, 58, 160, 34, 74, 73, 127, 163, 197, 58, 160, 34, 198, 4, 32, 198, 197, 58, 128, 92, 240, 123, 32, 198, 197, 58, 128, 92, 240, 123, 32, 198, 197, 58, 128, 92, 240, 123, 32, 198, 197, 58, 128, 92, 240, 123, 198, 4, 93, 240, 123, 224, 220, 73, 73, 127, 93, 240, 123, 224, 220, 73, 73, 127, 93, 240, 123, 224, 220, 73, 73, 127, 93, 240, 123, 224, 220, 73, 73, 127, 198, 4, 198, 95, 221, 73, 131, 31, 198, 197, 198, 95, 221, 73, 131, 31, 198, 197, 198, 95, 221, 73, 131, 31, 198, 197, 198, 95, 221, 73, 131, 31, 198, 197, 198, 4, 172, 249, 140, 46, 117, 67, 160, 178, 172, 249, 140, 46, 117, 67, 160, 178, 172, 249, 140, 46, 117, 67, 160, 178, 172, 249, 140, 46, 117, 67, 160, 178, 198, 4, 46, 225, 117, 67, 114, 209, 222, 194, 46, 225, 117, 67, 114, 209, 222, 194, 46, 225, 117, 67, 114, 209, 222, 194, 46, 225, 117, 67, 114, 209, 222, 194, 198, 4, 210, 222, 194, 210, 76, 171, 249, 140, 210, 222, 194, 210, 76, 171, 249, 140, 210, 222, 194, 210, 76, 171, 249, 140, 210, 222, 194, 210, 76, 171, 249, 140, 198, 4, 189, 95, 77, 171, 60, 45, 225, 117, 189, 95, 77, 171, 60, 45, 225, 117, 189, 95, 77, 171, 60, 45, 225, 117, 189, 95, 77, 171, 60, 45, 225, 117, 198, 4, 95, 55, 4, 42, 236, 45, 44, 237, 95, 55, 4, 42, 236, 45, 44, 237, 95, 55, 4, 42, 236, 45, 44, 237, 95, 55, 4, 42, 236, 45, 44, 237, 198, 4, 49, 23, 237, 45, 251, 213, 180, 154, 49, 23, 237, 45, 251, 213, 180, 154, 49, 23, 237, 45, 251, 213, 180, 154, 49, 23, 237, 45, 251, 213, 180, 154, 198, 4, 214, 180, 154, 207, 18, 94, 55, 4, 214, 180, 154, 207, 18, 94, 55, 4, 214, 180, 154, 207, 18, 94, 55, 4, 214, 180, 154, 207, 18, 94, 55, 4, 198, 4, 211, 211, 18, 94, 100, 48, 23, 237, 211, 211, 18, 94, 100, 48, 23, 237, 211, 211, 18, 94, 100, 48, 23, 237, 211, 211, 18, 94, 100, 48, 23, 237, 198, 4, 124, 11, 75, 123, 172, 230, 51, 186, 124, 11, 75, 123, 172, 230, 51, 186, 124, 11, 75, 123, 172, 230, 51, 186, 124, 11, 75, 123, 172, 230, 51, 186, 198, 4, 127, 53, 173, 230, 180, 132, 215, 13, 127, 53, 173, 230, 180, 132, 215, 13, 127, 53, 173, 230, 180, 132, 215, 13, 127, 53, 173, 230, 180, 132, 215, 13, 198, 4, 133, 215, 13, 129, 69, 123, 11, 75, 133, 215, 13, 129, 69, 123, 11, 75, 133, 215, 13, 129, 69, 123, 11, 75, 133, 215, 13, 129, 69, 123, 11, 75, 198, 4, 26, 204, 69, 123, 241, 126, 53, 173, 26, 204, 69, 123, 241, 126, 53, 173, 26, 204, 69, 123, 241, 126, 53, 173, 26, 204, 69, 123, 241, 126, 53, 173, 198, 4, 212, 106, 62, 163, 119, 221, 16, 168, 212, 106, 62, 163, 119, 221, 16, 168, 212, 106, 62, 163, 119, 221, 16, 168, 212, 106, 62, 163, 119, 221, 16, 168, 198, 4, 80, 75, 120, 221, 192, 92, 180, 183, 80, 75, 120, 221, 192, 92, 180, 183, 80, 75, 120, 221, 192, 92, 180, 183, 80, 75, 120, 221, 192, 92, 180, 183, 198, 4, 93, 180, 183, 176, 87, 211, 106, 62, 93, 180, 183, 176, 87, 211, 106, 62, 93, 180, 183, 176, 87, 211, 106, 62, 93, 180, 183, 176, 87, 211, 106, 62, 198, 4, 35, 239, 87, 211, 71, 79, 75, 120, 35, 239, 87, 211, 71, 79, 75, 120, 35, 239, 87, 211, 71, 79, 75, 120, 35, 239, 87, 211, 71, 79, 75, 120, 198, 4, 236, 134, 64, 101, 189, 133, 165, 61, 236, 134, 64, 101, 189, 133, 165, 61, 236, 134, 64, 101, 189, 133, 165, 61, 236, 134, 64, 101, 189, 133, 165, 61, 198, 4, 231, 162, 189, 133, 190, 154, 86, 243, 231, 162, 189, 133, 190, 154, 86, 243, 231, 162, 189, 133, 190, 154, 86, 243, 231, 162, 189, 133, 190, 154, 86, 243, 198, 4, 155, 86, 243, 25, 194, 235, 134, 64, 155, 86, 243, 25, 194, 235, 134, 64, 155, 86, 243, 25, 194, 235, 134, 64, 155, 86, 243, 25, 194, 235, 134, 64, 198, 4, 123, 90, 194, 235, 11, 230, 162, 189, 123, 90, 194, 235, 11, 230, 162, 189, 123, 90, 194, 235, 11, 230, 162, 189, 123, 90, 194, 235, 11, 230, 162, 189, 198, 4, 219, 91, 88, 218, 104, 53, 159, 209, 219, 91, 88, 218, 104, 53, 159, 209, 219, 91, 88, 218, 104, 53, 159, 209, 219, 91, 88, 218, 104, 53, 159, 209, 198, 4, 248, 171, 105, 53, 167, 37, 188, 110, 248, 171, 105, 53, 167, 37, 188, 110, 248, 171, 105, 53, 167, 37, 188, 110, 248, 171, 105, 53, 167, 37, 188, 110, 198, 4, 38, 188, 110, 8, 46, 218, 91, 88, 38, 188, 110, 8, 46, 218, 91, 88, 38, 188, 110, 8, 46, 218, 91, 88, 38, 188, 110, 8, 46, 218, 91, 88, 198, 4, 203, 96, 46, 218, 144, 247, 171, 105, 203, 96, 46, 218, 144, 247, 171, 105, 203, 96, 46, 218, 144, 247, 171, 105, 203, 96, 46, 218, 144, 247, 171, 105, 198, 4, 91, 205, 103, 116, 174, 27, 2, 149, 91, 205, 103, 116, 174, 27, 2, 149, 91, 205, 103, 116, 174, 27, 2, 149, 91, 205, 103, 116, 174, 27, 2, 149, 198, 4, 106, 9, 175, 27, 152, 139, 246, 22, 106, 9, 175, 27, 152, 139, 246, 22, 106, 9, 175, 27, 152, 139, 246, 22, 106, 9, 175, 27, 152, 139, 246, 22, 198, 4, 140, 246, 22, 150, 106, 90, 205, 103, 140, 246, 22, 150, 106, 90, 205, 103, 140, 246, 22, 150, 106, 90, 205, 103, 140, 246, 22, 150, 106, 90, 205, 103, 198, 4, 229, 253, 106, 90, 232, 105, 9, 175, 229, 253, 106, 90, 232, 105, 9, 175, 229, 253, 106, 90, 232, 105, 9, 175, 229, 253, 106, 90, 232, 105, 9, 175, 198, 4, 241, 186, 33, 80, 104, 111, 97, 105, 241, 186, 33, 80, 104, 111, 97, 105, 241, 186, 33, 80, 104, 111, 97, 105, 241, 186, 33, 80, 104, 111, 97, 105, 198, 4, 132, 185, 104, 111, 221, 175, 166, 213, 132, 185, 104, 111, 221, 175, 166, 213, 132, 185, 104, 111, 221, 175, 166, 213, 132, 185, 104, 111, 221, 175, 166, 213, 198, 4, 176, 166, 213, 124, 150, 240, 186, 33, 176, 166, 213, 124, 150, 240, 186, 33, 176, 166, 213, 124, 150, 240, 186, 33, 176, 166, 213, 124, 150, 240, 186, 33, 198, 4, 145, 158, 150, 240, 41, 131, 185, 104, 145, 158, 150, 240, 41, 131, 185, 104, 145, 158, 150, 240, 41, 131, 185, 104, 145, 158, 150, 240, 41, 131, 185, 104, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 1, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 153, 4, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 2, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 1, 0, 0, 1, 255, 254, 255, 254, 1, 0, 0, 1, 255, 254, 255, 254, 1, 0, 0, 1, 255, 254, 255, 254, 1, 0, 0, 1, 255, 254, 255, 254, 198, 4, 1, 0, 0, 1, 255, 254, 255, 254, 1, 0, 0, 1, 255, 254, 255, 254, 1, 0, 0, 1, 255, 254, 255, 254, 1, 0, 0, 1, 255, 254, 255, 254, 198, 4, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 198, 4, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 198, 4, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 198, 4, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 198, 4, 2, 0, 1, 0, 254, 255, 255, 255, 2, 0, 1, 0, 254, 255, 255, 255, 2, 0, 1, 0, 254, 255, 255, 255, 2, 0, 1, 0, 254, 255, 255, 255, 198, 4, 2, 0, 1, 0, 254, 255, 255, 255, 2, 0, 1, 0, 254, 255, 255, 255, 2, 0, 1, 0, 254, 255, 255, 255, 2, 0, 1, 0, 254, 255, 255, 255, 198, 4, 0, 240, 255, 239, 255, 15, 0, 0, 0, 240, 255, 239, 255, 15, 0, 0, 0, 240, 255, 239, 255, 15, 0, 0, 0, 240, 255, 239, 255, 15, 0, 0, 198, 4, 0, 240, 255, 239, 255, 15, 0, 0, 0, 240, 255, 239, 255, 15, 0, 0, 0, 240, 255, 239, 255, 15, 0, 0, 0, 240, 255, 239, 255, 15, 0, 0, 198, 4, 0, 240, 255, 15, 0, 16, 0, 0, 0, 240, 255, 15, 0, 16, 0, 0, 0, 240, 255, 15, 0, 16, 0, 0, 0, 240, 255, 15, 0, 16, 0, 0, 198, 4, 0, 240, 255, 15, 0, 16, 0, 0, 0, 240, 255, 15, 0, 16, 0, 0, 0, 240, 255, 15, 0, 16, 0, 0, 0, 240, 255, 15, 0, 16, 0, 0, 198, 4, 17, 0, 0, 0, 255, 255, 239, 255, 17, 0, 0, 0, 255, 255, 239, 255, 17, 0, 0, 0, 255, 255, 239, 255, 17, 0, 0, 0, 255, 255, 239, 255, 198, 4, 17, 0, 0, 0, 255, 255, 239, 255, 17, 0, 0, 0, 255, 255, 239, 255, 17, 0, 0, 0, 255, 255, 239, 255, 17, 0, 0, 0, 255, 255, 239, 255, 198, 4, 241, 255, 255, 255, 254, 255, 239, 255, 241, 255, 255, 255, 254, 255, 239, 255, 241, 255, 255, 255, 254, 255, 239, 255, 241, 255, 255, 255, 254, 255, 239, 255, 198, 4, 241, 255, 255, 255, 254, 255, 239, 255, 241, 255, 255, 255, 254, 255, 239, 255, 241, 255, 255, 255, 254, 255, 239, 255, 241, 255, 255, 255, 254, 255, 239, 255, 198, 4, 0, 4, 0, 0, 0, 0, 0, 4, 0, 4, 0, 0, 0, 0, 0, 4, 0, 4, 0, 0, 0, 0, 0, 4, 0, 4, 0, 0, 0, 0, 0, 4, 198, 4, 0, 4, 0, 0, 0, 0, 0, 4, 0, 4, 0, 0, 0, 0, 0, 4, 0, 4, 0, 0, 0, 0, 0, 4, 0, 4, 0, 0, 0, 0, 0, 4, 198, 4, 1, 4, 0, 0, 255, 255, 255, 251, 1, 4, 0, 0, 255, 255, 255, 251, 1, 4, 0, 0, 255, 255, 255, 251, 1, 4, 0, 0, 255, 255, 255, 251, 198, 4, 1, 4, 0, 0, 255, 255, 255, 251, 1, 4, 0, 0, 255, 255, 255, 251, 1, 4, 0, 0, 255, 255, 255, 251, 1, 4, 0, 0, 255, 255, 255, 251, 198, 4, 0, 0, 252, 255, 251, 255, 3, 0, 0, 0, 252, 255, 251, 255, 3, 0, 0, 0, 252, 255, 251, 255, 3, 0, 0, 0, 252, 255, 251, 255, 3, 0, 198, 4, 0, 0, 252, 255, 251, 255, 3, 0, 0, 0, 252, 255, 251, 255, 3, 0, 0, 0, 252, 255, 251, 255, 3, 0, 0, 0, 252, 255, 251, 255, 3, 0, 198, 4, 0, 0, 252, 255, 3, 0, 4, 0, 0, 0, 252, 255, 3, 0, 4, 0, 0, 0, 252, 255, 3, 0, 4, 0, 0, 0, 252, 255, 3, 0, 4, 0, 198, 4, 0, 0, 252, 255, 3, 0, 4, 0, 0, 0, 252, 255, 3, 0, 4, 0, 0, 0, 252, 255, 3, 0, 4, 0, 0, 0, 252, 255, 3, 0, 4, 0, 198, 4, 1, 0, 0, 64, 255, 191, 255, 191, 1, 0, 0, 64, 255, 191, 255, 191, 1, 0, 0, 64, 255, 191, 255, 191, 1, 0, 0, 64, 255, 191, 255, 191, 198, 4, 1, 0, 0, 64, 255, 191, 255, 191, 1, 0, 0, 64, 255, 191, 255, 191, 1, 0, 0, 64, 255, 191, 255, 191, 1, 0, 0, 64, 255, 191, 255, 191, 198, 4, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 198, 4, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 198, 4, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 198, 4, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 198, 4, 65, 0, 64, 0, 191, 255, 255, 255, 65, 0, 64, 0, 191, 255, 255, 255, 65, 0, 64, 0, 191, 255, 255, 255, 65, 0, 64, 0, 191, 255, 255, 255, 198, 4, 65, 0, 64, 0, 191, 255, 255, 255, 65, 0, 64, 0, 191, 255, 255, 255, 65, 0, 64, 0, 191, 255, 255, 255, 65, 0, 64, 0, 191, 255, 255, 255, 198, 4, 0, 254, 255, 253, 255, 1, 0, 0, 0, 254, 255, 253, 255, 1, 0, 0, 0, 254, 255, 253, 255, 1, 0, 0, 0, 254, 255, 253, 255, 1, 0, 0, 198, 4, 0, 254, 255, 253, 255, 1, 0, 0, 0, 254, 255, 253, 255, 1, 0, 0, 0, 254, 255, 253, 255, 1, 0, 0, 0, 254, 255, 253, 255, 1, 0, 0, 198, 4, 0, 254, 255, 1, 0, 2, 0, 0, 0, 254, 255, 1, 0, 2, 0, 0, 0, 254, 255, 1, 0, 2, 0, 0, 0, 254, 255, 1, 0, 2, 0, 0, 198, 4, 0, 254, 255, 1, 0, 2, 0, 0, 0, 254, 255, 1, 0, 2, 0, 0, 0, 254, 255, 1, 0, 2, 0, 0, 0, 254, 255, 1, 0, 2, 0, 0, 198, 4, 3, 0, 0, 0, 255, 255, 253, 255, 3, 0, 0, 0, 255, 255, 253, 255, 3, 0, 0, 0, 255, 255, 253, 255, 3, 0, 0, 0, 255, 255, 253, 255, 198, 4, 3, 0, 0, 0, 255, 255, 253, 255, 3, 0, 0, 0, 255, 255, 253, 255, 3, 0, 0, 0, 255, 255, 253, 255, 3, 0, 0, 0, 255, 255, 253, 255, 198, 4, 255, 255, 255, 255, 254, 255, 253, 255, 255, 255, 255, 255, 254, 255, 253, 255, 255, 255, 255, 255, 254, 255, 253, 255, 255, 255, 255, 255, 254, 255, 253, 255, 198, 4, 255, 255, 255, 255, 254, 255, 253, 255, 255, 255, 255, 255, 254, 255, 253, 255, 255, 255, 255, 255, 254, 255, 253, 255, 255, 255, 255, 255, 254, 255, 253, 255, 198, 4, 0, 32, 0, 0, 0, 0, 0, 32, 0, 32, 0, 0, 0, 0, 0, 32, 0, 32, 0, 0, 0, 0, 0, 32, 0, 32, 0, 0, 0, 0, 0, 32, 198, 4, 0, 32, 0, 0, 0, 0, 0, 32, 0, 32, 0, 0, 0, 0, 0, 32, 0, 32, 0, 0, 0, 0, 0, 32, 0, 32, 0, 0, 0, 0, 0, 32, 198, 4, 1, 32, 0, 0, 255, 255, 255, 223, 1, 32, 0, 0, 255, 255, 255, 223, 1, 32, 0, 0, 255, 255, 255, 223, 1, 32, 0, 0, 255, 255, 255, 223, 198, 4, 1, 32, 0, 0, 255, 255, 255, 223, 1, 32, 0, 0, 255, 255, 255, 223, 1, 32, 0, 0, 255, 255, 255, 223, 1, 32, 0, 0, 255, 255, 255, 223, 198, 4, 0, 0, 224, 255, 223, 255, 31, 0, 0, 0, 224, 255, 223, 255, 31, 0, 0, 0, 224, 255, 223, 255, 31, 0, 0, 0, 224, 255, 223, 255, 31, 0, 198, 4, 0, 0, 224, 255, 223, 255, 31, 0, 0, 0, 224, 255, 223, 255, 31, 0, 0, 0, 224, 255, 223, 255, 31, 0, 0, 0, 224, 255, 223, 255, 31, 0, 198, 4, 0, 0, 224, 255, 31, 0, 32, 0, 0, 0, 224, 255, 31, 0, 32, 0, 0, 0, 224, 255, 31, 0, 32, 0, 0, 0, 224, 255, 31, 0, 32, 0, 198, 4, 0, 0, 224, 255, 31, 0, 32, 0, 0, 0, 224, 255, 31, 0, 32, 0, 0, 0, 224, 255, 31, 0, 32, 0, 0, 0, 224, 255, 31, 0, 32, 0, 198, 4, 1, 0, 0, 8, 255, 247, 255, 247, 1, 0, 0, 8, 255, 247, 255, 247, 1, 0, 0, 8, 255, 247, 255, 247, 1, 0, 0, 8, 255, 247, 255, 247, 198, 4, 1, 0, 0, 8, 255, 247, 255, 247, 1, 0, 0, 8, 255, 247, 255, 247, 1, 0, 0, 8, 255, 247, 255, 247, 1, 0, 0, 8, 255, 247, 255, 247, 198, 4, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 198, 4, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 198, 4, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 198, 4, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 198, 4, 9, 0, 8, 0, 247, 255, 255, 255, 9, 0, 8, 0, 247, 255, 255, 255, 9, 0, 8, 0, 247, 255, 255, 255, 9, 0, 8, 0, 247, 255, 255, 255, 198, 4, 9, 0, 8, 0, 247, 255, 255, 255, 9, 0, 8, 0, 247, 255, 255, 255, 9, 0, 8, 0, 247, 255, 255, 255, 9, 0, 8, 0, 247, 255, 255, 255, 198, 4, 0, 128, 255, 127, 255, 127, 0, 0, 0, 128, 255, 127, 255, 127, 0, 0, 0, 128, 255, 127, 255, 127, 0, 0, 0, 128, 255, 127, 255, 127, 0, 0, 198, 4, 0, 128, 255, 127, 255, 127, 0, 0, 0, 128, 255, 127, 255, 127, 0, 0, 0, 128, 255, 127, 255, 127, 0, 0, 0, 128, 255, 127, 255, 127, 0, 0, 198, 4, 0, 128, 255, 127, 0, 128, 0, 0, 0, 128, 255, 127, 0, 128, 0, 0, 0, 128, 255, 127, 0, 128, 0, 0, 0, 128, 255, 127, 0, 128, 0, 0, 198, 4, 0, 128, 255, 127, 0, 128, 0, 0, 0, 128, 255, 127, 0, 128, 0, 0, 0, 128, 255, 127, 0, 128, 0, 0, 0, 128, 255, 127, 0, 128, 0, 0, 198, 4, 129, 0, 0, 0, 255, 255, 127, 255, 129, 0, 0, 0, 255, 255, 127, 255, 129, 0, 0, 0, 255, 255, 127, 255, 129, 0, 0, 0, 255, 255, 127, 255, 198, 4, 129, 0, 0, 0, 255, 255, 127, 255, 129, 0, 0, 0, 255, 255, 127, 255, 129, 0, 0, 0, 255, 255, 127, 255, 129, 0, 0, 0, 255, 255, 127, 255, 198, 4, 129, 255, 255, 255, 254, 255, 127, 255, 129, 255, 255, 255, 254, 255, 127, 255, 129, 255, 255, 255, 254, 255, 127, 255, 129, 255, 255, 255, 254, 255, 127, 255, 198, 4, 129, 255, 255, 255, 254, 255, 127, 255, 129, 255, 255, 255, 254, 255, 127, 255, 129, 255, 255, 255, 254, 255, 127, 255, 129, 255, 255, 255, 254, 255, 127, 255, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 2, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 250, 4, 7, 0, 254, 251, 4, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 2, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 254, 30, 5, 1, 0, 123, 198, 4, 1, 0, 2, 0, 255, 255, 253, 255, 1, 0, 2, 0, 255, 255, 253, 255, 1, 0, 2, 0, 255, 255, 253, 255, 1, 0, 2, 0, 255, 255, 253, 255, 254, 34, 5, 1, 0, 123, 198, 4, 1, 254, 255, 255, 254, 255, 255, 255, 1, 254, 255, 255, 254, 255, 255, 255, 1, 254, 255, 255, 254, 255, 255, 255, 1, 254, 255, 255, 254, 255, 255, 255, 254, 38, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 254, 42, 5, 1, 0, 123, 198, 4, 33, 0, 0, 0, 223, 255, 255, 255, 33, 0, 0, 0, 223, 255, 255, 255, 33, 0, 0, 0, 223, 255, 255, 255, 33, 0, 0, 0, 223, 255, 255, 255, 254, 46, 5, 1, 0, 123, 198, 4, 1, 0, 224, 255, 254, 255, 255, 255, 1, 0, 224, 255, 254, 255, 255, 255, 1, 0, 224, 255, 254, 255, 255, 255, 1, 0, 224, 255, 254, 255, 255, 255, 254, 50, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 254, 54, 5, 1, 0, 123, 198, 4, 1, 0, 0, 32, 255, 255, 255, 223, 1, 0, 0, 32, 255, 255, 255, 223, 1, 0, 0, 32, 255, 255, 255, 223, 1, 0, 0, 32, 255, 255, 255, 223, 254, 58, 5, 1, 0, 123, 198, 4, 249, 255, 255, 255, 254, 255, 255, 255, 249, 255, 255, 255, 254, 255, 255, 255, 249, 255, 255, 255, 254, 255, 255, 255, 249, 255, 255, 255, 254, 255, 255, 255, 254, 62, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 8, 0, 254, 66, 5, 1, 0, 123, 198, 4, 1, 8, 0, 0, 255, 247, 255, 255, 1, 8, 0, 0, 255, 247, 255, 255, 1, 8, 0, 0, 255, 247, 255, 255, 1, 8, 0, 0, 255, 247, 255, 255, 254, 70, 5, 1, 0, 123, 198, 4, 1, 0, 0, 248, 254, 255, 255, 255, 1, 0, 0, 248, 254, 255, 255, 255, 1, 0, 0, 248, 254, 255, 255, 255, 1, 0, 0, 248, 254, 255, 255, 255, 254, 74, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 254, 78, 5, 1, 0, 123, 198, 4, 1, 0, 128, 0, 255, 255, 127, 255, 1, 0, 128, 0, 255, 255, 127, 255, 1, 0, 128, 0, 255, 255, 127, 255, 1, 0, 128, 0, 255, 255, 127, 255, 254, 82, 5, 1, 0, 123, 198, 4, 1, 128, 255, 255, 254, 255, 255, 255, 1, 128, 255, 255, 254, 255, 255, 255, 1, 128, 255, 255, 254, 255, 255, 255, 1, 128, 255, 255, 254, 255, 255, 255, 254, 86, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 254, 90, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 4, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 99, 5, 7, 0, 254, 100, 5, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 2, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 5, 0, 0, 0, 251, 255, 255, 255, 5, 0, 0, 0, 251, 255, 255, 255, 5, 0, 0, 0, 251, 255, 255, 255, 5, 0, 0, 0, 251, 255, 255, 255, 254, 135, 5, 1, 0, 123, 198, 4, 1, 0, 252, 255, 254, 255, 255, 255, 1, 0, 252, 255, 254, 255, 255, 255, 1, 0, 252, 255, 254, 255, 255, 255, 1, 0, 252, 255, 254, 255, 255, 255, 254, 139, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 254, 143, 5, 1, 0, 123, 198, 4, 1, 0, 0, 4, 255, 255, 255, 251, 1, 0, 0, 4, 255, 255, 255, 251, 1, 0, 0, 4, 255, 255, 255, 251, 1, 0, 0, 4, 255, 255, 255, 251, 254, 147, 5, 1, 0, 123, 198, 4, 193, 255, 255, 255, 254, 255, 255, 255, 193, 255, 255, 255, 254, 255, 255, 255, 193, 255, 255, 255, 254, 255, 255, 255, 193, 255, 255, 255, 254, 255, 255, 255, 254, 151, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 64, 0, 254, 155, 5, 1, 0, 123, 198, 4, 1, 64, 0, 0, 255, 191, 255, 255, 1, 64, 0, 0, 255, 191, 255, 255, 1, 64, 0, 0, 255, 191, 255, 255, 1, 64, 0, 0, 255, 191, 255, 255, 254, 159, 5, 1, 0, 123, 198, 4, 1, 0, 0, 192, 254, 255, 255, 255, 1, 0, 0, 192, 254, 255, 255, 255, 1, 0, 0, 192, 254, 255, 255, 255, 1, 0, 0, 192, 254, 255, 255, 255, 254, 163, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 8, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 172, 5, 7, 0, 254, 173, 5, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 2, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 254, 208, 5, 1, 0, 123, 198, 4, 1, 0, 16, 0, 255, 255, 239, 255, 1, 0, 16, 0, 255, 255, 239, 255, 1, 0, 16, 0, 255, 255, 239, 255, 1, 0, 16, 0, 255, 255, 239, 255, 254, 212, 5, 1, 0, 123, 198, 4, 1, 240, 255, 255, 254, 255, 255, 255, 1, 240, 255, 255, 254, 255, 255, 255, 1, 240, 255, 255, 254, 255, 255, 255, 1, 240, 255, 255, 254, 255, 255, 255, 254, 216, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 16, 254, 220, 5, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 16, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 229, 5, 7, 0, 254, 230, 5, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 2, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 1, 1, 0, 0, 255, 254, 255, 255, 1, 1, 0, 0, 255, 254, 255, 255, 1, 1, 0, 0, 255, 254, 255, 255, 1, 1, 0, 0, 255, 254, 255, 255, 254, 9, 6, 1, 0, 123, 198, 4, 1, 0, 0, 255, 254, 255, 255, 255, 1, 0, 0, 255, 254, 255, 255, 255, 1, 0, 0, 255, 254, 255, 255, 255, 1, 0, 0, 255, 254, 255, 255, 255, 254, 13, 6, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 32, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 22, 6, 7, 0, 254, 23, 6, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 2, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 254, 58, 6, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 64, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 67, 6, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 2, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 104, 104, 105, 183, 0, 0, 0, 0, 0, 0, 0, 0, 164, 254, 95, 6, 8, 0, 111, 187, 207, 3, 0, 0, 0, 111, 194, 148, 3, 164, 105, 104, 183, 0, 0, 0, 0, 0, 0, 0, 0, 9, 98, 117, 116, 116, 101, 114, 102, 108, 121, 0, 0, 9, 98, 117, 116, 116, 101, 114, 102, 108, 121, 0, 0, 0, 46, 0, 148, 7, 127, 148, 7, 127, 146, 148, 7, 162, 147, 148, 7, 163, 123, 125, 148, 3, 127, 148, 3, 127, 146, 148, 3, 162, 147, 148, 3, 163, 142, 160, 148, 5, 127, 148, 5, 127, 146, 148, 5, 162, 147, 148, 5, 163, 7, 102, 111, 114, 119, 97, 114, 100, 1, 0, 7, 102, 111, 114, 119, 97, 114, 100, 1, 128, 0, 167, 1, 183, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 51, 0, 10, 0, 112, 187, 111, 194, 149, 3, 165, 148, 3, 164, 105, 104, 104, 198, 4, 1, 0, 0, 0, 255, 255, 254, 255, 1, 0, 0, 0, 255, 255, 254, 255, 1, 0, 0, 0, 255, 255, 254, 255, 1, 0, 0, 0, 255, 255, 254, 255, 254, 67, 0, 1, 0, 123, 198, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 183, 64, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 75, 0, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 0, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 254, 103, 0, 1, 0, 123, 198, 4, 0, 255, 255, 255, 255, 0, 0, 0, 0, 255, 255, 255, 255, 0, 0, 0, 0, 255, 255, 255, 255, 0, 0, 0, 0, 255, 255, 255, 255, 0, 0, 0, 254, 107, 0, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 32, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 116, 0, 7, 0, 254, 117, 0, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 0, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 1, 0, 0, 0, 255, 255, 255, 239, 1, 0, 0, 0, 255, 255, 255, 239, 1, 0, 0, 0, 255, 255, 255, 239, 1, 0, 0, 0, 255, 255, 255, 239, 254, 152, 0, 1, 0, 123, 198, 4, 0, 16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 254, 156, 0, 1, 0, 123, 198, 4, 0, 0, 240, 255, 255, 255, 15, 0, 0, 0, 240, 255, 255, 255, 15, 0, 0, 0, 240, 255, 255, 255, 15, 0, 0, 0, 240, 255, 255, 255, 15, 0, 254, 160, 0, 1, 0, 123, 198, 4, 1, 0, 0, 0, 239, 255, 255, 255, 1, 0, 0, 0, 239, 255, 255, 255, 1, 0, 0, 0, 239, 255, 255, 255, 1, 0, 0, 0, 239, 255, 255, 255, 254, 164, 0, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 16, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 173, 0, 7, 0, 254, 174, 0, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 0, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 254, 209, 0, 1, 0, 123, 198, 4, 0, 192, 255, 255, 255, 63, 0, 0, 0, 192, 255, 255, 255, 63, 0, 0, 0, 192, 255, 255, 255, 63, 0, 0, 0, 192, 255, 255, 255, 63, 0, 0, 254, 213, 0, 1, 0, 123, 198, 4, 1, 0, 0, 0, 255, 255, 191, 255, 1, 0, 0, 0, 255, 255, 191, 255, 1, 0, 0, 0, 255, 255, 191, 255, 1, 0, 0, 0, 255, 255, 191, 255, 254, 217, 0, 1, 0, 123, 198, 4, 64, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 254, 221, 0, 1, 0, 123, 198, 4, 0, 0, 0, 252, 255, 255, 255, 3, 0, 0, 0, 252, 255, 255, 255, 3, 0, 0, 0, 252, 255, 255, 255, 3, 0, 0, 0, 252, 255, 255, 255, 3, 254, 225, 0, 1, 0, 123, 198, 4, 1, 0, 0, 0, 255, 251, 255, 255, 1, 0, 0, 0, 255, 251, 255, 255, 1, 0, 0, 0, 255, 251, 255, 255, 1, 0, 0, 0, 255, 251, 255, 255, 254, 229, 0, 1, 0, 123, 198, 4, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 254, 233, 0, 1, 0, 123, 198, 4, 252, 255, 255, 255, 3, 0, 0, 0, 252, 255, 255, 255, 3, 0, 0, 0, 252, 255, 255, 255, 3, 0, 0, 0, 252, 255, 255, 255, 3, 0, 0, 0, 254, 237, 0, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 8, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 246, 0, 7, 0, 254, 247, 0, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 0, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 1, 0, 0, 0, 255, 255, 255, 127, 1, 0, 0, 0, 255, 255, 255, 127, 1, 0, 0, 0, 255, 255, 255, 127, 1, 0, 0, 0, 255, 255, 255, 127, 254, 26, 1, 1, 0, 123, 198, 4, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 254, 30, 1, 1, 0, 123, 198, 4, 0, 0, 128, 255, 255, 255, 127, 0, 0, 0, 128, 255, 255, 255, 127, 0, 0, 0, 128, 255, 255, 255, 127, 0, 0, 0, 128, 255, 255, 255, 127, 0, 254, 34, 1, 1, 0, 123, 198, 4, 1, 0, 0, 0, 127, 255, 255, 255, 1, 0, 0, 0, 127, 255, 255, 255, 1, 0, 0, 0, 127, 255, 255, 255, 1, 0, 0, 0, 127, 255, 255, 255, 254, 38, 1, 1, 0, 123, 198, 4, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 254, 42, 1, 1, 0, 123, 198, 4, 0, 248, 255, 255, 255, 7, 0, 0, 0, 248, 255, 255, 255, 7, 0, 0, 0, 248, 255, 255, 255, 7, 0, 0, 0, 248, 255, 255, 255, 7, 0, 0, 254, 46, 1, 1, 0, 123, 198, 4, 1, 0, 0, 0, 255, 255, 247, 255, 1, 0, 0, 0, 255, 255, 247, 255, 1, 0, 0, 0, 255, 255, 247, 255, 1, 0, 0, 0, 255, 255, 247, 255, 254, 50, 1, 1, 0, 123, 198, 4, 8, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 254, 54, 1, 1, 0, 123, 198, 4, 0, 0, 0, 224, 255, 255, 255, 31, 0, 0, 0, 224, 255, 255, 255, 31, 0, 0, 0, 224, 255, 255, 255, 31, 0, 0, 0, 224, 255, 255, 255, 31, 254, 58, 1, 1, 0, 123, 198, 4, 1, 0, 0, 0, 255, 223, 255, 255, 1, 0, 0, 0, 255, 223, 255, 255, 1, 0, 0, 0, 255, 223, 255, 255, 1, 0, 0, 0, 255, 223, 255, 255, 254, 62, 1, 1, 0, 123, 198, 4, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 254, 66, 1, 1, 0, 123, 198, 4, 224, 255, 255, 255, 31, 0, 0, 0, 224, 255, 255, 255, 31, 0, 0, 0, 224, 255, 255, 255, 31, 0, 0, 0, 224, 255, 255, 255, 31, 0, 0, 0, 254, 70, 1, 1, 0, 123, 198, 4, 1, 0, 0, 0, 255, 255, 255, 253, 1, 0, 0, 0, 255, 255, 255, 253, 1, 0, 0, 0, 255, 255, 255, 253, 1, 0, 0, 0, 255, 255, 255, 253, 254, 74, 1, 1, 0, 123, 198, 4, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 254, 78, 1, 1, 0, 123, 198, 4, 0, 0, 254, 255, 255, 255, 1, 0, 0, 0, 254, 255, 255, 255, 1, 0, 0, 0, 254, 255, 255, 255, 1, 0, 0, 0, 254, 255, 255, 255, 1, 0, 254, 82, 1, 1, 0, 123, 198, 4, 1, 0, 0, 0, 253, 255, 255, 255, 1, 0, 0, 0, 253, 255, 255, 255, 1, 0, 0, 0, 253, 255, 255, 255, 1, 0, 0, 0, 253, 255, 255, 255, 254, 86, 1, 1, 0, 123, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 4, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 95, 1, 7, 0, 254, 96, 1, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 0, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 128, 0, 0, 0, 0, 0, 128, 0, 128, 0, 0, 0, 0, 0, 128, 0, 128, 0, 0, 0, 0, 0, 128, 0, 128, 0, 0, 0, 0, 0, 128, 0, 198, 4, 128, 0, 0, 0, 0, 0, 128, 0, 128, 0, 0, 0, 0, 0, 128, 0, 128, 0, 0, 0, 0, 0, 128, 0, 128, 0, 0, 0, 0, 0, 128, 0, 198, 4, 128, 255, 255, 255, 255, 255, 127, 0, 128, 255, 255, 255, 255, 255, 127, 0, 128, 255, 255, 255, 255, 255, 127, 0, 128, 255, 255, 255, 255, 255, 127, 0, 198, 4, 128, 255, 255, 255, 255, 255, 127, 0, 128, 255, 255, 255, 255, 255, 127, 0, 128, 255, 255, 255, 255, 255, 127, 0, 128, 255, 255, 255, 255, 255, 127, 0, 198, 4, 1, 128, 0, 128, 254, 127, 255, 255, 1, 128, 0, 128, 254, 127, 255, 255, 1, 128, 0, 128, 254, 127, 255, 255, 1, 128, 0, 128, 254, 127, 255, 255, 198, 4, 1, 128, 0, 128, 254, 127, 255, 255, 1, 128, 0, 128, 254, 127, 255, 255, 1, 128, 0, 128, 254, 127, 255, 255, 1, 128, 0, 128, 254, 127, 255, 255, 198, 4, 1, 128, 0, 128, 255, 127, 255, 255, 1, 128, 0, 128, 255, 127, 255, 255, 1, 128, 0, 128, 255, 127, 255, 255, 1, 128, 0, 128, 255, 127, 255, 255, 198, 4, 1, 128, 0, 128, 255, 127, 255, 255, 1, 128, 0, 128, 255, 127, 255, 255, 1, 128, 0, 128, 255, 127, 255, 255, 1, 128, 0, 128, 255, 127, 255, 255, 198, 4, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 198, 4, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 248, 255, 247, 255, 7, 0, 0, 0, 198, 4, 9, 0, 248, 255, 246, 255, 255, 255, 9, 0, 248, 255, 246, 255, 255, 255, 9, 0, 248, 255, 246, 255, 255, 255, 9, 0, 248, 255, 246, 255, 255, 255, 198, 4, 9, 0, 248, 255, 246, 255, 255, 255, 9, 0, 248, 255, 246, 255, 255, 255, 9, 0, 248, 255, 246, 255, 255, 255, 9, 0, 248, 255, 246, 255, 255, 255, 198, 4, 1, 0, 0, 8, 255, 7, 0, 248, 1, 0, 0, 8, 255, 7, 0, 248, 1, 0, 0, 8, 255, 7, 0, 248, 1, 0, 0, 8, 255, 7, 0, 248, 198, 4, 1, 0, 0, 8, 255, 7, 0, 248, 1, 0, 0, 8, 255, 7, 0, 248, 1, 0, 0, 8, 255, 7, 0, 248, 1, 0, 0, 8, 255, 7, 0, 248, 198, 4, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 198, 4, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 0, 0, 0, 248, 255, 7, 0, 8, 198, 4, 1, 0, 32, 0, 223, 255, 223, 255, 1, 0, 32, 0, 223, 255, 223, 255, 1, 0, 32, 0, 223, 255, 223, 255, 1, 0, 32, 0, 223, 255, 223, 255, 198, 4, 1, 0, 32, 0, 223, 255, 223, 255, 1, 0, 32, 0, 223, 255, 223, 255, 1, 0, 32, 0, 223, 255, 223, 255, 1, 0, 32, 0, 223, 255, 223, 255, 198, 4, 1, 0, 32, 0, 31, 0, 224, 255, 1, 0, 32, 0, 31, 0, 224, 255, 1, 0, 32, 0, 31, 0, 224, 255, 1, 0, 32, 0, 31, 0, 224, 255, 198, 4, 1, 0, 32, 0, 31, 0, 224, 255, 1, 0, 32, 0, 31, 0, 224, 255, 1, 0, 32, 0, 31, 0, 224, 255, 1, 0, 32, 0, 31, 0, 224, 255, 198, 4, 0, 224, 255, 255, 255, 255, 255, 31, 0, 224, 255, 255, 255, 255, 255, 31, 0, 224, 255, 255, 255, 255, 255, 31, 0, 224, 255, 255, 255, 255, 255, 31, 198, 4, 0, 224, 255, 255, 255, 255, 255, 31, 0, 224, 255, 255, 255, 255, 255, 31, 0, 224, 255, 255, 255, 255, 255, 31, 0, 224, 255, 255, 255, 255, 255, 31, 198, 4, 1, 224, 255, 255, 254, 255, 255, 223, 1, 224, 255, 255, 254, 255, 255, 223, 1, 224, 255, 255, 254, 255, 255, 223, 1, 224, 255, 255, 254, 255, 255, 223, 198, 4, 1, 224, 255, 255, 254, 255, 255, 223, 1, 224, 255, 255, 254, 255, 255, 223, 1, 224, 255, 255, 254, 255, 255, 223, 1, 224, 255, 255, 254, 255, 255, 223, 198, 4, 2, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 2, 0, 198, 4, 2, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 2, 0, 2, 0, 0, 0, 0, 0, 2, 0, 198, 4, 254, 255, 255, 255, 255, 255, 1, 0, 254, 255, 255, 255, 255, 255, 1, 0, 254, 255, 255, 255, 255, 255, 1, 0, 254, 255, 255, 255, 255, 255, 1, 0, 198, 4, 254, 255, 255, 255, 255, 255, 1, 0, 254, 255, 255, 255, 255, 255, 1, 0, 254, 255, 255, 255, 255, 255, 1, 0, 254, 255, 255, 255, 255, 255, 1, 0, 198, 4, 1, 2, 0, 254, 254, 253, 255, 255, 1, 2, 0, 254, 254, 253, 255, 255, 1, 2, 0, 254, 254, 253, 255, 255, 1, 2, 0, 254, 254, 253, 255, 255, 198, 4, 1, 2, 0, 254, 254, 253, 255, 255, 1, 2, 0, 254, 254, 253, 255, 255, 1, 2, 0, 254, 254, 253, 255, 255, 1, 2, 0, 254, 254, 253, 255, 255, 198, 4, 1, 2, 0, 2, 255, 253, 255, 255, 1, 2, 0, 2, 255, 253, 255, 255, 1, 2, 0, 2, 255, 253, 255, 255, 1, 2, 0, 2, 255, 253, 255, 255, 198, 4, 1, 2, 0, 2, 255, 253, 255, 255, 1, 2, 0, 2, 255, 253, 255, 255, 1, 2, 0, 2, 255, 253, 255, 255, 1, 2, 0, 2, 255, 253, 255, 255, 198, 4, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 198, 4, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 192, 255, 191, 255, 63, 0, 0, 0, 198, 4, 65, 0, 192, 255, 190, 255, 255, 255, 65, 0, 192, 255, 190, 255, 255, 255, 65, 0, 192, 255, 190, 255, 255, 255, 65, 0, 192, 255, 190, 255, 255, 255, 198, 4, 65, 0, 192, 255, 190, 255, 255, 255, 65, 0, 192, 255, 190, 255, 255, 255, 65, 0, 192, 255, 190, 255, 255, 255, 65, 0, 192, 255, 190, 255, 255, 255, 198, 4, 1, 0, 0, 64, 255, 63, 0, 192, 1, 0, 0, 64, 255, 63, 0, 192, 1, 0, 0, 64, 255, 63, 0, 192, 1, 0, 0, 64, 255, 63, 0, 192, 198, 4, 1, 0, 0, 64, 255, 63, 0, 192, 1, 0, 0, 64, 255, 63, 0, 192, 1, 0, 0, 64, 255, 63, 0, 192, 1, 0, 0, 64, 255, 63, 0, 192, 198, 4, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 198, 4, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 0, 0, 0, 192, 255, 63, 0, 64, 198, 4, 1, 0, 4, 0, 251, 255, 251, 255, 1, 0, 4, 0, 251, 255, 251, 255, 1, 0, 4, 0, 251, 255, 251, 255, 1, 0, 4, 0, 251, 255, 251, 255, 198, 4, 1, 0, 4, 0, 251, 255, 251, 255, 1, 0, 4, 0, 251, 255, 251, 255, 1, 0, 4, 0, 251, 255, 251, 255, 1, 0, 4, 0, 251, 255, 251, 255, 198, 4, 1, 0, 4, 0, 3, 0, 252, 255, 1, 0, 4, 0, 3, 0, 252, 255, 1, 0, 4, 0, 3, 0, 252, 255, 1, 0, 4, 0, 3, 0, 252, 255, 198, 4, 1, 0, 4, 0, 3, 0, 252, 255, 1, 0, 4, 0, 3, 0, 252, 255, 1, 0, 4, 0, 3, 0, 252, 255, 1, 0, 4, 0, 3, 0, 252, 255, 198, 4, 0, 252, 255, 255, 255, 255, 255, 3, 0, 252, 255, 255, 255, 255, 255, 3, 0, 252, 255, 255, 255, 255, 255, 3, 0, 252, 255, 255, 255, 255, 255, 3, 198, 4, 0, 252, 255, 255, 255, 255, 255, 3, 0, 252, 255, 255, 255, 255, 255, 3, 0, 252, 255, 255, 255, 255, 255, 3, 0, 252, 255, 255, 255, 255, 255, 3, 198, 4, 1, 252, 255, 255, 254, 255, 255, 251, 1, 252, 255, 255, 254, 255, 255, 251, 1, 252, 255, 255, 254, 255, 255, 251, 1, 252, 255, 255, 254, 255, 255, 251, 198, 4, 1, 252, 255, 255, 254, 255, 255, 251, 1, 252, 255, 255, 254, 255, 255, 251, 1, 252, 255, 255, 254, 255, 255, 251, 1, 252, 255, 255, 254, 255, 255, 251, 198, 4, 16, 0, 0, 0, 0, 0, 16, 0, 16, 0, 0, 0, 0, 0, 16, 0, 16, 0, 0, 0, 0, 0, 16, 0, 16, 0, 0, 0, 0, 0, 16, 0, 198, 4, 16, 0, 0, 0, 0, 0, 16, 0, 16, 0, 0, 0, 0, 0, 16, 0, 16, 0, 0, 0, 0, 0, 16, 0, 16, 0, 0, 0, 0, 0, 16, 0, 198, 4, 240, 255, 255, 255, 255, 255, 15, 0, 240, 255, 255, 255, 255, 255, 15, 0, 240, 255, 255, 255, 255, 255, 15, 0, 240, 255, 255, 255, 255, 255, 15, 0, 198, 4, 240, 255, 255, 255, 255, 255, 15, 0, 240, 255, 255, 255, 255, 255, 15, 0, 240, 255, 255, 255, 255, 255, 15, 0, 240, 255, 255, 255, 255, 255, 15, 0, 198, 4, 1, 16, 0, 240, 254, 239, 255, 255, 1, 16, 0, 240, 254, 239, 255, 255, 1, 16, 0, 240, 254, 239, 255, 255, 1, 16, 0, 240, 254, 239, 255, 255, 198, 4, 1, 16, 0, 240, 254, 239, 255, 255, 1, 16, 0, 240, 254, 239, 255, 255, 1, 16, 0, 240, 254, 239, 255, 255, 1, 16, 0, 240, 254, 239, 255, 255, 198, 4, 1, 16, 0, 16, 255, 239, 255, 255, 1, 16, 0, 16, 255, 239, 255, 255, 1, 16, 0, 16, 255, 239, 255, 255, 1, 16, 0, 16, 255, 239, 255, 255, 198, 4, 1, 16, 0, 16, 255, 239, 255, 255, 1, 16, 0, 16, 255, 239, 255, 255, 1, 16, 0, 16, 255, 239, 255, 255, 1, 16, 0, 16, 255, 239, 255, 255, 198, 4, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 198, 4, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 255, 255, 254, 255, 0, 0, 0, 0, 198, 4, 2, 0, 255, 255, 253, 255, 255, 255, 2, 0, 255, 255, 253, 255, 255, 255, 2, 0, 255, 255, 253, 255, 255, 255, 2, 0, 255, 255, 253, 255, 255, 255, 198, 4, 2, 0, 255, 255, 253, 255, 255, 255, 2, 0, 255, 255, 253, 255, 255, 255, 2, 0, 255, 255, 253, 255, 255, 255, 2, 0, 255, 255, 253, 255, 255, 255, 198, 4, 1, 0, 0, 1, 255, 0, 0, 255, 1, 0, 0, 1, 255, 0, 0, 255, 1, 0, 0, 1, 255, 0, 0, 255, 1, 0, 0, 1, 255, 0, 0, 255, 198, 4, 1, 0, 0, 1, 255, 0, 0, 255, 1, 0, 0, 1, 255, 0, 0, 255, 1, 0, 0, 1, 255, 0, 0, 255, 1, 0, 0, 1, 255, 0, 0, 255, 198, 4, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 198, 4, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0, 255, 255, 0, 0, 1, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 2, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 200, 1, 7, 0, 254, 201, 1, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 0, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 112, 97, 105, 15, 213, 124, 70, 151, 112, 97, 105, 15, 213, 124, 70, 151, 112, 97, 105, 15, 213, 124, 70, 151, 112, 97, 105, 15, 213, 124, 70, 151, 198, 4, 81, 89, 42, 131, 104, 15, 69, 222, 81, 89, 42, 131, 104, 15, 69, 222, 81, 89, 42, 131, 104, 15, 69, 222, 81, 89, 42, 131, 104, 15, 69, 222, 198, 4, 125, 70, 151, 144, 33, 80, 89, 42, 125, 70, 151, 144, 33, 80, 89, 42, 125, 70, 151, 144, 33, 80, 89, 42, 125, 70, 151, 144, 33, 80, 89, 42, 198, 4, 16, 69, 222, 175, 150, 144, 158, 150, 16, 69, 222, 175, 150, 144, 158, 150, 16, 69, 222, 175, 150, 144, 158, 150, 16, 69, 222, 175, 150, 144, 158, 150, 198, 4, 28, 2, 149, 165, 22, 150, 246, 80, 28, 2, 149, 165, 22, 150, 246, 80, 28, 2, 149, 165, 22, 150, 246, 80, 28, 2, 149, 165, 22, 150, 246, 80, 198, 4, 117, 9, 233, 105, 148, 165, 50, 152, 117, 9, 233, 105, 148, 165, 50, 152, 117, 9, 233, 105, 148, 165, 50, 152, 117, 9, 233, 105, 148, 165, 50, 152, 198, 4, 151, 246, 80, 228, 102, 116, 9, 233, 151, 246, 80, 228, 102, 116, 9, 233, 151, 246, 80, 228, 102, 116, 9, 233, 151, 246, 80, 228, 102, 116, 9, 233, 198, 4, 166, 50, 152, 139, 80, 228, 253, 106, 166, 50, 152, 139, 80, 228, 253, 106, 166, 50, 152, 139, 80, 228, 253, 106, 166, 50, 152, 139, 80, 228, 253, 106, 198, 4, 54, 159, 209, 37, 110, 8, 84, 150, 54, 159, 209, 37, 110, 8, 84, 150, 54, 159, 209, 37, 110, 8, 84, 150, 54, 159, 209, 37, 110, 8, 84, 150, 198, 4, 219, 67, 145, 247, 208, 37, 164, 167, 219, 67, 145, 247, 208, 37, 164, 167, 219, 67, 145, 247, 208, 37, 164, 167, 219, 67, 145, 247, 208, 37, 164, 167, 198, 4, 9, 84, 150, 202, 87, 218, 67, 145, 9, 84, 150, 202, 87, 218, 67, 145, 9, 84, 150, 202, 87, 218, 67, 145, 9, 84, 150, 202, 87, 218, 67, 145, 198, 4, 38, 164, 167, 37, 150, 202, 96, 46, 38, 164, 167, 37, 150, 202, 96, 46, 38, 164, 167, 37, 150, 202, 96, 46, 38, 164, 167, 37, 150, 202, 96, 46, 198, 4, 134, 165, 61, 20, 243, 25, 93, 66, 134, 165, 61, 20, 243, 25, 93, 66, 134, 165, 61, 20, 243, 25, 93, 66, 134, 165, 61, 20, 243, 25, 93, 66, 198, 4, 102, 169, 12, 230, 60, 20, 121, 191, 102, 169, 12, 230, 60, 20, 121, 191, 102, 169, 12, 230, 60, 20, 121, 191, 102, 169, 12, 230, 60, 20, 121, 191, 198, 4, 26, 93, 66, 122, 64, 101, 169, 12, 26, 93, 66, 122, 64, 101, 169, 12, 26, 93, 66, 122, 64, 101, 169, 12, 26, 93, 66, 122, 64, 101, 169, 12, 198, 4, 21, 121, 191, 154, 65, 122, 90, 194, 21, 121, 191, 154, 65, 122, 90, 194, 21, 121, 191, 154, 65, 122, 90, 194, 21, 121, 191, 154, 65, 122, 90, 194, 198, 4, 222, 16, 168, 44, 183, 176, 180, 135, 222, 16, 168, 44, 183, 176, 180, 135, 222, 16, 168, 44, 183, 176, 180, 135, 222, 16, 168, 44, 183, 176, 180, 135, 198, 4, 164, 75, 72, 79, 167, 44, 149, 193, 164, 75, 72, 79, 167, 44, 149, 193, 164, 75, 72, 79, 167, 44, 149, 193, 164, 75, 72, 79, 167, 44, 149, 193, 198, 4, 177, 180, 135, 34, 62, 163, 75, 72, 177, 180, 135, 34, 62, 163, 75, 72, 177, 180, 135, 34, 62, 163, 75, 72, 177, 180, 135, 34, 62, 163, 75, 72, 198, 4, 45, 149, 193, 92, 135, 34, 239, 87, 45, 149, 193, 92, 135, 34, 239, 87, 45, 149, 193, 92, 135, 34, 239, 87, 45, 149, 193, 92, 135, 34, 239, 87, 198, 4, 231, 51, 186, 132, 13, 129, 202, 82, 231, 51, 186, 132, 13, 129, 202, 82, 231, 51, 186, 132, 13, 129, 202, 82, 231, 51, 186, 132, 13, 129, 202, 82, 198, 4, 124, 40, 242, 126, 185, 132, 244, 180, 124, 40, 242, 126, 185, 132, 244, 180, 124, 40, 242, 126, 185, 132, 244, 180, 124, 40, 242, 126, 185, 132, 244, 180, 198, 4, 130, 202, 82, 25, 74, 123, 40, 242, 130, 202, 82, 25, 74, 123, 40, 242, 130, 202, 82, 25, 74, 123, 40, 242, 130, 202, 82, 25, 74, 123, 40, 242, 198, 4, 133, 244, 180, 132, 82, 25, 204, 69, 133, 244, 180, 132, 82, 25, 204, 69, 133, 244, 180, 132, 82, 25, 204, 69, 133, 244, 180, 132, 82, 25, 204, 69, 198, 4, 46, 44, 237, 161, 154, 207, 232, 18, 46, 44, 237, 161, 154, 207, 232, 18, 46, 44, 237, 161, 154, 207, 232, 18, 46, 44, 237, 161, 154, 207, 232, 18, 198, 4, 43, 75, 101, 48, 236, 161, 200, 251, 43, 75, 101, 48, 236, 161, 200, 251, 43, 75, 101, 48, 236, 161, 200, 251, 43, 75, 101, 48, 236, 161, 200, 251, 198, 4, 208, 232, 18, 210, 3, 42, 75, 101, 208, 232, 18, 210, 3, 42, 75, 101, 208, 232, 18, 210, 3, 42, 75, 101, 208, 232, 18, 210, 3, 42, 75, 101, 198, 4, 162, 200, 251, 213, 18, 210, 211, 18, 162, 200, 251, 213, 18, 210, 211, 18, 162, 200, 251, 213, 18, 210, 211, 18, 162, 200, 251, 213, 18, 210, 211, 18, 198, 4, 68, 160, 178, 84, 194, 210, 30, 138, 68, 160, 178, 84, 194, 210, 30, 138, 68, 160, 178, 84, 194, 210, 30, 138, 68, 160, 178, 84, 194, 210, 30, 138, 198, 4, 47, 33, 61, 45, 178, 84, 6, 115, 47, 33, 61, 45, 178, 84, 6, 115, 47, 33, 61, 45, 178, 84, 6, 115, 47, 33, 61, 45, 178, 84, 6, 115, 198, 4, 211, 30, 138, 188, 140, 46, 33, 61, 211, 30, 138, 188, 140, 46, 33, 61, 211, 30, 138, 188, 140, 46, 33, 61, 211, 30, 138, 188, 140, 46, 33, 61, 198, 4, 85, 6, 115, 209, 137, 188, 95, 77, 85, 6, 115, 209, 137, 188, 95, 77, 85, 6, 115, 209, 137, 188, 95, 77, 85, 6, 115, 209, 137, 188, 95, 77, 198, 4, 59, 160, 34, 182, 123, 224, 57, 58, 59, 160, 34, 182, 123, 224, 57, 58, 59, 160, 34, 182, 123, 224, 57, 58, 59, 160, 34, 182, 123, 224, 57, 58, 198, 4, 164, 15, 132, 31, 34, 182, 182, 128, 164, 15, 132, 31, 34, 182, 182, 128, 164, 15, 132, 31, 34, 182, 182, 128, 164, 15, 132, 31, 34, 182, 182, 128, 198, 4, 225, 57, 58, 197, 126, 163, 15, 132, 225, 57, 58, 197, 126, 163, 15, 132, 225, 57, 58, 197, 126, 163, 15, 132, 225, 57, 58, 197, 126, 163, 15, 132, 198, 4, 183, 182, 128, 92, 57, 197, 95, 221, 183, 182, 128, 92, 57, 197, 95, 221, 183, 182, 128, 92, 57, 197, 95, 221, 183, 182, 128, 92, 57, 197, 95, 221, 198, 4, 245, 55, 250, 64, 3, 42, 98, 107, 245, 55, 250, 64, 3, 42, 98, 107, 245, 55, 250, 64, 3, 42, 98, 107, 245, 55, 250, 64, 3, 42, 98, 107, 198, 4, 164, 83, 252, 213, 249, 64, 248, 97, 164, 83, 252, 213, 249, 64, 248, 97, 164, 83, 252, 213, 249, 64, 248, 97, 164, 83, 252, 213, 249, 64, 248, 97, 198, 4, 43, 98, 107, 11, 157, 163, 83, 252, 43, 98, 107, 11, 157, 163, 83, 252, 43, 98, 107, 11, 157, 163, 83, 252, 43, 98, 107, 11, 157, 163, 83, 252, 198, 4, 65, 248, 97, 92, 107, 11, 200, 5, 65, 248, 97, 92, 107, 11, 200, 5, 65, 248, 97, 92, 107, 11, 200, 5, 65, 248, 97, 92, 107, 11, 200, 5, 198, 4, 31, 120, 142, 78, 210, 223, 232, 3, 31, 120, 142, 78, 210, 223, 232, 3, 31, 120, 142, 78, 210, 223, 232, 3, 31, 120, 142, 78, 210, 223, 232, 3, 198, 4, 137, 173, 45, 32, 142, 78, 241, 87, 137, 173, 45, 32, 142, 78, 241, 87, 137, 173, 45, 32, 142, 78, 241, 87, 137, 173, 45, 32, 142, 78, 241, 87, 198, 4, 224, 232, 3, 225, 167, 136, 173, 45, 224, 232, 3, 225, 167, 136, 173, 45, 224, 232, 3, 225, 167, 136, 173, 45, 224, 232, 3, 225, 167, 136, 173, 45, 198, 4, 79, 241, 87, 119, 3, 225, 135, 113, 79, 241, 87, 119, 3, 225, 135, 113, 79, 241, 87, 119, 3, 225, 135, 113, 79, 241, 87, 119, 3, 225, 135, 113, 198, 4, 129, 138, 216, 218, 129, 231, 232, 20, 129, 138, 216, 218, 129, 231, 232, 20, 129, 138, 216, 218, 129, 231, 232, 20, 129, 138, 216, 218, 129, 231, 232, 20, 198, 4, 63, 16, 126, 24, 216, 218, 2, 114, 63, 16, 126, 24, 216, 218, 2, 114, 63, 16, 126, 24, 216, 218, 2, 114, 63, 16, 126, 24, 216, 218, 2, 114, 198, 4, 232, 232, 20, 127, 141, 62, 16, 126, 232, 232, 20, 127, 141, 62, 16, 126, 232, 232, 20, 127, 141, 62, 16, 126, 232, 232, 20, 127, 141, 62, 16, 126, 198, 4, 219, 2, 114, 193, 20, 127, 117, 39, 219, 2, 114, 193, 20, 127, 117, 39, 219, 2, 114, 193, 20, 127, 117, 39, 219, 2, 114, 193, 20, 127, 117, 39, 198, 4, 165, 191, 209, 7, 29, 80, 17, 91, 165, 191, 209, 7, 29, 80, 17, 91, 165, 191, 209, 7, 29, 80, 17, 91, 165, 191, 209, 7, 29, 80, 17, 91, 198, 4, 29, 157, 226, 175, 209, 7, 194, 15, 29, 157, 226, 175, 209, 7, 194, 15, 29, 157, 226, 175, 209, 7, 194, 15, 29, 157, 226, 175, 209, 7, 194, 15, 198, 4, 81, 17, 91, 91, 239, 28, 157, 226, 81, 17, 91, 91, 239, 28, 157, 226, 81, 17, 91, 91, 239, 28, 157, 226, 81, 17, 91, 91, 239, 28, 157, 226, 198, 4, 8, 194, 15, 227, 90, 91, 64, 46, 8, 194, 15, 227, 90, 91, 64, 46, 8, 194, 15, 227, 90, 91, 64, 46, 8, 194, 15, 227, 90, 91, 64, 46, 198, 4, 4, 207, 209, 41, 250, 27, 125, 32, 4, 207, 209, 41, 250, 27, 125, 32, 4, 207, 209, 41, 250, 27, 125, 32, 4, 207, 209, 41, 250, 27, 125, 32, 198, 4, 178, 181, 5, 228, 208, 41, 254, 234, 178, 181, 5, 228, 208, 41, 254, 234, 178, 181, 5, 228, 208, 41, 254, 234, 178, 181, 5, 228, 208, 41, 254, 234, 198, 4, 28, 125, 32, 252, 20, 177, 181, 5, 28, 125, 32, 252, 20, 177, 181, 5, 28, 125, 32, 252, 20, 177, 181, 5, 28, 125, 32, 252, 20, 177, 181, 5, 198, 4, 42, 254, 234, 78, 32, 252, 48, 46, 42, 254, 234, 78, 32, 252, 48, 46, 42, 254, 234, 78, 32, 252, 48, 46, 42, 254, 234, 78, 32, 252, 48, 46, 198, 4, 8, 84, 196, 214, 14, 60, 71, 167, 8, 84, 196, 214, 14, 60, 71, 167, 8, 84, 196, 214, 14, 60, 71, 167, 8, 84, 196, 214, 14, 60, 71, 167, 198, 4, 245, 129, 240, 195, 195, 214, 22, 144, 245, 129, 240, 195, 195, 214, 22, 144, 245, 129, 240, 195, 195, 214, 22, 144, 245, 129, 240, 195, 195, 214, 22, 144, 198, 4, 61, 71, 167, 248, 110, 244, 129, 240, 61, 71, 167, 248, 110, 244, 129, 240, 61, 71, 167, 248, 110, 244, 129, 240, 61, 71, 167, 248, 110, 244, 129, 240, 198, 4, 215, 22, 144, 11, 167, 248, 171, 59, 215, 22, 144, 11, 167, 248, 171, 59, 215, 22, 144, 11, 167, 248, 171, 59, 215, 22, 144, 11, 167, 248, 171, 59, 198, 4, 255, 70, 31, 8, 64, 69, 108, 109, 255, 70, 31, 8, 64, 69, 108, 109, 255, 70, 31, 8, 64, 69, 108, 109, 255, 70, 31, 8, 64, 69, 108, 109, 198, 4, 117, 138, 191, 186, 30, 8, 63, 140, 117, 138, 191, 186, 30, 8, 63, 140, 117, 138, 191, 186, 30, 8, 63, 140, 117, 138, 191, 186, 30, 8, 63, 140, 198, 4, 70, 108, 109, 1, 115, 116, 138, 191, 70, 108, 109, 1, 115, 116, 138, 191, 70, 108, 109, 1, 115, 116, 138, 191, 70, 108, 109, 1, 115, 116, 138, 191, 198, 4, 9, 63, 140, 139, 108, 1, 185, 224, 9, 63, 140, 139, 108, 1, 185, 224, 9, 63, 140, 139, 108, 1, 185, 224, 9, 63, 140, 139, 108, 1, 185, 224, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 1, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 49, 2, 21, 0, 115, 187, 142, 116, 187, 157, 157, 157, 157, 207, 0, 0, 0, 0, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 130, 46, 200, 144, 131, 200, 85, 172, 130, 46, 200, 144, 131, 200, 85, 172, 227, 194, 123, 55, 199, 144, 5, 247, 227, 194, 123, 55, 199, 144, 5, 247, 198, 4, 201, 85, 172, 126, 8, 226, 194, 123, 201, 85, 172, 126, 8, 226, 194, 123, 145, 5, 247, 29, 172, 126, 209, 55, 145, 5, 247, 29, 172, 126, 209, 55, 198, 4, 144, 32, 46, 188, 231, 130, 12, 89, 144, 32, 46, 188, 231, 130, 12, 89, 198, 234, 23, 125, 45, 188, 119, 163, 198, 234, 23, 125, 45, 188, 119, 163, 198, 4, 131, 12, 89, 112, 92, 197, 234, 23, 131, 12, 89, 112, 92, 197, 234, 23, 189, 119, 163, 58, 88, 112, 223, 209, 189, 119, 163, 58, 88, 112, 223, 209, 198, 4, 34, 114, 21, 171, 61, 130, 184, 240, 34, 114, 21, 171, 61, 130, 184, 240, 51, 100, 193, 125, 20, 171, 95, 244, 51, 100, 193, 125, 20, 171, 95, 244, 198, 4, 131, 184, 240, 222, 10, 50, 100, 193, 131, 184, 240, 222, 10, 50, 100, 193, 172, 95, 244, 205, 239, 222, 141, 234, 172, 95, 244, 205, 239, 222, 141, 234, 198, 4, 187, 32, 67, 22, 33, 87, 177, 250, 187, 32, 67, 22, 33, 87, 177, 250, 12, 239, 221, 168, 66, 22, 220, 119, 12, 239, 221, 168, 66, 22, 220, 119, 198, 4, 88, 177, 250, 69, 135, 11, 239, 221, 88, 177, 250, 69, 135, 11, 239, 221, 23, 220, 119, 244, 249, 69, 223, 188, 23, 220, 119, 244, 249, 69, 223, 188, 198, 4, 126, 4, 113, 225, 63, 23, 100, 200, 126, 4, 113, 225, 63, 23, 100, 200, 43, 86, 191, 232, 112, 225, 189, 27, 43, 86, 191, 232, 112, 225, 189, 27, 198, 4, 24, 100, 200, 130, 227, 42, 86, 191, 24, 100, 200, 130, 227, 42, 86, 191, 226, 189, 27, 213, 199, 130, 251, 142, 226, 189, 27, 213, 199, 130, 251, 142, 198, 4, 69, 174, 98, 245, 70, 16, 23, 222, 69, 174, 98, 245, 70, 16, 23, 222, 135, 44, 184, 239, 97, 245, 139, 190, 135, 44, 184, 239, 97, 245, 139, 190, 198, 4, 17, 23, 222, 187, 64, 134, 44, 184, 17, 23, 222, 187, 64, 134, 44, 184, 246, 139, 190, 121, 221, 187, 81, 157, 246, 139, 190, 121, 221, 187, 81, 157, 198, 4, 209, 5, 25, 178, 15, 185, 138, 213, 209, 5, 25, 178, 15, 185, 138, 213, 93, 120, 239, 70, 24, 178, 224, 190, 93, 120, 239, 70, 24, 178, 224, 190, 198, 4, 186, 138, 213, 47, 64, 92, 120, 239, 186, 138, 213, 47, 64, 92, 120, 239, 179, 224, 190, 163, 212, 47, 250, 230, 179, 224, 190, 163, 212, 47, 250, 230, 198, 4, 18, 196, 133, 247, 92, 144, 33, 11, 18, 196, 133, 247, 92, 144, 33, 11, 89, 253, 162, 111, 133, 247, 110, 84, 89, 253, 162, 111, 133, 247, 110, 84, 198, 4, 145, 33, 11, 238, 170, 88, 253, 162, 145, 33, 11, 238, 170, 88, 253, 162, 248, 110, 84, 167, 10, 238, 59, 122, 248, 110, 84, 167, 10, 238, 59, 122, 198, 4, 82, 78, 7, 222, 201, 89, 83, 82, 82, 78, 7, 222, 201, 89, 83, 82, 166, 207, 53, 166, 6, 222, 27, 168, 166, 207, 53, 166, 6, 222, 27, 168, 198, 4, 90, 83, 82, 174, 87, 165, 207, 53, 90, 83, 82, 174, 87, 165, 207, 53, 223, 27, 168, 90, 81, 174, 177, 248, 223, 27, 168, 90, 81, 174, 177, 248, 198, 4, 127, 85, 250, 92, 228, 116, 224, 189, 127, 85, 250, 92, 228, 116, 224, 189, 38, 229, 26, 139, 249, 92, 99, 202, 38, 229, 26, 139, 249, 92, 99, 202, 198, 4, 117, 224, 189, 129, 53, 37, 229, 26, 117, 224, 189, 129, 53, 37, 229, 26, 93, 99, 202, 218, 189, 129, 170, 5, 93, 99, 202, 218, 189, 129, 170, 5, 198, 4, 115, 214, 148, 148, 248, 85, 233, 115, 115, 214, 148, 148, 248, 85, 233, 115, 130, 247, 6, 170, 148, 148, 107, 44, 130, 247, 6, 170, 148, 148, 107, 44, 198, 4, 86, 233, 115, 141, 211, 129, 247, 6, 86, 233, 115, 141, 211, 129, 247, 6, 149, 107, 44, 126, 115, 141, 41, 107, 149, 107, 44, 126, 115, 141, 41, 107, 198, 4, 58, 29, 120, 111, 102, 77, 73, 185, 58, 29, 120, 111, 102, 77, 73, 185, 63, 215, 152, 178, 119, 111, 160, 106, 63, 215, 152, 178, 119, 111, 160, 106, 198, 4, 78, 73, 185, 198, 148, 62, 215, 152, 78, 73, 185, 198, 148, 62, 215, 152, 112, 160, 106, 193, 184, 198, 226, 135, 112, 160, 106, 193, 184, 198, 226, 135, 198, 4, 243, 171, 210, 231, 39, 167, 3, 239, 243, 171, 210, 231, 39, 167, 3, 239, 42, 41, 215, 88, 210, 231, 26, 83, 42, 41, 215, 88, 210, 231, 26, 83, 198, 4, 168, 3, 239, 13, 172, 41, 41, 215, 168, 3, 239, 13, 172, 41, 41, 215, 232, 26, 83, 214, 238, 13, 84, 45, 232, 26, 83, 214, 238, 13, 84, 45, 198, 4, 207, 154, 146, 114, 190, 42, 125, 174, 207, 154, 146, 114, 190, 42, 125, 174, 241, 222, 64, 213, 145, 114, 141, 197, 241, 222, 64, 213, 145, 114, 141, 197, 198, 4, 43, 125, 174, 49, 58, 240, 222, 64, 43, 125, 174, 49, 58, 240, 222, 64, 115, 141, 197, 15, 174, 49, 101, 109, 115, 141, 197, 15, 174, 49, 101, 109, 198, 4, 203, 233, 192, 123, 56, 107, 74, 202, 203, 233, 192, 123, 56, 107, 74, 202, 245, 185, 198, 148, 192, 123, 3, 85, 245, 185, 198, 148, 192, 123, 3, 85, 198, 4, 108, 74, 202, 53, 170, 244, 185, 198, 108, 74, 202, 53, 170, 244, 185, 198, 124, 3, 85, 11, 202, 53, 22, 63, 124, 3, 85, 11, 202, 53, 22, 63, 198, 4, 176, 74, 159, 107, 156, 14, 188, 55, 176, 74, 159, 107, 156, 14, 188, 55, 165, 92, 99, 241, 158, 107, 76, 89, 165, 92, 99, 241, 158, 107, 76, 89, 198, 4, 15, 188, 55, 80, 166, 164, 92, 99, 15, 188, 55, 80, 166, 164, 92, 99, 108, 76, 89, 91, 55, 80, 181, 96, 108, 76, 89, 91, 55, 80, 181, 96, 198, 4, 47, 163, 143, 236, 74, 116, 43, 234, 47, 163, 143, 236, 74, 116, 43, 234, 69, 41, 180, 139, 143, 236, 121, 23, 69, 41, 180, 139, 143, 236, 121, 23, 198, 4, 117, 43, 234, 209, 231, 68, 41, 180, 117, 43, 234, 209, 231, 68, 41, 180, 237, 121, 23, 187, 233, 209, 92, 112, 237, 121, 23, 187, 233, 209, 92, 112, 198, 4, 137, 78, 148, 66, 50, 250, 200, 158, 137, 78, 148, 66, 50, 250, 200, 158, 163, 30, 205, 5, 148, 66, 187, 72, 163, 30, 205, 5, 148, 66, 187, 72, 198, 4, 251, 200, 158, 119, 182, 162, 30, 205, 251, 200, 158, 119, 182, 162, 30, 205, 67, 187, 72, 93, 158, 119, 177, 107, 67, 187, 72, 93, 158, 119, 177, 107, 198, 4, 19, 221, 138, 122, 33, 58, 81, 10, 19, 221, 138, 122, 33, 58, 81, 10, 36, 123, 222, 197, 138, 122, 52, 23, 36, 123, 222, 197, 138, 122, 52, 23, 198, 4, 59, 81, 10, 237, 231, 35, 123, 222, 59, 81, 10, 237, 231, 35, 123, 222, 123, 52, 23, 220, 9, 237, 34, 117, 123, 52, 23, 220, 9, 237, 34, 117, 198, 4, 141, 62, 178, 231, 208, 173, 168, 71, 141, 62, 178, 231, 208, 173, 168, 71, 166, 208, 46, 82, 177, 231, 93, 236, 166, 208, 46, 82, 177, 231, 93, 236, 198, 4, 174, 168, 71, 115, 19, 165, 208, 46, 174, 168, 71, 115, 19, 165, 208, 46, 232, 93, 236, 90, 71, 115, 193, 77, 232, 93, 236, 90, 71, 115, 193, 77, 198, 4, 68, 116, 162, 20, 150, 209, 71, 246, 68, 116, 162, 20, 150, 209, 71, 246, 22, 245, 104, 46, 162, 20, 218, 69, 22, 245, 104, 46, 162, 20, 218, 69, 198, 4, 210, 71, 246, 188, 185, 21, 245, 104, 210, 71, 246, 188, 185, 21, 245, 104, 21, 218, 69, 234, 245, 188, 139, 93, 21, 218, 69, 234, 245, 188, 139, 93, 198, 4, 163, 91, 81, 143, 67, 39, 74, 161, 163, 91, 81, 143, 67, 39, 74, 161, 101, 207, 187, 216, 80, 143, 230, 130, 101, 207, 187, 216, 80, 143, 230, 130, 198, 4, 40, 74, 161, 93, 124, 100, 207, 187, 40, 74, 161, 93, 124, 100, 207, 187, 144, 230, 130, 155, 160, 93, 164, 174, 144, 230, 130, 155, 160, 93, 164, 174, 198, 4, 102, 244, 145, 61, 137, 110, 69, 61, 102, 244, 145, 61, 137, 110, 69, 61, 41, 133, 118, 145, 145, 61, 239, 98, 41, 133, 118, 145, 145, 61, 239, 98, 198, 4, 111, 69, 61, 154, 156, 40, 133, 118, 111, 69, 61, 154, 156, 40, 133, 118, 62, 239, 98, 215, 60, 154, 11, 110, 62, 239, 98, 215, 60, 154, 11, 110, 198, 4, 210, 137, 82, 104, 69, 31, 217, 243, 210, 137, 82, 104, 69, 31, 217, 243, 213, 163, 185, 224, 81, 104, 23, 169, 213, 163, 185, 224, 81, 104, 23, 169, 198, 4, 32, 217, 243, 46, 86, 212, 163, 185, 32, 217, 243, 46, 86, 212, 163, 185, 105, 23, 169, 43, 243, 46, 118, 173, 105, 23, 169, 43, 243, 46, 118, 173, 198, 4, 129, 198, 25, 222, 66, 146, 79, 45, 129, 198, 25, 222, 66, 146, 79, 45, 151, 244, 188, 109, 25, 222, 195, 88, 151, 244, 188, 109, 25, 222, 195, 88, 198, 4, 147, 79, 45, 127, 166, 150, 244, 188, 147, 79, 45, 127, 166, 150, 244, 188, 223, 195, 88, 105, 44, 127, 57, 230, 223, 195, 88, 105, 44, 127, 57, 230, 198, 4, 116, 106, 73, 207, 103, 156, 225, 61, 116, 106, 73, 207, 103, 156, 225, 61, 213, 242, 151, 99, 73, 207, 219, 6, 213, 242, 151, 99, 73, 207, 219, 6, 198, 4, 157, 225, 61, 140, 248, 212, 242, 151, 157, 225, 61, 140, 248, 212, 242, 151, 208, 219, 6, 43, 61, 140, 149, 182, 208, 219, 6, 43, 61, 140, 149, 182, 198, 4, 145, 228, 83, 203, 206, 169, 37, 61, 145, 228, 83, 203, 206, 169, 37, 61, 135, 247, 48, 86, 83, 203, 95, 142, 135, 247, 48, 86, 83, 203, 95, 142, 198, 4, 170, 37, 61, 111, 113, 134, 247, 48, 170, 37, 61, 111, 113, 134, 247, 48, 204, 95, 142, 121, 60, 111, 27, 172, 204, 95, 142, 121, 60, 111, 27, 172, 198, 4, 27, 103, 120, 15, 72, 62, 181, 252, 27, 103, 120, 15, 72, 62, 181, 252, 211, 243, 182, 193, 119, 15, 99, 165, 211, 243, 182, 193, 119, 15, 99, 165, 198, 4, 63, 181, 252, 229, 89, 210, 243, 182, 63, 181, 252, 229, 89, 210, 243, 182, 16, 99, 165, 45, 252, 229, 152, 135, 16, 99, 165, 45, 252, 229, 152, 135, 198, 4, 159, 83, 75, 122, 63, 227, 12, 239, 159, 83, 75, 122, 63, 227, 12, 239, 168, 150, 191, 28, 75, 122, 222, 54, 168, 150, 191, 28, 75, 122, 222, 54, 198, 4, 228, 12, 239, 97, 200, 167, 150, 191, 228, 12, 239, 97, 200, 167, 150, 191, 123, 222, 54, 88, 238, 97, 172, 180, 123, 222, 54, 88, 238, 97, 172, 180, 198, 4, 147, 124, 106, 249, 56, 181, 164, 231, 147, 124, 106, 249, 56, 181, 164, 231, 241, 30, 198, 74, 106, 249, 203, 49, 241, 30, 198, 74, 106, 249, 203, 49, 198, 4, 182, 164, 231, 109, 205, 240, 30, 198, 182, 164, 231, 109, 205, 240, 30, 198, 250, 203, 49, 15, 231, 109, 131, 149, 250, 203, 49, 15, 231, 109, 131, 149, 198, 4, 209, 56, 195, 123, 71, 242, 169, 229, 209, 56, 195, 123, 71, 242, 169, 229, 147, 158, 183, 13, 195, 123, 24, 43, 147, 158, 183, 13, 195, 123, 24, 43, 198, 4, 243, 169, 229, 47, 212, 146, 158, 183, 243, 169, 229, 47, 212, 146, 158, 183, 124, 24, 43, 109, 229, 47, 199, 60, 124, 24, 43, 109, 229, 47, 199, 60, 198, 4, 79, 45, 233, 121, 140, 51, 188, 135, 79, 45, 233, 121, 140, 51, 188, 135, 91, 254, 114, 204, 232, 121, 219, 96, 91, 254, 114, 204, 232, 121, 219, 96, 198, 4, 52, 188, 135, 177, 158, 90, 254, 114, 52, 188, 135, 177, 158, 90, 254, 114, 122, 219, 96, 165, 135, 177, 210, 22, 122, 219, 96, 165, 135, 177, 210, 22, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 1, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 146, 2, 29, 0, 115, 187, 142, 116, 187, 165, 165, 151, 151, 157, 157, 157, 157, 207, 0, 0, 0, 0, 165, 165, 151, 151, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 198, 4, 43, 219, 179, 40, 232, 196, 107, 252, 225, 218, 22, 59, 179, 40, 19, 160, 197, 107, 252, 213, 95, 224, 218, 22, 41, 19, 160, 31, 252, 213, 36, 76, 198, 4, 255, 5, 174, 109, 178, 61, 139, 50, 199, 95, 77, 194, 173, 109, 177, 67, 62, 139, 50, 1, 188, 198, 95, 77, 110, 177, 67, 57, 50, 1, 250, 81, 198, 4, 59, 241, 26, 127, 250, 23, 184, 182, 45, 202, 4, 232, 26, 127, 53, 9, 24, 184, 182, 197, 246, 44, 202, 4, 128, 53, 9, 211, 181, 197, 14, 229, 198, 4, 109, 207, 162, 76, 19, 175, 241, 87, 108, 91, 236, 80, 162, 76, 128, 126, 176, 241, 87, 147, 128, 107, 91, 236, 77, 128, 126, 148, 87, 147, 48, 93, 198, 4, 247, 47, 112, 109, 148, 237, 89, 148, 54, 254, 106, 18, 112, 109, 139, 29, 238, 89, 148, 9, 226, 53, 254, 106, 110, 139, 29, 202, 147, 9, 208, 143, 198, 4, 40, 94, 227, 175, 254, 2, 215, 182, 70, 153, 0, 253, 226, 175, 38, 97, 3, 215, 182, 216, 158, 69, 153, 0, 176, 38, 97, 186, 182, 216, 161, 28, 198, 4, 102, 123, 22, 101, 156, 120, 141, 191, 93, 219, 98, 135, 21, 101, 2, 244, 121, 141, 191, 154, 11, 92, 219, 98, 102, 2, 244, 163, 190, 154, 132, 233, 198, 4, 192, 192, 181, 45, 182, 103, 81, 38, 249, 171, 73, 152, 181, 45, 118, 40, 104, 81, 38, 64, 215, 248, 171, 73, 46, 118, 40, 7, 38, 64, 63, 74, 198, 4, 207, 250, 164, 26, 127, 49, 137, 192, 210, 36, 128, 206, 164, 26, 78, 44, 50, 137, 192, 49, 211, 209, 36, 128, 27, 78, 44, 46, 192, 49, 5, 91, 198, 4, 60, 29, 77, 2, 172, 79, 170, 225, 9, 28, 83, 176, 76, 2, 232, 108, 80, 170, 225, 196, 146, 8, 28, 83, 3, 232, 108, 247, 224, 196, 226, 178, 198, 4, 96, 76, 34, 112, 236, 116, 52, 9, 170, 134, 19, 139, 33, 112, 76, 193, 117, 52, 9, 160, 62, 169, 134, 19, 113, 76, 193, 86, 8, 160, 179, 221, 198, 4, 236, 147, 106, 56, 197, 36, 2, 199, 148, 0, 58, 219, 105, 56, 177, 184, 37, 2, 199, 20, 71, 147, 0, 58, 57, 177, 184, 108, 198, 20, 108, 149, 198, 4, 217, 233, 104, 18, 103, 125, 82, 13, 69, 224, 152, 130, 104, 18, 64, 103, 126, 82, 13, 39, 152, 68, 224, 152, 19, 64, 103, 187, 12, 39, 22, 151, 198, 4, 140, 73, 4, 142, 157, 142, 38, 1, 214, 112, 98, 113, 3, 142, 41, 216, 143, 38, 1, 116, 39, 213, 112, 98, 143, 41, 216, 42, 0, 116, 182, 251, 198, 4, 90, 159, 84, 195, 47, 38, 17, 56, 155, 4, 208, 217, 83, 195, 137, 197, 39, 17, 56, 166, 57, 154, 4, 208, 196, 137, 197, 101, 55, 166, 96, 171, 198, 4, 168, 163, 73, 0, 245, 73, 53, 156, 130, 99, 10, 182, 72, 0, 157, 237, 74, 53, 156, 88, 18, 129, 99, 10, 1, 157, 237, 126, 155, 88, 92, 182, 198, 4, 9, 157, 133, 70, 121, 191, 87, 7, 35, 178, 134, 64, 133, 70, 130, 92, 192, 87, 7, 247, 162, 34, 178, 134, 71, 130, 92, 221, 6, 247, 98, 122, 198, 4, 56, 42, 34, 107, 208, 89, 104, 36, 118, 112, 47, 166, 33, 107, 8, 132, 90, 104, 36, 200, 123, 117, 112, 47, 108, 8, 132, 138, 35, 200, 213, 221, 198, 4, 223, 239, 213, 193, 222, 168, 136, 172, 162, 145, 32, 87, 213, 193, 189, 152, 169, 136, 172, 33, 103, 161, 145, 32, 194, 189, 152, 94, 172, 33, 16, 42, 198, 4, 117, 22, 26, 9, 253, 94, 29, 220, 201, 26, 2, 161, 25, 9, 114, 117, 95, 29, 220, 139, 138, 200, 26, 2, 10, 114, 117, 55, 219, 139, 233, 229, 198, 4, 191, 81, 17, 89, 132, 206, 66, 35, 172, 131, 123, 49, 17, 89, 67, 32, 207, 66, 35, 65, 223, 171, 131, 123, 90, 67, 32, 84, 34, 65, 174, 238, 198, 4, 252, 189, 58, 184, 27, 21, 145, 53, 53, 18, 228, 234, 57, 184, 23, 211, 22, 145, 53, 4, 44, 52, 18, 228, 185, 23, 211, 203, 52, 4, 66, 197, 198, 4, 162, 179, 208, 72, 238, 247, 234, 224, 69, 214, 16, 8, 208, 72, 144, 171, 248, 234, 224, 94, 84, 68, 214, 16, 73, 144, 171, 187, 224, 94, 76, 47, 198, 4, 71, 69, 100, 13, 58, 11, 141, 4, 15, 238, 197, 244, 99, 13, 129, 80, 12, 141, 4, 185, 174, 14, 238, 197, 14, 129, 80, 241, 3, 185, 186, 155, 198, 4, 50, 106, 216, 121, 138, 0, 253, 18, 43, 115, 117, 255, 215, 121, 188, 106, 1, 253, 18, 206, 148, 42, 115, 117, 122, 188, 106, 213, 18, 206, 149, 39, 198, 4, 85, 169, 50, 87, 162, 134, 157, 199, 48, 225, 92, 121, 50, 87, 247, 47, 135, 157, 199, 171, 207, 47, 225, 92, 88, 247, 47, 208, 198, 171, 86, 205, 198, 4, 35, 64, 191, 132, 80, 165, 202, 92, 119, 30, 175, 90, 190, 132, 115, 229, 166, 202, 92, 221, 25, 118, 30, 175, 133, 115, 229, 137, 92, 221, 191, 64, 198, 4, 169, 97, 231, 241, 1, 244, 75, 56, 205, 213, 253, 11, 231, 241, 170, 85, 245, 75, 56, 87, 169, 204, 213, 253, 242, 170, 85, 51, 56, 87, 158, 24, 198, 4, 162, 74, 149, 185, 24, 53, 236, 60, 127, 9, 231, 202, 148, 185, 186, 127, 54, 236, 60, 94, 127, 126, 9, 231, 186, 186, 127, 129, 60, 94, 181, 106, 198, 4, 5, 232, 151, 112, 169, 84, 153, 171, 207, 227, 85, 171, 151, 112, 174, 60, 85, 153, 171, 251, 194, 206, 227, 85, 113, 174, 60, 49, 171, 251, 23, 104, 198, 4, 71, 13, 59, 143, 16, 160, 95, 194, 102, 174, 238, 95, 58, 143, 87, 173, 161, 95, 194, 185, 81, 101, 174, 238, 144, 87, 173, 154, 193, 185, 242, 196, 198, 4, 43, 85, 230, 234, 211, 176, 243, 120, 38, 156, 43, 79, 230, 234, 254, 5, 177, 243, 120, 213, 249, 37, 156, 43, 235, 254, 5, 218, 120, 213, 170, 25, 198, 4, 87, 118, 201, 139, 156, 21, 234, 190, 77, 181, 98, 234, 200, 139, 243, 139, 22, 234, 190, 169, 115, 76, 181, 98, 140, 243, 139, 179, 190, 169, 137, 54, 198, 4, 65, 199, 84, 43, 101, 151, 188, 56, 239, 155, 154, 104, 84, 43, 166, 94, 152, 188, 56, 191, 160, 238, 155, 154, 44, 166, 94, 17, 56, 191, 56, 171, 198, 4, 104, 133, 186, 111, 2, 29, 83, 173, 243, 226, 252, 226, 185, 111, 106, 162, 30, 83, 173, 152, 92, 242, 226, 252, 112, 106, 162, 13, 173, 152, 122, 69, 198, 4, 218, 37, 47, 206, 85, 168, 251, 166, 214, 138, 169, 87, 46, 206, 47, 206, 169, 251, 166, 38, 49, 213, 138, 169, 207, 47, 206, 42, 166, 38, 218, 208, 198, 4, 7, 58, 166, 90, 42, 187, 228, 197, 118, 223, 212, 68, 165, 90, 49, 245, 188, 228, 197, 249, 9, 117, 223, 212, 91, 49, 245, 138, 197, 249, 197, 89, 198, 4, 173, 80, 247, 77, 160, 99, 170, 21, 95, 156, 95, 156, 246, 77, 77, 180, 100, 170, 21, 83, 75, 94, 156, 95, 78, 77, 180, 161, 21, 83, 175, 8, 198, 4, 203, 46, 121, 113, 179, 66, 221, 55, 170, 86, 76, 189, 120, 113, 126, 113, 67, 221, 55, 53, 142, 169, 86, 76, 114, 126, 113, 86, 55, 53, 209, 134, 198, 4, 233, 152, 106, 197, 235, 146, 23, 231, 126, 83, 19, 109, 106, 197, 212, 43, 147, 23, 231, 23, 212, 125, 83, 19, 198, 212, 43, 130, 230, 23, 103, 149, 198, 4, 166, 46, 234, 233, 158, 76, 47, 145, 231, 132, 96, 179, 233, 233, 68, 123, 77, 47, 145, 90, 132, 230, 132, 96, 234, 68, 123, 25, 145, 90, 209, 21, 198, 4, 76, 104, 78, 8, 234, 162, 158, 78, 19, 169, 21, 93, 78, 8, 54, 11, 163, 158, 78, 180, 244, 18, 169, 21, 9, 54, 11, 237, 77, 180, 151, 177, 198, 4, 40, 211, 75, 164, 46, 161, 57, 33, 123, 58, 209, 94, 75, 164, 86, 116, 162, 57, 33, 216, 138, 122, 58, 209, 165, 86, 116, 133, 32, 216, 44, 180, 198, 4, 187, 168, 167, 19, 50, 189, 68, 106, 20, 130, 205, 66, 167, 19, 237, 101, 190, 68, 106, 69, 153, 19, 130, 205, 20, 237, 101, 236, 105, 69, 87, 88, 198, 4, 94, 66, 115, 66, 82, 23, 245, 116, 152, 72, 173, 232, 114, 66, 176, 89, 24, 245, 116, 162, 165, 151, 72, 173, 67, 176, 89, 104, 116, 162, 189, 140, 198, 4, 101, 122, 137, 212, 37, 52, 39, 4, 80, 39, 218, 203, 136, 212, 138, 174, 53, 39, 4, 155, 80, 79, 39, 218, 213, 138, 174, 176, 3, 155, 133, 118, 198, 4, 213, 69, 61, 157, 147, 233, 37, 82, 157, 16, 108, 22, 61, 157, 104, 47, 234, 37, 82, 43, 208, 156, 16, 108, 158, 104, 47, 99, 81, 43, 186, 194, 198, 4, 10, 205, 9, 193, 92, 212, 211, 137, 35, 181, 162, 43, 9, 193, 102, 161, 213, 211, 137, 246, 93, 34, 181, 162, 194, 102, 161, 221, 136, 246, 50, 246, 198, 4, 149, 17, 35, 214, 204, 81, 72, 167, 149, 130, 50, 174, 34, 214, 97, 99, 82, 72, 167, 107, 156, 148, 130, 50, 215, 97, 99, 107, 166, 107, 238, 220, 198, 4, 202, 73, 41, 40, 25, 49, 98, 29, 117, 186, 230, 206, 40, 40, 227, 122, 50, 98, 29, 54, 132, 116, 186, 230, 41, 227, 122, 139, 28, 54, 182, 214, 198, 4, 116, 20, 210, 233, 38, 39, 165, 160, 137, 117, 216, 216, 209, 233, 154, 59, 40, 165, 160, 140, 195, 136, 117, 216, 234, 154, 59, 119, 160, 140, 235, 45, 198, 4, 71, 140, 88, 135, 70, 33, 157, 174, 11, 202, 184, 222, 87, 135, 141, 173, 34, 157, 174, 185, 81, 10, 202, 184, 136, 141, 173, 245, 173, 185, 115, 167, 198, 4, 80, 78, 74, 65, 201, 136, 17, 235, 165, 211, 53, 119, 73, 65, 25, 215, 137, 17, 235, 176, 40, 164, 211, 53, 66, 25, 215, 91, 234, 176, 177, 181, 198, 4, 143, 66, 58, 93, 228, 164, 20, 148, 178, 14, 27, 91, 57, 93, 115, 231, 165, 20, 148, 113, 24, 177, 14, 27, 94, 115, 231, 78, 147, 113, 189, 197, 198, 4, 51, 98, 196, 58, 57, 10, 233, 116, 83, 80, 198, 245, 195, 58, 108, 108, 11, 233, 116, 205, 146, 82, 80, 198, 59, 108, 108, 173, 116, 205, 157, 59, 198, 4, 58, 41, 5, 101, 34, 70, 172, 195, 79, 215, 220, 185, 4, 101, 92, 111, 71, 172, 195, 198, 143, 78, 215, 220, 102, 92, 111, 177, 194, 198, 214, 250, 198, 4, 134, 235, 53, 213, 183, 7, 236, 170, 223, 127, 71, 248, 52, 213, 61, 243, 8, 236, 170, 122, 12, 222, 127, 71, 214, 61, 243, 33, 170, 122, 20, 202, 198, 4, 205, 224, 253, 119, 183, 94, 83, 221, 175, 170, 71, 161, 253, 119, 132, 63, 95, 83, 221, 51, 192, 174, 170, 71, 120, 132, 63, 81, 221, 51, 31, 2, 198, 4, 239, 1, 187, 170, 47, 131, 247, 223, 78, 117, 207, 124, 186, 170, 30, 133, 132, 247, 223, 17, 122, 77, 117, 207, 171, 30, 133, 178, 223, 17, 254, 68, 198, 4, 175, 215, 84, 247, 29, 176, 171, 234, 0, 30, 225, 79, 84, 247, 204, 135, 177, 171, 234, 81, 119, 255, 29, 225, 248, 204, 135, 0, 234, 81, 40, 171, 198, 4, 98, 6, 239, 191, 193, 245, 154, 234, 119, 85, 61, 10, 238, 191, 35, 252, 246, 154, 234, 158, 3, 118, 85, 61, 192, 35, 252, 137, 234, 158, 249, 16, 198, 4, 62, 96, 87, 213, 101, 240, 254, 59, 170, 238, 153, 15, 87, 213, 163, 80, 241, 254, 59, 194, 174, 169, 238, 153, 214, 163, 80, 86, 59, 194, 159, 168, 198, 4, 113, 189, 166, 186, 246, 128, 93, 85, 252, 239, 8, 127, 166, 186, 103, 62, 129, 93, 85, 143, 193, 251, 239, 8, 187, 103, 62, 4, 85, 143, 66, 89, 198, 4, 26, 188, 255, 142, 214, 107, 170, 123, 86, 245, 40, 148, 255, 142, 240, 39, 108, 170, 123, 230, 215, 85, 245, 40, 143, 240, 39, 170, 123, 230, 67, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 183, 1, 0, 0, 0, 0, 0, 0, 0, 168, 183, 0, 0, 0, 0, 0, 0, 0, 0, 168, 254, 251, 2, 36, 0, 115, 187, 142, 116, 187, 146, 127, 150, 149, 149, 149, 151, 151, 157, 157, 157, 157, 207, 0, 0, 0, 0, 149, 127, 149, 149, 151, 150, 151, 116, 194, 142, 115, 194, 152, 3, 168, 153, 3, 169, 104, 104, 105, 105, 183, 0, 0, 0, 0, 0, 0, 0, 0, 10, 105, 98, 117, 116, 116, 101, 114, 102, 108, 121, 2, 0, 10, 105, 98, 117, 116, 116, 101, 114, 102, 108, 121, 0, 0, 0, 47, 0, 125, 125, 148, 3, 127, 148, 3, 127, 146, 148, 3, 162, 147, 148, 3, 163, 160, 161, 148, 5, 127, 148, 5, 127, 146, 148, 5, 162, 147, 148, 5, 163, 160, 148, 7, 127, 148, 7, 127, 146, 148, 7, 162, 147, 148, 7, 163, 11, 109, 117, 108, 95, 98, 121, 95, 105, 110, 118, 78, 3, 0, 11, 109, 117, 108, 95, 98, 121, 95, 105, 110, 118, 78, 0, 0, 0, 14, 0, 198, 1, 1, 0, 128, 0, 255, 255, 127, 255, 7, 127, 198, 1, 1, 0, 128, 0, 255, 255, 127, 255, 7, 127, 146, 198, 1, 1, 0, 128, 0, 255, 255, 127, 255, 7, 162, 147, 198, 1, 1, 0, 128, 0, 255, 255, 127, 255, 7, 163]),
+("std::math::u64",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 109, 97, 116, 104, 58, 58, 117, 54, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),"# ===== HELPER FUNCTIONS ==========================================================================
+
+#! Asserts that both values at the top of the stack are u64 values.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+proc.u32assert4
+    u32assert.2
+    movup.3
+    movup.3
+    u32assert.2
+    movup.3
+    movup.3
+end
+
+# ===== ADDITION ==================================================================================
+
+#! Performs addition of two unsigned 64 bit integers preserving the overflow.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [overflowing_flag, c_hi, c_lo, ...], where c = (a + b) % 2^64
+export.overflowing_add
+    swap
+    movup.3
+    u32overflowing_add
+    movup.3
+    movup.3
+    u32overflowing_add3
+end
+
+#! Performs addition of two unsigned 64 bit integers discarding the overflow.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64
+export.wrapping_add
+    exec.overflowing_add
+    drop
+end
+
+#! Performs addition of two unsigned 64 bit integers, fails when overflowing.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64
+export.checked_add
+    swap
+    movup.3
+    u32assert.2
+    u32overflowing_add
+    movup.3
+    movup.3
+    u32assert.2
+    u32overflowing_add3
+    eq.0
+    assert
+end
+
+# ===== SUBTRACTION ===============================================================================
+
+#! Performs subtraction of two unsigned 64 bit integers discarding the overflow.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a - b) % 2^64
+export.wrapping_sub
+    movup.3
+    movup.2
+    u32overflowing_sub
+    movup.3
+    movup.3
+    u32overflowing_sub
+    drop
+    swap
+    u32overflowing_sub
+    drop
+end
+
+#! Performs subtraction of two unsigned 64 bit integers, fails when underflowing.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a - b) % 2^64
+export.checked_sub
+    movup.3
+    movup.2
+    u32assert.2
+    u32overflowing_sub
+    movup.3
+    movup.3
+    u32assert.2
+    u32overflowing_sub
+    eq.0
+    assert
+    swap
+    u32overflowing_sub
+    eq.0
+    assert
+end
+
+#! Performs subtraction of two unsigned 64 bit integers preserving the overflow.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [underflowing_flag, c_hi, c_lo, ...], where c = (a - b) % 2^64
+export.overflowing_sub
+    movup.3
+    movup.2
+    u32overflowing_sub
+    movup.3
+    movup.3
+    u32overflowing_sub
+    swap
+    movup.2
+    u32overflowing_sub
+    movup.2
+    or
+end
+
+# ===== MULTIPLICATION ============================================================================
+
+#! Performs multiplication of two unsigned 64 bit integers discarding the overflow.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64
+export.wrapping_mul
+    dup.3
+    dup.2
+    u32overflowing_mul
+    movup.4
+    movup.4
+    u32overflowing_madd
+    drop
+    movup.3
+    movup.3
+    u32overflowing_madd
+    drop
+end
+
+#! Performs multiplication of two unsigned 64 bit integers preserving the overflow.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_mid_hi, c_mid_lo, c_lo, ...], where c = (a * b) % 2^64
+#! This takes 18 cycles.
+export.overflowing_mul
+    dup.3
+    dup.2
+    u32overflowing_mul
+    dup.4
+    movup.4
+    u32overflowing_madd
+    swap
+    movup.5
+    dup.4
+    u32overflowing_madd
+    movup.5
+    movup.5
+    u32overflowing_madd
+    movup.3
+    movup.2
+    u32overflowing_add
+    movup.2
+    add
+end
+
+#! Performs multiplication of two unsigned 64 bit integers, fails when overflowing.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64
+export.checked_mul
+    dup.3
+    dup.2
+    u32assert.2         # make sure lower limbs of operands are 32-bit
+    u32overflowing_mul
+    dup.4
+    movup.4
+    u32overflowing_madd
+    swap
+    movup.5
+    dup.4
+    u32overflowing_madd
+    movup.5
+    movup.5
+    u32assert.2         # make sure higher limbs of operands are 32-bit
+    u32overflowing_madd
+    movup.3
+    movup.2
+    u32overflowing_add
+    add
+    add
+    eq.0
+    assert
+end
+
+# ===== COMPARISONS ===============================================================================
+
+#! Performs less-than comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise.
+export.unchecked_lt
+    movup.3
+    movup.2
+    u32overflowing_sub
+    movdn.3
+    drop
+    u32overflowing_sub
+    swap
+    eq.0
+    movup.2
+    and
+    or
+end
+
+#! Performs less-than comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise.
+export.checked_lt
+    movup.3
+    movup.2
+    u32assert.2
+    u32overflowing_sub
+    movdn.3
+    drop
+    u32assert.2
+    u32overflowing_sub
+    swap
+    eq.0
+    movup.2
+    and
+    or
+end
+
+#! Performs greater-than comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise.
+#! This takes 11 cycles.
+export.unchecked_gt
+    movup.2
+    u32overflowing_sub
+    movup.2
+    movup.3
+    u32overflowing_sub
+    swap
+    drop
+    movup.2
+    eq.0
+    and
+    or
+end
+
+#! Performs greater-than comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise.
+export.checked_gt
+    movup.2
+    u32assert.2
+    u32overflowing_sub
+    movup.2
+    movup.3
+    u32assert.2
+    u32overflowing_sub
+    swap
+    drop
+    movup.2
+    eq.0
+    and
+    or
+end
+
+#! Performs less-than-or-equal comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise.
+export.unchecked_lte
+    exec.unchecked_gt
+    not
+end
+
+#! Performs less-than-or-equal comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise.
+export.checked_lte
+    exec.checked_gt
+    not
+end
+
+#! Performs greater-than-or-equal comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise.
+export.unchecked_gte
+    exec.unchecked_lt
+    not
+end
+
+#! Performs greater-than-or-equal comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise.
+export.checked_gte
+    exec.checked_lt
+    not
+end
+
+#! Performs equality comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise.
+export.unchecked_eq
+    movup.2
+    u32checked_eq
+    swap
+    movup.2
+    u32checked_eq
+    and
+end
+
+#! Performs equality comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise.
+export.checked_eq
+    movup.2
+    u32checked_eq
+    swap
+    movup.2
+    u32checked_eq
+    and
+end
+
+#! Performs inequality comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a != b, and 0 otherwise.
+export.unchecked_neq
+    movup.2
+    u32checked_neq
+    swap
+    movup.2
+    u32checked_neq
+    or
+end
+
+#! Performs inequality comparison of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise.
+export.checked_neq
+    exec.checked_eq
+    not
+end
+
+#! Performs comparison to zero of an unsigned 64 bit integer.
+#! The input value is assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise.
+export.unchecked_eqz
+    eq.0
+    swap
+    eq.0
+    and
+end
+
+#! Performs comparison to zero of an unsigned 64 bit integer.
+#! The input value is assumed to be represented using 32 bit limbs, fails if it is not.
+#! Stack transition looks as follows:
+#! [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise.
+export.checked_eqz
+    u32assert.2
+    eq.0
+    swap
+    eq.0
+    and
+end
+
+#! Compares two unsigned 64 bit integers and drop the larger one from the stack.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a when a < b, and b otherwise.
+export.unchecked_min
+    dupw
+    exec.unchecked_gt
+    movup.4
+    movup.3
+    dup.2
+    cdrop
+    movdn.3
+    cdrop
+end
+
+#! Compares two unsigned 64 bit integers and drop the larger one from the stack.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a when a < b, and b otherwise.
+export.checked_min
+    exec.u32assert4
+    exec.unchecked_min
+end
+
+#! Compares two unsigned 64 bit integers and drop the smaller one from the stack.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a when a > b, and b otherwise.
+export.unchecked_max
+    dupw
+    exec.unchecked_lt
+    movup.4
+    movup.3
+    dup.2
+    cdrop
+    movdn.3
+    cdrop
+end
+
+#! Compares two unsigned 64 bit integers and drop the smaller one from the stack.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a when a > b, and b otherwise.
+export.checked_max
+    exec.u32assert4
+    exec.unchecked_max
+end
+
+
+# ===== DIVISION ==================================================================================
+
+#! Performs division of two unsigned 64 bit integers discarding the remainder.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b
+export.unchecked_div
+    adv.u64div          # inject the quotient and the remainder into the advice tape
+
+    adv_push.2          # read the quotient from the advice tape and make sure it consists of
+    u32assert.2         # 32-bit limbs
+
+    dup.3               # multiply quotient by the divisor and make sure the resulting value
+    dup.2               # fits into 2 32-bit limbs
+    u32overflowing_mul
+    dup.4
+    dup.4
+    u32overflowing_madd
+    eq.0
+    assert
+    dup.5
+    dup.3
+    u32overflowing_madd
+    eq.0
+    assert
+    dup.4
+    dup.3
+    mul
+    eq.0
+    assert
+
+    adv_push.2          # read the remainder from the advice tape and make sure it consists of
+    u32assert.2         # 32-bit limbs
+
+    movup.7             # make sure the divisor is greater than the remainder. this also consumes
+    movup.7             # the divisor
+    dup.3
+    dup.3
+    exec.unchecked_gt
+    assert
+
+    swap                # add remainder to the previous result; this also consumes the remainder
+    movup.3
+    u32overflowing_add
+    movup.3
+    movup.3
+    u32overflowing_add3
+    eq.0
+    assert
+
+    movup.4             # make sure the result we got is equal to the dividend
+    assert_eq
+    movup.3
+    assert_eq           # quotient remains on the stack
+end
+
+#! Performs division of two unsigned 64 bit integers discarding the remainder.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b
+export.checked_div
+    exec.u32assert4
+    exec.unchecked_div
+end
+
+# ===== MODULO OPERATION ==========================================================================
+
+#! Performs modulo operation of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b
+export.unchecked_mod
+    adv.u64div          # inject the quotient and the remainder into the advice tape
+
+    adv_push.2          # read the quotient from the advice tape and make sure it consists of
+    u32assert.2         # 32-bit limbs
+
+    dup.3               # multiply quotient by the divisor and make sure the resulting value
+    dup.2               # fits into 2 32-bit limbs
+    u32overflowing_mul
+    dup.4
+    movup.4
+    u32overflowing_madd
+    eq.0
+    assert
+    dup.4
+    dup.3
+    u32overflowing_madd
+    eq.0
+    assert
+    dup.3
+    movup.3
+    mul
+    eq.0
+    assert
+
+    adv_push.2          # read the remainder from the advice tape and make sure it consists of
+    u32assert.2         # 32-bit limbs
+
+    movup.5             # make sure the divisor is greater than the remainder. this also consumes
+    movup.5             # the divisor
+    dup.3
+    dup.3
+    exec.unchecked_gt
+    assert
+
+    dup.1               # add remainder to the previous result
+    movup.4
+    u32overflowing_add
+    movup.4
+    dup.3
+    u32overflowing_add3
+    eq.0
+    assert
+
+    movup.4             # make sure the result we got is equal to the dividend
+    assert_eq
+    movup.3
+    assert_eq           # remainder remains on the stack
+end
+
+#! Performs modulo operation of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b
+export.checked_mod
+    exec.u32assert4
+    exec.unchecked_mod
+end
+
+# ===== DIVMOD OPERATION ==========================================================================
+
+#! Performs divmod operation of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [r_hi, r_lo, q_hi, q_lo ...], where r = a % b, q = a / b
+export.unchecked_divmod
+    adv.u64div          # inject the quotient and the remainder into the advice tape
+
+    adv_push.2          # read the quotient from the advice tape and make sure it consists of
+    u32assert.2         # 32-bit limbs
+
+    dup.3               # multiply quotient by the divisor and make sure the resulting value
+    dup.2               # fits into 2 32-bit limbs
+    u32overflowing_mul
+    dup.4
+    dup.4
+    u32overflowing_madd
+    eq.0
+    assert
+    dup.5
+    dup.3
+    u32overflowing_madd
+    eq.0
+    assert
+    dup.4
+    dup.3
+    mul
+    eq.0
+    assert
+
+    adv_push.2          # read the remainder from the advice tape and make sure it consists of
+    u32assert.2         # 32-bit limbs
+
+    movup.7             # make sure the divisor is greater than the remainder. this also consumes
+    movup.7             # the divisor
+    dup.3
+    dup.3
+    exec.unchecked_gt
+    assert
+
+    dup.1               # add remainder to the previous result
+    movup.4
+    u32overflowing_add
+    movup.4
+    dup.3
+    u32overflowing_add3
+    eq.0
+    assert
+
+    movup.6             # make sure the result we got is equal to the dividend
+    assert_eq
+    movup.5
+    assert_eq           # remainder remains on the stack
+end
+
+#! Performs divmod operation of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [r_hi, r_lo, q_hi, q_lo ...], where r = a % b, q = a / b
+export.checked_divmod
+    exec.u32assert4
+    exec.unchecked_divmod
+end
+
+# ===== BITWISE OPERATIONS ========================================================================
+
+#! Performs bitwise AND of two unsigned 64-bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a AND b.
+export.checked_and
+    swap
+    movup.3
+    u32checked_and
+    swap
+    movup.2
+    u32checked_and
+end
+
+#! Performs bitwise OR of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a OR b.
+export.checked_or
+    swap
+    movup.3
+    u32checked_or
+    swap
+    movup.2
+    u32checked_or
+end
+
+#! Performs bitwise XOR of two unsigned 64 bit integers.
+#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
+#! Stack transition looks as follows:
+#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a XOR b.
+export.checked_xor
+    swap
+    movup.3
+    u32checked_xor
+    swap
+    movup.2
+    u32checked_xor
+end
+
+#! Performs left shift of one unsigned 64-bit integer using the pow2 operation.
+#! The input value to be shifted is assumed to be represented using 32 bit limbs.
+#! The shift value should be in the range [0, 64), otherwise it will result in an
+#! error.
+#! Stack transition looks as follows:
+#! [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64.
+#! This takes 28 cycles.
+export.unchecked_shl
+    pow2
+    u32split
+    exec.wrapping_mul
+end
+
+
+#! Performs right shift of one unsigned 64-bit integer using the pow2 operation.
+#! The input value to be shifted is assumed to be represented using 32 bit limbs.
+#! The shift value should be in the range [0, 64), otherwise it will result in an
+#! error.
+#! Stack transition looks as follows:
+#! [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a >> b.
+#! This takes 44 cycles.
+export.unchecked_shr
+    pow2
+    u32split
+
+    dup.1
+    add
+    movup.2
+    swap
+    u32unchecked_divmod
+    movup.3
+    movup.3
+    dup
+    eq.0
+    u32overflowing_sub
+    not
+    movdn.4
+    dup
+    movdn.4
+    u32unchecked_divmod
+    drop
+    push.4294967296
+    dup.5
+    mul
+    movup.4
+    div
+    movup.2
+    mul
+    add
+    movup.2
+    cswap
+end
+
+#! Performs left shift of one unsigned 64-bit integer preserving the overflow and
+#! using the pow2 operation.
+#! The input value to be shifted is assumed to be represented using 32 bit limbs.
+#! The shift value should be in the range [0, 64), otherwise it will result in an
+#! error.
+#! Stack transition looks as follows:
+#! [b, a_hi, a_lo, ...] -> [d_hi, d_lo, c_hi, c_lo, ...], where (d,c) = a << b,
+#! which d contains the bits shifted out.
+#! This takes 35 cycles.
+export.overflowing_shl
+    pow2
+    u32split
+    exec.overflowing_mul
+end
+
+#! Performs right shift of one unsigned 64-bit integer preserving the overflow and
+#! using the pow2 operation.
+#! The input value to be shifted is assumed to be represented using 32 bit limbs.
+#! The shift value should be in the range [0, 64), otherwise it will result in an
+#! error.
+#! Stack transition looks as follows:
+#! [b, a_hi, a_lo, ...] -> [d_hi, d_lo, c_hi, c_lo, ...], where c = a >> b, d = a << (64 - b).
+#! This takes 94 cycles.
+export.overflowing_shr
+    push.64             # (64 - b)
+    dup.1
+    sub
+
+    dup.3               # dup [b, a_hi, a_lo]
+    dup.3
+    dup.3
+    exec.unchecked_shr  # c = a >> b
+
+    movdn.5             # move result [c_hi, c_lo] to be in the format [d_hi, d_lo, c_hi, c_lo, ...]
+    movdn.5
+
+    padw                # padding positions 0, 1, 2, 3 and 4 to be able to use cdropw
+    push.0
+
+    movup.6             # bring and b
+    eq.0
+    cdropw              # if b is 0, swap the positions 0, 1, 2 and 3 with 0, (64 - b), a_hi, a_lo
+                        # regardless of this condition, drop 0, 1, 2 and 3
+    drop                # drop the last added 0 or dup b to keep the format [b, a_hi, a_lo, ....]
+
+    exec.unchecked_shl  # d = a << (64 - b)
+end
+
+#! Performs left rotation of one unsigned 64-bit integer using the pow2 operation.
+#! The input value to be shifted is assumed to be represented using 32 bit limbs.
+#! The shift value should be in the range [0, 64), otherwise it will result in an
+#! error.
+#! Stack transition looks as follows:
+#! [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64.
+#! This takes 35 cycles.
+export.unchecked_rotl
+    push.31
+    dup.1
+    u32overflowing_sub
+    swap
+    drop
+    movdn.3
+
+    # Shift the low limb.
+    push.31
+    u32checked_and
+    pow2
+    dup
+    movup.3
+    u32overflowing_mul
+
+    # Shift the high limb.
+    movup.3
+    movup.3
+    u32overflowing_madd
+
+    # Carry the overflow shift to the low bits.
+    movup.2
+    add
+    swap
+
+    # Conditionally select the limb order based on whether it's shifting by > 31 or not.
+    movup.2
+    cswap
+end
+
+#! Performs right rotation of one unsigned 64-bit integer using the pow2 operation.
+#! The input value to be shifted is assumed to be represented using 32 bit limbs.
+#! The shift value should be in the range [0, 64), otherwise it will result in an
+#! error.
+#! Stack transition looks as follows:
+#! [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64.
+#! This takes 40 cycles.
+export.unchecked_rotr
+    push.31
+    dup.1
+    u32overflowing_sub
+    swap
+    drop
+    movdn.3
+
+    # Shift the low limb left by 32-b.
+    push.31
+    u32checked_and
+    push.32
+    swap
+    u32overflowing_sub
+    drop
+    pow2
+    dup
+    movup.3
+    u32overflowing_mul
+
+    # Shift the high limb left by 32-b.
+    movup.3
+    movup.3
+    u32overflowing_madd
+
+    # Carry the overflow shift to the low bits.
+    movup.2
+    add
+    swap
+
+    # Conditionally select the limb order based on whether it's shifting by > 31 or not.
+    movup.2
+    not
+    cswap
+end
+",&[43, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 97, 100, 100, 3, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 97, 100, 100, 1, 0, 0, 10, 0, 127, 147, 30, 38, 147, 147, 30, 40, 19, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 97, 110, 100, 34, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 97, 110, 100, 1, 0, 0, 6, 0, 127, 147, 68, 127, 146, 68, 11, 99, 104, 101, 99, 107, 101, 100, 95, 100, 105, 118, 29, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 100, 105, 118, 1, 0, 0, 2, 0, 207, 0, 0, 0, 0, 207, 28, 0, 0, 0, 14, 99, 104, 101, 99, 107, 101, 100, 95, 100, 105, 118, 109, 111, 100, 33, 0, 14, 99, 104, 101, 99, 107, 101, 100, 95, 100, 105, 118, 109, 111, 100, 1, 0, 0, 2, 0, 207, 0, 0, 0, 0, 207, 32, 0, 0, 0, 10, 99, 104, 101, 99, 107, 101, 100, 95, 101, 113, 19, 0, 10, 99, 104, 101, 99, 107, 101, 100, 95, 101, 113, 1, 0, 0, 6, 0, 146, 88, 127, 146, 88, 16, 11, 99, 104, 101, 99, 107, 101, 100, 95, 101, 113, 122, 23, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 101, 113, 122, 1, 0, 0, 5, 0, 30, 19, 127, 19, 16, 10, 99, 104, 101, 99, 107, 101, 100, 95, 103, 116, 13, 0, 10, 99, 104, 101, 99, 107, 101, 100, 95, 103, 116, 1, 0, 0, 13, 0, 146, 30, 46, 146, 147, 30, 46, 127, 104, 146, 19, 16, 17, 11, 99, 104, 101, 99, 107, 101, 100, 95, 103, 116, 101, 17, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 103, 116, 101, 1, 0, 0, 2, 0, 207, 11, 0, 0, 0, 15, 10, 99, 104, 101, 99, 107, 101, 100, 95, 108, 116, 11, 0, 10, 99, 104, 101, 99, 107, 101, 100, 95, 108, 116, 1, 0, 0, 13, 0, 147, 146, 30, 46, 163, 104, 30, 46, 127, 19, 146, 16, 17, 11, 99, 104, 101, 99, 107, 101, 100, 95, 108, 116, 101, 15, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 108, 116, 101, 1, 0, 0, 2, 0, 207, 13, 0, 0, 0, 15, 11, 99, 104, 101, 99, 107, 101, 100, 95, 109, 97, 120, 27, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 109, 97, 120, 1, 0, 0, 2, 0, 207, 0, 0, 0, 0, 207, 26, 0, 0, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 109, 105, 110, 25, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 109, 105, 110, 1, 0, 0, 2, 0, 207, 0, 0, 0, 0, 207, 24, 0, 0, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 109, 111, 100, 31, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 109, 111, 100, 1, 0, 0, 2, 0, 207, 0, 0, 0, 0, 207, 30, 0, 0, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 109, 117, 108, 9, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 109, 117, 108, 1, 0, 0, 22, 0, 110, 109, 30, 52, 111, 148, 54, 127, 149, 111, 54, 149, 149, 30, 54, 147, 146, 38, 3, 3, 19, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 110, 101, 113, 21, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 110, 101, 113, 1, 0, 0, 2, 0, 207, 19, 0, 0, 0, 15, 10, 99, 104, 101, 99, 107, 101, 100, 95, 111, 114, 35, 0, 10, 99, 104, 101, 99, 107, 101, 100, 95, 111, 114, 1, 0, 0, 6, 0, 127, 147, 69, 127, 146, 69, 11, 99, 104, 101, 99, 107, 101, 100, 95, 115, 117, 98, 5, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 115, 117, 98, 1, 0, 0, 14, 0, 147, 146, 30, 46, 147, 147, 30, 46, 19, 0, 127, 46, 19, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 120, 111, 114, 36, 0, 11, 99, 104, 101, 99, 107, 101, 100, 95, 120, 111, 114, 1, 0, 0, 6, 0, 127, 147, 70, 127, 146, 70, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 97, 100, 100, 1, 0, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 97, 100, 100, 1, 0, 0, 6, 0, 127, 147, 38, 147, 147, 40, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 109, 117, 108, 8, 0, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 109, 117, 108, 1, 0, 0, 18, 0, 110, 109, 52, 111, 148, 54, 127, 149, 111, 54, 149, 149, 54, 147, 146, 38, 146, 3, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 115, 104, 108, 39, 0, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 115, 104, 108, 1, 0, 0, 3, 0, 13, 32, 207, 8, 0, 0, 0, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 115, 104, 114, 40, 0, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 115, 104, 114, 1, 0, 0, 16, 0, 198, 1, 64, 0, 0, 0, 0, 0, 0, 0, 108, 5, 110, 110, 110, 207, 38, 0, 0, 0, 165, 165, 106, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 150, 19, 181, 104, 207, 37, 0, 0, 0, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 115, 117, 98, 6, 0, 15, 111, 118, 101, 114, 102, 108, 111, 119, 105, 110, 103, 95, 115, 117, 98, 1, 0, 0, 11, 0, 147, 146, 46, 147, 147, 46, 127, 146, 46, 146, 17, 10, 117, 51, 50, 97, 115, 115, 101, 114, 116, 52, 0, 0, 10, 117, 51, 50, 97, 115, 115, 101, 114, 116, 52, 0, 0, 0, 6, 0, 30, 147, 147, 30, 147, 147, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 100, 105, 118, 28, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 100, 105, 118, 1, 0, 0, 41, 0, 199, 183, 2, 0, 0, 0, 0, 0, 0, 0, 30, 110, 109, 52, 111, 111, 54, 19, 0, 112, 110, 54, 19, 0, 111, 110, 7, 19, 0, 183, 2, 0, 0, 0, 0, 0, 0, 0, 30, 151, 151, 110, 110, 207, 12, 0, 0, 0, 0, 127, 147, 38, 147, 147, 40, 19, 0, 148, 1, 147, 1, 16, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 100, 105, 118, 109, 111, 100, 32, 0, 16, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 100, 105, 118, 109, 111, 100, 1, 0, 0, 41, 0, 199, 183, 2, 0, 0, 0, 0, 0, 0, 0, 30, 110, 109, 52, 111, 111, 54, 19, 0, 112, 110, 54, 19, 0, 111, 110, 7, 19, 0, 183, 2, 0, 0, 0, 0, 0, 0, 0, 30, 151, 151, 110, 110, 207, 12, 0, 0, 0, 0, 108, 148, 38, 148, 110, 40, 19, 0, 150, 1, 149, 1, 12, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 101, 113, 18, 0, 12, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 101, 113, 1, 0, 0, 6, 0, 146, 88, 127, 146, 88, 16, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 101, 113, 122, 22, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 101, 113, 122, 1, 0, 0, 4, 0, 19, 127, 19, 16, 12, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 103, 116, 12, 0, 12, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 103, 116, 1, 0, 0, 11, 0, 146, 46, 146, 147, 46, 127, 104, 146, 19, 16, 17, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 103, 116, 101, 16, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 103, 116, 101, 1, 0, 0, 2, 0, 207, 10, 0, 0, 0, 15, 12, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 108, 116, 10, 0, 12, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 108, 116, 1, 0, 0, 11, 0, 147, 146, 46, 163, 104, 46, 127, 19, 146, 16, 17, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 108, 116, 101, 14, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 108, 116, 101, 1, 0, 0, 2, 0, 207, 12, 0, 0, 0, 15, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 109, 97, 120, 26, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 109, 97, 120, 1, 0, 0, 8, 0, 123, 207, 10, 0, 0, 0, 148, 147, 109, 180, 163, 180, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 109, 105, 110, 24, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 109, 105, 110, 1, 0, 0, 8, 0, 123, 207, 12, 0, 0, 0, 148, 147, 109, 180, 163, 180, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 109, 111, 100, 30, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 109, 111, 100, 1, 0, 0, 41, 0, 199, 183, 2, 0, 0, 0, 0, 0, 0, 0, 30, 110, 109, 52, 111, 148, 54, 19, 0, 111, 110, 54, 19, 0, 110, 147, 7, 19, 0, 183, 2, 0, 0, 0, 0, 0, 0, 0, 30, 149, 149, 110, 110, 207, 12, 0, 0, 0, 0, 108, 148, 38, 148, 110, 40, 19, 0, 148, 1, 147, 1, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 110, 101, 113, 20, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 110, 101, 113, 1, 0, 0, 6, 0, 146, 90, 127, 146, 90, 17, 14, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 114, 111, 116, 108, 41, 0, 14, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 114, 111, 116, 108, 1, 0, 0, 20, 0, 198, 1, 31, 0, 0, 0, 0, 0, 0, 0, 108, 46, 127, 104, 163, 198, 1, 31, 0, 0, 0, 0, 0, 0, 0, 68, 13, 107, 147, 52, 147, 147, 54, 146, 3, 127, 146, 178, 14, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 114, 111, 116, 114, 42, 0, 14, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 114, 111, 116, 114, 1, 0, 0, 25, 0, 198, 1, 31, 0, 0, 0, 0, 0, 0, 0, 108, 46, 127, 104, 163, 198, 1, 31, 0, 0, 0, 0, 0, 0, 0, 68, 198, 1, 32, 0, 0, 0, 0, 0, 0, 0, 127, 46, 104, 13, 107, 147, 52, 147, 147, 54, 146, 3, 127, 146, 15, 178, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 115, 104, 108, 37, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 115, 104, 108, 1, 0, 0, 3, 0, 13, 32, 207, 7, 0, 0, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 115, 104, 114, 38, 0, 13, 117, 110, 99, 104, 101, 99, 107, 101, 100, 95, 115, 104, 114, 1, 0, 0, 28, 0, 13, 32, 108, 3, 146, 127, 66, 147, 147, 107, 19, 46, 15, 164, 107, 164, 66, 104, 198, 1, 0, 0, 0, 0, 1, 0, 0, 0, 112, 7, 148, 9, 146, 7, 3, 146, 178, 12, 119, 114, 97, 112, 112, 105, 110, 103, 95, 97, 100, 100, 2, 0, 12, 119, 114, 97, 112, 112, 105, 110, 103, 95, 97, 100, 100, 1, 0, 0, 2, 0, 207, 1, 0, 0, 0, 104, 12, 119, 114, 97, 112, 112, 105, 110, 103, 95, 109, 117, 108, 7, 0, 12, 119, 114, 97, 112, 112, 105, 110, 103, 95, 109, 117, 108, 1, 0, 0, 11, 0, 110, 109, 52, 148, 148, 54, 104, 147, 147, 54, 104, 12, 119, 114, 97, 112, 112, 105, 110, 103, 95, 115, 117, 98, 4, 0, 12, 119, 114, 97, 112, 112, 105, 110, 103, 95, 115, 117, 98, 1, 0, 0, 10, 0, 147, 146, 46, 147, 147, 46, 104, 127, 46, 104]),
+("std::math::ec_ext5",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 109, 97, 116, 104, 58, 58, 101, 99, 95, 101, 120, 116, 53, 0, 0, 0, 0, 0, 0]),"use.std::math::ext5
+
+#! Given an encoded elliptic curve point `w` s.t. it's expressed using
+#! an element ∈ GF(p^5) | p = 2^64 - 2^32 + 1, this routine verifies whether
+#! given point can be successfully decoded or not
+#!
+#! Expected stack state 
+#!
+#! [w0, w1, w2, w3, w4, ...]
+#!
+#! Final stack state 
+#!
+#! [flg, ...]
+#!
+#! If w can be decoded, flg = 1
+#! Else flg = 0
+#!
+#! Note, if w = (0, 0, 0, 0, 0), it can be successfully decoded to point 
+#! at infinity i.e. flg = 1, in that case.
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1043-L1052
+#! for reference implementation
+export.validate
+    repeat.5
+        dup.4
+    end
+
+    exec.ext5::square
+    sub.2 # = e
+
+    exec.ext5::square
+    swap
+    sub.1052
+    swap # = delta
+    
+    exec.ext5::legendre
+    eq.1
+    movdn.5
+
+    push.1
+    repeat.5
+        swap
+        eq.0
+        and
+    end
+
+    or
+end
+
+#! Given an encoded elliptic curve point `w` s.t. it's expressed using
+#! an element ∈ GF(p^5) | p = 2^64 - 2^32 + 1, this routine attempts to decode
+#! it into x, y coordinates, along with boolean field element denoting whether it's
+#! point-at-infinity or not.
+#!
+#! Expected stack state 
+#!
+#! [w0, w1, w2, w3, w4, ...]
+#!
+#! Final state state 
+#!
+#! [x0, x1, x2, x3, x4, y0, y1, y2, y3, y4, inf, flg, ...]
+#!
+#! If `w` has be decoded, flg = 1
+#! Else flg = 0 and x, y = (0, 0)
+#!
+#! Note, when w = (0, 0, 0, 0, 0), it will be successfully decoded to
+#! point-at-infinity i.e. x, y = (0, 0) and flg = 1
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1022-L1041
+#! for reference implementation
+export.decode
+    repeat.5
+        dup.4
+    end
+
+    exec.ext5::square
+    sub.2 # = e
+
+    repeat.5
+        dup.4
+    end
+
+    exec.ext5::square
+    swap
+    sub.1052
+    swap # = delta
+
+    exec.ext5::sqrt # = (r, c)
+
+    repeat.5
+        dup.10
+    end
+
+    repeat.5
+        dup.9
+    end
+
+    exec.ext5::add
+    push.0.0.0.0.9223372034707292161
+    exec.ext5::mul # = x1
+
+    repeat.5
+        movup.9
+    end
+
+    repeat.5
+        movup.15
+    end
+
+    exec.ext5::sub
+    push.0.0.0.0.9223372034707292161
+    exec.ext5::mul # = x2
+
+    repeat.5
+        movup.9
+    end
+
+    repeat.5
+        dup.4
+    end
+
+    exec.ext5::legendre
+    eq.1
+
+    if.true
+        repeat.5
+            movup.5
+            drop
+        end
+    else
+        repeat.5
+            drop
+        end
+    end # = x
+
+    repeat.5
+        dup.10
+    end
+
+    repeat.5
+        dup.9
+    end
+
+    exec.ext5::mul
+    repeat.5
+        movup.4
+        neg
+    end # = y
+
+    dup.10
+    not # = inf
+
+    push.1
+    repeat.5
+        movup.13
+        eq.0
+        and
+    end
+
+    movup.12
+    or # = c
+
+    swap
+
+    repeat.5
+        movup.6
+    end
+
+    repeat.5
+        movup.11
+    end
+
+    add.6148914689804861441 # = x
+end
+
+#! Given an elliptic curve point as Weierstraß coordinates (X, Y) along with
+#! boolean field element `inf`, denoting whether this is point-at-infinity or not, 
+#! this routine encodes it to a single element ∈ GF(p^5) | p = 2^64 - 2^32 + 1
+#!
+#! Expected stack state 
+#!
+#! [x0, x1, x2, x3, x4, y0, y1, y2, y3, y4, inf, ...]
+#!
+#! Final stack state 
+#!
+#! [w0, w1, w2, w3, w4, ...]
+#!
+#! Note, when inf = 1, encoded point w = (0, 0, 0, 0, 0)
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1214-L1216
+#! for reference implementation.
+export.encode
+    push.0.0.0.0.6148914689804861441 # = a/ 3
+
+    exec.ext5::sub # = (a/ 3) - x
+
+    repeat.5
+        movup.9
+    end
+
+    exec.ext5::div # = w = y/ ((a/ 3) - x)
+
+    movup.5
+    if.true
+        repeat.5
+            drop
+        end
+
+        push.0.0.0.0.0
+    end
+end
+
+#! Given two elliptic curve points ( say a, b ) as Weierstraß coordinates (X, Y) on stack,
+#! this routine computes elliptic curve point c, resulting from a + b.
+#!
+#! Following point addition formula is complete and it works when two points are 
+#! same/ different or input operands are point-at-infinity.
+#!
+#! Expected stack state
+#!
+#! [x1_0, x1_1, x1_2, x1_3, x1_4, y1_0, y1_1, y1_2, y1_3, y1_4, inf1, x2_0, x2_1, x2_2, x2_3, x2_4, y2_0, y2_1, y2_2, y2_3, y2_4, inf2, ...]
+#!
+#! s.t. x1_{0..5} -> x1, y1_{0..5} -> y1 |> a = (x1, y1, inf1)
+#!      x2_{0..5} -> x2, y2_{0..5} -> y2 |> b = (x2, y2, inf2)
+#!
+#! Final stack state
+#!
+#! [x3_0, x3_1, x3_2, x3_3, x3_4, y3_0, y3_1, y3_2, y3_3, y3_4, inf3, ...]
+#!
+#! Read point addition section ( on page 8 ) of https://ia.cr/2022/274
+#! For reference implementation see https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1228-L1255
+export.add.10
+    loc_storew.0
+    dropw
+    loc_store.1 # cached x1
+    drop
+
+    loc_storew.2
+    dropw
+    loc_store.3 # cached y1
+    drop
+
+    loc_store.4 # cached inf1
+    drop
+
+    loc_storew.5
+    dropw
+    loc_store.6 # cached x2
+    drop
+
+    loc_storew.7
+    dropw
+    loc_store.8 # cached y2
+    drop
+
+    loc_store.9 # cached inf2
+    drop
+
+    loc_load.6
+    push.0.0.0.0
+    loc_loadw.5 # bring x2
+
+    loc_load.1
+    push.0.0.0.0
+    loc_loadw.0 # bring x1
+
+    exec.ext5::eq
+    dup
+
+    if.true
+        loc_load.1
+        push.0.0.0.0
+        loc_loadw.0 # bring x1
+
+        exec.ext5::square
+
+        repeat.5
+            movup.4
+            mul.3
+        end
+
+        add.6148914689804861439
+        swap
+        add.263
+        swap
+    else
+        loc_load.3
+        push.0.0.0.0
+        loc_loadw.2 # bring y1
+
+        loc_load.8
+        push.0.0.0.0
+        loc_loadw.7 # bring y2
+
+        exec.ext5::sub
+    end # = λ0
+
+    dup.5
+
+    if.true
+        loc_load.3
+        push.0.0.0.0
+        loc_loadw.2 # bring y1
+
+        repeat.5
+            movup.4
+            mul.2
+        end
+    else
+        loc_load.1
+        push.0.0.0.0
+        loc_loadw.0 # bring x1
+
+        loc_load.6
+        push.0.0.0.0
+        loc_loadw.5 # bring x2
+
+        exec.ext5::sub
+    end # = λ1
+
+    repeat.5
+        movup.9
+    end
+
+    exec.ext5::div # = λ
+
+    repeat.5
+        dup.4
+    end
+
+    exec.ext5::square # = λ^2
+
+    loc_load.6
+    push.0.0.0.0
+    loc_loadw.5 # bring x2
+
+    loc_load.1
+    push.0.0.0.0
+    loc_loadw.0 # bring x1
+
+    exec.ext5::add
+
+    repeat.5
+        movup.9
+    end
+
+    exec.ext5::sub # compute x3
+
+    repeat.5
+        dup.4
+    end
+
+    loc_load.1
+    push.0.0.0.0
+    loc_loadw.0 # bring x1
+
+    exec.ext5::sub
+
+    repeat.5
+        movup.14
+    end
+
+    exec.ext5::mul
+
+    loc_load.3
+    push.0.0.0.0
+    loc_loadw.2 # bring y1
+
+    repeat.5
+        movup.9
+    end
+
+    exec.ext5::sub # compute y3
+
+    movup.10
+
+    loc_load.3
+    push.0.0.0.0
+    loc_loadw.2 # bring y1
+
+    loc_load.8
+    push.0.0.0.0
+    loc_loadw.7 # bring y2
+
+    exec.ext5::neq
+
+    and # compute inf3
+
+    movdn.5
+
+    # finalize selection of y3
+
+    loc_load.8
+    push.0.0.0.0
+    loc_loadw.7 # bring y2
+
+    loc_load.4 # bring inf1
+
+    if.true
+        repeat.5
+            movup.5
+            drop
+        end
+    else
+        repeat.5
+            drop
+        end
+    end
+
+    loc_load.3
+    push.0.0.0.0
+    loc_loadw.2 # bring y1
+
+    loc_load.9 # bring inf2
+
+    if.true
+        repeat.5
+            movup.5
+            drop
+        end
+    else
+        repeat.5
+            drop
+        end
+    end
+
+    # finalize selection of x3
+
+    repeat.5
+        movup.10
+    end
+
+    loc_load.6
+    push.0.0.0.0
+    loc_loadw.5 # bring x2
+
+    loc_load.4 # bring inf1
+
+    if.true
+        repeat.5
+            movup.5
+            drop
+        end
+    else
+        repeat.5
+            drop
+        end
+    end
+
+    loc_load.1
+    push.0.0.0.0
+    loc_loadw.0 # bring x1
+
+    loc_load.9 # bring inf2
+
+    if.true
+        repeat.5
+            movup.5
+            drop
+        end
+    else
+        repeat.5
+            drop
+        end
+    end
+
+    # finalize selection of inf3
+
+    movup.10
+    loc_load.9 # bring inf2
+    loc_load.4 # bring inf1
+    cdrop
+
+    loc_load.4 # bring inf1
+    loc_load.9 # bring inf2
+    cdrop
+
+    movdn.10
+end
+
+#! Given one elliptic curve point ( say a ) as Weierstraß coordinates (X, Y) on stack,
+#! this routine computes elliptic curve point b s.t. b = 2 * a.
+#!
+#! Following point doubling formula is complete and it works only when input operand is
+#! a non-infinity point, then resulting point b should also be non-infinity.
+#!
+#! Note, result of add(a, b) = double(a) | a = b
+#!
+#! Expected stack state
+#!
+#! [x0, x1, x2, x3, x4, y0, y1, y2, y3, y4, inf, ...]
+#!
+#! s.t. x{0..5} -> x, y{0..5} -> y |> a = (x, y, inf)
+#!
+#! Final stack state
+#!
+#! [x'0, x'1, x'2, x'3, x'4, y'0, y'1, y'2, y'3, y'4, inf, ...]
+#!
+#! Read point addition section ( on page 8 ) of https://ia.cr/2022/274
+#! For reference implementation see https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1270-L1280
+export.double.5
+    loc_storew.0
+    dropw
+    loc_store.1 # cached x
+    drop
+
+    loc_storew.2
+    dropw
+    loc_store.3 # cached y
+    drop
+
+    loc_store.4 # cached inf
+    drop
+
+    loc_load.3
+    push.0.0.0.0
+    loc_loadw.2 # bring y
+
+    repeat.5
+        movup.4
+        mul.2
+    end # compute λ1
+
+    loc_load.1
+    push.0.0.0.0
+    loc_loadw.0 # bring x
+
+    exec.ext5::square
+
+    repeat.5
+        movup.4
+        mul.3
+    end
+
+    add.6148914689804861439
+    swap
+    add.263
+    swap # compute λ0
+
+    exec.ext5::div # compute λ
+
+    loc_load.1
+    push.0.0.0.0
+    loc_loadw.0 # bring x
+
+    repeat.5
+        movup.4
+        mul.2
+    end
+
+    repeat.5
+        dup.9
+    end
+
+    exec.ext5::square
+    exec.ext5::sub # compute x'
+
+    repeat.5
+        dup.4
+    end
+
+    loc_load.1
+    push.0.0.0.0
+    loc_loadw.0 # bring x
+
+    exec.ext5::sub
+
+    repeat.5
+        movup.14
+    end
+
+    exec.ext5::mul
+
+    loc_load.3
+    push.0.0.0.0
+    loc_loadw.2 # bring y
+
+    repeat.5
+        movup.9
+    end
+
+    exec.ext5::sub # compute y'
+
+    repeat.5
+        movup.9
+    end
+
+    loc_load.4
+    movdn.10
+end
+
+#! Given an elliptic curve point ( say a ) as Weierstraß coordinates (X, Y) and a 319 -bit scalar ( say e )
+#! on stack, this routine computes elliptic curve point b s.t. b =  e * a, using double-and-add technique.
+#!
+#! Scalar e should be lesser than 1067993516717146951041484916571792702745057740581727230159139685185762082554198619328292418486241 ( prime number ).
+#! Note, scalar e should be provided as 10 limbs on stack, each of 32 -bit ( in little endian byte order ).
+#! 
+#! Given a scalar e ( as arbitrary width big integer ), following python code snippet should convert it to desired input form
+#!
+#! [(a >> (32*i)) & 0xffff_ffff for i in range(10)]
+#!
+#! Expected stack state
+#!
+#! [x0, x1, x2, x3, x4, y0, y1, y2, y3, y4, inf, e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, ...]
+#!
+#! Point a = (x, y, inf)
+#! Scalar e = (e0, e1, e2, e3, e4, e5, e6, e7, e8, e9)
+#!
+#! Final stack state
+#!
+#! [x'0, x'1, x'2, x'3, x'4, y'0, y'1, y'2, y'3, y'4, inf, ...]
+#!
+#! Point b = (x', y' inf') | b = e * a
+#!
+#! See https://github.com/itzmeanjan/secp256k1/blob/cbbe199/point.py#L174-L186 for source of inpiration.
+export.mul.10
+    loc_storew.0
+    dropw
+    loc_store.1 # cached base_x
+    drop
+
+    loc_storew.2
+    dropw
+    loc_store.3 # cached base_y
+    drop
+
+    loc_store.4 # cached base_inf
+    drop
+
+    push.0.0.0.0
+    loc_storew.5
+    dropw
+    push.0
+    loc_store.6 # initialize and cache res_x
+    drop
+
+    push.0.0.0.0
+    loc_storew.7
+    dropw
+    push.0
+    loc_store.8 # initialize and cache res_y
+    drop
+
+    push.1
+    loc_store.9 # initialize and cache res_inf
+    drop
+
+    repeat.10
+        repeat.32
+            dup
+            push.1
+            u32checked_and
+
+            if.true
+                # bring base
+                loc_load.4
+
+                loc_load.3
+                push.0.0.0.0
+                loc_loadw.2
+
+                loc_load.1
+                push.0.0.0.0
+                loc_loadw.0
+
+                # bring res
+                loc_load.9
+
+                loc_load.8
+                push.0.0.0.0
+                loc_loadw.7
+
+                loc_load.6
+                push.0.0.0.0
+                loc_loadw.5
+
+                exec.add
+
+                # write back res
+                loc_storew.5
+                dropw
+                loc_store.6
+                drop
+
+                loc_storew.7
+                dropw
+                loc_store.8
+                drop
+
+                loc_store.9
+                drop
+            end
+
+            # bring base
+            loc_load.4
+
+            loc_load.3
+            push.0.0.0.0
+            loc_loadw.2
+
+            loc_load.1
+            push.0.0.0.0
+            loc_loadw.0
+
+            exec.double
+
+            # write back base
+            loc_storew.0
+            dropw
+            loc_store.1
+            drop
+
+            loc_storew.2
+            dropw
+            loc_store.3
+            drop
+
+            loc_store.4
+            drop
+
+            u32unchecked_shr.1
+        end
+
+        drop
+    end
+
+    # bring res
+    loc_load.9
+
+    loc_load.8
+    push.0.0.0.0
+    loc_loadw.7
+
+    loc_load.6
+    push.0.0.0.0
+    loc_loadw.5
+end
+",&[6, 0, 3, 97, 100, 100, 3, 0, 3, 97, 100, 100, 1, 10, 0, 95, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 193, 1, 0, 0, 0, 0, 0, 0, 0, 104, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 193, 3, 0, 0, 0, 0, 0, 0, 0, 104, 193, 4, 0, 0, 0, 0, 0, 0, 0, 104, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 193, 6, 0, 0, 0, 0, 0, 0, 0, 104, 196, 7, 0, 0, 0, 0, 0, 0, 0, 105, 193, 8, 0, 0, 0, 0, 0, 0, 0, 104, 193, 9, 0, 0, 0, 0, 0, 0, 0, 104, 189, 6, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 208, 193, 152, 91, 237, 37, 69, 70, 135, 11, 228, 220, 113, 147, 49, 149, 81, 16, 118, 120, 87, 87, 12, 226, 234, 107, 253, 9, 0, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 208, 123, 11, 18, 96, 79, 68, 216, 164, 216, 9, 106, 225, 21, 75, 189, 202, 248, 94, 41, 244, 239, 175, 61, 63, 254, 151, 0, 2, 0, 148, 7, 3, 127, 3, 127, 7, 0, 189, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 189, 8, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 112, 253, 4, 0, 189, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 254, 173, 0, 2, 0, 148, 7, 7, 0, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 189, 6, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 254, 186, 0, 1, 0, 153, 208, 104, 121, 166, 177, 157, 137, 124, 238, 20, 148, 237, 36, 234, 92, 222, 219, 22, 119, 84, 176, 24, 174, 59, 229, 254, 190, 0, 1, 0, 111, 208, 123, 11, 18, 96, 79, 68, 216, 164, 216, 9, 106, 225, 21, 75, 189, 202, 248, 94, 41, 244, 239, 175, 61, 63, 189, 6, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 208, 86, 49, 45, 244, 136, 130, 11, 45, 233, 25, 243, 66, 103, 68, 132, 243, 239, 79, 45, 193, 115, 9, 17, 149, 254, 201, 0, 1, 0, 153, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 254, 205, 0, 1, 0, 111, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 254, 212, 0, 1, 0, 158, 208, 14, 28, 171, 83, 83, 32, 255, 54, 152, 60, 86, 23, 119, 109, 189, 213, 184, 10, 82, 204, 116, 172, 34, 97, 189, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 254, 219, 0, 1, 0, 153, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 154, 189, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 189, 8, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 208, 72, 210, 24, 136, 250, 93, 123, 6, 162, 112, 191, 4, 4, 57, 236, 129, 193, 39, 125, 108, 25, 68, 223, 210, 16, 165, 189, 8, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 189, 4, 0, 0, 0, 0, 0, 0, 0, 253, 1, 0, 254, 238, 0, 2, 0, 149, 104, 1, 0, 254, 243, 0, 1, 0, 104, 189, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 189, 9, 0, 0, 0, 0, 0, 0, 0, 253, 1, 0, 254, 252, 0, 2, 0, 149, 104, 1, 0, 254, 1, 1, 1, 0, 104, 254, 5, 1, 1, 0, 154, 189, 6, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 189, 4, 0, 0, 0, 0, 0, 0, 0, 253, 1, 0, 254, 13, 1, 2, 0, 149, 104, 1, 0, 254, 18, 1, 1, 0, 104, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 189, 9, 0, 0, 0, 0, 0, 0, 0, 253, 1, 0, 254, 27, 1, 2, 0, 149, 104, 1, 0, 254, 32, 1, 1, 0, 104, 154, 189, 9, 0, 0, 0, 0, 0, 0, 0, 189, 4, 0, 0, 0, 0, 0, 0, 0, 180, 189, 4, 0, 0, 0, 0, 0, 0, 0, 189, 9, 0, 0, 0, 0, 0, 0, 0, 180, 170, 6, 100, 101, 99, 111, 100, 101, 1, 0, 6, 100, 101, 99, 111, 100, 101, 1, 0, 0, 38, 0, 254, 23, 0, 1, 0, 111, 208, 123, 11, 18, 96, 79, 68, 216, 164, 216, 9, 106, 225, 21, 75, 189, 202, 248, 94, 41, 244, 239, 175, 61, 63, 5, 254, 28, 0, 1, 0, 111, 208, 123, 11, 18, 96, 79, 68, 216, 164, 216, 9, 106, 225, 21, 75, 189, 202, 248, 94, 41, 244, 239, 175, 61, 63, 127, 5, 127, 208, 93, 7, 187, 74, 22, 167, 186, 255, 99, 31, 216, 35, 169, 124, 128, 212, 245, 66, 175, 202, 208, 178, 23, 1, 254, 36, 0, 1, 0, 117, 254, 39, 0, 1, 0, 116, 208, 86, 49, 45, 244, 136, 130, 11, 45, 233, 25, 243, 66, 103, 68, 132, 243, 239, 79, 45, 193, 115, 9, 17, 149, 198, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 128, 255, 255, 255, 127, 208, 14, 28, 171, 83, 83, 32, 255, 54, 152, 60, 86, 23, 119, 109, 189, 213, 184, 10, 82, 204, 116, 172, 34, 97, 254, 45, 0, 1, 0, 153, 254, 48, 0, 1, 0, 159, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 198, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 128, 255, 255, 255, 127, 208, 14, 28, 171, 83, 83, 32, 255, 54, 152, 60, 86, 23, 119, 109, 189, 213, 184, 10, 82, 204, 116, 172, 34, 97, 254, 54, 0, 1, 0, 153, 254, 57, 0, 1, 0, 111, 208, 38, 46, 26, 203, 191, 187, 185, 14, 167, 98, 82, 183, 68, 13, 49, 144, 251, 135, 82, 199, 138, 11, 168, 197, 19, 253, 1, 0, 254, 63, 0, 2, 0, 149, 104, 1, 0, 254, 68, 0, 1, 0, 104, 254, 72, 0, 1, 0, 117, 254, 75, 0, 1, 0, 116, 208, 14, 28, 171, 83, 83, 32, 255, 54, 152, 60, 86, 23, 119, 109, 189, 213, 184, 10, 82, 204, 116, 172, 34, 97, 254, 79, 0, 2, 0, 148, 11, 117, 15, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 254, 86, 0, 3, 0, 157, 19, 16, 156, 17, 127, 254, 94, 0, 1, 0, 150, 254, 97, 0, 1, 0, 155, 3, 6, 100, 111, 117, 98, 108, 101, 4, 0, 6, 100, 111, 117, 98, 108, 101, 1, 5, 0, 46, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 193, 1, 0, 0, 0, 0, 0, 0, 0, 104, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 193, 3, 0, 0, 0, 0, 0, 0, 0, 104, 193, 4, 0, 0, 0, 0, 0, 0, 0, 104, 189, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 254, 59, 1, 2, 0, 148, 7, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 208, 123, 11, 18, 96, 79, 68, 216, 164, 216, 9, 106, 225, 21, 75, 189, 202, 248, 94, 41, 244, 239, 175, 61, 63, 254, 67, 1, 2, 0, 148, 7, 3, 127, 3, 127, 208, 104, 121, 166, 177, 157, 137, 124, 238, 20, 148, 237, 36, 234, 92, 222, 219, 22, 119, 84, 176, 24, 174, 59, 229, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 254, 79, 1, 2, 0, 148, 7, 254, 83, 1, 1, 0, 116, 208, 123, 11, 18, 96, 79, 68, 216, 164, 216, 9, 106, 225, 21, 75, 189, 202, 248, 94, 41, 244, 239, 175, 61, 63, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 254, 88, 1, 1, 0, 111, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 254, 95, 1, 1, 0, 158, 208, 14, 28, 171, 83, 83, 32, 255, 54, 152, 60, 86, 23, 119, 109, 189, 213, 184, 10, 82, 204, 116, 172, 34, 97, 189, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 254, 102, 1, 1, 0, 153, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 254, 106, 1, 1, 0, 153, 189, 4, 0, 0, 0, 0, 0, 0, 0, 170, 6, 101, 110, 99, 111, 100, 101, 2, 0, 6, 101, 110, 99, 111, 100, 101, 1, 0, 0, 6, 0, 198, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 85, 85, 85, 85, 208, 234, 95, 121, 92, 168, 18, 198, 185, 94, 230, 82, 197, 3, 198, 51, 170, 89, 168, 192, 247, 130, 80, 66, 63, 254, 105, 0, 1, 0, 153, 208, 104, 121, 166, 177, 157, 137, 124, 238, 20, 148, 237, 36, 234, 92, 222, 219, 22, 119, 84, 176, 24, 174, 59, 229, 149, 253, 2, 0, 254, 111, 0, 1, 0, 104, 198, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 109, 117, 108, 5, 0, 3, 109, 117, 108, 1, 10, 0, 33, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 193, 1, 0, 0, 0, 0, 0, 0, 0, 104, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 193, 3, 0, 0, 0, 0, 0, 0, 0, 104, 193, 4, 0, 0, 0, 0, 0, 0, 0, 104, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 193, 6, 0, 0, 0, 0, 0, 0, 0, 104, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 7, 0, 0, 0, 0, 0, 0, 0, 105, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 193, 8, 0, 0, 0, 0, 0, 0, 0, 104, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 193, 9, 0, 0, 0, 0, 0, 0, 0, 104, 254, 138, 1, 2, 0, 254, 139, 1, 23, 0, 107, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 68, 253, 25, 0, 189, 4, 0, 0, 0, 0, 0, 0, 0, 189, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 189, 9, 0, 0, 0, 0, 0, 0, 0, 189, 8, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 189, 6, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 207, 3, 0, 0, 0, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 193, 6, 0, 0, 0, 0, 0, 0, 0, 104, 196, 7, 0, 0, 0, 0, 0, 0, 0, 105, 193, 8, 0, 0, 0, 0, 0, 0, 0, 104, 193, 9, 0, 0, 0, 0, 0, 0, 0, 104, 0, 0, 189, 4, 0, 0, 0, 0, 0, 0, 0, 189, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 189, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 4, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 193, 1, 0, 0, 0, 0, 0, 0, 0, 104, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 193, 3, 0, 0, 0, 0, 0, 0, 0, 104, 193, 4, 0, 0, 0, 0, 0, 0, 0, 104, 75, 1, 104, 189, 9, 0, 0, 0, 0, 0, 0, 0, 189, 8, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 189, 6, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 8, 118, 97, 108, 105, 100, 97, 116, 101, 0, 0, 8, 118, 97, 108, 105, 100, 97, 116, 101, 1, 0, 0, 13, 0, 254, 2, 0, 1, 0, 111, 208, 123, 11, 18, 96, 79, 68, 216, 164, 216, 9, 106, 225, 21, 75, 189, 202, 248, 94, 41, 244, 239, 175, 61, 63, 5, 208, 123, 11, 18, 96, 79, 68, 216, 164, 216, 9, 106, 225, 21, 75, 189, 202, 248, 94, 41, 244, 239, 175, 61, 63, 127, 5, 127, 208, 38, 46, 26, 203, 191, 187, 185, 14, 167, 98, 82, 183, 68, 13, 49, 144, 251, 135, 82, 199, 138, 11, 168, 197, 19, 165, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 254, 15, 0, 3, 0, 127, 19, 16, 17]),
+("std::math::u256",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 109, 97, 116, 104, 58, 58, 117, 50, 53, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0]),"export.add_unsafe
+    swapw.3
+    movup.3
+    movup.7
+    u32overflowing_add
+    movup.4
+    movup.7
+    u32overflowing_add3
+    movup.4
+    movup.6
+    u32overflowing_add3
+    movup.4
+    movup.5
+    u32overflowing_add3
+    movdn.12
+    swapw.2
+    movup.12
+    movup.4
+    movup.8
+    u32overflowing_add3
+    movup.4
+    movup.7
+    u32overflowing_add3
+    movup.4
+    movup.6
+    u32overflowing_add3
+    movup.4
+    movup.5
+    u32overflowing_add3
+    drop
+end
+
+export.sub_unsafe
+    swapw.3
+    movup.3
+    movup.7
+    u32overflowing_sub
+    movup.7
+    u32overflowing_add
+    movup.5
+    movup.2
+    u32overflowing_sub
+    movup.2
+    add
+    movup.6
+    u32overflowing_add
+    movup.5
+    movup.2
+    u32overflowing_sub
+    movup.2
+    add
+    movup.5
+    u32overflowing_add
+    movup.5
+    movup.2
+    u32overflowing_sub
+    movup.2
+    add
+    movdn.12
+    swapw.2
+    movup.12
+    movup.4
+    u32overflowing_add
+    movup.8
+    movup.2
+    u32overflowing_sub
+    movup.2
+    add
+    movup.4
+    u32overflowing_add
+    movup.7
+    movup.2
+    u32overflowing_sub
+    movup.2
+    add
+    movup.4
+    u32overflowing_add
+    movup.6
+    movup.2
+    u32overflowing_sub
+    movup.2
+    add
+    movup.5
+    movup.5
+    movup.2
+    u32overflowing_add
+    drop
+    u32overflowing_sub
+    drop
+end
+
+export.and
+    swapw.3
+    movup.3
+    movup.7
+    u32checked_and
+    movup.3
+    movup.6
+    u32checked_and
+    movup.3
+    movup.5
+    u32checked_and
+    movup.3
+    movup.4
+    u32checked_and
+    swapw.2
+    movup.3
+    movup.7
+    u32checked_and
+    movup.3
+    movup.6
+    u32checked_and
+    movup.3
+    movup.5
+    u32checked_and
+    movup.3
+    movup.4
+    u32checked_and
+end
+
+export.or
+    swapw.3
+    movup.3
+    movup.7
+    u32checked_or
+    movup.3
+    movup.6
+    u32checked_or
+    movup.3
+    movup.5
+    u32checked_or
+    movup.3
+    movup.4
+    u32checked_or
+    swapw.2
+    movup.3
+    movup.7
+    u32checked_or
+    movup.3
+    movup.6
+    u32checked_or
+    movup.3
+    movup.5
+    u32checked_or
+    movup.3
+    movup.4
+    u32checked_or
+end
+
+export.xor
+    swapw.3
+    movup.3
+    movup.7
+    u32checked_xor
+    movup.3
+    movup.6
+    u32checked_xor
+    movup.3
+    movup.5
+    u32checked_xor
+    movup.3
+    movup.4
+    u32checked_xor
+    swapw.2
+    movup.3
+    movup.7
+    u32checked_xor
+    movup.3
+    movup.6
+    u32checked_xor
+    movup.3
+    movup.5
+    u32checked_xor
+    movup.3
+    movup.4
+    u32checked_xor
+end
+
+export.iszero_unsafe
+    eq.0
+    repeat.7
+        swap
+        eq.0
+        and
+    end
+end
+
+export.eq_unsafe
+    swapw.3
+    eqw
+    movdn.8
+    dropw
+    dropw
+    movdn.8
+    eqw
+    movdn.8
+    dropw
+    dropw
+    and
+end
+
+# ===== MULTIPLICATION ============================================================================
+
+proc.mulstep
+    movdn.2
+    u32overflowing_madd
+    movdn.2
+    u32overflowing_add
+    movup.2
+    add
+end
+
+proc.mulstep4
+    movup.12
+    dup.1
+    movup.10
+    push.0 # start k at 0
+    exec.mulstep
+    swap
+    movdn.9
+    dup.1
+    movup.9
+    movup.13
+    swap.3
+    exec.mulstep
+    swap
+    movdn.8
+    dup.1
+    movup.8
+    movup.12
+    swap.3
+    exec.mulstep
+    swap
+    movdn.7
+    dup.1
+    movup.7
+    movup.11
+    swap.3
+    exec.mulstep
+    swap
+    movdn.6
+end
+
+#! Performs addition of two unsigned 256 bit integers discarding the overflow.
+#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
+#! Stack transition looks as follows:
+#! [b7, b6, b5, b4, b3, b2, b1, b0, a7, a6, a5, a4, a3, a2, a1, a0, ...] -> [c7, c6, c5, c4, c3, c2, c1, c0, ...]
+#! where c = (a * b) % 2^256, and a0, b0, and c0 are least significant 32-bit limbs of a, b, and c respectively.
+export.mul_unsafe.6
+    # Memory storing setup
+    loc_storew.0
+    dropw
+    # b[5-8] at 0
+    loc_storew.1
+    # b[0-4] at 1
+    push.0 dropw
+    # b[0] at top of stack, followed by a[0-7]
+    movdn.8
+    loc_storew.2
+    # a[0-4] at 2
+    swapw
+    loc_storew.3
+    # a[5-8] at 3
+    padw
+    loc_storew.4
+    loc_storew.5
+    # p at 4 and 5
+
+    # b[0]
+    dropw
+    swapw
+    push.0.0.0.0
+    loc_loadw.4
+    movdnw.2
+    movup.12
+
+    exec.mulstep4
+
+    movdn.9
+    movdn.9
+    swapw
+    loc_storew.4
+    dropw
+    push.0.0.0.0
+    loc_loadw.5
+    swapw
+    movup.9
+    movup.9
+
+    dup.1
+    movup.6
+    movup.10
+    swap.3
+    exec.mulstep
+    swap
+    movdn.5
+    dup.1
+    movup.5
+    movup.9
+    swap.3
+    exec.mulstep
+    swap
+    movdn.4
+    dup.1
+    movup.4
+    movup.8
+    swap.3
+    exec.mulstep
+    swap
+    movdn.3
+    swap
+    movup.2
+    movup.6
+    swap.3
+    exec.mulstep
+
+    drop
+    loc_storew.5
+    dropw
+
+    # b[1]
+    push.0.0.0.0
+    loc_loadw.4
+    push.0.0.0.0
+    loc_loadw.5
+    movup.7
+    dropw
+    push.0.0.0.0
+    loc_loadw.3 push.0.0.0.0
+    loc_loadw.2 # load the xs
+    push.0.0.0.0
+    loc_loadw.1
+    movup.2
+    movdn.3
+    push.0 dropw # only need b[1]
+
+    exec.mulstep4
+
+    movdn.9
+    movdn.9
+    swapw
+    movdn.3
+    push.0.0.0.0
+    loc_loadw.4
+    push.0 dropw # only need p[0]
+    movdn.3
+    # save p[0-3] to memory, not needed any more
+    loc_storew.4
+    dropw
+
+    push.0.0.0.0
+    loc_loadw.5
+    movup.3
+    drop
+    swapw
+    movup.9
+    movup.9
+
+    dup.1
+    movup.6
+    movup.9
+    swap.3
+    exec.mulstep
+    swap
+    movdn.7
+    dup.1
+    movup.5
+    movup.7
+    swap.3
+    exec.mulstep
+    swap
+    movdn.5
+    swap
+    movup.3
+    movup.4
+    swap.3
+    exec.mulstep
+
+    drop
+    swap
+    drop
+    loc_storew.5
+    dropw
+
+    # b[2]
+    push.0.0.0.0
+    loc_loadw.4
+    push.0.0.0.0
+    loc_loadw.5
+    movup.7
+    movup.7
+    dropw
+    push.0.0.0.0
+    loc_loadw.3 push.0.0.0.0
+    loc_loadw.2 # load the xs
+    push.0.0.0.0
+    loc_loadw.1
+    swap
+    movdn.3
+    push.0 dropw # only need b[1]
+
+    exec.mulstep4
+
+    movdn.9
+    movdn.9
+    swapw
+    movdn.3
+    movdn.3
+    push.0.0.0.0
+    loc_loadw.4
+    drop drop
+    movdn.3
+    movdn.3
+    loc_storew.4
+    dropw
+
+    push.0.0.0.0
+    loc_loadw.5
+    movup.3
+    movup.3
+    drop
+    drop
+    swapw
+    movup.9
+    movup.9
+
+    dup.1
+    movup.6
+    movup.8
+    swap.3
+    exec.mulstep
+    swap
+    movdn.6
+    dup.1
+    movup.5
+    movup.6
+    swap.3
+    exec.mulstep
+    swap
+    swap drop
+    movdn.3
+    drop drop drop
+    loc_storew.5
+    dropw
+
+    # b[3]
+    push.0.0.0.0
+    loc_loadw.4
+    push.0.0.0.0
+    loc_loadw.5
+
+    movup.7 movup.7 movup.7
+    dropw
+    push.0.0.0.0
+    loc_loadw.3 push.0.0.0.0
+    loc_loadw.2
+
+    push.0.0.0.0
+    loc_loadw.1
+    movdn.3
+    push.0 dropw
+
+    exec.mulstep4
+
+    movdn.9
+    movdn.9
+
+    swapw
+    movup.3
+    push.0.0.0.0
+    loc_loadw.4
+    drop
+    movup.3
+
+    loc_storew.4
+    dropw
+    push.0.0.0.0
+    loc_loadw.5
+    movdn.3
+    push.0 dropw
+    swapw
+    movup.9
+    movup.9
+
+    swap
+    movup.5
+    movup.6
+    swap.3
+    exec.mulstep
+
+    drop
+    movdn.3
+    push.0 dropw
+
+    # b[4]
+    push.0.0.0.0
+    loc_loadw.3 push.0.0.0.0
+    loc_loadw.2 # load the xs
+    # OPTIM: don't need a[4-7], but can't use mulstep4 if we don't load
+
+    push.0.0.0.0
+    loc_loadw.0
+    push.0 dropw # b[4]
+
+    exec.mulstep4
+    dropw drop drop # OPTIM: don't need a[4-7], but can't use mulstep4 if we don't load
+
+    # b[5]
+    push.0.0.0.0
+    loc_loadw.3
+    push.0.0.0.0
+    loc_loadw.0
+    movup.2 movdn.3
+    push.0 dropw
+    movup.7
+    dup.1
+    movup.6
+    push.0
+    exec.mulstep
+    swap
+    movdn.7
+    movup.4
+    dup.2
+    movup.7
+    swap.3
+    exec.mulstep
+    swap
+    movdn.5
+    swap
+    movup.3
+    movup.4
+    swap.3
+    exec.mulstep
+    drop
+    swap
+    drop
+
+    # b[6]
+    push.0.0.0.0
+    loc_loadw.3
+    push.0.0.0.0
+    loc_loadw.0
+    swap
+    movdn.3
+    push.0 dropw
+    movup.6
+    dup.1
+    movup.6
+    push.0
+    exec.mulstep
+    swap
+    movdn.6
+    swap
+    movup.4
+    movup.5
+    swap.3
+    exec.mulstep
+    drop
+    movdn.2
+    drop drop
+
+    # b[7]
+    push.0.0.0.0
+    loc_loadw.3
+    push.0.0.0.0
+    loc_loadw.0
+
+    movdn.3 push.0 dropw
+    movup.4
+    movup.5
+    movdn.2
+    push.0
+    exec.mulstep
+    drop
+    movdn.3
+    drop drop drop
+
+    push.0.0.0.0
+    loc_loadw.4
+    swapw
+end",&[10, 0, 10, 97, 100, 100, 95, 117, 110, 115, 97, 102, 101, 0, 0, 10, 97, 100, 100, 95, 117, 110, 115, 97, 102, 101, 1, 0, 0, 29, 0, 144, 147, 151, 38, 148, 151, 40, 148, 150, 40, 148, 149, 40, 172, 143, 156, 148, 152, 40, 148, 151, 40, 148, 150, 40, 148, 149, 40, 104, 3, 97, 110, 100, 2, 0, 3, 97, 110, 100, 1, 0, 0, 26, 0, 144, 147, 151, 68, 147, 150, 68, 147, 149, 68, 147, 148, 68, 143, 147, 151, 68, 147, 150, 68, 147, 149, 68, 147, 148, 68, 9, 101, 113, 95, 117, 110, 115, 97, 102, 101, 6, 0, 9, 101, 113, 95, 117, 110, 115, 97, 102, 101, 1, 0, 0, 11, 0, 144, 23, 168, 105, 105, 168, 23, 168, 105, 105, 16, 13, 105, 115, 122, 101, 114, 111, 95, 117, 110, 115, 97, 102, 101, 5, 0, 13, 105, 115, 122, 101, 114, 111, 95, 117, 110, 115, 97, 102, 101, 1, 0, 0, 2, 0, 19, 254, 175, 0, 3, 0, 127, 19, 16, 10, 109, 117, 108, 95, 117, 110, 115, 97, 102, 101, 9, 0, 10, 109, 117, 108, 95, 117, 110, 115, 97, 102, 101, 1, 6, 0, 53, 1, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 168, 196, 2, 0, 0, 0, 0, 0, 0, 0, 142, 196, 3, 0, 0, 0, 0, 0, 0, 0, 106, 196, 4, 0, 0, 0, 0, 0, 0, 0, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 142, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 176, 156, 207, 8, 0, 0, 0, 169, 169, 142, 196, 4, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 142, 153, 153, 108, 150, 154, 129, 207, 7, 0, 0, 0, 127, 165, 108, 149, 153, 129, 207, 7, 0, 0, 0, 127, 164, 108, 148, 152, 129, 207, 7, 0, 0, 0, 127, 163, 127, 146, 150, 129, 207, 7, 0, 0, 0, 104, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 151, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 146, 163, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 207, 8, 0, 0, 0, 169, 169, 142, 163, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 163, 196, 4, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 147, 104, 142, 153, 153, 108, 150, 153, 129, 207, 7, 0, 0, 0, 127, 167, 108, 149, 151, 129, 207, 7, 0, 0, 0, 127, 165, 127, 147, 148, 129, 207, 7, 0, 0, 0, 104, 127, 104, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 151, 151, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 127, 163, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 207, 8, 0, 0, 0, 169, 169, 142, 163, 163, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 104, 104, 163, 163, 196, 4, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 147, 147, 104, 104, 142, 153, 153, 108, 150, 152, 129, 207, 7, 0, 0, 0, 127, 166, 108, 149, 150, 129, 207, 7, 0, 0, 0, 127, 127, 104, 163, 104, 104, 104, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 151, 151, 151, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 163, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 207, 8, 0, 0, 0, 169, 169, 142, 147, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 104, 147, 196, 4, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 163, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 142, 153, 153, 127, 149, 150, 129, 207, 7, 0, 0, 0, 104, 163, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 207, 8, 0, 0, 0, 105, 104, 104, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 146, 163, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 151, 108, 150, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 207, 7, 0, 0, 0, 127, 167, 148, 109, 151, 129, 207, 7, 0, 0, 0, 127, 165, 127, 147, 148, 129, 207, 7, 0, 0, 0, 104, 127, 104, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 127, 163, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 150, 108, 150, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 207, 7, 0, 0, 0, 127, 166, 127, 148, 149, 129, 207, 7, 0, 0, 0, 104, 162, 104, 104, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 163, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 148, 149, 162, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 207, 7, 0, 0, 0, 104, 163, 104, 104, 104, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 142, 7, 109, 117, 108, 115, 116, 101, 112, 7, 0, 7, 109, 117, 108, 115, 116, 101, 112, 0, 0, 0, 6, 0, 162, 54, 162, 38, 146, 3, 8, 109, 117, 108, 115, 116, 101, 112, 52, 8, 0, 8, 109, 117, 108, 115, 116, 101, 112, 52, 0, 0, 0, 28, 0, 156, 108, 154, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 207, 7, 0, 0, 0, 127, 169, 108, 153, 157, 129, 207, 7, 0, 0, 0, 127, 168, 108, 152, 156, 129, 207, 7, 0, 0, 0, 127, 167, 108, 151, 155, 129, 207, 7, 0, 0, 0, 127, 166, 2, 111, 114, 3, 0, 2, 111, 114, 1, 0, 0, 26, 0, 144, 147, 151, 69, 147, 150, 69, 147, 149, 69, 147, 148, 69, 143, 147, 151, 69, 147, 150, 69, 147, 149, 69, 147, 148, 69, 10, 115, 117, 98, 95, 117, 110, 115, 97, 102, 101, 1, 0, 10, 115, 117, 98, 95, 117, 110, 115, 97, 102, 101, 1, 0, 0, 56, 0, 144, 147, 151, 46, 151, 38, 149, 146, 46, 146, 3, 150, 38, 149, 146, 46, 146, 3, 149, 38, 149, 146, 46, 146, 3, 172, 143, 156, 148, 38, 152, 146, 46, 146, 3, 148, 38, 151, 146, 46, 146, 3, 148, 38, 150, 146, 46, 146, 3, 149, 149, 146, 38, 104, 46, 104, 3, 120, 111, 114, 4, 0, 3, 120, 111, 114, 1, 0, 0, 26, 0, 144, 147, 151, 70, 147, 150, 70, 147, 149, 70, 147, 148, 70, 143, 147, 151, 70, 147, 150, 70, 147, 149, 70, 147, 148, 70]),
+("std::math::ext2",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 109, 97, 116, 104, 58, 58, 101, 120, 116, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0]),"#! Given a stack with initial configuration given by [a1,a0,b1,b0,...] where a = (a0,a1) and
+#! b = (b0,b1) represent elements in the extension field of degree 2, the procedure outputs the 
+#! product c = (c1,c0) where c0 = a0b0 - 2(a1b1) and c1 = (a0 + a1)(b0 + b1) - a0b0
+export.mul
+    dupw            #[a1,a0,b1,b0,a1,a0,b1,b0,...]
+    swap.3          #[b0,a0,b1,a1,a1,a0,b1,b0,...]
+    mul             #[b0a0,b1,a1,a1,a0,b1,b0,...]
+    dup             #[b0a0,b0a0,b1,a1,a1,a0,b1,b0,...]
+    movdn.7         #[b0a0,b1,a1,a1,a0,b1,b0,b0a0,...]
+    movdn.2         #[b1,a1,b0a0,a1,a0,b1,b0,b0a0,...]
+    mul.2           #[2b1,a1,b0a0,a1,a0,b1,b0,b0a0,...]
+    mul             #[2b1a1,b0a0,a1,a0,b1,b0,b0a0,...]
+    sub             #[b0a0-2b1a1,a1,a0,b1,b0,b0a0,...]
+    movdn.5         #[a1,a0,b1,b0,b0a0,b0a0-2b1a1,...]
+    add             #[a1+a0,b1,b0,b0a0,b0a0-2b1a1,...]
+    swap.2          #[b0,b1,a1+a0,b0a0,b0a0-2b1a1,...]
+    add             #[b0+b1,a1+a0,b0a0,b0a0-2b1a1,...]
+    mul             #[(b0+b1)(a1+a0),b0a0,b0a0-2b1a1,...]
+    swap            #[b0a0,(b0+b1)(a1+a0),b0a0-2b1a1,...]
+    sub             #[(b0+b1)(a1+a0)-b0a0,b0a0-2b1a1,...]
+end
+
+#! Given a stack with initial configuration given by [x,a1,a0,...] where a = (a0,a1) is an element
+#! in the field extension and x is an element of the base field, this procedure computes the multiplication
+#! of x, when looked at as (x,0), with a in the extension field. The output is [xa1,xa0,...]
+export.mul_base
+    dup         #[x,x,a1,a0,...]
+    movdn.3     #[x,a1,a0,x,...]
+    mul         #[xa1,a0,x,...]
+    movdn.2     #[a0,x,xa1,...]
+    mul         #[xa0,xa1,...]
+    swap        #[xa1,xa0,...]
+end
+
+#! Given a stack in the following initial configuration [a1,a0,b1,b0,...] the following
+#! procedure computes [a1+b1,a0+b0,...]
+export.add
+    swap        #[a0,a1,b1,b0,...]
+    movup.3     #[b0,a0,a1,b1,...]
+    add         #[b0+a0,a1,b1,...]
+    movdn.2     #[a1,b1,b0+a0,...]
+    add         #[a1+b1,b0+a0,...]
+end
+
+#! Given a stack in the following initial configuration [a1,a0,b1,b0,...] the following
+#! procedure computes [a1-b1,a0-b0,...]
+export.sub
+    swap        #[a0,a1,b1,b0,...]
+    movup.3     #[b0,a0,a1,b1,...]
+    sub         #[a0-b0,a1,b1,...]
+    movdn.2     #[a1,b1,a0-b0,...]
+    swap        #[b1,a1,a0-b0,...]
+    sub         #[a1-b1,a0-b0,...]
+end",&[4, 0, 3, 97, 100, 100, 2, 0, 3, 97, 100, 100, 1, 0, 0, 5, 0, 127, 147, 3, 162, 3, 3, 109, 117, 108, 0, 0, 3, 109, 117, 108, 1, 0, 0, 16, 0, 123, 129, 7, 107, 167, 162, 7, 7, 5, 165, 3, 128, 3, 7, 127, 5, 8, 109, 117, 108, 95, 98, 97, 115, 101, 1, 0, 8, 109, 117, 108, 95, 98, 97, 115, 101, 1, 0, 0, 6, 0, 107, 163, 7, 162, 7, 127, 3, 115, 117, 98, 3, 0, 3, 115, 117, 98, 1, 0, 0, 6, 0, 127, 147, 5, 162, 127, 5]),
+("std::math::poly512",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 109, 97, 116, 104, 58, 58, 112, 111, 108, 121, 53, 49, 50, 0, 0, 0, 0, 0, 0]),"use.std::math::ntt512
 use.std::math::u64
 
 #! Given two consecutive words on stack, this routine performs 
@@ -11373,9 +11145,8 @@ export.sub_zq.128
     locaddr.0
     exec.add_zq
 end
-"#),
-// ----- std::math::secp256k1 ---------------------------------------------------------------------
-("std::math::secp256k1", r#"#! Given [b, c, a, carry] on stack top, following function computes
+",&[12, 0, 8, 97, 100, 100, 95, 119, 111, 114, 100, 1, 0, 8, 97, 100, 100, 95, 119, 111, 114, 100, 0, 0, 0, 11, 0, 148, 3, 166, 147, 3, 165, 146, 3, 164, 3, 163, 6, 97, 100, 100, 95, 122, 113, 9, 0, 6, 97, 100, 100, 95, 122, 113, 1, 0, 0, 6, 0, 198, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 189, 0, 19, 0, 115, 187, 142, 116, 187, 207, 1, 0, 0, 0, 207, 3, 0, 0, 0, 113, 194, 150, 3, 166, 149, 3, 165, 148, 3, 164, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 105, 105, 105, 9, 109, 111, 100, 95, 49, 50, 50, 56, 57, 2, 0, 9, 109, 111, 100, 95, 49, 50, 50, 56, 57, 1, 0, 0, 29, 0, 32, 198, 2, 1, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 199, 183, 2, 0, 0, 0, 0, 0, 0, 0, 30, 127, 198, 1, 1, 48, 0, 0, 0, 0, 0, 0, 52, 146, 198, 1, 1, 48, 0, 0, 0, 0, 0, 0, 54, 104, 183, 2, 0, 0, 0, 0, 0, 0, 0, 104, 30, 107, 147, 38, 147, 38, 104, 149, 1, 148, 1, 127, 104, 127, 104, 14, 109, 111, 100, 95, 49, 50, 50, 56, 57, 95, 119, 111, 114, 100, 3, 0, 14, 109, 111, 100, 95, 49, 50, 50, 56, 57, 95, 119, 111, 114, 100, 0, 0, 0, 10, 0, 207, 2, 0, 0, 0, 127, 207, 2, 0, 0, 0, 127, 146, 207, 2, 0, 0, 0, 162, 147, 207, 2, 0, 0, 0, 163, 8, 109, 117, 108, 95, 119, 111, 114, 100, 0, 0, 8, 109, 117, 108, 95, 119, 111, 114, 100, 0, 0, 0, 11, 0, 148, 7, 166, 147, 7, 165, 146, 7, 164, 7, 163, 6, 109, 117, 108, 95, 122, 113, 8, 0, 6, 109, 117, 108, 95, 122, 113, 1, 128, 0, 22, 0, 208, 121, 42, 204, 249, 233, 220, 62, 115, 134, 57, 253, 74, 205, 30, 94, 131, 235, 18, 101, 84, 52, 222, 139, 77, 183, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 128, 0, 10, 0, 112, 187, 111, 194, 149, 3, 165, 148, 3, 164, 105, 104, 104, 208, 121, 42, 204, 249, 233, 220, 62, 115, 134, 57, 253, 74, 205, 30, 94, 131, 235, 18, 101, 84, 52, 222, 139, 77, 183, 0, 0, 0, 0, 0, 0, 0, 0, 198, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 146, 0, 15, 0, 116, 187, 142, 115, 187, 207, 0, 0, 0, 0, 111, 194, 149, 3, 165, 148, 3, 164, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 105, 105, 104, 104, 183, 0, 0, 0, 0, 0, 0, 0, 0, 208, 210, 191, 35, 22, 225, 99, 65, 123, 88, 60, 150, 249, 33, 160, 178, 175, 104, 179, 18, 22, 53, 132, 108, 84, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 170, 0, 11, 0, 111, 187, 207, 7, 0, 0, 0, 112, 194, 149, 3, 165, 148, 3, 164, 105, 104, 104, 3, 110, 101, 103, 4, 0, 3, 110, 101, 103, 0, 0, 0, 4, 0, 207, 2, 0, 0, 0, 198, 1, 1, 48, 0, 0, 0, 0, 0, 0, 127, 5, 8, 110, 101, 103, 95, 119, 111, 114, 100, 5, 0, 8, 110, 101, 103, 95, 119, 111, 114, 100, 0, 0, 0, 10, 0, 207, 4, 0, 0, 0, 127, 207, 4, 0, 0, 0, 127, 146, 207, 4, 0, 0, 0, 162, 147, 207, 4, 0, 0, 0, 163, 6, 110, 101, 103, 95, 122, 113, 10, 0, 6, 110, 101, 103, 95, 122, 113, 1, 0, 0, 5, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 254, 217, 0, 11, 0, 111, 187, 207, 5, 0, 0, 0, 112, 194, 149, 3, 165, 148, 3, 164, 105, 104, 104, 6, 114, 101, 100, 117, 99, 101, 6, 0, 6, 114, 101, 100, 117, 99, 101, 0, 0, 0, 4, 0, 107, 198, 1, 0, 0, 0, 128, 255, 255, 255, 127, 26, 253, 5, 0, 207, 2, 0, 0, 0, 107, 198, 1, 90, 27, 0, 0, 0, 0, 0, 0, 99, 253, 1, 0, 5, 6, 0, 198, 1, 90, 27, 0, 0, 0, 0, 0, 0, 127, 5, 198, 1, 1, 48, 0, 0, 0, 0, 0, 0, 127, 5, 1, 0, 207, 2, 0, 0, 0, 11, 114, 101, 100, 117, 99, 101, 95, 119, 111, 114, 100, 7, 0, 11, 114, 101, 100, 117, 99, 101, 95, 119, 111, 114, 100, 0, 0, 0, 10, 0, 207, 6, 0, 0, 0, 127, 207, 6, 0, 0, 0, 127, 146, 207, 6, 0, 0, 0, 162, 147, 207, 6, 0, 0, 0, 163, 6, 115, 117, 98, 95, 122, 113, 11, 0, 6, 115, 117, 98, 95, 122, 113, 1, 128, 0, 5, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 146, 207, 10, 0, 0, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 207, 9, 0, 0, 0]),
+("std::math::secp256k1",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 109, 97, 116, 104, 58, 58, 115, 101, 99, 112, 50, 53, 54, 107, 49, 0, 0, 0, 0]),"#! Given [b, c, a, carry] on stack top, following function computes
 #!
 #!  tmp = a + (b * c) + carry
 #!  hi = tmp >> 32
@@ -15322,1460 +15093,1676 @@ export.gen_mul.20
   mem_storew
   dropw              # write z[4..8] to memory
 end
-"#),
-// ----- std::math::u256 --------------------------------------------------------------------------
-("std::math::u256", r#"export.add_unsafe
-    swapw.3
-    movup.3
-    movup.7
-    u32overflowing_add
-    movup.4
-    movup.7
-    u32overflowing_add3
-    movup.4
-    movup.6
-    u32overflowing_add3
-    movup.4
-    movup.5
-    u32overflowing_add3
-    movdn.12
-    swapw.2
-    movup.12
-    movup.4
-    movup.8
-    u32overflowing_add3
-    movup.4
-    movup.7
-    u32overflowing_add3
-    movup.4
-    movup.6
-    u32overflowing_add3
-    movup.4
-    movup.5
-    u32overflowing_add3
-    drop
-end
-
-export.sub_unsafe
-    swapw.3
-    movup.3
-    movup.7
-    u32overflowing_sub
-    movup.7
-    u32overflowing_add
-    movup.5
-    movup.2
-    u32overflowing_sub
-    movup.2
-    add
-    movup.6
-    u32overflowing_add
-    movup.5
-    movup.2
-    u32overflowing_sub
-    movup.2
-    add
-    movup.5
-    u32overflowing_add
-    movup.5
-    movup.2
-    u32overflowing_sub
-    movup.2
-    add
-    movdn.12
-    swapw.2
-    movup.12
-    movup.4
-    u32overflowing_add
-    movup.8
-    movup.2
-    u32overflowing_sub
-    movup.2
-    add
-    movup.4
-    u32overflowing_add
-    movup.7
-    movup.2
-    u32overflowing_sub
-    movup.2
-    add
-    movup.4
-    u32overflowing_add
-    movup.6
-    movup.2
-    u32overflowing_sub
-    movup.2
-    add
-    movup.5
-    movup.5
-    movup.2
-    u32overflowing_add
-    drop
-    u32overflowing_sub
-    drop
-end
-
-export.and
-    swapw.3
-    movup.3
-    movup.7
-    u32checked_and
-    movup.3
-    movup.6
-    u32checked_and
-    movup.3
-    movup.5
-    u32checked_and
-    movup.3
-    movup.4
-    u32checked_and
-    swapw.2
-    movup.3
-    movup.7
-    u32checked_and
-    movup.3
-    movup.6
-    u32checked_and
-    movup.3
-    movup.5
-    u32checked_and
-    movup.3
-    movup.4
-    u32checked_and
-end
-
-export.or
-    swapw.3
-    movup.3
-    movup.7
-    u32checked_or
-    movup.3
-    movup.6
-    u32checked_or
-    movup.3
-    movup.5
-    u32checked_or
-    movup.3
-    movup.4
-    u32checked_or
-    swapw.2
-    movup.3
-    movup.7
-    u32checked_or
-    movup.3
-    movup.6
-    u32checked_or
-    movup.3
-    movup.5
-    u32checked_or
-    movup.3
-    movup.4
-    u32checked_or
-end
-
-export.xor
-    swapw.3
-    movup.3
-    movup.7
-    u32checked_xor
-    movup.3
-    movup.6
-    u32checked_xor
-    movup.3
-    movup.5
-    u32checked_xor
-    movup.3
-    movup.4
-    u32checked_xor
-    swapw.2
-    movup.3
-    movup.7
-    u32checked_xor
-    movup.3
-    movup.6
-    u32checked_xor
-    movup.3
-    movup.5
-    u32checked_xor
-    movup.3
-    movup.4
-    u32checked_xor
-end
-
-export.iszero_unsafe
-    eq.0
-    repeat.7
-        swap
-        eq.0
-        and
+",&[15, 0, 9, 102, 114, 111, 109, 95, 109, 111, 110, 116, 10, 0, 9, 102, 114, 111, 109, 95, 109, 111, 110, 116, 1, 0, 0, 3, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 7, 103, 101, 110, 95, 109, 117, 108, 14, 0, 7, 103, 101, 110, 95, 109, 117, 108, 1, 20, 0, 59, 6, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 209, 3, 0, 0, 0, 0, 0, 0, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 3, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 4, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 196, 18, 0, 0, 0, 0, 0, 0, 0, 105, 196, 19, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 155, 130, 82, 105, 0, 0, 0, 0, 219, 165, 58, 210, 0, 0, 0, 0, 193, 171, 19, 222, 0, 0, 0, 0, 152, 81, 57, 27, 0, 0, 0, 0, 198, 4, 56, 156, 118, 142, 0, 0, 0, 0, 106, 240, 105, 76, 0, 0, 0, 0, 133, 44, 147, 130, 0, 0, 0, 0, 110, 37, 47, 205, 0, 0, 0, 0, 198, 4, 99, 28, 59, 226, 0, 0, 0, 0, 2, 126, 156, 204, 0, 0, 0, 0, 247, 181, 130, 206, 0, 0, 0, 0, 172, 46, 129, 105, 0, 0, 0, 0, 198, 4, 1, 101, 183, 6, 0, 0, 0, 0, 6, 34, 194, 91, 0, 0, 0, 0, 127, 32, 85, 1, 0, 0, 0, 0, 203, 142, 178, 49, 0, 0, 0, 0, 198, 4, 229, 243, 150, 88, 0, 0, 0, 0, 202, 66, 27, 179, 0, 0, 0, 0, 93, 87, 245, 65, 0, 0, 0, 0, 255, 146, 96, 46, 0, 0, 0, 0, 198, 4, 77, 68, 35, 150, 0, 0, 0, 0, 139, 109, 104, 86, 0, 0, 0, 0, 222, 233, 158, 252, 0, 0, 0, 0, 143, 224, 131, 93, 0, 0, 0, 0, 198, 4, 128, 240, 253, 197, 0, 0, 0, 0, 106, 8, 178, 203, 0, 0, 0, 0, 44, 228, 177, 5, 0, 0, 0, 0, 127, 67, 107, 33, 0, 0, 0, 0, 198, 4, 159, 202, 158, 56, 0, 0, 0, 0, 163, 185, 200, 110, 0, 0, 0, 0, 151, 173, 10, 194, 0, 0, 0, 0, 201, 184, 236, 37, 0, 0, 0, 0, 198, 4, 44, 77, 203, 164, 0, 0, 0, 0, 65, 79, 112, 134, 0, 0, 0, 0, 30, 67, 215, 31, 0, 0, 0, 0, 189, 89, 154, 75, 0, 0, 0, 0, 198, 4, 8, 201, 71, 169, 0, 0, 0, 0, 226, 252, 112, 200, 0, 0, 0, 0, 250, 237, 185, 32, 0, 0, 0, 0, 130, 175, 65, 101, 0, 0, 0, 0, 198, 4, 184, 26, 166, 233, 0, 0, 0, 0, 118, 40, 94, 23, 0, 0, 0, 0, 159, 53, 120, 72, 0, 0, 0, 0, 104, 231, 0, 113, 0, 0, 0, 0, 198, 4, 178, 69, 2, 130, 0, 0, 0, 0, 112, 215, 50, 112, 0, 0, 0, 0, 218, 176, 33, 116, 0, 0, 0, 0, 6, 106, 188, 137, 0, 0, 0, 0, 198, 4, 199, 158, 32, 253, 0, 0, 0, 0, 22, 160, 171, 211, 0, 0, 0, 0, 165, 115, 153, 228, 0, 0, 0, 0, 17, 237, 217, 12, 0, 0, 0, 0, 198, 4, 94, 109, 93, 89, 0, 0, 0, 0, 175, 84, 183, 236, 0, 0, 0, 0, 119, 204, 47, 132, 0, 0, 0, 0, 122, 123, 79, 195, 0, 0, 0, 0, 198, 4, 74, 53, 6, 38, 0, 0, 0, 0, 40, 251, 20, 254, 0, 0, 0, 0, 49, 107, 111, 171, 0, 0, 0, 0, 142, 204, 201, 228, 0, 0, 0, 0, 198, 4, 249, 40, 26, 156, 0, 0, 0, 0, 70, 195, 84, 195, 0, 0, 0, 0, 17, 155, 225, 151, 0, 0, 0, 0, 114, 119, 67, 137, 0, 0, 0, 0, 198, 4, 33, 109, 126, 88, 0, 0, 0, 0, 187, 201, 188, 67, 0, 0, 0, 0, 24, 117, 195, 244, 0, 0, 0, 0, 32, 240, 188, 155, 0, 0, 0, 0, 198, 4, 119, 199, 28, 81, 0, 0, 0, 0, 129, 160, 99, 222, 0, 0, 0, 0, 240, 173, 178, 36, 0, 0, 0, 0, 207, 60, 195, 116, 0, 0, 0, 0, 198, 4, 84, 117, 21, 244, 0, 0, 0, 0, 148, 114, 159, 127, 0, 0, 0, 0, 231, 15, 155, 118, 0, 0, 0, 0, 123, 212, 123, 65, 0, 0, 0, 0, 198, 4, 7, 59, 106, 168, 0, 0, 0, 0, 149, 41, 214, 77, 0, 0, 0, 0, 122, 193, 50, 50, 0, 0, 0, 0, 171, 82, 186, 55, 0, 0, 0, 0, 198, 4, 69, 105, 138, 212, 0, 0, 0, 0, 255, 48, 125, 154, 0, 0, 0, 0, 67, 114, 104, 147, 0, 0, 0, 0, 211, 41, 43, 241, 0, 0, 0, 0, 198, 4, 108, 150, 198, 78, 0, 0, 0, 0, 146, 224, 24, 79, 0, 0, 0, 0, 20, 2, 249, 172, 0, 0, 0, 0, 142, 8, 150, 241, 0, 0, 0, 0, 198, 4, 202, 90, 156, 224, 0, 0, 0, 0, 252, 87, 127, 19, 0, 0, 0, 0, 19, 27, 20, 147, 0, 0, 0, 0, 211, 178, 221, 91, 0, 0, 0, 0, 198, 4, 74, 62, 155, 188, 0, 0, 0, 0, 111, 210, 155, 149, 0, 0, 0, 0, 94, 116, 148, 80, 0, 0, 0, 0, 27, 247, 100, 16, 0, 0, 0, 0, 198, 4, 146, 118, 46, 203, 0, 0, 0, 0, 35, 58, 212, 0, 0, 0, 0, 0, 23, 144, 188, 168, 0, 0, 0, 0, 152, 49, 190, 114, 0, 0, 0, 0, 198, 4, 55, 195, 211, 32, 0, 0, 0, 0, 139, 113, 143, 71, 0, 0, 0, 0, 221, 227, 71, 185, 0, 0, 0, 0, 199, 6, 214, 101, 0, 0, 0, 0, 198, 4, 91, 101, 208, 0, 0, 0, 0, 0, 98, 106, 209, 27, 0, 0, 0, 0, 24, 133, 242, 138, 0, 0, 0, 0, 178, 108, 209, 183, 0, 0, 0, 0, 198, 4, 27, 107, 41, 22, 0, 0, 0, 0, 133, 50, 211, 250, 0, 0, 0, 0, 2, 214, 55, 68, 0, 0, 0, 0, 194, 152, 28, 126, 0, 0, 0, 0, 198, 4, 85, 228, 56, 206, 0, 0, 0, 0, 83, 203, 5, 212, 0, 0, 0, 0, 34, 80, 8, 200, 0, 0, 0, 0, 199, 26, 168, 12, 0, 0, 0, 0, 198, 4, 86, 126, 205, 177, 0, 0, 0, 0, 20, 213, 187, 156, 0, 0, 0, 0, 29, 98, 95, 116, 0, 0, 0, 0, 167, 253, 87, 248, 0, 0, 0, 0, 198, 4, 132, 192, 195, 138, 0, 0, 0, 0, 161, 79, 235, 24, 0, 0, 0, 0, 243, 51, 148, 77, 0, 0, 0, 0, 65, 169, 22, 85, 0, 0, 0, 0, 198, 4, 230, 249, 230, 24, 0, 0, 0, 0, 120, 81, 33, 138, 0, 0, 0, 0, 138, 25, 245, 235, 0, 0, 0, 0, 10, 47, 51, 66, 0, 0, 0, 0, 198, 4, 227, 152, 157, 173, 0, 0, 0, 0, 69, 107, 243, 103, 0, 0, 0, 0, 213, 41, 99, 205, 0, 0, 0, 0, 234, 253, 22, 64, 0, 0, 0, 0, 198, 4, 143, 214, 101, 50, 0, 0, 0, 0, 228, 243, 223, 255, 0, 0, 0, 0, 171, 30, 126, 18, 0, 0, 0, 0, 154, 14, 23, 180, 0, 0, 0, 0, 198, 4, 70, 243, 209, 51, 0, 0, 0, 0, 180, 238, 142, 5, 0, 0, 0, 0, 225, 42, 35, 207, 0, 0, 0, 0, 39, 241, 176, 81, 0, 0, 0, 0, 198, 4, 7, 238, 165, 234, 0, 0, 0, 0, 120, 246, 58, 165, 0, 0, 0, 0, 66, 42, 86, 71, 0, 0, 0, 0, 30, 125, 110, 88, 0, 0, 0, 0, 198, 4, 29, 203, 5, 206, 0, 0, 0, 0, 229, 57, 47, 220, 0, 0, 0, 0, 129, 76, 197, 138, 0, 0, 0, 0, 208, 201, 18, 174, 0, 0, 0, 0, 198, 4, 125, 162, 21, 150, 0, 0, 0, 0, 81, 147, 72, 180, 0, 0, 0, 0, 131, 73, 219, 93, 0, 0, 0, 0, 139, 58, 118, 91, 0, 0, 0, 0, 198, 4, 112, 231, 243, 145, 0, 0, 0, 0, 92, 17, 109, 203, 0, 0, 0, 0, 31, 120, 89, 198, 0, 0, 0, 0, 238, 166, 120, 141, 0, 0, 0, 0, 198, 4, 117, 158, 0, 217, 0, 0, 0, 0, 86, 162, 29, 139, 0, 0, 0, 0, 45, 75, 67, 96, 0, 0, 0, 0, 192, 233, 66, 149, 0, 0, 0, 0, 198, 4, 195, 214, 243, 221, 0, 0, 0, 0, 200, 10, 46, 104, 0, 0, 0, 0, 153, 127, 81, 197, 0, 0, 0, 0, 27, 30, 29, 17, 0, 0, 0, 0, 198, 4, 112, 255, 74, 171, 0, 0, 0, 0, 109, 46, 97, 33, 0, 0, 0, 0, 184, 233, 225, 82, 0, 0, 0, 0, 151, 136, 81, 38, 0, 0, 0, 0, 198, 4, 135, 166, 234, 123, 0, 0, 0, 0, 134, 204, 191, 215, 0, 0, 0, 0, 112, 33, 108, 232, 0, 0, 0, 0, 251, 220, 208, 135, 0, 0, 0, 0, 198, 4, 109, 40, 168, 130, 0, 0, 0, 0, 152, 68, 92, 221, 0, 0, 0, 0, 41, 96, 188, 111, 0, 0, 0, 0, 248, 105, 53, 15, 0, 0, 0, 0, 198, 4, 239, 138, 36, 24, 0, 0, 0, 0, 179, 79, 200, 205, 0, 0, 0, 0, 185, 185, 92, 254, 0, 0, 0, 0, 135, 145, 131, 250, 0, 0, 0, 0, 198, 4, 186, 80, 37, 15, 0, 0, 0, 0, 97, 199, 3, 237, 0, 0, 0, 0, 137, 233, 24, 63, 0, 0, 0, 0, 194, 204, 132, 184, 0, 0, 0, 0, 198, 4, 146, 88, 14, 78, 0, 0, 0, 0, 222, 101, 69, 130, 0, 0, 0, 0, 87, 220, 255, 106, 0, 0, 0, 0, 24, 76, 33, 224, 0, 0, 0, 0, 198, 4, 234, 123, 238, 8, 0, 0, 0, 0, 184, 249, 154, 2, 0, 0, 0, 0, 110, 138, 46, 34, 0, 0, 0, 0, 1, 160, 229, 23, 0, 0, 0, 0, 198, 4, 252, 154, 206, 179, 0, 0, 0, 0, 26, 117, 144, 71, 0, 0, 0, 0, 107, 160, 12, 157, 0, 0, 0, 0, 87, 149, 189, 163, 0, 0, 0, 0, 198, 4, 41, 216, 243, 181, 0, 0, 0, 0, 93, 187, 92, 103, 0, 0, 0, 0, 229, 93, 15, 112, 0, 0, 0, 0, 56, 12, 148, 0, 0, 0, 0, 0, 198, 4, 144, 29, 61, 164, 0, 0, 0, 0, 100, 16, 166, 190, 0, 0, 0, 0, 191, 148, 118, 243, 0, 0, 0, 0, 228, 125, 45, 66, 0, 0, 0, 0, 198, 4, 186, 70, 123, 91, 0, 0, 0, 0, 253, 152, 24, 156, 0, 0, 0, 0, 93, 171, 177, 216, 0, 0, 0, 0, 71, 224, 225, 235, 0, 0, 0, 0, 198, 4, 80, 2, 182, 199, 0, 0, 0, 0, 116, 106, 28, 207, 0, 0, 0, 0, 143, 141, 139, 36, 0, 0, 0, 0, 209, 191, 149, 138, 0, 0, 0, 0, 198, 4, 211, 74, 64, 71, 0, 0, 0, 0, 24, 216, 126, 50, 0, 0, 0, 0, 159, 40, 31, 62, 0, 0, 0, 0, 55, 172, 64, 140, 0, 0, 0, 0, 198, 4, 180, 67, 219, 10, 0, 0, 0, 0, 218, 8, 61, 235, 0, 0, 0, 0, 127, 212, 151, 139, 0, 0, 0, 0, 245, 243, 165, 227, 0, 0, 0, 0, 198, 4, 8, 126, 127, 108, 0, 0, 0, 0, 239, 24, 72, 223, 0, 0, 0, 0, 201, 168, 222, 245, 0, 0, 0, 0, 146, 49, 204, 163, 0, 0, 0, 0, 198, 4, 79, 83, 25, 100, 0, 0, 0, 0, 144, 9, 111, 150, 0, 0, 0, 0, 250, 38, 34, 183, 0, 0, 0, 0, 101, 91, 14, 210, 0, 0, 0, 0, 198, 4, 112, 107, 210, 38, 0, 0, 0, 0, 68, 185, 26, 249, 0, 0, 0, 0, 14, 39, 166, 204, 0, 0, 0, 0, 156, 105, 195, 146, 0, 0, 0, 0, 198, 4, 102, 173, 164, 255, 0, 0, 0, 0, 186, 180, 146, 72, 0, 0, 0, 0, 61, 227, 85, 145, 0, 0, 0, 0, 219, 69, 87, 66, 0, 0, 0, 0, 198, 4, 30, 183, 78, 43, 0, 0, 0, 0, 113, 47, 152, 254, 0, 0, 0, 0, 10, 6, 160, 39, 0, 0, 0, 0, 74, 99, 200, 160, 0, 0, 0, 0, 198, 4, 244, 221, 28, 65, 0, 0, 0, 0, 224, 89, 172, 114, 0, 0, 0, 0, 27, 111, 118, 255, 0, 0, 0, 0, 58, 202, 202, 162, 0, 0, 0, 0, 198, 4, 43, 23, 89, 72, 0, 0, 0, 0, 234, 201, 25, 227, 0, 0, 0, 0, 8, 102, 233, 208, 0, 0, 0, 0, 156, 86, 65, 179, 0, 0, 0, 0, 198, 4, 55, 240, 255, 237, 0, 0, 0, 0, 40, 143, 13, 129, 0, 0, 0, 0, 36, 42, 102, 149, 0, 0, 0, 0, 169, 133, 24, 130, 0, 0, 0, 0, 198, 4, 55, 141, 217, 99, 0, 0, 0, 0, 90, 155, 117, 147, 0, 0, 0, 0, 65, 202, 144, 96, 0, 0, 0, 0, 183, 49, 44, 109, 0, 0, 0, 0, 198, 4, 115, 35, 218, 143, 0, 0, 0, 0, 198, 96, 225, 243, 0, 0, 0, 0, 105, 31, 130, 252, 0, 0, 0, 0, 221, 155, 62, 244, 0, 0, 0, 0, 198, 4, 71, 7, 101, 35, 0, 0, 0, 0, 71, 157, 38, 214, 0, 0, 0, 0, 220, 132, 180, 12, 0, 0, 0, 0, 124, 1, 111, 49, 0, 0, 0, 0, 198, 4, 99, 7, 78, 22, 0, 0, 0, 0, 173, 248, 27, 80, 0, 0, 0, 0, 255, 240, 174, 226, 0, 0, 0, 0, 0, 35, 234, 118, 0, 0, 0, 0, 198, 4, 94, 152, 201, 65, 0, 0, 0, 0, 94, 37, 111, 109, 0, 0, 0, 0, 219, 202, 76, 213, 0, 0, 0, 0, 92, 254, 123, 246, 0, 0, 0, 0, 198, 4, 32, 15, 197, 82, 0, 0, 0, 0, 148, 18, 239, 26, 0, 0, 0, 0, 212, 135, 136, 199, 0, 0, 0, 0, 85, 244, 199, 137, 0, 0, 0, 0, 198, 4, 37, 249, 32, 98, 0, 0, 0, 0, 8, 153, 244, 68, 0, 0, 0, 0, 172, 222, 142, 68, 0, 0, 0, 0, 207, 66, 112, 190, 0, 0, 0, 0, 198, 4, 240, 65, 254, 57, 0, 0, 0, 0, 169, 57, 24, 80, 0, 0, 0, 0, 176, 200, 171, 109, 0, 0, 0, 0, 5, 64, 82, 153, 0, 0, 0, 0, 198, 4, 18, 96, 180, 49, 0, 0, 0, 0, 145, 71, 174, 173, 0, 0, 0, 0, 249, 78, 205, 183, 0, 0, 0, 0, 147, 17, 0, 179, 0, 0, 0, 0, 198, 4, 5, 213, 208, 83, 0, 0, 0, 0, 173, 253, 134, 47, 0, 0, 0, 0, 197, 137, 50, 250, 0, 0, 0, 0, 59, 186, 91, 4, 0, 0, 0, 0, 198, 4, 9, 12, 178, 53, 0, 0, 0, 0, 114, 59, 195, 196, 0, 0, 0, 0, 52, 44, 62, 6, 0, 0, 0, 0, 97, 192, 3, 105, 0, 0, 0, 0, 198, 4, 65, 3, 244, 141, 0, 0, 0, 0, 186, 12, 35, 246, 0, 0, 0, 0, 27, 155, 121, 204, 0, 0, 0, 0, 152, 224, 11, 120, 0, 0, 0, 0, 198, 4, 202, 158, 17, 48, 0, 0, 0, 0, 138, 185, 10, 216, 0, 0, 0, 0, 229, 232, 139, 173, 0, 0, 0, 0, 116, 160, 73, 190, 0, 0, 0, 0, 198, 4, 242, 30, 51, 6, 0, 0, 0, 0, 221, 151, 208, 104, 0, 0, 0, 0, 46, 121, 225, 203, 0, 0, 0, 0, 168, 58, 117, 239, 0, 0, 0, 0, 198, 4, 5, 175, 200, 117, 0, 0, 0, 0, 81, 73, 194, 10, 0, 0, 0, 0, 90, 47, 56, 91, 0, 0, 0, 0, 157, 93, 249, 86, 0, 0, 0, 0, 198, 4, 129, 245, 249, 113, 0, 0, 0, 0, 76, 41, 58, 87, 0, 0, 0, 0, 81, 49, 102, 215, 0, 0, 0, 0, 12, 178, 156, 1, 0, 0, 0, 0, 198, 4, 77, 27, 224, 150, 0, 0, 0, 0, 76, 161, 75, 15, 0, 0, 0, 0, 233, 98, 212, 18, 0, 0, 0, 0, 158, 230, 20, 9, 0, 0, 0, 0, 198, 4, 179, 112, 83, 111, 0, 0, 0, 0, 225, 61, 117, 2, 0, 0, 0, 0, 205, 245, 126, 121, 0, 0, 0, 0, 212, 175, 114, 145, 0, 0, 0, 0, 198, 4, 9, 219, 64, 125, 0, 0, 0, 0, 200, 66, 250, 15, 0, 0, 0, 0, 249, 144, 6, 216, 0, 0, 0, 0, 4, 145, 149, 206, 0, 0, 0, 0, 198, 4, 186, 33, 125, 74, 0, 0, 0, 0, 214, 141, 115, 44, 0, 0, 0, 0, 132, 115, 34, 9, 0, 0, 0, 0, 93, 185, 20, 168, 0, 0, 0, 0, 198, 4, 177, 42, 109, 187, 0, 0, 0, 0, 134, 183, 249, 141, 0, 0, 0, 0, 201, 67, 183, 156, 0, 0, 0, 0, 92, 5, 83, 170, 0, 0, 0, 0, 198, 4, 8, 233, 56, 35, 0, 0, 0, 0, 126, 129, 255, 204, 0, 0, 0, 0, 187, 14, 157, 174, 0, 0, 0, 0, 38, 245, 125, 151, 0, 0, 0, 0, 198, 4, 191, 94, 53, 81, 0, 0, 0, 0, 175, 89, 74, 126, 0, 0, 0, 0, 21, 14, 36, 191, 0, 0, 0, 0, 107, 104, 241, 156, 0, 0, 0, 0, 198, 4, 173, 218, 145, 199, 0, 0, 0, 0, 188, 44, 209, 182, 0, 0, 0, 0, 238, 112, 120, 197, 0, 0, 0, 0, 78, 160, 74, 154, 0, 0, 0, 0, 198, 4, 115, 113, 115, 224, 0, 0, 0, 0, 206, 90, 106, 146, 0, 0, 0, 0, 27, 112, 129, 50, 0, 0, 0, 0, 71, 76, 241, 145, 0, 0, 0, 0, 198, 4, 78, 25, 193, 48, 0, 0, 0, 0, 96, 76, 236, 13, 0, 0, 0, 0, 60, 175, 222, 235, 0, 0, 0, 0, 187, 39, 215, 12, 0, 0, 0, 0, 198, 4, 241, 91, 53, 242, 0, 0, 0, 0, 70, 181, 192, 27, 0, 0, 0, 0, 115, 111, 95, 207, 0, 0, 0, 0, 39, 53, 201, 201, 0, 0, 0, 0, 198, 4, 127, 23, 246, 90, 0, 0, 0, 0, 15, 36, 238, 158, 0, 0, 0, 0, 2, 255, 60, 85, 0, 0, 0, 0, 239, 1, 188, 17, 0, 0, 0, 0, 198, 4, 250, 41, 88, 220, 0, 0, 0, 0, 101, 73, 251, 131, 0, 0, 0, 0, 227, 246, 34, 31, 0, 0, 0, 0, 78, 202, 210, 76, 0, 0, 0, 0, 198, 4, 14, 69, 133, 218, 0, 0, 0, 0, 20, 250, 16, 230, 0, 0, 0, 0, 69, 11, 238, 105, 0, 0, 0, 0, 181, 69, 89, 25, 0, 0, 0, 0, 198, 4, 162, 34, 122, 59, 0, 0, 0, 0, 211, 26, 236, 131, 0, 0, 0, 0, 82, 26, 54, 225, 0, 0, 0, 0, 224, 189, 97, 83, 0, 0, 0, 0, 198, 4, 70, 138, 175, 206, 0, 0, 0, 0, 158, 106, 228, 138, 0, 0, 0, 0, 23, 202, 57, 214, 0, 0, 0, 0, 238, 246, 88, 43, 0, 0, 0, 0, 198, 4, 234, 109, 252, 61, 0, 0, 0, 0, 110, 147, 119, 253, 0, 0, 0, 0, 1, 143, 128, 56, 0, 0, 0, 0, 124, 74, 175, 3, 0, 0, 0, 0, 198, 4, 142, 125, 18, 157, 0, 0, 0, 0, 107, 79, 210, 14, 0, 0, 0, 0, 207, 174, 104, 73, 0, 0, 0, 0, 230, 231, 178, 190, 0, 0, 0, 0, 198, 4, 223, 182, 253, 119, 0, 0, 0, 0, 74, 123, 51, 56, 0, 0, 0, 0, 163, 178, 19, 31, 0, 0, 0, 0, 74, 68, 157, 227, 0, 0, 0, 0, 198, 4, 245, 39, 12, 22, 0, 0, 0, 0, 4, 148, 215, 216, 0, 0, 0, 0, 89, 184, 143, 189, 0, 0, 0, 0, 198, 3, 206, 50, 0, 0, 0, 0, 198, 4, 193, 99, 203, 170, 0, 0, 0, 0, 108, 167, 200, 220, 0, 0, 0, 0, 89, 175, 207, 198, 0, 0, 0, 0, 16, 106, 240, 124, 0, 0, 0, 0, 198, 4, 18, 235, 43, 201, 0, 0, 0, 0, 60, 244, 133, 38, 0, 0, 0, 0, 121, 118, 244, 106, 0, 0, 0, 0, 244, 151, 3, 145, 0, 0, 0, 0, 198, 4, 16, 66, 132, 148, 0, 0, 0, 0, 94, 154, 129, 109, 0, 0, 0, 0, 151, 201, 69, 109, 0, 0, 0, 0, 161, 63, 156, 105, 0, 0, 0, 0, 198, 4, 39, 28, 240, 209, 0, 0, 0, 0, 0, 85, 153, 120, 0, 0, 0, 0, 167, 1, 34, 20, 0, 0, 0, 0, 224, 205, 19, 202, 0, 0, 0, 0, 198, 4, 33, 138, 71, 117, 0, 0, 0, 0, 204, 186, 166, 63, 0, 0, 0, 0, 165, 99, 19, 47, 0, 0, 0, 0, 114, 6, 161, 113, 0, 0, 0, 0, 198, 4, 31, 47, 29, 235, 0, 0, 0, 0, 147, 1, 28, 167, 0, 0, 0, 0, 157, 5, 173, 59, 0, 0, 0, 0, 134, 251, 181, 155, 0, 0, 0, 0, 198, 4, 62, 58, 245, 195, 0, 0, 0, 0, 4, 70, 138, 186, 0, 0, 0, 0, 134, 165, 89, 31, 0, 0, 0, 0, 102, 10, 54, 160, 0, 0, 0, 0, 198, 4, 87, 238, 144, 219, 0, 0, 0, 0, 85, 30, 21, 219, 0, 0, 0, 0, 19, 217, 108, 96, 0, 0, 0, 0, 249, 17, 13, 202, 0, 0, 0, 0, 198, 4, 0, 16, 213, 170, 0, 0, 0, 0, 101, 158, 192, 108, 0, 0, 0, 0, 210, 251, 56, 236, 0, 0, 0, 0, 114, 44, 8, 224, 0, 0, 0, 0, 198, 4, 11, 27, 165, 132, 0, 0, 0, 0, 9, 136, 136, 174, 0, 0, 0, 0, 237, 93, 101, 77, 0, 0, 0, 0, 142, 128, 105, 45, 0, 0, 0, 0, 198, 4, 205, 188, 119, 234, 0, 0, 0, 0, 139, 123, 63, 236, 0, 0, 0, 0, 139, 20, 91, 52, 0, 0, 0, 0, 175, 6, 15, 225, 0, 0, 0, 0, 198, 4, 80, 107, 234, 61, 0, 0, 0, 0, 52, 220, 121, 114, 0, 0, 0, 0, 2, 223, 236, 74, 0, 0, 0, 0, 67, 209, 172, 59, 0, 0, 0, 0, 198, 4, 140, 234, 197, 62, 0, 0, 0, 0, 64, 56, 87, 99, 0, 0, 0, 0, 103, 73, 10, 72, 0, 0, 0, 0, 24, 10, 202, 192, 0, 0, 0, 0, 198, 4, 200, 198, 77, 230, 0, 0, 0, 0, 233, 34, 42, 145, 0, 0, 0, 0, 154, 228, 91, 141, 0, 0, 0, 0, 129, 4, 150, 194, 0, 0, 0, 0, 198, 4, 230, 100, 97, 41, 0, 0, 0, 0, 109, 91, 170, 131, 0, 0, 0, 0, 217, 193, 18, 147, 0, 0, 0, 0, 199, 186, 232, 170, 0, 0, 0, 0, 198, 4, 198, 110, 86, 232, 0, 0, 0, 0, 83, 234, 24, 147, 0, 0, 0, 0, 147, 207, 33, 61, 0, 0, 0, 0, 116, 223, 209, 186, 0, 0, 0, 0, 198, 4, 102, 102, 229, 43, 0, 0, 0, 0, 44, 34, 226, 142, 0, 0, 0, 0, 121, 147, 15, 53, 0, 0, 0, 0, 191, 228, 87, 177, 0, 0, 0, 0, 198, 4, 102, 171, 54, 227, 0, 0, 0, 0, 99, 209, 85, 143, 0, 0, 0, 0, 169, 136, 57, 29, 0, 0, 0, 0, 130, 237, 173, 191, 0, 0, 0, 0, 198, 4, 233, 187, 234, 96, 0, 0, 0, 0, 179, 19, 215, 49, 0, 0, 0, 0, 112, 254, 148, 225, 0, 0, 0, 0, 6, 127, 92, 8, 0, 0, 0, 0, 198, 4, 134, 11, 144, 31, 0, 0, 0, 0, 40, 121, 55, 38, 0, 0, 0, 0, 229, 62, 66, 234, 0, 0, 0, 0, 226, 115, 124, 177, 0, 0, 0, 0, 198, 4, 40, 196, 121, 214, 0, 0, 0, 0, 5, 228, 13, 100, 0, 0, 0, 0, 56, 10, 214, 29, 0, 0, 0, 0, 14, 176, 182, 97, 0, 0, 0, 0, 198, 4, 175, 152, 0, 182, 0, 0, 0, 0, 66, 211, 201, 192, 0, 0, 0, 0, 44, 27, 10, 222, 0, 0, 0, 0, 91, 182, 188, 183, 0, 0, 0, 0, 198, 4, 131, 58, 93, 152, 0, 0, 0, 0, 165, 131, 124, 5, 0, 0, 0, 0, 56, 245, 198, 217, 0, 0, 0, 0, 197, 28, 95, 131, 0, 0, 0, 0, 198, 4, 254, 56, 73, 146, 0, 0, 0, 0, 20, 251, 123, 164, 0, 0, 0, 0, 90, 241, 56, 113, 0, 0, 0, 0, 17, 103, 119, 166, 0, 0, 0, 0, 198, 4, 165, 236, 127, 102, 0, 0, 0, 0, 50, 75, 204, 26, 0, 0, 0, 0, 81, 254, 10, 108, 0, 0, 0, 0, 227, 25, 56, 72, 0, 0, 0, 0, 198, 4, 194, 101, 200, 239, 0, 0, 0, 0, 56, 15, 217, 202, 0, 0, 0, 0, 202, 162, 135, 9, 0, 0, 0, 0, 24, 189, 92, 83, 0, 0, 0, 0, 198, 4, 201, 180, 114, 146, 0, 0, 0, 0, 46, 66, 14, 208, 0, 0, 0, 0, 12, 201, 114, 145, 0, 0, 0, 0, 2, 231, 16, 11, 0, 0, 0, 0, 198, 4, 216, 10, 185, 224, 0, 0, 0, 0, 115, 56, 172, 145, 0, 0, 0, 0, 198, 109, 237, 225, 0, 0, 0, 0, 223, 53, 243, 88, 0, 0, 0, 0, 198, 4, 241, 194, 208, 197, 0, 0, 0, 0, 193, 197, 158, 245, 0, 0, 0, 0, 36, 167, 149, 104, 0, 0, 0, 0, 35, 57, 219, 16, 0, 0, 0, 0, 198, 4, 234, 25, 162, 134, 0, 0, 0, 0, 35, 112, 25, 224, 0, 0, 0, 0, 179, 215, 142, 217, 0, 0, 0, 0, 118, 62, 97, 44, 0, 0, 0, 0, 198, 4, 165, 81, 106, 27, 0, 0, 0, 0, 65, 18, 84, 132, 0, 0, 0, 0, 253, 134, 160, 76, 0, 0, 0, 0, 215, 243, 224, 250, 0, 0, 0, 0, 198, 4, 248, 29, 91, 236, 0, 0, 0, 0, 177, 117, 114, 24, 0, 0, 0, 0, 170, 77, 230, 210, 0, 0, 0, 0, 5, 1, 91, 102, 0, 0, 0, 0, 198, 4, 133, 81, 0, 47, 0, 0, 0, 0, 223, 212, 104, 82, 0, 0, 0, 0, 175, 159, 63, 152, 0, 0, 0, 0, 66, 130, 34, 213, 0, 0, 0, 0, 198, 4, 154, 74, 97, 114, 0, 0, 0, 0, 166, 243, 82, 235, 0, 0, 0, 0, 209, 227, 228, 148, 0, 0, 0, 0, 248, 38, 182, 228, 0, 0, 0, 0, 198, 4, 96, 16, 10, 34, 0, 0, 0, 0, 174, 29, 204, 158, 0, 0, 0, 0, 22, 206, 182, 71, 0, 0, 0, 0, 84, 175, 242, 91, 0, 0, 0, 0, 198, 4, 37, 68, 183, 49, 0, 0, 0, 0, 156, 52, 135, 31, 0, 0, 0, 0, 166, 88, 210, 87, 0, 0, 0, 0, 124, 170, 173, 89, 0, 0, 0, 0, 198, 4, 247, 198, 132, 9, 0, 0, 0, 0, 55, 247, 145, 75, 0, 0, 0, 0, 22, 127, 15, 69, 0, 0, 0, 0, 83, 7, 1, 101, 0, 0, 0, 0, 198, 4, 154, 216, 234, 62, 0, 0, 0, 0, 26, 142, 236, 4, 0, 0, 0, 0, 121, 107, 162, 217, 0, 0, 0, 0, 59, 119, 252, 77, 0, 0, 0, 0, 198, 4, 19, 244, 224, 115, 0, 0, 0, 0, 120, 43, 82, 74, 0, 0, 0, 0, 94, 234, 145, 202, 0, 0, 0, 0, 25, 32, 183, 239, 0, 0, 0, 0, 198, 4, 133, 122, 166, 79, 0, 0, 0, 0, 162, 41, 241, 84, 0, 0, 0, 0, 218, 140, 218, 19, 0, 0, 0, 0, 235, 166, 202, 189, 0, 0, 0, 0, 198, 4, 60, 113, 191, 0, 0, 0, 0, 0, 126, 31, 147, 58, 0, 0, 0, 0, 224, 192, 71, 192, 0, 0, 0, 0, 243, 210, 77, 80, 0, 0, 0, 0, 198, 4, 88, 198, 86, 32, 0, 0, 0, 0, 225, 19, 14, 247, 0, 0, 0, 0, 177, 169, 98, 151, 0, 0, 0, 0, 10, 222, 221, 2, 0, 0, 0, 0, 198, 4, 151, 136, 95, 207, 0, 0, 0, 0, 34, 29, 131, 64, 0, 0, 0, 0, 155, 255, 214, 150, 0, 0, 0, 0, 116, 116, 63, 12, 0, 0, 0, 0, 198, 4, 244, 31, 241, 91, 0, 0, 0, 0, 59, 14, 175, 233, 0, 0, 0, 0, 250, 131, 46, 206, 0, 0, 0, 0, 221, 129, 29, 46, 0, 0, 0, 0, 198, 4, 46, 33, 50, 37, 0, 0, 0, 0, 79, 231, 76, 227, 0, 0, 0, 0, 95, 147, 46, 241, 0, 0, 0, 0, 212, 94, 62, 68, 0, 0, 0, 0, 198, 4, 48, 183, 40, 19, 0, 0, 0, 0, 162, 107, 193, 99, 0, 0, 0, 0, 242, 194, 200, 182, 0, 0, 0, 0, 153, 196, 77, 38, 0, 0, 0, 0, 198, 4, 177, 178, 160, 246, 0, 0, 0, 0, 234, 251, 118, 49, 0, 0, 0, 0, 49, 202, 15, 60, 0, 0, 0, 0, 65, 89, 97, 228, 0, 0, 0, 0, 198, 4, 221, 50, 242, 45, 0, 0, 0, 0, 236, 251, 185, 46, 0, 0, 0, 0, 79, 106, 8, 187, 0, 0, 0, 0, 40, 229, 121, 82, 0, 0, 0, 0, 198, 4, 44, 219, 160, 106, 0, 0, 0, 0, 249, 16, 131, 127, 0, 0, 0, 0, 229, 86, 176, 249, 0, 0, 0, 0, 4, 224, 123, 232, 0, 0, 0, 0, 198, 4, 48, 210, 164, 137, 0, 0, 0, 0, 118, 217, 163, 190, 0, 0, 0, 0, 2, 141, 173, 71, 0, 0, 0, 0, 86, 112, 187, 41, 0, 0, 0, 0, 198, 4, 196, 14, 99, 124, 0, 0, 0, 0, 172, 97, 16, 195, 0, 0, 0, 0, 137, 84, 230, 244, 0, 0, 0, 0, 77, 8, 150, 17, 0, 0, 0, 0, 198, 4, 183, 51, 176, 238, 0, 0, 0, 0, 151, 56, 209, 248, 0, 0, 0, 0, 59, 131, 191, 237, 0, 0, 0, 0, 34, 208, 76, 9, 0, 0, 0, 0, 198, 4, 227, 84, 188, 161, 0, 0, 0, 0, 80, 111, 158, 46, 0, 0, 0, 0, 171, 75, 98, 122, 0, 0, 0, 0, 47, 217, 151, 230, 0, 0, 0, 0, 198, 4, 22, 111, 114, 146, 0, 0, 0, 0, 203, 189, 215, 126, 0, 0, 0, 0, 13, 217, 186, 122, 0, 0, 0, 0, 105, 211, 3, 69, 0, 0, 0, 0, 198, 4, 244, 52, 192, 148, 0, 0, 0, 0, 127, 37, 49, 98, 0, 0, 0, 0, 66, 36, 29, 90, 0, 0, 0, 0, 254, 25, 179, 16, 0, 0, 0, 0, 198, 4, 67, 232, 154, 60, 0, 0, 0, 0, 10, 254, 126, 24, 0, 0, 0, 0, 97, 25, 99, 13, 0, 0, 0, 0, 202, 226, 213, 153, 0, 0, 0, 0, 198, 4, 70, 74, 39, 79, 0, 0, 0, 0, 213, 40, 42, 85, 0, 0, 0, 0, 235, 23, 98, 211, 0, 0, 0, 0, 136, 166, 118, 75, 0, 0, 0, 0, 198, 4, 215, 239, 238, 177, 0, 0, 0, 0, 175, 243, 12, 134, 0, 0, 0, 0, 237, 180, 75, 27, 0, 0, 0, 0, 165, 132, 206, 92, 0, 0, 0, 0, 198, 4, 204, 217, 18, 116, 0, 0, 0, 0, 106, 86, 80, 112, 0, 0, 0, 0, 69, 238, 139, 129, 0, 0, 0, 0, 241, 152, 250, 190, 0, 0, 0, 0, 198, 4, 141, 163, 26, 47, 0, 0, 0, 0, 190, 66, 21, 214, 0, 0, 0, 0, 189, 57, 104, 62, 0, 0, 0, 0, 23, 29, 17, 62, 0, 0, 0, 0, 198, 4, 57, 181, 207, 120, 0, 0, 0, 0, 246, 213, 87, 173, 0, 0, 0, 0, 216, 69, 55, 227, 0, 0, 0, 0, 15, 148, 84, 77, 0, 0, 0, 0, 198, 4, 89, 119, 174, 234, 0, 0, 0, 0, 181, 228, 243, 43, 0, 0, 0, 0, 203, 106, 196, 249, 0, 0, 0, 0, 32, 115, 155, 28, 0, 0, 0, 0, 198, 4, 168, 212, 93, 12, 0, 0, 0, 0, 225, 220, 217, 27, 0, 0, 0, 0, 200, 246, 116, 108, 0, 0, 0, 0, 158, 125, 105, 94, 0, 0, 0, 0, 198, 4, 92, 144, 215, 180, 0, 0, 0, 0, 188, 239, 168, 200, 0, 0, 0, 0, 71, 17, 204, 128, 0, 0, 0, 0, 183, 172, 96, 179, 0, 0, 0, 0, 198, 4, 103, 118, 91, 191, 0, 0, 0, 0, 78, 86, 87, 41, 0, 0, 0, 0, 99, 147, 108, 206, 0, 0, 0, 0, 51, 133, 105, 196, 0, 0, 0, 0, 198, 4, 185, 102, 89, 1, 0, 0, 0, 0, 24, 241, 106, 46, 0, 0, 0, 0, 217, 177, 192, 181, 0, 0, 0, 0, 70, 225, 65, 43, 0, 0, 0, 0, 198, 4, 7, 214, 115, 196, 0, 0, 0, 0, 153, 164, 59, 235, 0, 0, 0, 0, 59, 104, 89, 78, 0, 0, 0, 0, 71, 158, 126, 111, 0, 0, 0, 0, 198, 4, 80, 189, 243, 25, 0, 0, 0, 0, 16, 208, 131, 31, 0, 0, 0, 0, 129, 57, 208, 22, 0, 0, 0, 0, 51, 143, 4, 77, 0, 0, 0, 0, 198, 4, 57, 80, 245, 1, 0, 0, 0, 0, 213, 79, 143, 171, 0, 0, 0, 0, 255, 49, 67, 212, 0, 0, 0, 0, 93, 45, 155, 235, 0, 0, 0, 0, 198, 4, 196, 43, 0, 181, 0, 0, 0, 0, 166, 228, 111, 86, 0, 0, 0, 0, 220, 89, 248, 236, 0, 0, 0, 0, 200, 75, 184, 90, 0, 0, 0, 0, 198, 4, 174, 31, 172, 77, 0, 0, 0, 0, 239, 174, 64, 39, 0, 0, 0, 0, 248, 243, 71, 222, 0, 0, 0, 0, 172, 148, 197, 26, 0, 0, 0, 0, 198, 4, 121, 72, 83, 80, 0, 0, 0, 0, 62, 7, 77, 5, 0, 0, 0, 0, 17, 192, 40, 50, 0, 0, 0, 0, 131, 41, 254, 216, 0, 0, 0, 0, 198, 4, 167, 49, 23, 145, 0, 0, 0, 0, 113, 142, 148, 29, 0, 0, 0, 0, 66, 117, 68, 115, 0, 0, 0, 0, 12, 101, 129, 107, 0, 0, 0, 0, 198, 4, 10, 46, 50, 28, 0, 0, 0, 0, 145, 70, 30, 79, 0, 0, 0, 0, 235, 237, 22, 68, 0, 0, 0, 0, 29, 144, 173, 22, 0, 0, 0, 0, 198, 4, 222, 152, 165, 243, 0, 0, 0, 0, 248, 192, 9, 159, 0, 0, 0, 0, 165, 116, 92, 31, 0, 0, 0, 0, 194, 32, 249, 52, 0, 0, 0, 0, 198, 4, 49, 5, 176, 151, 0, 0, 0, 0, 218, 176, 200, 81, 0, 0, 0, 0, 107, 136, 54, 36, 0, 0, 0, 0, 227, 233, 43, 93, 0, 0, 0, 0, 198, 4, 188, 49, 252, 209, 0, 0, 0, 0, 47, 202, 150, 45, 0, 0, 0, 0, 95, 1, 97, 35, 0, 0, 0, 0, 38, 37, 50, 228, 0, 0, 0, 0, 198, 4, 131, 113, 48, 151, 0, 0, 0, 0, 203, 9, 35, 30, 0, 0, 0, 0, 74, 80, 242, 122, 0, 0, 0, 0, 175, 39, 114, 180, 0, 0, 0, 0, 198, 4, 152, 88, 164, 174, 0, 0, 0, 0, 38, 46, 12, 182, 0, 0, 0, 0, 141, 66, 220, 123, 0, 0, 0, 0, 83, 109, 92, 193, 0, 0, 0, 0, 198, 4, 181, 200, 70, 209, 0, 0, 0, 0, 220, 89, 89, 23, 0, 0, 0, 0, 64, 105, 15, 126, 0, 0, 0, 0, 184, 179, 78, 69, 0, 0, 0, 0, 198, 4, 198, 240, 116, 176, 0, 0, 0, 0, 83, 245, 185, 131, 0, 0, 0, 0, 68, 204, 23, 62, 0, 0, 0, 0, 63, 173, 190, 118, 0, 0, 0, 0, 198, 4, 13, 11, 114, 92, 0, 0, 0, 0, 125, 22, 168, 255, 0, 0, 0, 0, 97, 124, 126, 26, 0, 0, 0, 0, 216, 5, 28, 78, 0, 0, 0, 0, 198, 4, 55, 77, 248, 51, 0, 0, 0, 0, 234, 214, 171, 203, 0, 0, 0, 0, 225, 138, 131, 221, 0, 0, 0, 0, 91, 102, 181, 0, 0, 0, 0, 0, 198, 4, 199, 209, 77, 156, 0, 0, 0, 0, 42, 209, 129, 214, 0, 0, 0, 0, 176, 9, 114, 205, 0, 0, 0, 0, 74, 60, 151, 50, 0, 0, 0, 0, 198, 4, 128, 89, 222, 216, 0, 0, 0, 0, 135, 11, 89, 21, 0, 0, 0, 0, 80, 241, 248, 217, 0, 0, 0, 0, 204, 170, 61, 234, 0, 0, 0, 0, 198, 4, 129, 165, 252, 244, 0, 0, 0, 0, 164, 94, 208, 15, 0, 0, 0, 0, 244, 26, 113, 61, 0, 0, 0, 0, 95, 105, 58, 188, 0, 0, 0, 0, 198, 4, 116, 74, 231, 9, 0, 0, 0, 0, 28, 31, 138, 7, 0, 0, 0, 0, 107, 99, 98, 201, 0, 0, 0, 0, 150, 47, 64, 222, 0, 0, 0, 0, 198, 4, 56, 56, 132, 174, 0, 0, 0, 0, 65, 130, 145, 106, 0, 0, 0, 0, 89, 175, 113, 218, 0, 0, 0, 0, 84, 209, 211, 172, 0, 0, 0, 0, 198, 4, 250, 22, 161, 146, 0, 0, 0, 0, 255, 202, 193, 117, 0, 0, 0, 0, 134, 62, 145, 254, 0, 0, 0, 0, 41, 32, 24, 29, 0, 0, 0, 0, 198, 4, 67, 89, 191, 155, 0, 0, 0, 0, 135, 196, 144, 143, 0, 0, 0, 0, 41, 186, 160, 46, 0, 0, 0, 0, 57, 249, 214, 155, 0, 0, 0, 0, 198, 4, 197, 243, 121, 72, 0, 0, 0, 0, 33, 99, 78, 52, 0, 0, 0, 0, 248, 130, 92, 87, 0, 0, 0, 0, 109, 122, 89, 200, 0, 0, 0, 0, 198, 4, 24, 106, 210, 33, 0, 0, 0, 0, 110, 28, 140, 178, 0, 0, 0, 0, 195, 100, 181, 169, 0, 0, 0, 0, 24, 246, 79, 156, 0, 0, 0, 0, 198, 4, 42, 18, 188, 177, 0, 0, 0, 0, 90, 77, 28, 151, 0, 0, 0, 0, 250, 56, 29, 0, 0, 0, 0, 0, 222, 67, 240, 138, 0, 0, 0, 0, 198, 4, 238, 206, 131, 76, 0, 0, 0, 0, 229, 45, 108, 196, 0, 0, 0, 0, 215, 229, 179, 212, 0, 0, 0, 0, 9, 69, 249, 110, 0, 0, 0, 0, 198, 4, 90, 94, 17, 120, 0, 0, 0, 0, 157, 93, 132, 112, 0, 0, 0, 0, 232, 42, 37, 138, 0, 0, 0, 0, 128, 221, 126, 80, 0, 0, 0, 0, 198, 4, 169, 224, 221, 235, 0, 0, 0, 0, 154, 105, 160, 57, 0, 0, 0, 0, 213, 91, 37, 59, 0, 0, 0, 0, 132, 7, 73, 8, 0, 0, 0, 0, 198, 4, 226, 56, 34, 169, 0, 0, 0, 0, 81, 221, 41, 12, 0, 0, 0, 0, 93, 99, 213, 83, 0, 0, 0, 0, 126, 148, 202, 115, 0, 0, 0, 0, 198, 4, 37, 144, 238, 204, 0, 0, 0, 0, 125, 194, 161, 190, 0, 0, 0, 0, 180, 169, 40, 199, 0, 0, 0, 0, 172, 175, 140, 100, 0, 0, 0, 0, 198, 4, 156, 161, 141, 139, 0, 0, 0, 0, 51, 25, 188, 196, 0, 0, 0, 0, 171, 108, 4, 232, 0, 0, 0, 0, 178, 104, 125, 147, 0, 0, 0, 0, 198, 4, 235, 81, 121, 199, 0, 0, 0, 0, 136, 230, 190, 191, 0, 0, 0, 0, 77, 60, 229, 123, 0, 0, 0, 0, 249, 231, 26, 164, 0, 0, 0, 0, 198, 4, 180, 9, 2, 76, 0, 0, 0, 0, 218, 211, 207, 77, 0, 0, 0, 0, 190, 73, 134, 219, 0, 0, 0, 0, 45, 251, 58, 86, 0, 0, 0, 0, 198, 4, 220, 200, 254, 18, 0, 0, 0, 0, 214, 172, 249, 201, 0, 0, 0, 0, 43, 209, 236, 17, 0, 0, 0, 0, 83, 134, 86, 25, 0, 0, 0, 0, 198, 4, 252, 228, 200, 187, 0, 0, 0, 0, 116, 84, 92, 254, 0, 0, 0, 0, 150, 129, 160, 146, 0, 0, 0, 0, 240, 245, 83, 203, 0, 0, 0, 0, 198, 4, 79, 208, 175, 37, 0, 0, 0, 0, 215, 109, 182, 81, 0, 0, 0, 0, 84, 97, 200, 240, 0, 0, 0, 0, 51, 162, 231, 42, 0, 0, 0, 0, 198, 4, 208, 99, 104, 230, 0, 0, 0, 0, 72, 221, 245, 35, 0, 0, 0, 0, 15, 144, 114, 193, 0, 0, 0, 0, 23, 251, 161, 6, 0, 0, 0, 0, 198, 4, 130, 74, 167, 126, 0, 0, 0, 0, 185, 72, 215, 172, 0, 0, 0, 0, 73, 170, 116, 141, 0, 0, 0, 0, 27, 14, 33, 103, 0, 0, 0, 0, 198, 4, 47, 178, 21, 110, 0, 0, 0, 0, 84, 73, 211, 147, 0, 0, 0, 0, 45, 88, 63, 213, 0, 0, 0, 0, 253, 132, 161, 72, 0, 0, 0, 0, 198, 4, 112, 210, 228, 104, 0, 0, 0, 0, 151, 162, 227, 18, 0, 0, 0, 0, 155, 111, 119, 228, 0, 0, 0, 0, 78, 142, 113, 222, 0, 0, 0, 0, 198, 4, 206, 168, 166, 255, 0, 0, 0, 0, 152, 212, 23, 4, 0, 0, 0, 0, 196, 191, 109, 1, 0, 0, 0, 0, 108, 37, 109, 230, 0, 0, 0, 0, 198, 4, 40, 100, 115, 98, 0, 0, 0, 0, 21, 175, 105, 222, 0, 0, 0, 0, 82, 165, 145, 151, 0, 0, 0, 0, 225, 3, 31, 41, 0, 0, 0, 0, 198, 4, 89, 81, 200, 229, 0, 0, 0, 0, 50, 10, 155, 187, 0, 0, 0, 0, 64, 248, 192, 90, 0, 0, 0, 0, 79, 93, 126, 186, 0, 0, 0, 0, 198, 4, 206, 168, 234, 36, 0, 0, 0, 0, 235, 218, 153, 39, 0, 0, 0, 0, 152, 248, 127, 30, 0, 0, 0, 0, 79, 46, 227, 54, 0, 0, 0, 0, 198, 4, 167, 21, 83, 218, 0, 0, 0, 0, 174, 224, 67, 185, 0, 0, 0, 0, 144, 19, 222, 40, 0, 0, 0, 0, 99, 143, 126, 156, 0, 0, 0, 0, 198, 4, 218, 142, 141, 84, 0, 0, 0, 0, 81, 192, 106, 78, 0, 0, 0, 0, 2, 220, 62, 115, 0, 0, 0, 0, 18, 58, 232, 89, 0, 0, 0, 0, 198, 4, 164, 250, 240, 59, 0, 0, 0, 0, 164, 1, 10, 46, 0, 0, 0, 0, 204, 171, 99, 246, 0, 0, 0, 0, 215, 121, 10, 245, 0, 0, 0, 0, 198, 4, 46, 59, 69, 57, 0, 0, 0, 0, 110, 124, 125, 109, 0, 0, 0, 0, 23, 15, 84, 25, 0, 0, 0, 0, 223, 236, 222, 169, 0, 0, 0, 0, 198, 4, 129, 239, 179, 27, 0, 0, 0, 0, 191, 79, 22, 87, 0, 0, 0, 0, 79, 130, 93, 163, 0, 0, 0, 0, 189, 178, 202, 70, 0, 0, 0, 0, 198, 4, 5, 39, 30, 57, 0, 0, 0, 0, 158, 43, 204, 21, 0, 0, 0, 0, 5, 53, 206, 254, 0, 0, 0, 0, 175, 61, 166, 141, 0, 0, 0, 0, 198, 4, 209, 4, 245, 67, 0, 0, 0, 0, 54, 147, 205, 158, 0, 0, 0, 0, 117, 210, 246, 240, 0, 0, 0, 0, 71, 122, 133, 77, 0, 0, 0, 0, 198, 4, 31, 235, 201, 179, 0, 0, 0, 0, 40, 108, 170, 2, 0, 0, 0, 0, 153, 138, 116, 146, 0, 0, 0, 0, 57, 71, 193, 80, 0, 0, 0, 0, 198, 4, 4, 116, 141, 242, 0, 0, 0, 0, 85, 196, 54, 147, 0, 0, 0, 0, 20, 151, 217, 223, 0, 0, 0, 0, 45, 156, 222, 16, 0, 0, 0, 0, 198, 4, 212, 53, 211, 166, 0, 0, 0, 0, 100, 216, 191, 72, 0, 0, 0, 0, 25, 240, 216, 138, 0, 0, 0, 0, 65, 130, 240, 7, 0, 0, 0, 0, 198, 4, 171, 151, 14, 229, 0, 0, 0, 0, 40, 138, 19, 249, 0, 0, 0, 0, 150, 96, 160, 168, 0, 0, 0, 0, 187, 77, 19, 196, 0, 0, 0, 0, 198, 4, 54, 213, 255, 27, 0, 0, 0, 0, 52, 212, 98, 220, 0, 0, 0, 0, 160, 142, 118, 92, 0, 0, 0, 0, 46, 164, 48, 34, 0, 0, 0, 0, 198, 4, 111, 211, 191, 167, 0, 0, 0, 0, 118, 39, 42, 20, 0, 0, 0, 0, 3, 149, 232, 191, 0, 0, 0, 0, 13, 48, 33, 103, 0, 0, 0, 0, 198, 4, 20, 19, 137, 15, 0, 0, 0, 0, 239, 146, 211, 148, 0, 0, 0, 0, 133, 4, 61, 207, 0, 0, 0, 0, 99, 54, 114, 222, 0, 0, 0, 0, 198, 4, 196, 77, 115, 207, 0, 0, 0, 0, 248, 142, 249, 202, 0, 0, 0, 0, 116, 130, 170, 158, 0, 0, 0, 0, 73, 155, 238, 27, 0, 0, 0, 0, 198, 4, 84, 104, 167, 6, 0, 0, 0, 0, 45, 146, 183, 84, 0, 0, 0, 0, 101, 108, 197, 85, 0, 0, 0, 0, 66, 41, 70, 184, 0, 0, 0, 0, 198, 4, 117, 209, 65, 182, 0, 0, 0, 0, 139, 87, 207, 239, 0, 0, 0, 0, 153, 90, 48, 77, 0, 0, 0, 0, 49, 85, 192, 96, 0, 0, 0, 0, 198, 4, 168, 136, 125, 77, 0, 0, 0, 0, 55, 74, 117, 250, 0, 0, 0, 0, 230, 33, 197, 119, 0, 0, 0, 0, 98, 244, 187, 183, 0, 0, 0, 0, 198, 4, 39, 183, 156, 211, 0, 0, 0, 0, 174, 30, 241, 23, 0, 0, 0, 0, 118, 117, 202, 7, 0, 0, 0, 0, 91, 132, 239, 70, 0, 0, 0, 0, 198, 4, 207, 220, 3, 149, 0, 0, 0, 0, 131, 113, 246, 13, 0, 0, 0, 0, 12, 40, 183, 193, 0, 0, 0, 0, 104, 83, 146, 72, 0, 0, 0, 0, 198, 4, 224, 188, 197, 14, 0, 0, 0, 0, 251, 37, 71, 105, 0, 0, 0, 0, 168, 173, 24, 131, 0, 0, 0, 0, 246, 112, 215, 156, 0, 0, 0, 0, 198, 4, 45, 7, 208, 4, 0, 0, 0, 0, 63, 253, 219, 103, 0, 0, 0, 0, 163, 80, 75, 148, 0, 0, 0, 0, 221, 122, 82, 32, 0, 0, 0, 0, 198, 4, 205, 196, 113, 23, 0, 0, 0, 0, 189, 231, 81, 73, 0, 0, 0, 0, 112, 56, 107, 118, 0, 0, 0, 0, 236, 94, 207, 40, 0, 0, 0, 0, 198, 4, 169, 211, 248, 122, 0, 0, 0, 0, 50, 102, 155, 132, 0, 0, 0, 0, 238, 47, 76, 93, 0, 0, 0, 0, 105, 236, 83, 211, 0, 0, 0, 0, 198, 4, 159, 23, 211, 41, 0, 0, 0, 0, 25, 124, 120, 148, 0, 0, 0, 0, 91, 214, 108, 101, 0, 0, 0, 0, 221, 245, 45, 110, 0, 0, 0, 0, 198, 4, 25, 103, 135, 141, 0, 0, 0, 0, 174, 75, 44, 43, 0, 0, 0, 0, 224, 132, 91, 21, 0, 0, 0, 0, 190, 173, 92, 127, 0, 0, 0, 0, 198, 4, 11, 100, 220, 64, 0, 0, 0, 0, 93, 196, 9, 45, 0, 0, 0, 0, 92, 110, 250, 44, 0, 0, 0, 0, 51, 249, 37, 29, 0, 0, 0, 0, 198, 4, 194, 85, 3, 93, 0, 0, 0, 0, 193, 194, 27, 87, 0, 0, 0, 0, 170, 129, 101, 96, 0, 0, 0, 0, 21, 207, 67, 235, 0, 0, 0, 0, 198, 4, 158, 125, 85, 162, 0, 0, 0, 0, 187, 205, 208, 46, 0, 0, 0, 0, 188, 143, 110, 255, 0, 0, 0, 0, 10, 187, 202, 158, 0, 0, 0, 0, 198, 4, 97, 59, 234, 85, 0, 0, 0, 0, 141, 229, 158, 235, 0, 0, 0, 0, 173, 66, 165, 74, 0, 0, 0, 0, 186, 202, 7, 130, 0, 0, 0, 0, 198, 4, 7, 236, 247, 82, 0, 0, 0, 0, 131, 72, 171, 209, 0, 0, 0, 0, 212, 216, 124, 155, 0, 0, 0, 0, 74, 56, 210, 29, 0, 0, 0, 0, 198, 4, 174, 26, 196, 9, 0, 0, 0, 0, 72, 218, 221, 177, 0, 0, 0, 0, 15, 128, 56, 145, 0, 0, 0, 0, 158, 13, 34, 43, 0, 0, 0, 0, 198, 4, 211, 175, 173, 135, 0, 0, 0, 0, 177, 107, 185, 254, 0, 0, 0, 0, 244, 180, 15, 187, 0, 0, 0, 0, 139, 98, 211, 133, 0, 0, 0, 0, 198, 4, 144, 119, 53, 60, 0, 0, 0, 0, 236, 96, 190, 83, 0, 0, 0, 0, 215, 228, 94, 147, 0, 0, 0, 0, 126, 192, 107, 137, 0, 0, 0, 0, 198, 4, 205, 195, 183, 246, 0, 0, 0, 0, 122, 91, 40, 81, 0, 0, 0, 0, 126, 136, 59, 2, 0, 0, 0, 0, 102, 239, 202, 190, 0, 0, 0, 0, 198, 4, 170, 209, 206, 194, 0, 0, 0, 0, 97, 32, 12, 34, 0, 0, 0, 0, 73, 91, 180, 232, 0, 0, 0, 0, 169, 112, 101, 202, 0, 0, 0, 0, 198, 4, 140, 45, 222, 167, 0, 0, 0, 0, 107, 15, 146, 163, 0, 0, 0, 0, 92, 1, 230, 190, 0, 0, 0, 0, 14, 205, 76, 16, 0, 0, 0, 0, 198, 4, 101, 77, 111, 70, 0, 0, 0, 0, 47, 37, 104, 43, 0, 0, 0, 0, 33, 71, 105, 151, 0, 0, 0, 0, 220, 117, 60, 173, 0, 0, 0, 0, 198, 4, 217, 167, 24, 242, 0, 0, 0, 0, 0, 40, 194, 147, 0, 0, 0, 0, 112, 32, 132, 226, 0, 0, 0, 0, 183, 89, 242, 238, 0, 0, 0, 0, 198, 4, 154, 68, 110, 140, 0, 0, 0, 0, 82, 200, 216, 86, 0, 0, 0, 0, 59, 93, 145, 30, 0, 0, 0, 0, 10, 15, 140, 90, 0, 0, 0, 0, 198, 4, 35, 136, 217, 91, 0, 0, 0, 0, 179, 137, 156, 33, 0, 0, 0, 0, 89, 202, 66, 156, 0, 0, 0, 0, 116, 237, 86, 159, 0, 0, 0, 0, 198, 4, 177, 223, 252, 13, 0, 0, 0, 0, 58, 189, 79, 15, 0, 0, 0, 0, 5, 140, 28, 3, 0, 0, 0, 0, 189, 109, 49, 157, 0, 0, 0, 0, 198, 4, 106, 105, 154, 160, 0, 0, 0, 0, 221, 178, 109, 152, 0, 0, 0, 0, 190, 187, 2, 187, 0, 0, 0, 0, 151, 1, 237, 73, 0, 0, 0, 0, 198, 4, 210, 10, 34, 236, 0, 0, 0, 0, 125, 172, 197, 228, 0, 0, 0, 0, 31, 121, 10, 177, 0, 0, 0, 0, 48, 237, 215, 32, 0, 0, 0, 0, 198, 4, 200, 45, 73, 144, 0, 0, 0, 0, 102, 142, 177, 148, 0, 0, 0, 0, 80, 25, 54, 43, 0, 0, 0, 0, 113, 11, 123, 99, 0, 0, 0, 0, 198, 4, 36, 217, 17, 100, 0, 0, 0, 0, 228, 47, 221, 48, 0, 0, 0, 0, 157, 124, 218, 54, 0, 0, 0, 0, 80, 84, 132, 208, 0, 0, 0, 0, 198, 4, 82, 90, 23, 204, 0, 0, 0, 0, 189, 200, 58, 243, 0, 0, 0, 0, 253, 133, 212, 178, 0, 0, 0, 0, 140, 148, 62, 213, 0, 0, 0, 0, 198, 4, 215, 110, 13, 22, 0, 0, 0, 0, 56, 88, 57, 199, 0, 0, 0, 0, 234, 171, 240, 149, 0, 0, 0, 0, 16, 143, 164, 83, 0, 0, 0, 0, 198, 4, 2, 148, 174, 9, 0, 0, 0, 0, 163, 52, 60, 165, 0, 0, 0, 0, 44, 105, 9, 77, 0, 0, 0, 0, 64, 163, 137, 8, 0, 0, 0, 0, 198, 4, 95, 73, 82, 99, 0, 0, 0, 0, 138, 138, 176, 110, 0, 0, 0, 0, 213, 253, 252, 114, 0, 0, 0, 0, 79, 173, 74, 209, 0, 0, 0, 0, 198, 4, 106, 250, 179, 60, 0, 0, 0, 0, 47, 133, 250, 255, 0, 0, 0, 0, 53, 41, 203, 173, 0, 0, 0, 0, 67, 54, 34, 22, 0, 0, 0, 0, 198, 4, 158, 49, 31, 24, 0, 0, 0, 0, 191, 17, 170, 251, 0, 0, 0, 0, 64, 50, 233, 132, 0, 0, 0, 0, 131, 35, 23, 126, 0, 0, 0, 0, 198, 4, 1, 170, 114, 68, 0, 0, 0, 0, 70, 132, 0, 117, 0, 0, 0, 0, 207, 6, 74, 188, 0, 0, 0, 0, 101, 168, 31, 198, 0, 0, 0, 0, 198, 4, 39, 6, 165, 46, 0, 0, 0, 0, 37, 156, 233, 143, 0, 0, 0, 0, 195, 215, 248, 252, 0, 0, 0, 0, 189, 206, 253, 20, 0, 0, 0, 0, 198, 4, 38, 77, 3, 241, 0, 0, 0, 0, 141, 147, 209, 143, 0, 0, 0, 0, 113, 223, 76, 45, 0, 0, 0, 0, 222, 123, 134, 156, 0, 0, 0, 0, 198, 4, 139, 29, 215, 171, 0, 0, 0, 0, 175, 182, 191, 183, 0, 0, 0, 0, 62, 240, 63, 53, 0, 0, 0, 0, 60, 254, 229, 115, 0, 0, 0, 0, 198, 4, 166, 199, 172, 200, 0, 0, 0, 0, 219, 225, 150, 23, 0, 0, 0, 0, 177, 248, 223, 56, 0, 0, 0, 0, 175, 135, 162, 237, 0, 0, 0, 0, 198, 4, 136, 210, 40, 247, 0, 0, 0, 0, 103, 147, 34, 19, 0, 0, 0, 0, 144, 34, 69, 209, 0, 0, 0, 0, 102, 227, 57, 76, 0, 0, 0, 0, 198, 4, 54, 119, 81, 57, 0, 0, 0, 0, 253, 185, 22, 3, 0, 0, 0, 0, 66, 30, 71, 8, 0, 0, 0, 0, 20, 139, 75, 23, 0, 0, 0, 0, 198, 4, 149, 250, 174, 192, 0, 0, 0, 0, 50, 69, 33, 52, 0, 0, 0, 0, 65, 25, 236, 115, 0, 0, 0, 0, 159, 107, 125, 155, 0, 0, 0, 0, 198, 4, 209, 133, 25, 10, 0, 0, 0, 0, 11, 227, 204, 232, 0, 0, 0, 0, 233, 50, 174, 157, 0, 0, 0, 0, 244, 172, 155, 180, 0, 0, 0, 0, 198, 4, 159, 147, 222, 163, 0, 0, 0, 0, 4, 168, 84, 28, 0, 0, 0, 0, 150, 252, 74, 117, 0, 0, 0, 0, 147, 206, 200, 235, 0, 0, 0, 0, 198, 4, 29, 135, 243, 125, 0, 0, 0, 0, 81, 201, 115, 218, 0, 0, 0, 0, 48, 241, 174, 225, 0, 0, 0, 0, 186, 10, 251, 136, 0, 0, 0, 0, 198, 4, 121, 228, 97, 153, 0, 0, 0, 0, 232, 83, 210, 215, 0, 0, 0, 0, 117, 54, 184, 191, 0, 0, 0, 0, 124, 221, 201, 109, 0, 0, 0, 0, 198, 4, 81, 53, 84, 250, 0, 0, 0, 0, 29, 99, 211, 77, 0, 0, 0, 0, 25, 187, 155, 156, 0, 0, 0, 0, 6, 3, 149, 106, 0, 0, 0, 0, 198, 4, 96, 32, 198, 67, 0, 0, 0, 0, 193, 33, 196, 204, 0, 0, 0, 0, 98, 25, 206, 206, 0, 0, 0, 0, 210, 170, 11, 240, 0, 0, 0, 0, 198, 4, 25, 64, 113, 222, 0, 0, 0, 0, 110, 54, 124, 138, 0, 0, 0, 0, 254, 81, 207, 157, 0, 0, 0, 0, 251, 39, 48, 220, 0, 0, 0, 0, 198, 4, 163, 150, 81, 94, 0, 0, 0, 0, 96, 209, 98, 75, 0, 0, 0, 0, 222, 230, 89, 175, 0, 0, 0, 0, 49, 60, 202, 210, 0, 0, 0, 0, 198, 4, 222, 42, 199, 152, 0, 0, 0, 0, 99, 64, 25, 67, 0, 0, 0, 0, 204, 72, 164, 30, 0, 0, 0, 0, 5, 70, 4, 67, 0, 0, 0, 0, 198, 4, 199, 43, 70, 107, 0, 0, 0, 0, 53, 248, 128, 183, 0, 0, 0, 0, 164, 116, 85, 15, 0, 0, 0, 0, 221, 52, 63, 224, 0, 0, 0, 0, 198, 4, 195, 98, 29, 221, 0, 0, 0, 0, 36, 218, 198, 32, 0, 0, 0, 0, 203, 44, 165, 133, 0, 0, 0, 0, 39, 44, 225, 222, 0, 0, 0, 0, 198, 4, 62, 217, 186, 26, 0, 0, 0, 0, 66, 218, 177, 205, 0, 0, 0, 0, 54, 228, 131, 32, 0, 0, 0, 0, 132, 73, 155, 71, 0, 0, 0, 0, 198, 4, 252, 100, 157, 216, 0, 0, 0, 0, 253, 73, 42, 190, 0, 0, 0, 0, 59, 127, 147, 52, 0, 0, 0, 0, 175, 49, 119, 234, 0, 0, 0, 0, 198, 4, 238, 5, 116, 80, 0, 0, 0, 0, 20, 254, 75, 192, 0, 0, 0, 0, 148, 178, 82, 108, 0, 0, 0, 0, 179, 89, 114, 252, 0, 0, 0, 0, 198, 4, 48, 41, 137, 80, 0, 0, 0, 0, 240, 83, 39, 250, 0, 0, 0, 0, 126, 42, 134, 253, 0, 0, 0, 0, 127, 183, 49, 41, 0, 0, 0, 0, 198, 4, 234, 247, 162, 163, 0, 0, 0, 0, 236, 247, 1, 47, 0, 0, 0, 0, 189, 129, 217, 252, 0, 0, 0, 0, 2, 189, 54, 97, 0, 0, 0, 0, 198, 4, 224, 137, 168, 159, 0, 0, 0, 0, 225, 251, 203, 182, 0, 0, 0, 0, 51, 244, 10, 196, 0, 0, 0, 0, 177, 29, 102, 74, 0, 0, 0, 0, 198, 4, 102, 240, 58, 217, 0, 0, 0, 0, 33, 207, 126, 222, 0, 0, 0, 0, 140, 236, 126, 140, 0, 0, 0, 0, 47, 1, 80, 40, 0, 0, 0, 0, 198, 4, 235, 57, 52, 114, 0, 0, 0, 0, 189, 116, 153, 220, 0, 0, 0, 0, 47, 72, 167, 78, 0, 0, 0, 0, 22, 0, 175, 34, 0, 0, 0, 0, 198, 4, 108, 37, 27, 183, 0, 0, 0, 0, 91, 82, 98, 187, 0, 0, 0, 0, 50, 9, 68, 79, 0, 0, 0, 0, 5, 174, 84, 160, 0, 0, 0, 0, 198, 4, 237, 237, 154, 96, 0, 0, 0, 0, 197, 88, 162, 57, 0, 0, 0, 0, 194, 116, 112, 193, 0, 0, 0, 0, 189, 104, 108, 112, 0, 0, 0, 0, 198, 4, 22, 109, 146, 181, 0, 0, 0, 0, 30, 54, 96, 21, 0, 0, 0, 0, 66, 215, 61, 228, 0, 0, 0, 0, 150, 187, 195, 27, 0, 0, 0, 0, 198, 4, 118, 50, 74, 56, 0, 0, 0, 0, 130, 47, 121, 154, 0, 0, 0, 0, 63, 152, 67, 149, 0, 0, 0, 0, 66, 98, 204, 33, 0, 0, 0, 0, 198, 4, 150, 8, 212, 233, 0, 0, 0, 0, 195, 94, 124, 6, 0, 0, 0, 0, 200, 168, 43, 225, 0, 0, 0, 0, 112, 79, 131, 88, 0, 0, 0, 0, 198, 4, 101, 12, 147, 161, 0, 0, 0, 0, 89, 151, 82, 96, 0, 0, 0, 0, 176, 220, 153, 32, 0, 0, 0, 0, 133, 215, 3, 193, 0, 0, 0, 0, 198, 4, 253, 249, 244, 151, 0, 0, 0, 0, 195, 246, 185, 244, 0, 0, 0, 0, 212, 8, 51, 207, 0, 0, 0, 0, 159, 79, 133, 177, 0, 0, 0, 0, 198, 4, 128, 147, 64, 168, 0, 0, 0, 0, 66, 177, 196, 55, 0, 0, 0, 0, 41, 131, 223, 85, 0, 0, 0, 0, 225, 203, 70, 30, 0, 0, 0, 0, 198, 4, 210, 115, 92, 181, 0, 0, 0, 0, 106, 224, 245, 169, 0, 0, 0, 0, 220, 193, 91, 46, 0, 0, 0, 0, 179, 161, 156, 251, 0, 0, 0, 0, 198, 4, 139, 185, 31, 179, 0, 0, 0, 0, 21, 251, 95, 20, 0, 0, 0, 0, 219, 28, 100, 222, 0, 0, 0, 0, 214, 250, 26, 9, 0, 0, 0, 0, 198, 4, 230, 181, 56, 219, 0, 0, 0, 0, 36, 199, 87, 95, 0, 0, 0, 0, 184, 211, 172, 128, 0, 0, 0, 0, 127, 192, 228, 62, 0, 0, 0, 0, 198, 4, 111, 142, 110, 186, 0, 0, 0, 0, 71, 229, 106, 180, 0, 0, 0, 0, 146, 179, 203, 117, 0, 0, 0, 0, 244, 90, 212, 92, 0, 0, 0, 0, 198, 4, 198, 224, 194, 60, 0, 0, 0, 0, 35, 245, 63, 66, 0, 0, 0, 0, 22, 69, 11, 32, 0, 0, 0, 0, 102, 64, 66, 227, 0, 0, 0, 0, 198, 4, 255, 227, 45, 136, 0, 0, 0, 0, 64, 178, 132, 107, 0, 0, 0, 0, 171, 203, 84, 211, 0, 0, 0, 0, 131, 231, 71, 81, 0, 0, 0, 0, 198, 4, 79, 95, 10, 115, 0, 0, 0, 0, 98, 97, 218, 236, 0, 0, 0, 0, 202, 53, 44, 185, 0, 0, 0, 0, 121, 29, 46, 237, 0, 0, 0, 0, 198, 4, 160, 176, 138, 104, 0, 0, 0, 0, 248, 152, 249, 206, 0, 0, 0, 0, 223, 94, 212, 187, 0, 0, 0, 0, 224, 74, 111, 201, 0, 0, 0, 0, 198, 4, 194, 147, 219, 90, 0, 0, 0, 0, 171, 221, 141, 209, 0, 0, 0, 0, 163, 47, 239, 232, 0, 0, 0, 0, 220, 128, 68, 98, 0, 0, 0, 0, 198, 4, 2, 179, 68, 57, 0, 0, 0, 0, 1, 226, 118, 41, 0, 0, 0, 0, 214, 228, 13, 214, 0, 0, 0, 0, 23, 116, 140, 39, 0, 0, 0, 0, 198, 4, 155, 216, 213, 118, 0, 0, 0, 0, 75, 201, 78, 31, 0, 0, 0, 0, 22, 93, 93, 50, 0, 0, 0, 0, 13, 160, 251, 232, 0, 0, 0, 0, 198, 4, 240, 242, 29, 161, 0, 0, 0, 0, 111, 122, 13, 158, 0, 0, 0, 0, 147, 129, 227, 53, 0, 0, 0, 0, 105, 63, 87, 37, 0, 0, 0, 0, 198, 4, 75, 181, 11, 210, 0, 0, 0, 0, 14, 123, 90, 19, 0, 0, 0, 0, 239, 152, 194, 208, 0, 0, 0, 0, 64, 203, 117, 67, 0, 0, 0, 0, 198, 4, 162, 149, 79, 226, 0, 0, 0, 0, 8, 45, 213, 184, 0, 0, 0, 0, 144, 240, 225, 97, 0, 0, 0, 0, 182, 109, 137, 238, 0, 0, 0, 0, 198, 4, 160, 28, 248, 82, 0, 0, 0, 0, 151, 242, 248, 24, 0, 0, 0, 0, 36, 209, 211, 67, 0, 0, 0, 0, 106, 241, 14, 102, 0, 0, 0, 0, 198, 4, 127, 32, 220, 134, 0, 0, 0, 0, 46, 111, 99, 253, 0, 0, 0, 0, 151, 75, 238, 103, 0, 0, 0, 0, 81, 117, 194, 51, 0, 0, 0, 0, 198, 4, 208, 219, 139, 91, 0, 0, 0, 0, 117, 86, 173, 198, 0, 0, 0, 0, 207, 129, 205, 121, 0, 0, 0, 0, 120, 76, 153, 178, 0, 0, 0, 0, 198, 4, 211, 88, 66, 137, 0, 0, 0, 0, 113, 150, 74, 55, 0, 0, 0, 0, 54, 249, 13, 201, 0, 0, 0, 0, 102, 173, 53, 14, 0, 0, 0, 0, 198, 4, 74, 121, 164, 70, 0, 0, 0, 0, 232, 101, 2, 202, 0, 0, 0, 0, 249, 24, 167, 146, 0, 0, 0, 0, 20, 184, 215, 149, 0, 0, 0, 0, 198, 4, 198, 156, 103, 166, 0, 0, 0, 0, 10, 117, 75, 50, 0, 0, 0, 0, 203, 184, 222, 110, 0, 0, 0, 0, 247, 149, 65, 153, 0, 0, 0, 0, 198, 4, 201, 254, 128, 224, 0, 0, 0, 0, 44, 118, 70, 27, 0, 0, 0, 0, 22, 156, 152, 106, 0, 0, 0, 0, 46, 50, 1, 248, 0, 0, 0, 0, 198, 4, 85, 232, 55, 200, 0, 0, 0, 0, 77, 222, 69, 179, 0, 0, 0, 0, 128, 211, 214, 188, 0, 0, 0, 0, 1, 107, 113, 255, 0, 0, 0, 0, 198, 4, 83, 29, 171, 44, 0, 0, 0, 0, 233, 116, 73, 233, 0, 0, 0, 0, 18, 102, 23, 54, 0, 0, 0, 0, 218, 23, 33, 226, 0, 0, 0, 0, 198, 4, 249, 228, 8, 112, 0, 0, 0, 0, 236, 124, 194, 56, 0, 0, 0, 0, 250, 124, 98, 165, 0, 0, 0, 0, 134, 32, 246, 197, 0, 0, 0, 0, 198, 4, 218, 111, 76, 21, 0, 0, 0, 0, 218, 2, 2, 166, 0, 0, 0, 0, 27, 155, 37, 36, 0, 0, 0, 0, 99, 107, 209, 161, 0, 0, 0, 0, 198, 4, 70, 235, 60, 113, 0, 0, 0, 0, 61, 148, 6, 34, 0, 0, 0, 0, 131, 130, 172, 132, 0, 0, 0, 0, 190, 233, 174, 62, 0, 0, 0, 0, 198, 4, 229, 103, 32, 244, 0, 0, 0, 0, 18, 255, 98, 91, 0, 0, 0, 0, 224, 27, 170, 149, 0, 0, 0, 0, 103, 185, 152, 101, 0, 0, 0, 0, 198, 4, 74, 115, 121, 30, 0, 0, 0, 0, 113, 46, 71, 189, 0, 0, 0, 0, 121, 84, 134, 3, 0, 0, 0, 0, 190, 31, 192, 76, 0, 0, 0, 0, 198, 4, 35, 230, 89, 46, 0, 0, 0, 0, 164, 4, 128, 89, 0, 0, 0, 0, 103, 68, 64, 229, 0, 0, 0, 0, 52, 102, 11, 91, 0, 0, 0, 0, 198, 4, 189, 63, 235, 243, 0, 0, 0, 0, 68, 87, 138, 17, 0, 0, 0, 0, 3, 66, 236, 128, 0, 0, 0, 0, 109, 252, 172, 28, 0, 0, 0, 0, 198, 4, 126, 138, 61, 164, 0, 0, 0, 0, 89, 182, 203, 209, 0, 0, 0, 0, 166, 246, 206, 54, 0, 0, 0, 0, 92, 52, 227, 157, 0, 0, 0, 0, 198, 4, 47, 214, 176, 234, 0, 0, 0, 0, 151, 223, 157, 246, 0, 0, 0, 0, 69, 177, 33, 59, 0, 0, 0, 0, 36, 75, 91, 190, 0, 0, 0, 0, 198, 4, 104, 99, 69, 173, 0, 0, 0, 0, 97, 230, 191, 208, 0, 0, 0, 0, 0, 187, 246, 38, 0, 0, 0, 0, 115, 219, 109, 55, 0, 0, 0, 0, 198, 4, 88, 211, 188, 17, 0, 0, 0, 0, 0, 181, 90, 47, 0, 0, 0, 0, 4, 54, 63, 215, 0, 0, 0, 0, 31, 177, 154, 242, 0, 0, 0, 0, 198, 4, 179, 150, 195, 176, 0, 0, 0, 0, 23, 40, 71, 243, 0, 0, 0, 0, 195, 23, 233, 2, 0, 0, 0, 0, 227, 72, 76, 239, 0, 0, 0, 0, 198, 4, 121, 145, 129, 81, 0, 0, 0, 0, 143, 92, 231, 152, 0, 0, 0, 0, 139, 90, 40, 187, 0, 0, 0, 0, 111, 160, 45, 69, 0, 0, 0, 0, 198, 4, 139, 51, 134, 246, 0, 0, 0, 0, 200, 0, 42, 155, 0, 0, 0, 0, 151, 120, 20, 63, 0, 0, 0, 0, 141, 27, 145, 112, 0, 0, 0, 0, 198, 4, 186, 255, 191, 119, 0, 0, 0, 0, 244, 62, 144, 139, 0, 0, 0, 0, 55, 164, 235, 149, 0, 0, 0, 0, 51, 67, 131, 170, 0, 0, 0, 0, 198, 4, 233, 180, 117, 43, 0, 0, 0, 0, 110, 89, 118, 129, 0, 0, 0, 0, 230, 96, 139, 6, 0, 0, 0, 0, 42, 49, 67, 30, 0, 0, 0, 0, 198, 4, 44, 129, 181, 17, 0, 0, 0, 0, 65, 71, 81, 187, 0, 0, 0, 0, 183, 40, 226, 95, 0, 0, 0, 0, 9, 138, 101, 153, 0, 0, 0, 0, 198, 4, 225, 194, 196, 81, 0, 0, 0, 0, 232, 209, 207, 160, 0, 0, 0, 0, 219, 111, 116, 75, 0, 0, 0, 0, 45, 155, 33, 73, 0, 0, 0, 0, 198, 4, 111, 83, 92, 93, 0, 0, 0, 0, 208, 33, 30, 200, 0, 0, 0, 0, 38, 30, 111, 135, 0, 0, 0, 0, 245, 217, 236, 46, 0, 0, 0, 0, 198, 4, 23, 91, 250, 125, 0, 0, 0, 0, 87, 60, 206, 134, 0, 0, 0, 0, 238, 164, 98, 236, 0, 0, 0, 0, 212, 114, 27, 2, 0, 0, 0, 0, 198, 4, 226, 98, 22, 91, 0, 0, 0, 0, 96, 96, 84, 160, 0, 0, 0, 0, 163, 246, 31, 83, 0, 0, 0, 0, 163, 180, 173, 135, 0, 0, 0, 0, 198, 4, 54, 96, 254, 54, 0, 0, 0, 0, 77, 60, 70, 198, 0, 0, 0, 0, 105, 251, 75, 247, 0, 0, 0, 0, 165, 11, 91, 60, 0, 0, 0, 0, 198, 4, 230, 37, 107, 62, 0, 0, 0, 0, 196, 154, 168, 31, 0, 0, 0, 0, 209, 115, 208, 166, 0, 0, 0, 0, 99, 32, 143, 110, 0, 0, 0, 0, 198, 4, 135, 218, 90, 65, 0, 0, 0, 0, 255, 78, 85, 6, 0, 0, 0, 0, 50, 27, 245, 209, 0, 0, 0, 0, 62, 216, 143, 249, 0, 0, 0, 0, 198, 4, 183, 148, 72, 71, 0, 0, 0, 0, 177, 124, 159, 39, 0, 0, 0, 0, 25, 141, 173, 127, 0, 0, 0, 0, 81, 131, 1, 75, 0, 0, 0, 0, 198, 4, 33, 56, 169, 4, 0, 0, 0, 0, 39, 161, 82, 165, 0, 0, 0, 0, 56, 18, 63, 17, 0, 0, 0, 0, 205, 37, 219, 240, 0, 0, 0, 0, 198, 4, 89, 228, 146, 2, 0, 0, 0, 0, 43, 29, 154, 254, 0, 0, 0, 0, 129, 130, 86, 178, 0, 0, 0, 0, 232, 241, 2, 32, 0, 0, 0, 0, 198, 4, 112, 243, 55, 179, 0, 0, 0, 0, 138, 67, 211, 233, 0, 0, 0, 0, 48, 49, 170, 118, 0, 0, 0, 0, 193, 143, 189, 128, 0, 0, 0, 0, 198, 4, 184, 247, 242, 196, 0, 0, 0, 0, 60, 246, 64, 151, 0, 0, 0, 0, 138, 97, 94, 209, 0, 0, 0, 0, 125, 43, 187, 126, 0, 0, 0, 0, 198, 4, 145, 25, 214, 146, 0, 0, 0, 0, 47, 224, 179, 44, 0, 0, 0, 0, 193, 85, 152, 99, 0, 0, 0, 0, 84, 217, 116, 17, 0, 0, 0, 0, 198, 4, 79, 9, 161, 135, 0, 0, 0, 0, 112, 41, 38, 169, 0, 0, 0, 0, 156, 242, 179, 98, 0, 0, 0, 0, 179, 120, 60, 229, 0, 0, 0, 0, 198, 4, 42, 175, 166, 89, 0, 0, 0, 0, 8, 44, 169, 167, 0, 0, 0, 0, 251, 107, 96, 64, 0, 0, 0, 0, 91, 108, 90, 7, 0, 0, 0, 0, 198, 4, 136, 22, 140, 166, 0, 0, 0, 0, 128, 31, 207, 31, 0, 0, 0, 0, 235, 48, 101, 45, 0, 0, 0, 0, 236, 2, 147, 76, 0, 0, 0, 0, 198, 4, 202, 52, 223, 215, 0, 0, 0, 0, 67, 153, 170, 174, 0, 0, 0, 0, 186, 65, 190, 131, 0, 0, 0, 0, 71, 120, 123, 208, 0, 0, 0, 0, 198, 4, 178, 217, 59, 183, 0, 0, 0, 0, 245, 41, 139, 123, 0, 0, 0, 0, 139, 233, 201, 94, 0, 0, 0, 0, 190, 227, 16, 139, 0, 0, 0, 0, 198, 4, 76, 64, 106, 16, 0, 0, 0, 0, 40, 33, 76, 151, 0, 0, 0, 0, 231, 188, 252, 170, 0, 0, 0, 0, 175, 55, 40, 228, 0, 0, 0, 0, 198, 4, 171, 0, 213, 9, 0, 0, 0, 0, 116, 110, 204, 4, 0, 0, 0, 0, 197, 172, 11, 27, 0, 0, 0, 0, 65, 109, 55, 86, 0, 0, 0, 0, 198, 4, 212, 31, 153, 168, 0, 0, 0, 0, 118, 1, 119, 26, 0, 0, 0, 0, 127, 247, 192, 68, 0, 0, 0, 0, 177, 47, 57, 84, 0, 0, 0, 0, 198, 4, 206, 57, 123, 44, 0, 0, 0, 0, 211, 223, 34, 152, 0, 0, 0, 0, 178, 28, 140, 23, 0, 0, 0, 0, 217, 196, 140, 155, 0, 0, 0, 0, 198, 4, 71, 72, 98, 57, 0, 0, 0, 0, 20, 180, 96, 39, 0, 0, 0, 0, 133, 185, 240, 160, 0, 0, 0, 0, 252, 96, 161, 161, 0, 0, 0, 0, 198, 4, 38, 185, 151, 143, 0, 0, 0, 0, 185, 193, 93, 144, 0, 0, 0, 0, 160, 246, 230, 74, 0, 0, 0, 0, 122, 8, 134, 90, 0, 0, 0, 0, 198, 4, 131, 78, 159, 126, 0, 0, 0, 0, 27, 14, 237, 20, 0, 0, 0, 0, 172, 148, 133, 218, 0, 0, 0, 0, 181, 79, 14, 137, 0, 0, 0, 0, 198, 4, 98, 219, 26, 234, 0, 0, 0, 0, 146, 64, 67, 174, 0, 0, 0, 0, 208, 2, 106, 132, 0, 0, 0, 0, 170, 67, 29, 49, 0, 0, 0, 0, 198, 4, 71, 75, 16, 240, 0, 0, 0, 0, 60, 3, 143, 226, 0, 0, 0, 0, 244, 121, 195, 105, 0, 0, 0, 0, 244, 67, 207, 9, 0, 0, 0, 0, 198, 4, 86, 233, 64, 189, 0, 0, 0, 0, 51, 226, 54, 222, 0, 0, 0, 0, 212, 126, 59, 118, 0, 0, 0, 0, 63, 63, 73, 21, 0, 0, 0, 0, 198, 4, 13, 109, 4, 250, 0, 0, 0, 0, 101, 2, 148, 181, 0, 0, 0, 0, 69, 107, 172, 36, 0, 0, 0, 0, 92, 214, 9, 144, 0, 0, 0, 0, 198, 4, 116, 182, 48, 138, 0, 0, 0, 0, 238, 130, 138, 143, 0, 0, 0, 0, 7, 209, 42, 3, 0, 0, 0, 0, 150, 252, 60, 157, 0, 0, 0, 0, 198, 4, 23, 64, 212, 49, 0, 0, 0, 0, 230, 178, 35, 14, 0, 0, 0, 0, 70, 60, 1, 131, 0, 0, 0, 0, 244, 218, 113, 21, 0, 0, 0, 0, 198, 4, 96, 51, 109, 14, 0, 0, 0, 0, 143, 232, 218, 225, 0, 0, 0, 0, 208, 19, 205, 53, 0, 0, 0, 0, 145, 90, 253, 87, 0, 0, 0, 0, 198, 4, 162, 207, 208, 109, 0, 0, 0, 0, 147, 189, 232, 45, 0, 0, 0, 0, 60, 116, 131, 168, 0, 0, 0, 0, 167, 95, 89, 192, 0, 0, 0, 0, 198, 4, 99, 35, 138, 223, 0, 0, 0, 0, 110, 38, 79, 121, 0, 0, 0, 0, 197, 183, 168, 203, 0, 0, 0, 0, 7, 119, 224, 35, 0, 0, 0, 0, 198, 4, 228, 17, 254, 135, 0, 0, 0, 0, 151, 39, 183, 206, 0, 0, 0, 0, 53, 203, 52, 227, 0, 0, 0, 0, 96, 155, 217, 36, 0, 0, 0, 0, 198, 4, 123, 22, 80, 44, 0, 0, 0, 0, 117, 35, 228, 74, 0, 0, 0, 0, 40, 129, 191, 89, 0, 0, 0, 0, 144, 22, 38, 48, 0, 0, 0, 0, 198, 4, 232, 165, 6, 81, 0, 0, 0, 0, 182, 10, 55, 32, 0, 0, 0, 0, 175, 170, 6, 93, 0, 0, 0, 0, 247, 134, 16, 30, 0, 0, 0, 0, 198, 4, 227, 159, 66, 84, 0, 0, 0, 0, 44, 86, 235, 120, 0, 0, 0, 0, 219, 183, 130, 54, 0, 0, 0, 0, 81, 166, 93, 218, 0, 0, 0, 0, 198, 4, 239, 157, 48, 90, 0, 0, 0, 0, 84, 92, 84, 154, 0, 0, 0, 0, 162, 200, 107, 167, 0, 0, 0, 0, 211, 58, 226, 96, 0, 0, 0, 0, 198, 4, 157, 39, 91, 72, 0, 0, 0, 0, 85, 220, 85, 84, 0, 0, 0, 0, 148, 83, 65, 224, 0, 0, 0, 0, 9, 100, 114, 142, 0, 0, 0, 0, 198, 4, 107, 90, 143, 245, 0, 0, 0, 0, 140, 3, 200, 178, 0, 0, 0, 0, 83, 242, 199, 10, 0, 0, 0, 0, 181, 112, 218, 78, 0, 0, 0, 0, 198, 4, 165, 152, 44, 172, 0, 0, 0, 0, 246, 167, 14, 235, 0, 0, 0, 0, 21, 100, 147, 183, 0, 0, 0, 0, 95, 54, 160, 62, 0, 0, 0, 0, 198, 4, 163, 118, 201, 119, 0, 0, 0, 0, 83, 44, 208, 171, 0, 0, 0, 0, 252, 38, 108, 246, 0, 0, 0, 0, 116, 162, 141, 142, 0, 0, 0, 0, 198, 4, 196, 162, 28, 185, 0, 0, 0, 0, 199, 23, 66, 248, 0, 0, 0, 0, 166, 23, 54, 143, 0, 0, 0, 0, 116, 60, 56, 161, 0, 0, 0, 0, 198, 4, 233, 57, 98, 245, 0, 0, 0, 0, 30, 124, 128, 203, 0, 0, 0, 0, 199, 38, 193, 101, 0, 0, 0, 0, 153, 178, 148, 127, 0, 0, 0, 0, 198, 4, 85, 229, 57, 171, 0, 0, 0, 0, 94, 201, 253, 64, 0, 0, 0, 0, 34, 139, 217, 246, 0, 0, 0, 0, 165, 42, 222, 65, 0, 0, 0, 0, 198, 4, 173, 78, 25, 175, 0, 0, 0, 0, 75, 250, 111, 91, 0, 0, 0, 0, 32, 114, 35, 55, 0, 0, 0, 0, 213, 74, 120, 55, 0, 0, 0, 0, 198, 4, 23, 156, 29, 16, 0, 0, 0, 0, 24, 133, 52, 5, 0, 0, 0, 0, 161, 212, 244, 176, 0, 0, 0, 0, 242, 69, 196, 131, 0, 0, 0, 0, 198, 4, 27, 244, 35, 157, 0, 0, 0, 0, 0, 230, 211, 111, 0, 0, 0, 0, 179, 195, 115, 5, 0, 0, 0, 0, 216, 248, 83, 81, 0, 0, 0, 0, 198, 4, 223, 13, 146, 143, 0, 0, 0, 0, 117, 58, 223, 95, 0, 0, 0, 0, 138, 209, 30, 175, 0, 0, 0, 0, 32, 133, 15, 192, 0, 0, 0, 0, 198, 4, 106, 70, 65, 252, 0, 0, 0, 0, 104, 139, 214, 29, 0, 0, 0, 0, 154, 71, 8, 118, 0, 0, 0, 0, 18, 97, 137, 83, 0, 0, 0, 0, 198, 4, 64, 65, 142, 9, 0, 0, 0, 0, 33, 193, 223, 57, 0, 0, 0, 0, 247, 141, 205, 36, 0, 0, 0, 0, 54, 184, 49, 253, 0, 0, 0, 0, 198, 4, 167, 145, 27, 160, 0, 0, 0, 0, 161, 27, 22, 41, 0, 0, 0, 0, 94, 198, 39, 129, 0, 0, 0, 0, 106, 253, 186, 109, 0, 0, 0, 0, 198, 4, 186, 93, 207, 201, 0, 0, 0, 0, 59, 158, 134, 198, 0, 0, 0, 0, 147, 188, 121, 242, 0, 0, 0, 0, 170, 144, 153, 70, 0, 0, 0, 0, 198, 4, 217, 184, 9, 66, 0, 0, 0, 0, 247, 53, 247, 81, 0, 0, 0, 0, 218, 172, 127, 106, 0, 0, 0, 0, 210, 175, 78, 237, 0, 0, 0, 0, 198, 4, 80, 136, 119, 233, 0, 0, 0, 0, 228, 65, 117, 111, 0, 0, 0, 0, 182, 81, 114, 230, 0, 0, 0, 0, 102, 220, 159, 90, 0, 0, 0, 0, 198, 4, 35, 65, 198, 46, 0, 0, 0, 0, 27, 37, 179, 29, 0, 0, 0, 0, 175, 125, 229, 21, 0, 0, 0, 0, 184, 88, 228, 18, 0, 0, 0, 0, 198, 4, 186, 190, 141, 234, 0, 0, 0, 0, 51, 148, 49, 94, 0, 0, 0, 0, 206, 26, 38, 134, 0, 0, 0, 0, 173, 95, 218, 125, 0, 0, 0, 0, 198, 4, 182, 108, 72, 42, 0, 0, 0, 0, 89, 115, 229, 101, 0, 0, 0, 0, 174, 132, 145, 156, 0, 0, 0, 0, 150, 121, 176, 139, 0, 0, 0, 0, 198, 4, 74, 206, 162, 139, 0, 0, 0, 0, 124, 90, 7, 163, 0, 0, 0, 0, 206, 48, 73, 138, 0, 0, 0, 0, 205, 176, 83, 50, 0, 0, 0, 0, 198, 4, 146, 173, 29, 39, 0, 0, 0, 0, 216, 58, 128, 80, 0, 0, 0, 0, 29, 194, 12, 236, 0, 0, 0, 0, 101, 153, 36, 29, 0, 0, 0, 0, 198, 4, 21, 19, 119, 169, 0, 0, 0, 0, 64, 65, 253, 175, 0, 0, 0, 0, 82, 248, 49, 115, 0, 0, 0, 0, 169, 245, 32, 183, 0, 0, 0, 0, 198, 4, 108, 6, 56, 7, 0, 0, 0, 0, 35, 130, 136, 23, 0, 0, 0, 0, 187, 224, 103, 82, 0, 0, 0, 0, 191, 220, 65, 15, 0, 0, 0, 0, 198, 4, 86, 224, 231, 69, 0, 0, 0, 0, 46, 167, 42, 175, 0, 0, 0, 0, 75, 197, 221, 49, 0, 0, 0, 0, 27, 27, 18, 125, 0, 0, 0, 0, 198, 4, 185, 98, 204, 192, 0, 0, 0, 0, 33, 123, 246, 225, 0, 0, 0, 0, 189, 146, 236, 210, 0, 0, 0, 0, 185, 155, 28, 10, 0, 0, 0, 0, 198, 4, 203, 247, 104, 62, 0, 0, 0, 0, 153, 137, 56, 196, 0, 0, 0, 0, 125, 226, 34, 245, 0, 0, 0, 0, 198, 131, 158, 179, 0, 0, 0, 0, 198, 4, 122, 70, 137, 233, 0, 0, 0, 0, 11, 200, 80, 0, 0, 0, 0, 0, 105, 168, 213, 79, 0, 0, 0, 0, 60, 187, 191, 161, 0, 0, 0, 0, 198, 4, 62, 81, 2, 30, 0, 0, 0, 0, 194, 40, 39, 163, 0, 0, 0, 0, 116, 191, 116, 61, 0, 0, 0, 0, 137, 52, 173, 88, 0, 0, 0, 0, 198, 4, 218, 178, 37, 238, 0, 0, 0, 0, 100, 36, 242, 63, 0, 0, 0, 0, 199, 27, 221, 94, 0, 0, 0, 0, 236, 108, 165, 10, 0, 0, 0, 0, 198, 4, 107, 21, 187, 223, 0, 0, 0, 0, 161, 84, 203, 160, 0, 0, 0, 0, 1, 86, 127, 81, 0, 0, 0, 0, 182, 193, 234, 162, 0, 0, 0, 0, 198, 4, 73, 103, 112, 26, 0, 0, 0, 0, 238, 172, 210, 149, 0, 0, 0, 0, 95, 63, 234, 26, 0, 0, 0, 0, 196, 30, 250, 107, 0, 0, 0, 0, 198, 4, 189, 29, 219, 54, 0, 0, 0, 0, 129, 243, 140, 64, 0, 0, 0, 0, 80, 97, 127, 59, 0, 0, 0, 0, 75, 128, 147, 188, 0, 0, 0, 0, 198, 4, 235, 184, 8, 69, 0, 0, 0, 0, 52, 142, 121, 226, 0, 0, 0, 0, 241, 191, 177, 229, 0, 0, 0, 0, 249, 55, 178, 49, 0, 0, 0, 0, 198, 4, 53, 242, 59, 189, 0, 0, 0, 0, 137, 55, 20, 59, 0, 0, 0, 0, 66, 44, 73, 161, 0, 0, 0, 0, 1, 15, 134, 22, 0, 0, 0, 0, 198, 4, 136, 227, 143, 81, 0, 0, 0, 0, 137, 67, 185, 138, 0, 0, 0, 0, 113, 93, 78, 4, 0, 0, 0, 0, 0, 95, 96, 101, 0, 0, 0, 0, 198, 4, 36, 3, 249, 196, 0, 0, 0, 0, 96, 200, 180, 99, 0, 0, 0, 0, 132, 74, 42, 198, 0, 0, 0, 0, 145, 192, 47, 92, 0, 0, 0, 0, 198, 4, 252, 3, 230, 40, 0, 0, 0, 0, 130, 201, 92, 124, 0, 0, 0, 0, 247, 171, 184, 160, 0, 0, 0, 0, 137, 152, 36, 219, 0, 0, 0, 0, 198, 4, 218, 74, 214, 176, 0, 0, 0, 0, 99, 217, 43, 140, 0, 0, 0, 0, 22, 200, 70, 66, 0, 0, 0, 0, 79, 91, 213, 184, 0, 0, 0, 0, 198, 4, 243, 215, 194, 73, 0, 0, 0, 0, 59, 196, 68, 254, 0, 0, 0, 0, 225, 22, 138, 124, 0, 0, 0, 0, 43, 31, 245, 234, 0, 0, 0, 0, 198, 4, 72, 222, 145, 12, 0, 0, 0, 0, 95, 123, 148, 209, 0, 0, 0, 0, 18, 95, 216, 110, 0, 0, 0, 0, 242, 162, 78, 53, 0, 0, 0, 0, 198, 4, 94, 220, 150, 65, 0, 0, 0, 0, 1, 254, 61, 78, 0, 0, 0, 0, 4, 71, 166, 3, 0, 0, 0, 0, 86, 60, 45, 225, 0, 0, 0, 0, 198, 4, 173, 53, 152, 206, 0, 0, 0, 0, 117, 233, 127, 128, 0, 0, 0, 0, 20, 63, 60, 25, 0, 0, 0, 0, 85, 177, 167, 213, 0, 0, 0, 0, 198, 4, 82, 213, 226, 197, 0, 0, 0, 0, 15, 171, 181, 59, 0, 0, 0, 0, 115, 243, 226, 56, 0, 0, 0, 0, 93, 92, 152, 41, 0, 0, 0, 0, 198, 4, 58, 175, 252, 202, 0, 0, 0, 0, 238, 67, 220, 251, 0, 0, 0, 0, 205, 34, 185, 223, 0, 0, 0, 0, 148, 89, 236, 207, 0, 0, 0, 0, 198, 4, 214, 209, 155, 234, 0, 0, 0, 0, 173, 10, 99, 247, 0, 0, 0, 0, 93, 202, 10, 185, 0, 0, 0, 0, 83, 225, 54, 51, 0, 0, 0, 0, 198, 4, 196, 123, 117, 201, 0, 0, 0, 0, 228, 231, 195, 53, 0, 0, 0, 0, 119, 153, 0, 246, 0, 0, 0, 0, 32, 125, 171, 63, 0, 0, 0, 0, 198, 4, 3, 3, 102, 31, 0, 0, 0, 0, 141, 160, 183, 140, 0, 0, 0, 0, 170, 106, 186, 64, 0, 0, 0, 0, 245, 66, 240, 123, 0, 0, 0, 0, 198, 4, 11, 154, 219, 162, 0, 0, 0, 0, 226, 255, 172, 61, 0, 0, 0, 0, 155, 47, 90, 116, 0, 0, 0, 0, 64, 69, 236, 228, 0, 0, 0, 0, 198, 4, 134, 123, 115, 45, 0, 0, 0, 0, 246, 109, 239, 100, 0, 0, 0, 0, 228, 174, 197, 23, 0, 0, 0, 0, 167, 89, 111, 59, 0, 0, 0, 0, 198, 4, 209, 224, 159, 38, 0, 0, 0, 0, 113, 132, 130, 172, 0, 0, 0, 0, 234, 86, 113, 49, 0, 0, 0, 0, 38, 87, 93, 226, 0, 0, 0, 0, 198, 4, 180, 223, 3, 190, 0, 0, 0, 0, 53, 21, 230, 46, 0, 0, 0, 0, 88, 72, 158, 192, 0, 0, 0, 0, 54, 20, 115, 220, 0, 0, 0, 0, 198, 4, 87, 12, 230, 77, 0, 0, 0, 0, 204, 39, 138, 5, 0, 0, 0, 0, 208, 211, 61, 105, 0, 0, 0, 0, 140, 227, 29, 253, 0, 0, 0, 0, 198, 4, 66, 195, 95, 101, 0, 0, 0, 0, 251, 123, 101, 241, 0, 0, 0, 0, 233, 163, 239, 62, 0, 0, 0, 0, 109, 89, 227, 187, 0, 0, 0, 0, 198, 4, 26, 38, 6, 155, 0, 0, 0, 0, 255, 67, 48, 220, 0, 0, 0, 0, 231, 239, 55, 134, 0, 0, 0, 0, 232, 162, 198, 6, 0, 0, 0, 0, 198, 4, 93, 241, 221, 157, 0, 0, 0, 0, 190, 247, 212, 47, 0, 0, 0, 0, 210, 205, 236, 109, 0, 0, 0, 0, 101, 191, 44, 67, 0, 0, 0, 0, 198, 4, 219, 114, 98, 51, 0, 0, 0, 0, 22, 210, 241, 30, 0, 0, 0, 0, 7, 43, 179, 147, 0, 0, 0, 0, 194, 60, 153, 75, 0, 0, 0, 0, 198, 4, 203, 3, 107, 144, 0, 0, 0, 0, 28, 184, 35, 74, 0, 0, 0, 0, 6, 172, 53, 51, 0, 0, 0, 0, 59, 184, 106, 66, 0, 0, 0, 0, 198, 4, 61, 60, 20, 193, 0, 0, 0, 0, 212, 174, 74, 23, 0, 0, 0, 0, 223, 181, 96, 183, 0, 0, 0, 0, 254, 178, 34, 69, 0, 0, 0, 0, 198, 4, 124, 8, 181, 118, 0, 0, 0, 0, 39, 192, 137, 229, 0, 0, 0, 0, 99, 72, 125, 253, 0, 0, 0, 0, 145, 149, 168, 44, 0, 0, 0, 0, 198, 4, 135, 181, 148, 245, 0, 0, 0, 0, 157, 156, 108, 12, 0, 0, 0, 0, 84, 9, 23, 195, 0, 0, 0, 0, 53, 204, 212, 142, 0, 0, 0, 0, 198, 4, 222, 153, 160, 138, 0, 0, 0, 0, 97, 41, 180, 83, 0, 0, 0, 0, 63, 50, 9, 61, 0, 0, 0, 0, 193, 26, 125, 104, 0, 0, 0, 0, 198, 4, 64, 27, 207, 53, 0, 0, 0, 0, 67, 66, 97, 88, 0, 0, 0, 0, 241, 44, 47, 4, 0, 0, 0, 0, 76, 204, 206, 42, 0, 0, 0, 0, 198, 4, 123, 255, 91, 6, 0, 0, 0, 0, 247, 11, 127, 29, 0, 0, 0, 0, 25, 146, 30, 140, 0, 0, 0, 0, 206, 125, 159, 130, 0, 0, 0, 0, 198, 4, 53, 1, 169, 22, 0, 0, 0, 0, 130, 186, 238, 212, 0, 0, 0, 0, 76, 211, 91, 231, 0, 0, 0, 0, 225, 200, 141, 243, 0, 0, 0, 0, 198, 4, 119, 197, 131, 210, 0, 0, 0, 0, 237, 132, 157, 7, 0, 0, 0, 0, 170, 241, 241, 180, 0, 0, 0, 0, 214, 119, 211, 119, 0, 0, 0, 0, 198, 4, 236, 114, 77, 21, 0, 0, 0, 0, 144, 243, 122, 143, 0, 0, 0, 0, 181, 7, 182, 68, 0, 0, 0, 0, 62, 34, 98, 31, 0, 0, 0, 0, 198, 4, 165, 171, 164, 146, 0, 0, 0, 0, 82, 161, 7, 247, 0, 0, 0, 0, 176, 131, 41, 119, 0, 0, 0, 0, 72, 103, 213, 2, 0, 0, 0, 0, 198, 4, 242, 242, 152, 110, 0, 0, 0, 0, 160, 176, 156, 66, 0, 0, 0, 0, 71, 90, 101, 208, 0, 0, 0, 0, 119, 251, 236, 215, 0, 0, 0, 0, 198, 4, 250, 19, 33, 178, 0, 0, 0, 0, 219, 164, 233, 92, 0, 0, 0, 0, 241, 55, 24, 237, 0, 0, 0, 0, 142, 115, 79, 33, 0, 0, 0, 0, 198, 4, 195, 226, 186, 88, 0, 0, 0, 0, 168, 36, 120, 107, 0, 0, 0, 0, 125, 92, 186, 52, 0, 0, 0, 0, 61, 237, 209, 95, 0, 0, 0, 0, 198, 4, 43, 146, 131, 80, 0, 0, 0, 0, 232, 202, 193, 245, 0, 0, 0, 0, 46, 85, 70, 133, 0, 0, 0, 0, 192, 56, 250, 37, 0, 0, 0, 0, 198, 4, 91, 23, 114, 164, 0, 0, 0, 0, 90, 96, 236, 212, 0, 0, 0, 0, 158, 241, 125, 103, 0, 0, 0, 0, 3, 254, 55, 86, 0, 0, 0, 0, 198, 4, 140, 151, 94, 148, 0, 0, 0, 0, 124, 177, 19, 144, 0, 0, 0, 0, 244, 44, 174, 150, 0, 0, 0, 0, 132, 218, 192, 133, 0, 0, 0, 0, 198, 4, 208, 82, 175, 249, 0, 0, 0, 0, 7, 239, 169, 82, 0, 0, 0, 0, 117, 193, 38, 120, 0, 0, 0, 0, 43, 25, 104, 184, 0, 0, 0, 0, 198, 4, 189, 111, 90, 198, 0, 0, 0, 0, 171, 26, 88, 3, 0, 0, 0, 0, 150, 83, 254, 92, 0, 0, 0, 0, 229, 247, 111, 130, 0, 0, 0, 0, 198, 4, 179, 157, 177, 149, 0, 0, 0, 0, 157, 184, 185, 40, 0, 0, 0, 0, 254, 249, 47, 31, 0, 0, 0, 0, 102, 238, 252, 21, 0, 0, 0, 0, 198, 4, 172, 198, 24, 156, 0, 0, 0, 0, 16, 183, 210, 239, 0, 0, 0, 0, 109, 170, 193, 67, 0, 0, 0, 0, 25, 116, 128, 120, 0, 0, 0, 0, 198, 4, 57, 22, 44, 156, 0, 0, 0, 0, 203, 182, 121, 9, 0, 0, 0, 0, 244, 241, 8, 83, 0, 0, 0, 0, 250, 223, 118, 112, 0, 0, 0, 0, 198, 4, 116, 234, 28, 213, 0, 0, 0, 0, 122, 125, 181, 136, 0, 0, 0, 0, 144, 210, 254, 51, 0, 0, 0, 0, 104, 223, 92, 39, 0, 0, 0, 0, 198, 4, 198, 201, 104, 22, 0, 0, 0, 0, 241, 144, 147, 249, 0, 0, 0, 0, 232, 100, 14, 138, 0, 0, 0, 0, 44, 207, 189, 245, 0, 0, 0, 0, 198, 4, 29, 33, 66, 127, 0, 0, 0, 0, 175, 50, 227, 212, 0, 0, 0, 0, 182, 191, 76, 223, 0, 0, 0, 0, 82, 29, 24, 100, 0, 0, 0, 0, 198, 4, 133, 38, 134, 76, 0, 0, 0, 0, 186, 26, 143, 89, 0, 0, 0, 0, 83, 147, 35, 27, 0, 0, 0, 0, 57, 76, 250, 205, 0, 0, 0, 0, 198, 4, 206, 23, 51, 16, 0, 0, 0, 0, 43, 170, 226, 39, 0, 0, 0, 0, 33, 72, 166, 88, 0, 0, 0, 0, 60, 102, 233, 90, 0, 0, 0, 0, 198, 4, 232, 144, 255, 31, 0, 0, 0, 0, 68, 181, 124, 212, 0, 0, 0, 0, 97, 158, 234, 96, 0, 0, 0, 0, 201, 8, 245, 227, 0, 0, 0, 0, 198, 4, 235, 127, 4, 99, 0, 0, 0, 0, 133, 26, 25, 222, 0, 0, 0, 0, 150, 113, 171, 97, 0, 0, 0, 0, 251, 26, 142, 13, 0, 0, 0, 0, 198, 4, 154, 153, 220, 170, 0, 0, 0, 0, 99, 123, 101, 175, 0, 0, 0, 0, 41, 127, 203, 181, 0, 0, 0, 0, 82, 52, 154, 37, 0, 0, 0, 0, 198, 4, 107, 0, 234, 196, 0, 0, 0, 0, 167, 8, 200, 198, 0, 0, 0, 0, 171, 246, 103, 186, 0, 0, 0, 0, 104, 245, 129, 45, 0, 0, 0, 0, 198, 4, 170, 104, 55, 129, 0, 0, 0, 0, 24, 40, 141, 200, 0, 0, 0, 0, 116, 201, 106, 53, 0, 0, 0, 0, 99, 215, 87, 72, 0, 0, 0, 0, 198, 4, 201, 158, 113, 50, 0, 0, 0, 0, 32, 201, 40, 62, 0, 0, 0, 0, 113, 47, 82, 3, 0, 0, 0, 0, 189, 255, 116, 76, 0, 0, 0, 0, 198, 4, 52, 61, 237, 86, 0, 0, 0, 0, 254, 0, 28, 194, 0, 0, 0, 0, 156, 5, 241, 9, 0, 0, 0, 0, 118, 166, 227, 143, 0, 0, 0, 0, 198, 4, 247, 225, 61, 220, 0, 0, 0, 0, 201, 237, 186, 221, 0, 0, 0, 0, 169, 246, 162, 49, 0, 0, 0, 0, 47, 209, 21, 24, 0, 0, 0, 0, 198, 4, 224, 201, 126, 225, 0, 0, 0, 0, 225, 68, 125, 159, 0, 0, 0, 0, 93, 217, 100, 200, 0, 0, 0, 0, 62, 106, 251, 221, 0, 0, 0, 0, 198, 4, 109, 182, 178, 254, 0, 0, 0, 0, 196, 195, 245, 238, 0, 0, 0, 0, 149, 41, 80, 8, 0, 0, 0, 0, 166, 20, 144, 138, 0, 0, 0, 0, 198, 4, 234, 143, 212, 250, 0, 0, 0, 0, 172, 221, 14, 167, 0, 0, 0, 0, 124, 186, 37, 41, 0, 0, 0, 0, 144, 212, 236, 229, 0, 0, 0, 0, 198, 4, 25, 120, 238, 86, 0, 0, 0, 0, 241, 12, 246, 215, 0, 0, 0, 0, 239, 155, 187, 240, 0, 0, 0, 0, 7, 123, 226, 205, 0, 0, 0, 0, 198, 4, 53, 16, 91, 194, 0, 0, 0, 0, 102, 93, 40, 30, 0, 0, 0, 0, 78, 243, 131, 57, 0, 0, 0, 0, 138, 29, 188, 95, 0, 0, 0, 0, 198, 4, 188, 193, 120, 63, 0, 0, 0, 0, 159, 22, 208, 232, 0, 0, 0, 0, 137, 227, 129, 170, 0, 0, 0, 0, 63, 250, 42, 16, 0, 0, 0, 0, 198, 4, 218, 200, 186, 213, 0, 0, 0, 0, 149, 29, 121, 108, 0, 0, 0, 0, 54, 115, 177, 124, 0, 0, 0, 0, 35, 222, 103, 40, 0, 0, 0, 0, 198, 4, 199, 221, 3, 21, 0, 0, 0, 0, 180, 201, 84, 235, 0, 0, 0, 0, 77, 237, 137, 5, 0, 0, 0, 0, 128, 87, 163, 4, 0, 0, 0, 0, 198, 4, 194, 38, 144, 128, 0, 0, 0, 0, 74, 140, 174, 86, 0, 0, 0, 0, 93, 14, 109, 133, 0, 0, 0, 0, 131, 13, 22, 88, 0, 0, 0, 0, 198, 4, 60, 212, 209, 69, 0, 0, 0, 0, 222, 88, 164, 11, 0, 0, 0, 0, 221, 74, 117, 241, 0, 0, 0, 0, 100, 123, 48, 56, 0, 0, 0, 0, 198, 4, 84, 155, 78, 219, 0, 0, 0, 0, 78, 41, 125, 106, 0, 0, 0, 0, 60, 164, 127, 198, 0, 0, 0, 0, 1, 160, 55, 96, 0, 0, 0, 0, 198, 4, 116, 18, 49, 61, 0, 0, 0, 0, 144, 210, 168, 41, 0, 0, 0, 0, 176, 116, 156, 211, 0, 0, 0, 0, 190, 115, 196, 70, 0, 0, 0, 0, 198, 4, 150, 116, 56, 170, 0, 0, 0, 0, 62, 14, 220, 78, 0, 0, 0, 0, 183, 202, 173, 219, 0, 0, 0, 0, 204, 4, 123, 120, 0, 0, 0, 0, 198, 4, 88, 97, 247, 245, 0, 0, 0, 0, 113, 123, 110, 145, 0, 0, 0, 0, 192, 209, 214, 48, 0, 0, 0, 0, 177, 191, 55, 164, 0, 0, 0, 0, 198, 4, 233, 10, 113, 11, 0, 0, 0, 0, 189, 27, 142, 128, 0, 0, 0, 0, 244, 252, 125, 146, 0, 0, 0, 0, 147, 177, 251, 86, 0, 0, 0, 0, 198, 4, 77, 132, 206, 245, 0, 0, 0, 0, 20, 7, 246, 14, 0, 0, 0, 0, 232, 151, 87, 204, 0, 0, 0, 0, 200, 136, 239, 43, 0, 0, 0, 0, 198, 4, 205, 7, 36, 224, 0, 0, 0, 0, 202, 216, 49, 223, 0, 0, 0, 0, 139, 56, 173, 177, 0, 0, 0, 0, 170, 109, 222, 216, 0, 0, 0, 0, 198, 4, 177, 58, 55, 81, 0, 0, 0, 0, 27, 38, 153, 146, 0, 0, 0, 0, 165, 108, 146, 165, 0, 0, 0, 0, 195, 47, 174, 248, 0, 0, 0, 0, 198, 4, 112, 61, 47, 213, 0, 0, 0, 0, 30, 228, 195, 99, 0, 0, 0, 0, 51, 28, 219, 209, 0, 0, 0, 0, 96, 115, 93, 112, 0, 0, 0, 0, 198, 4, 219, 22, 70, 241, 0, 0, 0, 0, 100, 230, 255, 96, 0, 0, 0, 0, 211, 253, 40, 137, 0, 0, 0, 0, 10, 238, 20, 99, 0, 0, 0, 0, 198, 4, 142, 245, 3, 194, 0, 0, 0, 0, 255, 166, 139, 219, 0, 0, 0, 0, 149, 253, 70, 132, 0, 0, 0, 0, 216, 46, 218, 8, 0, 0, 0, 0, 198, 4, 90, 240, 254, 97, 0, 0, 0, 0, 164, 197, 165, 87, 0, 0, 0, 0, 214, 18, 156, 213, 0, 0, 0, 0, 193, 120, 49, 63, 0, 0, 0, 0, 198, 4, 51, 94, 186, 20, 0, 0, 0, 0, 251, 34, 187, 121, 0, 0, 0, 0, 245, 151, 136, 200, 0, 0, 0, 0, 3, 75, 255, 170, 0, 0, 0, 0, 198, 4, 20, 136, 104, 208, 0, 0, 0, 0, 17, 116, 49, 0, 0, 0, 0, 0, 173, 34, 81, 122, 0, 0, 0, 0, 61, 68, 128, 72, 0, 0, 0, 0, 198, 4, 177, 3, 11, 155, 0, 0, 0, 0, 130, 35, 231, 108, 0, 0, 0, 0, 233, 206, 85, 224, 0, 0, 0, 0, 231, 38, 222, 201, 0, 0, 0, 0, 198, 4, 155, 175, 60, 236, 0, 0, 0, 0, 220, 135, 40, 167, 0, 0, 0, 0, 51, 194, 93, 17, 0, 0, 0, 0, 171, 128, 84, 80, 0, 0, 0, 0, 198, 4, 167, 161, 222, 233, 0, 0, 0, 0, 180, 202, 125, 225, 0, 0, 0, 0, 55, 115, 124, 118, 0, 0, 0, 0, 235, 189, 167, 126, 0, 0, 0, 0, 198, 4, 183, 124, 12, 238, 0, 0, 0, 0, 183, 136, 247, 67, 0, 0, 0, 0, 174, 9, 111, 115, 0, 0, 0, 0, 63, 236, 0, 112, 0, 0, 0, 0, 198, 4, 59, 187, 151, 56, 0, 0, 0, 0, 52, 240, 217, 217, 0, 0, 0, 0, 107, 159, 210, 134, 0, 0, 0, 0, 0, 184, 217, 215, 0, 0, 0, 0, 198, 4, 193, 63, 52, 14, 0, 0, 0, 0, 11, 238, 127, 94, 0, 0, 0, 0, 96, 244, 192, 24, 0, 0, 0, 0, 178, 92, 43, 173, 0, 0, 0, 0, 198, 4, 120, 106, 18, 79, 0, 0, 0, 0, 158, 11, 173, 164, 0, 0, 0, 0, 28, 139, 202, 163, 0, 0, 0, 0, 27, 213, 65, 250, 0, 0, 0, 0, 198, 4, 23, 174, 28, 157, 0, 0, 0, 0, 29, 255, 150, 254, 0, 0, 0, 0, 133, 14, 234, 62, 0, 0, 0, 0, 139, 43, 240, 163, 0, 0, 0, 0, 198, 4, 33, 236, 206, 252, 0, 0, 0, 0, 130, 152, 199, 190, 0, 0, 0, 0, 100, 81, 124, 101, 0, 0, 0, 0, 178, 221, 78, 125, 0, 0, 0, 0, 198, 4, 228, 86, 200, 186, 0, 0, 0, 0, 56, 229, 199, 146, 0, 0, 0, 0, 158, 112, 104, 150, 0, 0, 0, 0, 97, 232, 150, 98, 0, 0, 0, 0, 198, 4, 18, 121, 96, 133, 0, 0, 0, 0, 32, 191, 64, 223, 0, 0, 0, 0, 61, 79, 134, 113, 0, 0, 0, 0, 172, 29, 166, 211, 0, 0, 0, 0, 198, 4, 21, 151, 248, 145, 0, 0, 0, 0, 146, 71, 59, 195, 0, 0, 0, 0, 229, 14, 236, 108, 0, 0, 0, 0, 144, 164, 203, 99, 0, 0, 0, 0, 198, 4, 232, 42, 162, 195, 0, 0, 0, 0, 106, 81, 78, 42, 0, 0, 0, 0, 70, 0, 248, 90, 0, 0, 0, 0, 202, 185, 173, 185, 0, 0, 0, 0, 198, 4, 146, 168, 134, 233, 0, 0, 0, 0, 183, 225, 136, 159, 0, 0, 0, 0, 75, 63, 207, 77, 0, 0, 0, 0, 82, 17, 120, 154, 0, 0, 0, 0, 198, 4, 125, 151, 199, 132, 0, 0, 0, 0, 43, 124, 218, 59, 0, 0, 0, 0, 149, 165, 161, 195, 0, 0, 0, 0, 9, 37, 111, 160, 0, 0, 0, 0, 198, 4, 109, 132, 181, 5, 0, 0, 0, 0, 173, 17, 250, 247, 0, 0, 0, 0, 78, 191, 4, 65, 0, 0, 0, 0, 65, 4, 242, 64, 0, 0, 0, 0, 198, 4, 115, 69, 38, 235, 0, 0, 0, 0, 53, 94, 139, 2, 0, 0, 0, 0, 126, 96, 87, 95, 0, 0, 0, 0, 214, 173, 118, 125, 0, 0, 0, 0, 198, 4, 52, 7, 179, 143, 0, 0, 0, 0, 224, 109, 3, 241, 0, 0, 0, 0, 110, 135, 135, 83, 0, 0, 0, 0, 101, 197, 60, 34, 0, 0, 0, 0, 198, 4, 56, 140, 109, 163, 0, 0, 0, 0, 236, 193, 81, 215, 0, 0, 0, 0, 249, 12, 70, 151, 0, 0, 0, 0, 230, 194, 14, 123, 0, 0, 0, 0, 198, 4, 47, 161, 150, 140, 0, 0, 0, 0, 135, 31, 200, 230, 0, 0, 0, 0, 118, 217, 202, 240, 0, 0, 0, 0, 191, 11, 212, 67, 0, 0, 0, 0, 198, 4, 248, 56, 110, 209, 0, 0, 0, 0, 200, 224, 131, 120, 0, 0, 0, 0, 161, 170, 43, 18, 0, 0, 0, 0, 25, 163, 169, 238, 0, 0, 0, 0, 198, 4, 191, 125, 148, 209, 0, 0, 0, 0, 35, 105, 203, 75, 0, 0, 0, 0, 180, 189, 144, 148, 0, 0, 0, 0, 146, 177, 157, 49, 0, 0, 0, 0, 198, 4, 150, 173, 78, 213, 0, 0, 0, 0, 77, 12, 3, 208, 0, 0, 0, 0, 170, 237, 11, 227, 0, 0, 0, 0, 149, 58, 235, 88, 0, 0, 0, 0, 198, 4, 154, 220, 202, 7, 0, 0, 0, 0, 96, 221, 0, 242, 0, 0, 0, 0, 189, 118, 60, 112, 0, 0, 0, 0, 194, 183, 104, 188, 0, 0, 0, 0, 198, 4, 45, 238, 247, 129, 0, 0, 0, 0, 40, 94, 240, 138, 0, 0, 0, 0, 123, 14, 88, 61, 0, 0, 0, 0, 54, 186, 243, 2, 0, 0, 0, 0, 198, 4, 67, 46, 222, 186, 0, 0, 0, 0, 130, 2, 45, 47, 0, 0, 0, 0, 198, 49, 42, 188, 0, 0, 0, 0, 185, 70, 74, 18, 0, 0, 0, 0, 198, 4, 150, 242, 132, 217, 0, 0, 0, 0, 197, 244, 227, 70, 0, 0, 0, 0, 15, 42, 164, 101, 0, 0, 0, 0, 209, 64, 10, 134, 0, 0, 0, 0, 198, 4, 203, 155, 201, 37, 0, 0, 0, 0, 206, 191, 230, 38, 0, 0, 0, 0, 239, 207, 80, 180, 0, 0, 0, 0, 65, 97, 24, 15, 0, 0, 0, 0, 198, 4, 250, 209, 145, 155, 0, 0, 0, 0, 111, 12, 56, 10, 0, 0, 0, 0, 129, 223, 63, 246, 0, 0, 0, 0, 55, 117, 137, 132, 0, 0, 0, 0, 198, 4, 176, 128, 89, 70, 0, 0, 0, 0, 51, 86, 164, 242, 0, 0, 0, 0, 109, 118, 191, 60, 0, 0, 0, 0, 223, 242, 10, 66, 0, 0, 0, 0, 198, 4, 180, 183, 200, 14, 0, 0, 0, 0, 174, 3, 151, 116, 0, 0, 0, 0, 44, 166, 88, 88, 0, 0, 0, 0, 229, 203, 11, 12, 0, 0, 0, 0, 198, 4, 92, 169, 173, 95, 0, 0, 0, 0, 119, 61, 228, 207, 0, 0, 0, 0, 50, 196, 222, 218, 0, 0, 0, 0, 219, 9, 152, 72, 0, 0, 0, 0, 198, 4, 126, 240, 93, 50, 0, 0, 0, 0, 200, 7, 239, 90, 0, 0, 0, 0, 83, 134, 186, 147, 0, 0, 0, 0, 172, 143, 200, 171, 0, 0, 0, 0, 198, 4, 162, 125, 14, 144, 0, 0, 0, 0, 188, 227, 62, 50, 0, 0, 0, 0, 146, 40, 30, 113, 0, 0, 0, 0, 23, 88, 12, 20, 0, 0, 0, 0, 198, 4, 54, 55, 155, 164, 0, 0, 0, 0, 229, 185, 24, 149, 0, 0, 0, 0, 186, 127, 180, 84, 0, 0, 0, 0, 135, 106, 62, 32, 0, 0, 0, 0, 198, 4, 244, 93, 126, 112, 0, 0, 0, 0, 83, 82, 238, 209, 0, 0, 0, 0, 137, 237, 201, 160, 0, 0, 0, 0, 105, 151, 144, 159, 0, 0, 0, 0, 198, 4, 48, 196, 39, 248, 0, 0, 0, 0, 167, 68, 56, 152, 0, 0, 0, 0, 1, 4, 185, 37, 0, 0, 0, 0, 53, 47, 12, 87, 0, 0, 0, 0, 198, 4, 178, 61, 55, 93, 0, 0, 0, 0, 2, 169, 204, 146, 0, 0, 0, 0, 99, 244, 144, 74, 0, 0, 0, 0, 6, 6, 19, 114, 0, 0, 0, 0, 198, 4, 146, 96, 49, 112, 0, 0, 0, 0, 76, 38, 142, 135, 0, 0, 0, 0, 25, 58, 168, 3, 0, 0, 0, 0, 165, 254, 214, 5, 0, 0, 0, 0, 198, 4, 75, 239, 212, 223, 0, 0, 0, 0, 216, 110, 49, 65, 0, 0, 0, 0, 214, 198, 216, 168, 0, 0, 0, 0, 8, 51, 98, 161, 0, 0, 0, 0, 198, 4, 101, 134, 151, 189, 0, 0, 0, 0, 53, 172, 180, 166, 0, 0, 0, 0, 17, 75, 65, 23, 0, 0, 0, 0, 5, 59, 217, 193, 0, 0, 0, 0, 198, 4, 20, 214, 192, 48, 0, 0, 0, 0, 178, 98, 54, 174, 0, 0, 0, 0, 129, 130, 42, 117, 0, 0, 0, 0, 246, 228, 228, 182, 0, 0, 0, 0, 198, 4, 122, 171, 14, 8, 0, 0, 0, 0, 82, 187, 40, 24, 0, 0, 0, 0, 33, 177, 90, 7, 0, 0, 0, 0, 41, 56, 121, 228, 0, 0, 0, 0, 198, 4, 219, 9, 123, 106, 0, 0, 0, 0, 69, 11, 41, 186, 0, 0, 0, 0, 149, 238, 239, 246, 0, 0, 0, 0, 171, 163, 62, 119, 0, 0, 0, 0, 198, 4, 176, 250, 127, 57, 0, 0, 0, 0, 112, 30, 190, 147, 0, 0, 0, 0, 216, 83, 254, 10, 0, 0, 0, 0, 181, 61, 198, 181, 0, 0, 0, 0, 198, 4, 7, 54, 109, 92, 0, 0, 0, 0, 93, 123, 41, 245, 0, 0, 0, 0, 155, 47, 29, 246, 0, 0, 0, 0, 101, 236, 173, 205, 0, 0, 0, 0, 198, 4, 252, 109, 233, 101, 0, 0, 0, 0, 151, 166, 44, 186, 0, 0, 0, 0, 128, 24, 161, 75, 0, 0, 0, 0, 115, 157, 50, 166, 0, 0, 0, 0, 198, 4, 179, 228, 151, 191, 0, 0, 0, 0, 172, 45, 194, 134, 0, 0, 0, 0, 219, 70, 144, 25, 0, 0, 0, 0, 215, 115, 178, 78, 0, 0, 0, 0, 198, 4, 176, 104, 132, 184, 0, 0, 0, 0, 91, 133, 9, 142, 0, 0, 0, 0, 223, 176, 103, 224, 0, 0, 0, 0, 217, 102, 99, 121, 0, 0, 0, 0, 198, 4, 188, 245, 107, 18, 0, 0, 0, 0, 222, 244, 59, 72, 0, 0, 0, 0, 110, 150, 93, 136, 0, 0, 0, 0, 121, 249, 176, 132, 0, 0, 0, 0, 198, 4, 177, 24, 8, 123, 0, 0, 0, 0, 227, 143, 113, 224, 0, 0, 0, 0, 250, 5, 210, 195, 0, 0, 0, 0, 98, 177, 217, 64, 0, 0, 0, 0, 198, 4, 114, 152, 1, 132, 0, 0, 0, 0, 148, 134, 237, 240, 0, 0, 0, 0, 7, 203, 206, 111, 0, 0, 0, 0, 56, 238, 228, 56, 0, 0, 0, 0, 198, 4, 187, 7, 185, 132, 0, 0, 0, 0, 8, 182, 7, 70, 0, 0, 0, 0, 253, 174, 92, 92, 0, 0, 0, 0, 206, 225, 217, 172, 0, 0, 0, 0, 198, 4, 224, 84, 9, 253, 0, 0, 0, 0, 72, 239, 37, 78, 0, 0, 0, 0, 234, 251, 48, 133, 0, 0, 0, 0, 83, 165, 209, 41, 0, 0, 0, 0, 198, 4, 38, 174, 214, 147, 0, 0, 0, 0, 13, 71, 10, 72, 0, 0, 0, 0, 73, 76, 228, 10, 0, 0, 0, 0, 211, 143, 191, 146, 0, 0, 0, 0, 198, 4, 129, 14, 75, 124, 0, 0, 0, 0, 249, 161, 198, 92, 0, 0, 0, 0, 193, 84, 148, 99, 0, 0, 0, 0, 163, 194, 160, 175, 0, 0, 0, 0, 198, 4, 170, 10, 71, 245, 0, 0, 0, 0, 152, 196, 210, 121, 0, 0, 0, 0, 113, 113, 26, 183, 0, 0, 0, 0, 179, 102, 70, 26, 0, 0, 0, 0, 198, 4, 207, 149, 209, 237, 0, 0, 0, 0, 53, 248, 93, 224, 0, 0, 0, 0, 45, 49, 36, 85, 0, 0, 0, 0, 103, 44, 176, 35, 0, 0, 0, 0, 198, 4, 51, 109, 54, 110, 0, 0, 0, 0, 53, 231, 142, 76, 0, 0, 0, 0, 217, 37, 89, 145, 0, 0, 0, 0, 67, 160, 131, 103, 0, 0, 0, 0, 198, 4, 248, 161, 165, 33, 0, 0, 0, 0, 205, 14, 106, 184, 0, 0, 0, 0, 166, 220, 105, 101, 0, 0, 0, 0, 190, 166, 78, 30, 0, 0, 0, 0, 198, 4, 195, 185, 54, 32, 0, 0, 0, 0, 68, 236, 153, 14, 0, 0, 0, 0, 7, 156, 243, 123, 0, 0, 0, 0, 74, 34, 169, 9, 0, 0, 0, 0, 198, 4, 205, 91, 230, 245, 0, 0, 0, 0, 18, 31, 225, 16, 0, 0, 0, 0, 102, 73, 61, 137, 0, 0, 0, 0, 205, 192, 125, 207, 0, 0, 0, 0, 198, 4, 136, 226, 226, 91, 0, 0, 0, 0, 56, 2, 123, 87, 0, 0, 0, 0, 59, 222, 248, 243, 0, 0, 0, 0, 63, 96, 140, 89, 0, 0, 0, 0, 198, 4, 170, 33, 79, 204, 0, 0, 0, 0, 98, 195, 243, 128, 0, 0, 0, 0, 206, 36, 14, 151, 0, 0, 0, 0, 156, 29, 240, 39, 0, 0, 0, 0, 198, 4, 134, 25, 107, 77, 0, 0, 0, 0, 225, 204, 199, 245, 0, 0, 0, 0, 184, 146, 64, 122, 0, 0, 0, 0, 152, 71, 164, 78, 0, 0, 0, 0, 198, 4, 77, 1, 140, 156, 0, 0, 0, 0, 189, 208, 164, 179, 0, 0, 0, 0, 60, 233, 106, 238, 0, 0, 0, 0, 29, 89, 39, 222, 0, 0, 0, 0, 198, 4, 161, 158, 190, 129, 0, 0, 0, 0, 141, 12, 143, 98, 0, 0, 0, 0, 69, 63, 253, 91, 0, 0, 0, 0, 43, 24, 243, 124, 0, 0, 0, 0, 198, 4, 48, 69, 88, 85, 0, 0, 0, 0, 23, 107, 65, 88, 0, 0, 0, 0, 203, 7, 157, 55, 0, 0, 0, 0, 114, 23, 219, 29, 0, 0, 0, 0, 198, 4, 201, 210, 135, 178, 0, 0, 0, 0, 208, 234, 142, 151, 0, 0, 0, 0, 36, 99, 182, 176, 0, 0, 0, 0, 45, 132, 171, 72, 0, 0, 0, 0, 198, 4, 229, 218, 244, 215, 0, 0, 0, 0, 1, 216, 62, 187, 0, 0, 0, 0, 166, 162, 55, 66, 0, 0, 0, 0, 182, 50, 214, 107, 0, 0, 0, 0, 198, 4, 202, 30, 42, 82, 0, 0, 0, 0, 140, 212, 207, 149, 0, 0, 0, 0, 111, 95, 242, 121, 0, 0, 0, 0, 140, 153, 38, 215, 0, 0, 0, 0, 198, 4, 235, 177, 19, 48, 0, 0, 0, 0, 235, 255, 112, 0, 0, 0, 0, 0, 62, 5, 44, 244, 0, 0, 0, 0, 20, 128, 82, 112, 0, 0, 0, 0, 198, 4, 219, 151, 119, 30, 0, 0, 0, 0, 83, 16, 181, 97, 0, 0, 0, 0, 145, 125, 113, 209, 0, 0, 0, 0, 56, 230, 180, 83, 0, 0, 0, 0, 198, 4, 154, 1, 158, 41, 0, 0, 0, 0, 4, 70, 74, 138, 0, 0, 0, 0, 255, 61, 144, 224, 0, 0, 0, 0, 129, 49, 202, 186, 0, 0, 0, 0, 198, 4, 122, 190, 99, 172, 0, 0, 0, 0, 53, 166, 199, 133, 0, 0, 0, 0, 73, 26, 160, 107, 0, 0, 0, 0, 130, 233, 76, 124, 0, 0, 0, 0, 198, 4, 14, 148, 158, 113, 0, 0, 0, 0, 241, 89, 179, 13, 0, 0, 0, 0, 65, 138, 122, 52, 0, 0, 0, 0, 117, 217, 114, 252, 0, 0, 0, 0, 198, 4, 130, 173, 156, 202, 0, 0, 0, 0, 160, 46, 254, 215, 0, 0, 0, 0, 226, 168, 108, 169, 0, 0, 0, 0, 226, 59, 190, 45, 0, 0, 0, 0, 198, 4, 159, 26, 195, 3, 0, 0, 0, 0, 176, 36, 200, 70, 0, 0, 0, 0, 110, 237, 64, 160, 0, 0, 0, 0, 128, 227, 54, 54, 0, 0, 0, 0, 198, 4, 171, 215, 31, 127, 0, 0, 0, 0, 64, 35, 30, 107, 0, 0, 0, 0, 158, 10, 41, 238, 0, 0, 0, 0, 61, 152, 118, 236, 0, 0, 0, 0, 198, 4, 222, 42, 26, 140, 0, 0, 0, 0, 204, 204, 12, 37, 0, 0, 0, 0, 189, 103, 78, 9, 0, 0, 0, 0, 55, 27, 45, 132, 0, 0, 0, 0, 198, 4, 22, 252, 147, 57, 0, 0, 0, 0, 255, 153, 40, 229, 0, 0, 0, 0, 177, 205, 124, 131, 0, 0, 0, 0, 152, 185, 12, 201, 0, 0, 0, 0, 198, 4, 78, 26, 226, 222, 0, 0, 0, 0, 131, 197, 26, 52, 0, 0, 0, 0, 174, 83, 197, 131, 0, 0, 0, 0, 184, 198, 6, 170, 0, 0, 0, 0, 198, 4, 68, 224, 109, 78, 0, 0, 0, 0, 245, 198, 143, 166, 0, 0, 0, 0, 103, 108, 194, 106, 0, 0, 0, 0, 255, 105, 165, 67, 0, 0, 0, 0, 198, 4, 17, 137, 69, 189, 0, 0, 0, 0, 139, 80, 34, 21, 0, 0, 0, 0, 155, 87, 178, 65, 0, 0, 0, 0, 40, 78, 135, 70, 0, 0, 0, 0, 198, 4, 195, 60, 111, 34, 0, 0, 0, 0, 131, 156, 174, 207, 0, 0, 0, 0, 130, 233, 85, 69, 0, 0, 0, 0, 115, 89, 217, 137, 0, 0, 0, 0, 198, 4, 226, 89, 189, 64, 0, 0, 0, 0, 129, 20, 85, 99, 0, 0, 0, 0, 185, 187, 18, 250, 0, 0, 0, 0, 79, 194, 63, 100, 0, 0, 0, 0, 198, 4, 46, 152, 103, 88, 0, 0, 0, 0, 157, 105, 101, 111, 0, 0, 0, 0, 57, 217, 179, 160, 0, 0, 0, 0, 238, 214, 52, 241, 0, 0, 0, 0, 198, 4, 97, 201, 88, 72, 0, 0, 0, 0, 230, 11, 153, 85, 0, 0, 0, 0, 180, 190, 15, 2, 0, 0, 0, 0, 57, 89, 172, 236, 0, 0, 0, 0, 198, 4, 201, 163, 232, 32, 0, 0, 0, 0, 38, 240, 106, 82, 0, 0, 0, 0, 159, 254, 46, 232, 0, 0, 0, 0, 141, 183, 144, 104, 0, 0, 0, 0, 198, 4, 53, 55, 148, 147, 0, 0, 0, 0, 146, 65, 156, 88, 0, 0, 0, 0, 78, 46, 79, 220, 0, 0, 0, 0, 115, 58, 203, 23, 0, 0, 0, 0, 198, 4, 130, 220, 165, 55, 0, 0, 0, 0, 193, 20, 36, 255, 0, 0, 0, 0, 11, 130, 186, 60, 0, 0, 0, 0, 162, 155, 125, 100, 0, 0, 0, 0, 198, 4, 158, 138, 8, 86, 0, 0, 0, 0, 102, 169, 52, 130, 0, 0, 0, 0, 200, 218, 254, 80, 0, 0, 0, 0, 157, 197, 179, 52, 0, 0, 0, 0, 198, 4, 89, 36, 45, 56, 0, 0, 0, 0, 91, 94, 142, 126, 0, 0, 0, 0, 203, 238, 144, 53, 0, 0, 0, 0, 223, 16, 56, 253, 0, 0, 0, 0, 198, 4, 236, 31, 216, 60, 0, 0, 0, 0, 141, 101, 36, 195, 0, 0, 0, 0, 91, 9, 188, 65, 0, 0, 0, 0, 84, 218, 82, 227, 0, 0, 0, 0, 198, 4, 80, 188, 116, 254, 0, 0, 0, 0, 207, 255, 251, 202, 0, 0, 0, 0, 88, 137, 206, 179, 0, 0, 0, 0, 145, 168, 39, 139, 0, 0, 0, 0, 198, 4, 180, 180, 68, 84, 0, 0, 0, 0, 119, 123, 114, 223, 0, 0, 0, 0, 65, 112, 23, 167, 0, 0, 0, 0, 97, 91, 191, 148, 0, 0, 0, 0, 198, 4, 5, 217, 211, 215, 0, 0, 0, 0, 241, 141, 51, 209, 0, 0, 0, 0, 140, 211, 154, 228, 0, 0, 0, 0, 50, 30, 243, 33, 0, 0, 0, 0, 198, 4, 92, 31, 10, 200, 0, 0, 0, 0, 248, 124, 140, 44, 0, 0, 0, 0, 107, 231, 51, 130, 0, 0, 0, 0, 152, 15, 86, 186, 0, 0, 0, 0, 198, 4, 43, 192, 33, 167, 0, 0, 0, 0, 114, 224, 19, 88, 0, 0, 0, 0, 76, 72, 88, 237, 0, 0, 0, 0, 191, 225, 187, 213, 0, 0, 0, 0, 198, 4, 3, 86, 198, 158, 0, 0, 0, 0, 127, 58, 130, 223, 0, 0, 0, 0, 51, 29, 199, 245, 0, 0, 0, 0, 54, 113, 151, 20, 0, 0, 0, 0, 198, 4, 159, 69, 118, 71, 0, 0, 0, 0, 151, 147, 24, 139, 0, 0, 0, 0, 93, 237, 18, 0, 0, 0, 0, 0, 193, 24, 196, 242, 0, 0, 0, 0, 198, 4, 114, 34, 187, 133, 0, 0, 0, 0, 77, 88, 0, 91, 0, 0, 0, 0, 201, 200, 154, 201, 0, 0, 0, 0, 230, 101, 90, 242, 0, 0, 0, 0, 198, 4, 9, 45, 56, 48, 0, 0, 0, 0, 228, 230, 9, 223, 0, 0, 0, 0, 194, 216, 76, 62, 0, 0, 0, 0, 45, 45, 10, 60, 0, 0, 0, 0, 198, 4, 51, 99, 113, 113, 0, 0, 0, 0, 220, 108, 253, 177, 0, 0, 0, 0, 24, 2, 205, 175, 0, 0, 0, 0, 14, 235, 213, 249, 0, 0, 0, 0, 198, 4, 122, 9, 174, 113, 0, 0, 0, 0, 6, 147, 106, 200, 0, 0, 0, 0, 75, 86, 202, 82, 0, 0, 0, 0, 197, 68, 94, 225, 0, 0, 0, 0, 198, 4, 233, 165, 216, 97, 0, 0, 0, 0, 45, 74, 16, 119, 0, 0, 0, 0, 141, 173, 239, 181, 0, 0, 0, 0, 12, 47, 125, 84, 0, 0, 0, 0, 198, 4, 171, 236, 51, 43, 0, 0, 0, 0, 193, 114, 23, 101, 0, 0, 0, 0, 155, 150, 205, 83, 0, 0, 0, 0, 51, 230, 163, 89, 0, 0, 0, 0, 198, 4, 26, 228, 202, 57, 0, 0, 0, 0, 235, 149, 53, 250, 0, 0, 0, 0, 90, 198, 241, 151, 0, 0, 0, 0, 91, 150, 126, 142, 0, 0, 0, 0, 198, 4, 36, 138, 77, 165, 0, 0, 0, 0, 85, 109, 247, 250, 0, 0, 0, 0, 225, 151, 70, 240, 0, 0, 0, 0, 140, 174, 119, 78, 0, 0, 0, 0, 198, 4, 198, 42, 54, 32, 0, 0, 0, 0, 178, 243, 185, 64, 0, 0, 0, 0, 2, 159, 248, 206, 0, 0, 0, 0, 169, 151, 43, 78, 0, 0, 0, 0, 198, 4, 152, 85, 74, 176, 0, 0, 0, 0, 106, 91, 104, 105, 0, 0, 0, 0, 211, 231, 145, 123, 0, 0, 0, 0, 113, 24, 72, 16, 0, 0, 0, 0, 198, 4, 177, 29, 166, 33, 0, 0, 0, 0, 46, 0, 5, 214, 0, 0, 0, 0, 207, 234, 160, 38, 0, 0, 0, 0, 33, 241, 28, 7, 0, 0, 0, 0, 198, 4, 246, 1, 39, 184, 0, 0, 0, 0, 151, 224, 150, 223, 0, 0, 0, 0, 123, 212, 115, 76, 0, 0, 0, 0, 191, 161, 201, 187, 0, 0, 0, 0, 198, 4, 244, 242, 153, 67, 0, 0, 0, 0, 40, 254, 34, 93, 0, 0, 0, 0, 165, 88, 43, 190, 0, 0, 0, 0, 194, 109, 169, 84, 0, 0, 0, 0, 198, 4, 116, 85, 134, 56, 0, 0, 0, 0, 246, 162, 39, 219, 0, 0, 0, 0, 199, 185, 217, 179, 0, 0, 0, 0, 50, 5, 2, 57, 0, 0, 0, 0, 198, 4, 171, 172, 89, 223, 0, 0, 0, 0, 199, 205, 80, 130, 0, 0, 0, 0, 134, 205, 65, 71, 0, 0, 0, 0, 29, 14, 106, 222, 0, 0, 0, 0, 198, 4, 97, 17, 41, 207, 0, 0, 0, 0, 200, 81, 77, 226, 0, 0, 0, 0, 114, 161, 249, 3, 0, 0, 0, 0, 165, 140, 250, 105, 0, 0, 0, 0, 198, 4, 212, 122, 91, 100, 0, 0, 0, 0, 163, 74, 141, 221, 0, 0, 0, 0, 93, 234, 59, 136, 0, 0, 0, 0, 189, 174, 117, 254, 0, 0, 0, 0, 198, 4, 217, 54, 153, 118, 0, 0, 0, 0, 36, 127, 142, 156, 0, 0, 0, 0, 113, 138, 159, 86, 0, 0, 0, 0, 55, 56, 180, 196, 0, 0, 0, 0, 198, 4, 202, 23, 56, 50, 0, 0, 0, 0, 201, 24, 247, 27, 0, 0, 0, 0, 239, 176, 144, 73, 0, 0, 0, 0, 241, 121, 53, 9, 0, 0, 0, 0, 198, 4, 181, 55, 104, 133, 0, 0, 0, 0, 172, 8, 7, 58, 0, 0, 0, 0, 194, 78, 192, 93, 0, 0, 0, 0, 237, 78, 87, 132, 0, 0, 0, 0, 198, 4, 198, 234, 55, 133, 0, 0, 0, 0, 83, 115, 100, 216, 0, 0, 0, 0, 155, 14, 87, 63, 0, 0, 0, 0, 208, 216, 197, 20, 0, 0, 0, 0, 198, 4, 243, 193, 250, 221, 0, 0, 0, 0, 221, 200, 219, 57, 0, 0, 0, 0, 253, 190, 20, 125, 0, 0, 0, 0, 191, 216, 199, 211, 0, 0, 0, 0, 198, 4, 216, 11, 90, 161, 0, 0, 0, 0, 66, 94, 61, 170, 0, 0, 0, 0, 85, 84, 216, 102, 0, 0, 0, 0, 114, 123, 151, 146, 0, 0, 0, 0, 198, 4, 93, 151, 81, 84, 0, 0, 0, 0, 65, 148, 77, 153, 0, 0, 0, 0, 172, 112, 143, 205, 0, 0, 0, 0, 80, 99, 171, 152, 0, 0, 0, 0, 198, 4, 109, 254, 20, 59, 0, 0, 0, 0, 117, 98, 20, 56, 0, 0, 0, 0, 37, 126, 143, 226, 0, 0, 0, 0, 35, 253, 251, 231, 0, 0, 0, 0, 198, 4, 2, 199, 34, 130, 0, 0, 0, 0, 70, 116, 39, 70, 0, 0, 0, 0, 88, 124, 193, 58, 0, 0, 0, 0, 196, 255, 188, 229, 0, 0, 0, 0, 198, 4, 255, 203, 188, 22, 0, 0, 0, 0, 252, 126, 126, 98, 0, 0, 0, 0, 243, 104, 163, 241, 0, 0, 0, 0, 218, 142, 36, 113, 0, 0, 0, 0, 198, 4, 74, 247, 220, 162, 0, 0, 0, 0, 107, 112, 152, 160, 0, 0, 0, 0, 153, 9, 146, 28, 0, 0, 0, 0, 128, 116, 26, 84, 0, 0, 0, 0, 198, 4, 65, 198, 218, 178, 0, 0, 0, 0, 53, 79, 96, 170, 0, 0, 0, 0, 214, 46, 230, 115, 0, 0, 0, 0, 166, 159, 87, 85, 0, 0, 0, 0, 198, 4, 59, 41, 194, 151, 0, 0, 0, 0, 177, 44, 22, 215, 0, 0, 0, 0, 48, 103, 94, 143, 0, 0, 0, 0, 195, 42, 182, 236, 0, 0, 0, 0, 198, 4, 6, 253, 162, 78, 0, 0, 0, 0, 149, 106, 150, 19, 0, 0, 0, 0, 152, 156, 192, 173, 0, 0, 0, 0, 207, 39, 131, 148, 0, 0, 0, 0, 198, 4, 168, 5, 63, 109, 0, 0, 0, 0, 177, 179, 183, 111, 0, 0, 0, 0, 113, 230, 35, 245, 0, 0, 0, 0, 2, 82, 71, 4, 0, 0, 0, 0, 198, 4, 192, 106, 72, 236, 0, 0, 0, 0, 86, 128, 220, 225, 0, 0, 0, 0, 141, 211, 232, 3, 0, 0, 0, 0, 89, 150, 82, 9, 0, 0, 0, 0, 198, 4, 156, 17, 159, 127, 0, 0, 0, 0, 147, 36, 124, 142, 0, 0, 0, 0, 157, 13, 225, 253, 0, 0, 0, 0, 168, 122, 140, 149, 0, 0, 0, 0, 198, 4, 218, 199, 205, 153, 0, 0, 0, 0, 198, 79, 174, 238, 0, 0, 0, 0, 48, 119, 41, 47, 0, 0, 0, 0, 84, 246, 80, 213, 0, 0, 0, 0, 198, 4, 202, 79, 239, 97, 0, 0, 0, 0, 26, 89, 62, 169, 0, 0, 0, 0, 66, 183, 247, 179, 0, 0, 0, 0, 117, 133, 62, 11, 0, 0, 0, 0, 198, 4, 188, 198, 197, 107, 0, 0, 0, 0, 72, 8, 94, 229, 0, 0, 0, 0, 28, 158, 6, 38, 0, 0, 0, 0, 0, 79, 90, 179, 0, 0, 0, 0, 198, 4, 107, 9, 103, 239, 0, 0, 0, 0, 252, 54, 109, 17, 0, 0, 0, 0, 238, 53, 142, 112, 0, 0, 0, 0, 191, 129, 101, 51, 0, 0, 0, 0, 198, 4, 203, 225, 120, 0, 0, 0, 0, 0, 55, 174, 65, 165, 0, 0, 0, 0, 94, 119, 110, 119, 0, 0, 0, 0, 6, 172, 4, 190, 0, 0, 0, 0, 198, 4, 204, 23, 155, 83, 0, 0, 0, 0, 142, 28, 64, 99, 0, 0, 0, 0, 153, 97, 36, 144, 0, 0, 0, 0, 70, 253, 130, 244, 0, 0, 0, 0, 198, 4, 193, 155, 137, 34, 0, 0, 0, 0, 97, 223, 46, 12, 0, 0, 0, 0, 230, 207, 61, 127, 0, 0, 0, 0, 109, 208, 33, 211, 0, 0, 0, 0, 198, 4, 188, 43, 188, 96, 0, 0, 0, 0, 230, 132, 139, 140, 0, 0, 0, 0, 96, 64, 116, 43, 0, 0, 0, 0, 189, 251, 107, 87, 0, 0, 0, 0, 198, 4, 15, 123, 118, 132, 0, 0, 0, 0, 246, 187, 34, 5, 0, 0, 0, 0, 29, 95, 47, 211, 0, 0, 0, 0, 196, 213, 113, 99, 0, 0, 0, 0, 198, 4, 218, 255, 76, 166, 0, 0, 0, 0, 54, 140, 141, 212, 0, 0, 0, 0, 72, 76, 42, 100, 0, 0, 0, 0, 126, 103, 236, 224, 0, 0, 0, 0, 198, 4, 247, 130, 95, 90, 0, 0, 0, 0, 0, 65, 47, 193, 0, 0, 0, 0, 212, 148, 158, 87, 0, 0, 0, 0, 110, 102, 43, 176, 0, 0, 0, 0, 198, 4, 129, 61, 107, 27, 0, 0, 0, 0, 160, 65, 197, 105, 0, 0, 0, 0, 31, 179, 5, 126, 0, 0, 0, 0, 104, 10, 147, 146, 0, 0, 0, 0, 198, 4, 231, 162, 23, 115, 0, 0, 0, 0, 228, 80, 168, 253, 0, 0, 0, 0, 99, 211, 109, 160, 0, 0, 0, 0, 148, 214, 8, 23, 0, 0, 0, 0, 198, 4, 202, 179, 243, 239, 0, 0, 0, 0, 248, 77, 150, 108, 0, 0, 0, 0, 253, 34, 209, 142, 0, 0, 0, 0, 2, 197, 162, 253, 0, 0, 0, 0, 198, 4, 12, 201, 142, 211, 0, 0, 0, 0, 115, 91, 0, 0, 0, 0, 0, 0, 124, 162, 138, 107, 0, 0, 0, 0, 163, 155, 45, 137, 0, 0, 0, 0, 198, 4, 195, 225, 52, 188, 0, 0, 0, 0, 81, 101, 24, 175, 0, 0, 0, 0, 37, 201, 226, 254, 0, 0, 0, 0, 17, 137, 83, 70, 0, 0, 0, 0, 198, 4, 36, 159, 46, 3, 0, 0, 0, 0, 208, 114, 233, 18, 0, 0, 0, 0, 194, 66, 109, 201, 0, 0, 0, 0, 195, 96, 171, 177, 0, 0, 0, 0, 198, 4, 16, 234, 91, 71, 0, 0, 0, 0, 20, 183, 212, 149, 0, 0, 0, 0, 163, 16, 109, 193, 0, 0, 0, 0, 72, 183, 106, 102, 0, 0, 0, 0, 198, 4, 90, 54, 204, 152, 0, 0, 0, 0, 75, 78, 88, 80, 0, 0, 0, 0, 186, 39, 58, 96, 0, 0, 0, 0, 115, 86, 174, 103, 0, 0, 0, 0, 198, 4, 111, 122, 9, 123, 0, 0, 0, 0, 71, 179, 229, 214, 0, 0, 0, 0, 99, 237, 139, 10, 0, 0, 0, 0, 36, 9, 96, 42, 0, 0, 0, 0, 198, 4, 149, 177, 211, 249, 0, 0, 0, 0, 217, 7, 174, 71, 0, 0, 0, 0, 122, 125, 127, 56, 0, 0, 0, 0, 146, 89, 29, 170, 0, 0, 0, 0, 198, 4, 149, 136, 203, 7, 0, 0, 0, 0, 3, 65, 249, 88, 0, 0, 0, 0, 141, 241, 167, 120, 0, 0, 0, 0, 167, 187, 221, 205, 0, 0, 0, 0, 198, 4, 147, 208, 213, 93, 0, 0, 0, 0, 118, 11, 228, 205, 0, 0, 0, 0, 117, 231, 41, 183, 0, 0, 0, 0, 118, 173, 110, 214, 0, 0, 0, 0, 198, 4, 8, 204, 234, 152, 0, 0, 0, 0, 23, 194, 86, 72, 0, 0, 0, 0, 24, 163, 156, 78, 0, 0, 0, 0, 7, 220, 79, 138, 0, 0, 0, 0, 198, 4, 117, 91, 174, 250, 0, 0, 0, 0, 223, 110, 195, 39, 0, 0, 0, 0, 248, 183, 98, 75, 0, 0, 0, 0, 4, 232, 111, 111, 0, 0, 0, 0, 198, 4, 183, 49, 155, 105, 0, 0, 0, 0, 174, 214, 121, 101, 0, 0, 0, 0, 217, 107, 52, 150, 0, 0, 0, 0, 160, 211, 6, 125, 0, 0, 0, 0, 198, 4, 7, 100, 189, 218, 0, 0, 0, 0, 61, 26, 205, 130, 0, 0, 0, 0, 120, 95, 183, 140, 0, 0, 0, 0, 67, 210, 91, 163, 0, 0, 0, 0, 198, 4, 159, 22, 210, 84, 0, 0, 0, 0, 254, 221, 215, 220, 0, 0, 0, 0, 70, 190, 102, 46, 0, 0, 0, 0, 223, 234, 218, 219, 0, 0, 0, 0, 198, 4, 43, 201, 3, 58, 0, 0, 0, 0, 135, 190, 251, 137, 0, 0, 0, 0, 2, 210, 233, 59, 0, 0, 0, 0, 57, 187, 249, 16, 0, 0, 0, 0, 198, 4, 197, 244, 61, 115, 0, 0, 0, 0, 117, 215, 61, 15, 0, 0, 0, 0, 201, 105, 201, 251, 0, 0, 0, 0, 18, 73, 130, 166, 0, 0, 0, 0, 198, 4, 155, 177, 88, 165, 0, 0, 0, 0, 140, 170, 171, 56, 0, 0, 0, 0, 53, 230, 113, 52, 0, 0, 0, 0, 80, 243, 230, 149, 0, 0, 0, 0, 198, 4, 211, 171, 65, 123, 0, 0, 0, 0, 191, 185, 210, 16, 0, 0, 0, 0, 27, 107, 17, 58, 0, 0, 0, 0, 245, 151, 77, 155, 0, 0, 0, 0, 198, 4, 2, 218, 32, 137, 0, 0, 0, 0, 77, 199, 252, 164, 0, 0, 0, 0, 243, 227, 187, 186, 0, 0, 0, 0, 213, 143, 41, 205, 0, 0, 0, 0, 198, 4, 106, 191, 119, 212, 0, 0, 0, 0, 79, 244, 69, 228, 0, 0, 0, 0, 190, 158, 19, 173, 0, 0, 0, 0, 133, 171, 12, 207, 0, 0, 0, 0, 198, 4, 43, 164, 248, 69, 0, 0, 0, 0, 188, 232, 208, 150, 0, 0, 0, 0, 120, 219, 120, 205, 0, 0, 0, 0, 48, 47, 236, 99, 0, 0, 0, 0, 198, 4, 121, 35, 117, 254, 0, 0, 0, 0, 194, 243, 125, 9, 0, 0, 0, 0, 2, 174, 18, 144, 0, 0, 0, 0, 85, 251, 9, 36, 0, 0, 0, 0, 198, 4, 4, 94, 194, 103, 0, 0, 0, 0, 116, 47, 163, 10, 0, 0, 0, 0, 173, 248, 62, 45, 0, 0, 0, 0, 243, 23, 60, 33, 0, 0, 0, 0, 198, 4, 43, 49, 195, 250, 0, 0, 0, 0, 162, 4, 86, 50, 0, 0, 0, 0, 179, 255, 143, 11, 0, 0, 0, 0, 229, 7, 5, 138, 0, 0, 0, 0, 198, 4, 72, 222, 0, 93, 0, 0, 0, 0, 72, 111, 86, 127, 0, 0, 0, 0, 211, 30, 27, 177, 0, 0, 0, 0, 154, 133, 80, 156, 0, 0, 0, 0, 198, 4, 65, 139, 149, 204, 0, 0, 0, 0, 194, 175, 150, 138, 0, 0, 0, 0, 231, 96, 238, 64, 0, 0, 0, 0, 24, 196, 132, 109, 0, 0, 0, 0, 198, 4, 103, 32, 193, 173, 0, 0, 0, 0, 221, 246, 81, 109, 0, 0, 0, 0, 201, 127, 232, 49, 0, 0, 0, 0, 76, 134, 189, 34, 0, 0, 0, 0, 198, 4, 169, 133, 197, 67, 0, 0, 0, 0, 218, 161, 125, 74, 0, 0, 0, 0, 209, 85, 177, 140, 0, 0, 0, 0, 155, 121, 176, 31, 0, 0, 0, 0, 198, 4, 247, 99, 118, 193, 0, 0, 0, 0, 8, 249, 158, 124, 0, 0, 0, 0, 143, 196, 183, 226, 0, 0, 0, 0, 126, 171, 50, 171, 0, 0, 0, 0, 198, 4, 118, 253, 202, 98, 0, 0, 0, 0, 104, 205, 65, 51, 0, 0, 0, 0, 220, 128, 136, 13, 0, 0, 0, 0, 182, 249, 76, 114, 0, 0, 0, 0, 198, 4, 147, 183, 194, 137, 0, 0, 0, 0, 187, 157, 3, 88, 0, 0, 0, 0, 28, 224, 155, 198, 0, 0, 0, 0, 157, 26, 255, 152, 0, 0, 0, 0, 198, 4, 25, 144, 221, 89, 0, 0, 0, 0, 116, 172, 99, 76, 0, 0, 0, 0, 172, 199, 38, 192, 0, 0, 0, 0, 195, 145, 66, 9, 0, 0, 0, 0, 198, 4, 203, 127, 84, 238, 0, 0, 0, 0, 161, 173, 25, 180, 0, 0, 0, 0, 218, 166, 160, 123, 0, 0, 0, 0, 31, 35, 214, 92, 0, 0, 0, 0, 198, 4, 203, 145, 75, 135, 0, 0, 0, 0, 150, 85, 28, 127, 0, 0, 0, 0, 225, 151, 64, 149, 0, 0, 0, 0, 139, 26, 122, 117, 0, 0, 0, 0, 198, 4, 254, 28, 196, 132, 0, 0, 0, 0, 52, 182, 205, 187, 0, 0, 0, 0, 241, 25, 223, 229, 0, 0, 0, 0, 237, 148, 169, 148, 0, 0, 0, 0, 198, 4, 119, 247, 138, 70, 0, 0, 0, 0, 33, 39, 252, 148, 0, 0, 0, 0, 108, 157, 67, 27, 0, 0, 0, 0, 17, 52, 223, 43, 0, 0, 0, 0, 198, 4, 42, 123, 132, 110, 0, 0, 0, 0, 8, 254, 222, 227, 0, 0, 0, 0, 249, 79, 68, 76, 0, 0, 0, 0, 61, 208, 7, 48, 0, 0, 0, 0, 198, 4, 27, 77, 253, 219, 0, 0, 0, 0, 11, 119, 210, 55, 0, 0, 0, 0, 32, 36, 212, 220, 0, 0, 0, 0, 87, 182, 185, 243, 0, 0, 0, 0, 198, 4, 162, 169, 21, 33, 0, 0, 0, 0, 250, 239, 160, 175, 0, 0, 0, 0, 32, 206, 0, 57, 0, 0, 0, 0, 61, 169, 5, 110, 0, 0, 0, 0, 198, 4, 208, 77, 43, 216, 0, 0, 0, 0, 107, 235, 224, 189, 0, 0, 0, 0, 139, 84, 188, 160, 0, 0, 0, 0, 127, 24, 69, 15, 0, 0, 0, 0, 198, 4, 127, 235, 101, 239, 0, 0, 0, 0, 104, 6, 25, 232, 0, 0, 0, 0, 72, 25, 234, 188, 0, 0, 0, 0, 181, 85, 62, 39, 0, 0, 0, 0, 198, 4, 195, 121, 248, 12, 0, 0, 0, 0, 220, 136, 134, 67, 0, 0, 0, 0, 121, 8, 174, 233, 0, 0, 0, 0, 244, 235, 245, 49, 0, 0, 0, 0, 198, 4, 45, 126, 248, 224, 0, 0, 0, 0, 164, 125, 206, 160, 0, 0, 0, 0, 223, 160, 79, 157, 0, 0, 0, 0, 79, 89, 50, 144, 0, 0, 0, 0, 198, 4, 4, 215, 245, 0, 0, 0, 0, 0, 250, 39, 183, 170, 0, 0, 0, 0, 194, 40, 11, 88, 0, 0, 0, 0, 59, 19, 228, 138, 0, 0, 0, 0, 198, 4, 18, 171, 238, 101, 0, 0, 0, 0, 186, 223, 163, 225, 0, 0, 0, 0, 244, 81, 54, 76, 0, 0, 0, 0, 138, 48, 96, 50, 0, 0, 0, 0, 198, 4, 0, 220, 16, 253, 0, 0, 0, 0, 18, 232, 200, 168, 0, 0, 0, 0, 227, 255, 105, 2, 0, 0, 0, 0, 93, 200, 204, 141, 0, 0, 0, 0, 198, 4, 152, 95, 75, 4, 0, 0, 0, 0, 185, 180, 4, 121, 0, 0, 0, 0, 248, 245, 250, 31, 0, 0, 0, 0, 6, 14, 158, 144, 0, 0, 0, 0, 198, 4, 122, 44, 219, 65, 0, 0, 0, 0, 220, 229, 8, 108, 0, 0, 0, 0, 35, 37, 110, 86, 0, 0, 0, 0, 214, 199, 156, 119, 0, 0, 0, 0, 198, 4, 5, 142, 109, 192, 0, 0, 0, 0, 58, 126, 27, 173, 0, 0, 0, 0, 49, 156, 188, 38, 0, 0, 0, 0, 228, 198, 198, 8, 0, 0, 0, 0, 198, 4, 86, 194, 48, 250, 0, 0, 0, 0, 155, 27, 33, 173, 0, 0, 0, 0, 194, 131, 196, 243, 0, 0, 0, 0, 248, 103, 2, 86, 0, 0, 0, 0, 198, 4, 206, 178, 21, 130, 0, 0, 0, 0, 209, 167, 233, 29, 0, 0, 0, 0, 36, 172, 106, 158, 0, 0, 0, 0, 31, 105, 209, 223, 0, 0, 0, 0, 198, 4, 41, 147, 223, 82, 0, 0, 0, 0, 119, 125, 80, 250, 0, 0, 0, 0, 10, 200, 112, 154, 0, 0, 0, 0, 117, 187, 64, 47, 0, 0, 0, 0, 198, 4, 68, 158, 251, 54, 0, 0, 0, 0, 67, 186, 231, 199, 0, 0, 0, 0, 2, 228, 97, 182, 0, 0, 0, 0, 243, 189, 11, 85, 0, 0, 0, 0, 198, 4, 79, 128, 39, 228, 0, 0, 0, 0, 56, 7, 225, 123, 0, 0, 0, 0, 94, 153, 247, 51, 0, 0, 0, 0, 161, 98, 245, 173, 0, 0, 0, 0, 198, 4, 254, 68, 202, 55, 0, 0, 0, 0, 14, 145, 221, 104, 0, 0, 0, 0, 130, 24, 40, 68, 0, 0, 0, 0, 187, 153, 202, 174, 0, 0, 0, 0, 198, 4, 23, 126, 47, 75, 0, 0, 0, 0, 136, 189, 222, 186, 0, 0, 0, 0, 238, 80, 50, 97, 0, 0, 0, 0, 93, 117, 82, 6, 0, 0, 0, 0, 198, 4, 80, 137, 184, 55, 0, 0, 0, 0, 187, 9, 22, 138, 0, 0, 0, 0, 101, 199, 116, 146, 0, 0, 0, 0, 18, 157, 80, 249, 0, 0, 0, 0, 198, 4, 149, 68, 91, 27, 0, 0, 0, 0, 100, 96, 8, 4, 0, 0, 0, 0, 0, 212, 167, 121, 0, 0, 0, 0, 109, 145, 89, 82, 0, 0, 0, 0, 198, 4, 122, 15, 72, 181, 0, 0, 0, 0, 156, 194, 25, 181, 0, 0, 0, 0, 187, 50, 126, 36, 0, 0, 0, 0, 242, 50, 136, 36, 0, 0, 0, 0, 198, 4, 93, 1, 4, 211, 0, 0, 0, 0, 71, 167, 16, 135, 0, 0, 0, 0, 251, 43, 102, 147, 0, 0, 0, 0, 150, 6, 186, 40, 0, 0, 0, 0, 198, 4, 216, 100, 10, 150, 0, 0, 0, 0, 134, 134, 247, 240, 0, 0, 0, 0, 197, 43, 223, 88, 0, 0, 0, 0, 97, 120, 143, 172, 0, 0, 0, 0, 198, 4, 248, 244, 158, 133, 0, 0, 0, 0, 245, 100, 135, 127, 0, 0, 0, 0, 233, 104, 161, 204, 0, 0, 0, 0, 199, 222, 109, 191, 0, 0, 0, 0, 198, 4, 11, 185, 29, 30, 0, 0, 0, 0, 56, 49, 161, 62, 0, 0, 0, 0, 75, 80, 39, 231, 0, 0, 0, 0, 234, 122, 237, 45, 0, 0, 0, 0, 198, 4, 196, 154, 163, 210, 0, 0, 0, 0, 29, 184, 66, 195, 0, 0, 0, 0, 102, 109, 99, 110, 0, 0, 0, 0, 173, 150, 213, 51, 0, 0, 0, 0, 198, 4, 67, 152, 173, 23, 0, 0, 0, 0, 44, 238, 145, 59, 0, 0, 0, 0, 46, 81, 182, 224, 0, 0, 0, 0, 153, 209, 71, 232, 0, 0, 0, 0, 198, 4, 172, 176, 138, 220, 0, 0, 0, 0, 75, 141, 179, 191, 0, 0, 0, 0, 216, 210, 204, 91, 0, 0, 0, 0, 92, 46, 153, 13, 0, 0, 0, 0, 198, 4, 149, 37, 54, 152, 0, 0, 0, 0, 151, 87, 9, 188, 0, 0, 0, 0, 218, 102, 154, 218, 0, 0, 0, 0, 228, 188, 143, 242, 0, 0, 0, 0, 198, 4, 118, 48, 83, 160, 0, 0, 0, 0, 102, 167, 191, 7, 0, 0, 0, 0, 116, 31, 233, 221, 0, 0, 0, 0, 161, 69, 190, 80, 0, 0, 0, 0, 198, 4, 161, 110, 196, 190, 0, 0, 0, 0, 195, 106, 73, 37, 0, 0, 0, 0, 74, 18, 54, 139, 0, 0, 0, 0, 201, 70, 132, 60, 0, 0, 0, 0, 198, 4, 13, 25, 182, 71, 0, 0, 0, 0, 222, 15, 20, 114, 0, 0, 0, 0, 25, 32, 153, 174, 0, 0, 0, 0, 211, 140, 166, 242, 0, 0, 0, 0, 198, 4, 181, 185, 17, 39, 0, 0, 0, 0, 29, 152, 58, 96, 0, 0, 0, 0, 235, 231, 12, 43, 0, 0, 0, 0, 8, 31, 118, 71, 0, 0, 0, 0, 198, 4, 150, 192, 76, 181, 0, 0, 0, 0, 123, 162, 130, 187, 0, 0, 0, 0, 121, 251, 22, 245, 0, 0, 0, 0, 145, 14, 211, 52, 0, 0, 0, 0, 198, 4, 34, 76, 214, 26, 0, 0, 0, 0, 8, 163, 86, 55, 0, 0, 0, 0, 33, 124, 34, 161, 0, 0, 0, 0, 13, 108, 198, 152, 0, 0, 0, 0, 198, 4, 43, 57, 55, 3, 0, 0, 0, 0, 231, 64, 12, 159, 0, 0, 0, 0, 146, 2, 8, 40, 0, 0, 0, 0, 19, 175, 164, 79, 0, 0, 0, 0, 198, 4, 237, 30, 63, 206, 0, 0, 0, 0, 244, 88, 44, 229, 0, 0, 0, 0, 48, 8, 184, 192, 0, 0, 0, 0, 95, 100, 49, 195, 0, 0, 0, 0, 198, 4, 239, 42, 40, 131, 0, 0, 0, 0, 149, 10, 23, 149, 0, 0, 0, 0, 101, 90, 229, 110, 0, 0, 0, 0, 14, 195, 50, 60, 0, 0, 0, 0, 198, 4, 87, 29, 59, 140, 0, 0, 0, 0, 130, 126, 211, 153, 0, 0, 0, 0, 107, 205, 97, 45, 0, 0, 0, 0, 156, 224, 64, 1, 0, 0, 0, 0, 198, 4, 80, 150, 192, 117, 0, 0, 0, 0, 219, 219, 182, 140, 0, 0, 0, 0, 79, 21, 74, 11, 0, 0, 0, 0, 26, 21, 68, 186, 0, 0, 0, 0, 198, 4, 172, 49, 110, 190, 0, 0, 0, 0, 166, 147, 152, 51, 0, 0, 0, 0, 187, 225, 211, 164, 0, 0, 0, 0, 220, 117, 114, 6, 0, 0, 0, 0, 198, 4, 107, 243, 51, 89, 0, 0, 0, 0, 65, 166, 15, 20, 0, 0, 0, 0, 245, 121, 48, 49, 0, 0, 0, 0, 176, 191, 156, 5, 0, 0, 0, 0, 198, 4, 168, 189, 217, 140, 0, 0, 0, 0, 83, 157, 68, 99, 0, 0, 0, 0, 43, 160, 90, 242, 0, 0, 0, 0, 141, 231, 183, 125, 0, 0, 0, 0, 198, 4, 199, 41, 141, 48, 0, 0, 0, 0, 191, 17, 230, 242, 0, 0, 0, 0, 226, 207, 7, 9, 0, 0, 0, 0, 127, 123, 166, 226, 0, 0, 0, 0, 198, 4, 92, 241, 183, 141, 0, 0, 0, 0, 64, 245, 29, 185, 0, 0, 0, 0, 41, 167, 70, 39, 0, 0, 0, 0, 143, 51, 96, 229, 0, 0, 0, 0, 198, 4, 191, 116, 84, 73, 0, 0, 0, 0, 211, 178, 219, 152, 0, 0, 0, 0, 96, 206, 177, 91, 0, 0, 0, 0, 194, 125, 231, 228, 0, 0, 0, 0, 198, 4, 200, 101, 56, 94, 0, 0, 0, 0, 241, 34, 144, 11, 0, 0, 0, 0, 201, 240, 138, 116, 0, 0, 0, 0, 6, 47, 189, 12, 0, 0, 0, 0, 198, 4, 73, 242, 180, 58, 0, 0, 0, 0, 246, 197, 78, 118, 0, 0, 0, 0, 221, 55, 25, 254, 0, 0, 0, 0, 96, 231, 25, 22, 0, 0, 0, 0, 198, 4, 17, 56, 193, 226, 0, 0, 0, 0, 14, 76, 23, 161, 0, 0, 0, 0, 252, 119, 152, 120, 0, 0, 0, 0, 217, 62, 32, 109, 0, 0, 0, 0, 198, 4, 150, 179, 206, 203, 0, 0, 0, 0, 38, 72, 173, 53, 0, 0, 0, 0, 81, 141, 14, 189, 0, 0, 0, 0, 55, 164, 83, 97, 0, 0, 0, 0, 198, 4, 36, 224, 136, 62, 0, 0, 0, 0, 88, 213, 80, 241, 0, 0, 0, 0, 213, 179, 222, 219, 0, 0, 0, 0, 138, 101, 97, 15, 0, 0, 0, 0, 198, 4, 175, 129, 248, 205, 0, 0, 0, 0, 203, 205, 115, 32, 0, 0, 0, 0, 203, 252, 76, 255, 0, 0, 0, 0, 48, 228, 105, 167, 0, 0, 0, 0, 198, 4, 159, 129, 210, 97, 0, 0, 0, 0, 167, 40, 66, 212, 0, 0, 0, 0, 150, 189, 101, 13, 0, 0, 0, 0, 219, 10, 47, 91, 0, 0, 0, 0, 198, 4, 45, 92, 198, 109, 0, 0, 0, 0, 106, 162, 62, 29, 0, 0, 0, 0, 101, 210, 247, 224, 0, 0, 0, 0, 250, 166, 97, 96, 0, 0, 0, 0, 198, 4, 178, 50, 6, 20, 0, 0, 0, 0, 111, 84, 178, 67, 0, 0, 0, 0, 170, 1, 82, 81, 0, 0, 0, 0, 180, 87, 79, 235, 0, 0, 0, 0, 198, 4, 70, 3, 253, 85, 0, 0, 0, 0, 203, 198, 167, 96, 0, 0, 0, 0, 128, 6, 99, 8, 0, 0, 0, 0, 234, 3, 115, 188, 0, 0, 0, 0, 198, 4, 118, 94, 193, 65, 0, 0, 0, 0, 225, 90, 24, 134, 0, 0, 0, 0, 85, 117, 29, 112, 0, 0, 0, 0, 70, 128, 223, 124, 0, 0, 0, 0, 198, 4, 56, 91, 16, 216, 0, 0, 0, 0, 89, 113, 109, 91, 0, 0, 0, 0, 187, 172, 128, 122, 0, 0, 0, 0, 36, 234, 231, 29, 0, 0, 0, 0, 198, 4, 49, 229, 36, 49, 0, 0, 0, 0, 14, 127, 239, 230, 0, 0, 0, 0, 135, 183, 78, 66, 0, 0, 0, 0, 170, 251, 250, 100, 0, 0, 0, 0, 198, 4, 149, 99, 44, 28, 0, 0, 0, 0, 71, 172, 219, 99, 0, 0, 0, 0, 64, 14, 202, 129, 0, 0, 0, 0, 161, 241, 156, 80, 0, 0, 0, 0, 198, 4, 253, 246, 243, 32, 0, 0, 0, 0, 112, 195, 8, 221, 0, 0, 0, 0, 130, 123, 115, 241, 0, 0, 0, 0, 113, 144, 211, 99, 0, 0, 0, 0, 198, 4, 195, 182, 36, 40, 0, 0, 0, 0, 40, 43, 84, 19, 0, 0, 0, 0, 24, 205, 118, 229, 0, 0, 0, 0, 133, 204, 128, 122, 0, 0, 0, 0, 198, 4, 89, 171, 81, 80, 0, 0, 0, 0, 53, 223, 5, 167, 0, 0, 0, 0, 153, 253, 15, 171, 0, 0, 0, 0, 189, 248, 153, 91, 0, 0, 0, 0, 198, 4, 57, 218, 231, 231, 0, 0, 0, 0, 171, 188, 65, 27, 0, 0, 0, 0, 81, 57, 109, 2, 0, 0, 0, 0, 28, 92, 38, 23, 0, 0, 0, 0, 198, 4, 225, 53, 60, 104, 0, 0, 0, 0, 94, 206, 105, 179, 0, 0, 0, 0, 120, 172, 13, 171, 0, 0, 0, 0, 101, 40, 24, 30, 0, 0, 0, 0, 198, 4, 84, 15, 190, 41, 0, 0, 0, 0, 214, 195, 209, 205, 0, 0, 0, 0, 194, 243, 65, 53, 0, 0, 0, 0, 47, 48, 32, 36, 0, 0, 0, 0, 198, 4, 2, 224, 175, 255, 0, 0, 0, 0, 40, 22, 116, 187, 0, 0, 0, 0, 18, 77, 114, 142, 0, 0, 0, 0, 215, 228, 166, 177, 0, 0, 0, 0, 198, 4, 163, 3, 45, 70, 0, 0, 0, 0, 196, 158, 74, 200, 0, 0, 0, 0, 114, 232, 167, 82, 0, 0, 0, 0, 185, 224, 147, 116, 0, 0, 0, 0, 198, 4, 111, 233, 198, 178, 0, 0, 0, 0, 96, 243, 99, 220, 0, 0, 0, 0, 10, 139, 167, 31, 0, 0, 0, 0, 174, 240, 21, 164, 0, 0, 0, 0, 198, 4, 219, 221, 38, 22, 0, 0, 0, 0, 111, 6, 149, 125, 0, 0, 0, 0, 40, 145, 120, 188, 0, 0, 0, 0, 61, 35, 232, 69, 0, 0, 0, 0, 198, 4, 80, 167, 60, 115, 0, 0, 0, 0, 49, 160, 230, 74, 0, 0, 0, 0, 223, 85, 234, 12, 0, 0, 0, 0, 67, 88, 247, 41, 0, 0, 0, 0, 198, 4, 36, 236, 25, 254, 0, 0, 0, 0, 226, 175, 18, 29, 0, 0, 0, 0, 23, 219, 100, 185, 0, 0, 0, 0, 140, 154, 10, 33, 0, 0, 0, 0, 198, 4, 167, 63, 99, 148, 0, 0, 0, 0, 180, 171, 237, 45, 0, 0, 0, 0, 227, 118, 128, 134, 0, 0, 0, 0, 207, 245, 6, 57, 0, 0, 0, 0, 198, 4, 184, 142, 189, 113, 0, 0, 0, 0, 51, 228, 102, 151, 0, 0, 0, 0, 236, 35, 103, 225, 0, 0, 0, 0, 192, 94, 90, 3, 0, 0, 0, 0, 198, 4, 98, 70, 112, 197, 0, 0, 0, 0, 58, 19, 97, 136, 0, 0, 0, 0, 246, 7, 188, 228, 0, 0, 0, 0, 59, 101, 223, 11, 0, 0, 0, 0, 198, 4, 205, 42, 163, 124, 0, 0, 0, 0, 188, 226, 1, 98, 0, 0, 0, 0, 28, 198, 7, 179, 0, 0, 0, 0, 233, 201, 59, 7, 0, 0, 0, 0, 198, 4, 107, 79, 232, 114, 0, 0, 0, 0, 103, 10, 82, 171, 0, 0, 0, 0, 84, 30, 186, 6, 0, 0, 0, 0, 112, 98, 61, 101, 0, 0, 0, 0, 198, 4, 105, 33, 48, 207, 0, 0, 0, 0, 243, 205, 20, 182, 0, 0, 0, 0, 158, 117, 222, 5, 0, 0, 0, 0, 39, 220, 142, 235, 0, 0, 0, 0, 198, 4, 212, 12, 238, 85, 0, 0, 0, 0, 240, 199, 108, 121, 0, 0, 0, 0, 4, 70, 2, 230, 0, 0, 0, 0, 140, 165, 245, 19, 0, 0, 0, 0, 198, 4, 107, 95, 188, 222, 0, 0, 0, 0, 38, 75, 47, 36, 0, 0, 0, 0, 83, 36, 158, 122, 0, 0, 0, 0, 214, 84, 58, 160, 0, 0, 0, 0, 198, 4, 202, 154, 69, 190, 0, 0, 0, 0, 122, 102, 189, 117, 0, 0, 0, 0, 214, 151, 7, 255, 0, 0, 0, 0, 251, 146, 7, 62, 0, 0, 0, 0, 198, 4, 217, 55, 59, 214, 0, 0, 0, 0, 93, 153, 81, 207, 0, 0, 0, 0, 249, 12, 234, 102, 0, 0, 0, 0, 41, 122, 188, 5, 0, 0, 0, 0, 198, 4, 44, 242, 148, 172, 0, 0, 0, 0, 40, 232, 7, 132, 0, 0, 0, 0, 174, 110, 74, 180, 0, 0, 0, 0, 159, 94, 24, 120, 0, 0, 0, 0, 198, 4, 140, 249, 237, 58, 0, 0, 0, 0, 157, 21, 10, 90, 0, 0, 0, 0, 215, 103, 88, 59, 0, 0, 0, 0, 140, 222, 110, 50, 0, 0, 0, 0, 198, 4, 121, 56, 157, 133, 0, 0, 0, 0, 56, 210, 241, 6, 0, 0, 0, 0, 229, 96, 168, 176, 0, 0, 0, 0, 17, 126, 198, 189, 0, 0, 0, 0, 198, 4, 75, 178, 163, 235, 0, 0, 0, 0, 105, 176, 206, 130, 0, 0, 0, 0, 57, 122, 227, 127, 0, 0, 0, 0, 48, 215, 74, 162, 0, 0, 0, 0, 198, 4, 123, 24, 188, 127, 0, 0, 0, 0, 163, 129, 126, 3, 0, 0, 0, 0, 241, 221, 36, 1, 0, 0, 0, 0, 11, 181, 247, 25, 0, 0, 0, 0, 198, 4, 237, 37, 54, 47, 0, 0, 0, 0, 46, 232, 107, 229, 0, 0, 0, 0, 41, 128, 40, 199, 0, 0, 0, 0, 135, 135, 250, 136, 0, 0, 0, 0, 198, 4, 187, 49, 134, 232, 0, 0, 0, 0, 178, 248, 130, 177, 0, 0, 0, 0, 150, 52, 149, 127, 0, 0, 0, 0, 40, 110, 112, 147, 0, 0, 0, 0, 198, 4, 64, 191, 17, 173, 0, 0, 0, 0, 158, 38, 229, 3, 0, 0, 0, 0, 45, 213, 156, 103, 0, 0, 0, 0, 251, 249, 250, 92, 0, 0, 0, 0, 198, 4, 128, 186, 216, 76, 0, 0, 0, 0, 16, 132, 38, 84, 0, 0, 0, 0, 132, 35, 34, 96, 0, 0, 0, 0, 211, 6, 11, 36, 0, 0, 0, 0, 198, 4, 47, 156, 23, 111, 0, 0, 0, 0, 82, 54, 142, 139, 0, 0, 0, 0, 208, 248, 148, 122, 0, 0, 0, 0, 85, 37, 219, 134, 0, 0, 0, 0, 198, 4, 88, 184, 254, 39, 0, 0, 0, 0, 126, 117, 228, 5, 0, 0, 0, 0, 198, 141, 173, 78, 0, 0, 0, 0, 115, 153, 6, 90, 0, 0, 0, 0, 198, 4, 203, 208, 84, 129, 0, 0, 0, 0, 15, 67, 165, 206, 0, 0, 0, 0, 11, 19, 137, 162, 0, 0, 0, 0, 19, 250, 150, 221, 0, 0, 0, 0, 198, 4, 203, 252, 16, 203, 0, 0, 0, 0, 236, 129, 36, 107, 0, 0, 0, 0, 239, 44, 196, 134, 0, 0, 0, 0, 82, 191, 195, 95, 0, 0, 0, 0, 198, 4, 188, 109, 89, 83, 0, 0, 0, 0, 74, 177, 26, 192, 0, 0, 0, 0, 102, 50, 11, 43, 0, 0, 0, 0, 132, 30, 105, 148, 0, 0, 0, 0, 198, 4, 227, 152, 28, 76, 0, 0, 0, 0, 152, 106, 226, 183, 0, 0, 0, 0, 101, 46, 99, 228, 0, 0, 0, 0, 59, 121, 66, 44, 0, 0, 0, 0, 198, 4, 161, 18, 36, 164, 0, 0, 0, 0, 164, 74, 161, 240, 0, 0, 0, 0, 235, 162, 15, 22, 0, 0, 0, 0, 200, 198, 113, 74, 0, 0, 0, 0, 198, 4, 127, 61, 227, 170, 0, 0, 0, 0, 15, 19, 217, 35, 0, 0, 0, 0, 215, 58, 173, 30, 0, 0, 0, 0, 144, 204, 26, 3, 0, 0, 0, 0, 198, 4, 32, 246, 123, 182, 0, 0, 0, 0, 253, 19, 233, 95, 0, 0, 0, 0, 141, 71, 155, 78, 0, 0, 0, 0, 202, 204, 183, 34, 0, 0, 0, 0, 198, 4, 141, 220, 224, 247, 0, 0, 0, 0, 27, 24, 7, 74, 0, 0, 0, 0, 29, 171, 21, 94, 0, 0, 0, 0, 238, 68, 241, 202, 0, 0, 0, 0, 198, 4, 23, 232, 203, 126, 0, 0, 0, 0, 144, 46, 149, 87, 0, 0, 0, 0, 92, 246, 96, 35, 0, 0, 0, 0, 176, 208, 42, 5, 0, 0, 0, 0, 198, 4, 22, 27, 241, 237, 0, 0, 0, 0, 194, 181, 228, 131, 0, 0, 0, 0, 246, 118, 3, 151, 0, 0, 0, 0, 241, 130, 43, 16, 0, 0, 0, 0, 198, 4, 184, 6, 195, 231, 0, 0, 0, 0, 38, 54, 230, 251, 0, 0, 0, 0, 225, 47, 218, 203, 0, 0, 0, 0, 17, 243, 127, 40, 0, 0, 0, 0, 198, 4, 192, 132, 253, 202, 0, 0, 0, 0, 78, 3, 233, 126, 0, 0, 0, 0, 60, 19, 79, 169, 0, 0, 0, 0, 163, 197, 188, 189, 0, 0, 0, 0, 198, 4, 34, 45, 115, 112, 0, 0, 0, 0, 254, 233, 171, 233, 0, 0, 0, 0, 177, 140, 96, 174, 0, 0, 0, 0, 128, 19, 26, 36, 0, 0, 0, 0, 198, 4, 166, 70, 107, 62, 0, 0, 0, 0, 115, 195, 160, 83, 0, 0, 0, 0, 221, 254, 72, 133, 0, 0, 0, 0, 169, 199, 42, 144, 0, 0, 0, 0, 198, 4, 198, 166, 244, 190, 0, 0, 0, 0, 174, 243, 91, 15, 0, 0, 0, 0, 218, 147, 245, 86, 0, 0, 0, 0, 1, 137, 131, 236, 0, 0, 0, 0, 198, 4, 151, 193, 27, 68, 0, 0, 0, 0, 227, 18, 234, 213, 0, 0, 0, 0, 235, 120, 247, 211, 0, 0, 0, 0, 225, 148, 236, 48, 0, 0, 0, 0, 198, 4, 151, 105, 220, 160, 0, 0, 0, 0, 225, 81, 84, 29, 0, 0, 0, 0, 145, 75, 15, 59, 0, 0, 0, 0, 40, 255, 60, 246, 0, 0, 0, 0, 198, 4, 3, 78, 147, 240, 0, 0, 0, 0, 195, 107, 217, 169, 0, 0, 0, 0, 14, 124, 112, 98, 0, 0, 0, 0, 205, 32, 7, 184, 0, 0, 0, 0, 198, 4, 241, 80, 53, 5, 0, 0, 0, 0, 93, 1, 31, 243, 0, 0, 0, 0, 2, 191, 182, 97, 0, 0, 0, 0, 201, 107, 120, 5, 0, 0, 0, 0, 198, 4, 5, 204, 17, 125, 0, 0, 0, 0, 122, 157, 146, 153, 0, 0, 0, 0, 211, 185, 141, 145, 0, 0, 0, 0, 236, 189, 170, 196, 0, 0, 0, 0, 198, 4, 6, 47, 155, 227, 0, 0, 0, 0, 157, 150, 173, 86, 0, 0, 0, 0, 173, 160, 20, 161, 0, 0, 0, 0, 192, 64, 16, 251, 0, 0, 0, 0, 198, 4, 8, 247, 182, 221, 0, 0, 0, 0, 163, 93, 250, 119, 0, 0, 0, 0, 216, 195, 94, 207, 0, 0, 0, 0, 150, 33, 175, 23, 0, 0, 0, 0, 198, 4, 61, 149, 197, 145, 0, 0, 0, 0, 252, 11, 103, 13, 0, 0, 0, 0, 87, 255, 127, 246, 0, 0, 0, 0, 37, 202, 171, 38, 0, 0, 0, 0, 198, 4, 129, 75, 126, 66, 0, 0, 0, 0, 51, 82, 32, 114, 0, 0, 0, 0, 40, 27, 18, 215, 0, 0, 0, 0, 73, 186, 123, 109, 0, 0, 0, 0, 198, 4, 224, 182, 75, 185, 0, 0, 0, 0, 138, 79, 24, 155, 0, 0, 0, 0, 60, 129, 4, 180, 0, 0, 0, 0, 232, 246, 165, 199, 0, 0, 0, 0, 198, 4, 165, 213, 160, 32, 0, 0, 0, 0, 1, 159, 195, 111, 0, 0, 0, 0, 213, 156, 188, 215, 0, 0, 0, 0, 129, 203, 167, 252, 0, 0, 0, 0, 198, 4, 122, 27, 51, 49, 0, 0, 0, 0, 129, 140, 187, 181, 0, 0, 0, 0, 117, 195, 245, 90, 0, 0, 0, 0, 28, 27, 248, 40, 0, 0, 0, 0, 198, 4, 120, 155, 125, 251, 0, 0, 0, 0, 56, 77, 240, 6, 0, 0, 0, 0, 42, 224, 181, 132, 0, 0, 0, 0, 206, 158, 61, 116, 0, 0, 0, 0, 198, 4, 49, 2, 56, 158, 0, 0, 0, 0, 170, 144, 232, 101, 0, 0, 0, 0, 233, 67, 37, 22, 0, 0, 0, 0, 66, 158, 234, 165, 0, 0, 0, 0, 198, 4, 8, 97, 139, 19, 0, 0, 0, 0, 112, 132, 105, 40, 0, 0, 0, 0, 51, 39, 177, 219, 0, 0, 0, 0, 142, 157, 223, 237, 0, 0, 0, 0, 198, 4, 64, 178, 233, 102, 0, 0, 0, 0, 212, 152, 96, 125, 0, 0, 0, 0, 234, 43, 172, 7, 0, 0, 0, 0, 106, 92, 47, 99, 0, 0, 0, 0, 198, 4, 69, 152, 239, 141, 0, 0, 0, 0, 116, 195, 75, 183, 0, 0, 0, 0, 97, 126, 130, 97, 0, 0, 0, 0, 68, 121, 76, 197, 0, 0, 0, 0, 198, 4, 144, 231, 51, 248, 0, 0, 0, 0, 83, 145, 131, 93, 0, 0, 0, 0, 42, 55, 209, 241, 0, 0, 0, 0, 154, 208, 240, 200, 0, 0, 0, 0, 198, 4, 121, 3, 36, 41, 0, 0, 0, 0, 37, 158, 122, 20, 0, 0, 0, 0, 207, 21, 251, 42, 0, 0, 0, 0, 212, 176, 118, 62, 0, 0, 0, 0, 198, 4, 253, 217, 134, 123, 0, 0, 0, 0, 251, 250, 44, 0, 0, 0, 0, 0, 210, 81, 192, 105, 0, 0, 0, 0, 34, 25, 13, 76, 0, 0, 0, 0, 198, 4, 86, 144, 34, 4, 0, 0, 0, 0, 196, 171, 148, 140, 0, 0, 0, 0, 186, 150, 211, 16, 0, 0, 0, 0, 214, 241, 177, 88, 0, 0, 0, 0, 198, 4, 221, 10, 243, 67, 0, 0, 0, 0, 125, 42, 14, 17, 0, 0, 0, 0, 17, 67, 19, 102, 0, 0, 0, 0, 163, 70, 113, 135, 0, 0, 0, 0, 198, 4, 87, 219, 250, 194, 0, 0, 0, 0, 95, 255, 200, 167, 0, 0, 0, 0, 69, 177, 139, 67, 0, 0, 0, 0, 191, 80, 156, 197, 0, 0, 0, 0, 198, 4, 155, 219, 54, 160, 0, 0, 0, 0, 201, 40, 95, 198, 0, 0, 0, 0, 60, 252, 59, 74, 0, 0, 0, 0, 244, 47, 204, 141, 0, 0, 0, 0, 198, 4, 170, 168, 180, 166, 0, 0, 0, 0, 207, 121, 210, 37, 0, 0, 0, 0, 83, 2, 31, 208, 0, 0, 0, 0, 145, 198, 74, 96, 0, 0, 0, 0, 198, 4, 198, 61, 227, 83, 0, 0, 0, 0, 19, 147, 251, 245, 0, 0, 0, 0, 181, 174, 109, 128, 0, 0, 0, 0, 21, 195, 196, 24, 0, 0, 0, 0, 198, 4, 21, 68, 135, 107, 0, 0, 0, 0, 199, 3, 194, 135, 0, 0, 0, 0, 219, 61, 109, 150, 0, 0, 0, 0, 20, 233, 208, 164, 0, 0, 0, 0, 198, 4, 61, 115, 170, 124, 0, 0, 0, 0, 194, 64, 129, 68, 0, 0, 0, 0, 237, 18, 40, 154, 0, 0, 0, 0, 247, 78, 37, 5, 0, 0, 0, 0, 198, 4, 19, 190, 76, 8, 0, 0, 0, 0, 13, 20, 117, 183, 0, 0, 0, 0, 83, 120, 5, 228, 0, 0, 0, 0, 76, 174, 215, 220, 0, 0, 0, 0, 198, 4, 250, 172, 11, 226, 0, 0, 0, 0, 156, 12, 193, 162, 0, 0, 0, 0, 52, 84, 61, 229, 0, 0, 0, 0, 210, 213, 206, 201, 0, 0, 0, 0, 198, 4, 37, 17, 163, 247, 0, 0, 0, 0, 65, 231, 34, 194, 0, 0, 0, 0, 228, 154, 167, 223, 0, 0, 0, 0, 226, 234, 187, 134, 0, 0, 0, 0, 198, 4, 25, 249, 148, 236, 0, 0, 0, 0, 97, 15, 118, 223, 0, 0, 0, 0, 6, 68, 129, 85, 0, 0, 0, 0, 92, 62, 175, 103, 0, 0, 0, 0, 198, 4, 120, 76, 190, 14, 0, 0, 0, 0, 92, 6, 161, 210, 0, 0, 0, 0, 25, 29, 216, 242, 0, 0, 0, 0, 251, 244, 214, 227, 0, 0, 0, 0, 198, 4, 165, 10, 100, 37, 0, 0, 0, 0, 146, 3, 144, 138, 0, 0, 0, 0, 220, 244, 245, 49, 0, 0, 0, 0, 49, 132, 119, 61, 0, 0, 0, 0, 198, 4, 229, 20, 152, 123, 0, 0, 0, 0, 73, 206, 75, 160, 0, 0, 0, 0, 76, 155, 121, 218, 0, 0, 0, 0, 18, 60, 124, 206, 0, 0, 0, 0, 198, 4, 49, 130, 183, 95, 0, 0, 0, 0, 88, 178, 110, 70, 0, 0, 0, 0, 20, 246, 17, 124, 0, 0, 0, 0, 253, 182, 18, 190, 0, 0, 0, 0, 198, 4, 166, 62, 136, 139, 0, 0, 0, 0, 173, 228, 150, 11, 0, 0, 0, 0, 80, 253, 190, 155, 0, 0, 0, 0, 64, 219, 215, 157, 0, 0, 0, 0, 198, 4, 187, 206, 89, 253, 0, 0, 0, 0, 236, 143, 191, 140, 0, 0, 0, 0, 251, 117, 205, 103, 0, 0, 0, 0, 238, 6, 25, 231, 0, 0, 0, 0, 198, 4, 184, 85, 52, 162, 0, 0, 0, 0, 97, 253, 251, 103, 0, 0, 0, 0, 96, 132, 111, 147, 0, 0, 0, 0, 119, 110, 201, 9, 0, 0, 0, 0, 198, 4, 194, 57, 15, 139, 0, 0, 0, 0, 105, 146, 105, 73, 0, 0, 0, 0, 183, 244, 22, 151, 0, 0, 0, 0, 249, 101, 254, 238, 0, 0, 0, 0, 198, 4, 114, 49, 135, 190, 0, 0, 0, 0, 138, 136, 30, 74, 0, 0, 0, 0, 112, 116, 63, 72, 0, 0, 0, 0, 213, 112, 175, 87, 0, 0, 0, 0, 198, 4, 59, 77, 36, 97, 0, 0, 0, 0, 248, 235, 133, 179, 0, 0, 0, 0, 203, 88, 226, 40, 0, 0, 0, 0, 211, 216, 100, 47, 0, 0, 0, 0, 198, 4, 78, 219, 129, 66, 0, 0, 0, 0, 246, 68, 218, 175, 0, 0, 0, 0, 215, 20, 55, 151, 0, 0, 0, 0, 41, 195, 59, 182, 0, 0, 0, 0, 198, 4, 11, 90, 13, 201, 0, 0, 0, 0, 207, 242, 247, 161, 0, 0, 0, 0, 172, 117, 10, 98, 0, 0, 0, 0, 98, 166, 100, 95, 0, 0, 0, 0, 198, 4, 10, 190, 114, 198, 0, 0, 0, 0, 221, 38, 96, 223, 0, 0, 0, 0, 58, 13, 99, 108, 0, 0, 0, 0, 146, 99, 151, 238, 0, 0, 0, 0, 198, 4, 124, 102, 165, 193, 0, 0, 0, 0, 129, 150, 162, 167, 0, 0, 0, 0, 8, 0, 105, 228, 0, 0, 0, 0, 180, 164, 26, 48, 0, 0, 0, 0, 198, 4, 93, 199, 93, 67, 0, 0, 0, 0, 85, 222, 237, 111, 0, 0, 0, 0, 201, 19, 9, 234, 0, 0, 0, 0, 203, 207, 14, 39, 0, 0, 0, 0, 198, 4, 203, 89, 245, 243, 0, 0, 0, 0, 185, 43, 212, 60, 0, 0, 0, 0, 78, 167, 93, 78, 0, 0, 0, 0, 123, 240, 78, 147, 0, 0, 0, 0, 198, 4, 160, 209, 117, 131, 0, 0, 0, 0, 153, 228, 94, 116, 0, 0, 0, 0, 70, 58, 38, 218, 0, 0, 0, 0, 139, 54, 55, 255, 0, 0, 0, 0, 198, 4, 177, 231, 116, 23, 0, 0, 0, 0, 12, 169, 59, 80, 0, 0, 0, 0, 20, 37, 228, 197, 0, 0, 0, 0, 54, 91, 25, 30, 0, 0, 0, 0, 198, 4, 96, 130, 171, 23, 0, 0, 0, 0, 102, 191, 61, 132, 0, 0, 0, 0, 179, 109, 215, 168, 0, 0, 0, 0, 122, 56, 159, 215, 0, 0, 0, 0, 198, 4, 168, 89, 241, 150, 0, 0, 0, 0, 235, 100, 140, 40, 0, 0, 0, 0, 107, 10, 172, 130, 0, 0, 0, 0, 243, 78, 100, 169, 0, 0, 0, 0, 198, 4, 14, 11, 47, 177, 0, 0, 0, 0, 3, 21, 152, 50, 0, 0, 0, 0, 131, 1, 227, 221, 0, 0, 0, 0, 80, 29, 153, 232, 0, 0, 0, 0, 198, 4, 76, 184, 206, 40, 0, 0, 0, 0, 89, 207, 6, 170, 0, 0, 0, 0, 111, 116, 136, 202, 0, 0, 0, 0, 249, 169, 118, 175, 0, 0, 0, 0, 198, 4, 250, 145, 153, 184, 0, 0, 0, 0, 252, 124, 72, 134, 0, 0, 0, 0, 201, 227, 149, 130, 0, 0, 0, 0, 135, 158, 62, 237, 0, 0, 0, 0, 198, 4, 50, 155, 133, 103, 0, 0, 0, 0, 242, 49, 24, 183, 0, 0, 0, 0, 80, 134, 168, 81, 0, 0, 0, 0, 220, 23, 253, 110, 0, 0, 0, 0, 198, 4, 229, 232, 178, 235, 0, 0, 0, 0, 248, 91, 15, 170, 0, 0, 0, 0, 209, 181, 122, 190, 0, 0, 0, 0, 72, 17, 91, 214, 0, 0, 0, 0, 198, 4, 239, 92, 205, 48, 0, 0, 0, 0, 175, 242, 79, 184, 0, 0, 0, 0, 99, 242, 42, 35, 0, 0, 0, 0, 76, 59, 137, 226, 0, 0, 0, 0, 198, 4, 11, 153, 195, 229, 0, 0, 0, 0, 79, 114, 198, 46, 0, 0, 0, 0, 151, 28, 255, 200, 0, 0, 0, 0, 181, 53, 150, 187, 0, 0, 0, 0, 198, 4, 10, 51, 49, 213, 0, 0, 0, 0, 77, 142, 79, 196, 0, 0, 0, 0, 102, 196, 166, 213, 0, 0, 0, 0, 156, 142, 180, 194, 0, 0, 0, 0, 198, 4, 170, 30, 220, 88, 0, 0, 0, 0, 254, 205, 113, 150, 0, 0, 0, 0, 56, 221, 198, 175, 0, 0, 0, 0, 215, 110, 188, 45, 0, 0, 0, 0, 198, 4, 79, 191, 83, 73, 0, 0, 0, 0, 49, 219, 170, 8, 0, 0, 0, 0, 122, 243, 129, 170, 0, 0, 0, 0, 174, 1, 89, 120, 0, 0, 0, 0, 198, 4, 7, 212, 147, 69, 0, 0, 0, 0, 204, 213, 202, 165, 0, 0, 0, 0, 238, 196, 48, 231, 0, 0, 0, 0, 225, 150, 204, 9, 0, 0, 0, 0, 198, 4, 146, 73, 36, 90, 0, 0, 0, 0, 94, 241, 248, 14, 0, 0, 0, 0, 117, 87, 233, 218, 0, 0, 0, 0, 245, 64, 176, 201, 0, 0, 0, 0, 198, 4, 111, 125, 168, 39, 0, 0, 0, 0, 65, 2, 154, 7, 0, 0, 0, 0, 203, 185, 80, 103, 0, 0, 0, 0, 126, 203, 236, 146, 0, 0, 0, 0, 198, 4, 82, 57, 89, 142, 0, 0, 0, 0, 77, 200, 1, 25, 0, 0, 0, 0, 33, 101, 156, 216, 0, 0, 0, 0, 37, 10, 33, 153, 0, 0, 0, 0, 198, 4, 42, 81, 135, 99, 0, 0, 0, 0, 89, 6, 164, 11, 0, 0, 0, 0, 223, 134, 32, 166, 0, 0, 0, 0, 109, 188, 156, 185, 0, 0, 0, 0, 198, 4, 130, 19, 220, 82, 0, 0, 0, 0, 18, 242, 104, 158, 0, 0, 0, 0, 179, 181, 190, 238, 0, 0, 0, 0, 44, 154, 39, 116, 0, 0, 0, 0, 198, 4, 145, 236, 154, 21, 0, 0, 0, 0, 243, 86, 112, 88, 0, 0, 0, 0, 227, 3, 97, 88, 0, 0, 0, 0, 224, 105, 167, 255, 0, 0, 0, 0, 198, 4, 225, 42, 221, 88, 0, 0, 0, 0, 246, 143, 248, 4, 0, 0, 0, 0, 220, 112, 37, 34, 0, 0, 0, 0, 201, 11, 27, 22, 0, 0, 0, 0, 198, 4, 192, 164, 112, 206, 0, 0, 0, 0, 173, 139, 118, 73, 0, 0, 0, 0, 250, 177, 168, 119, 0, 0, 0, 0, 253, 83, 13, 240, 0, 0, 0, 0, 198, 4, 48, 211, 151, 78, 0, 0, 0, 0, 105, 25, 107, 209, 0, 0, 0, 0, 90, 141, 63, 109, 0, 0, 0, 0, 21, 194, 113, 161, 0, 0, 0, 0, 198, 4, 237, 56, 167, 1, 0, 0, 0, 0, 197, 197, 227, 254, 0, 0, 0, 0, 140, 159, 120, 243, 0, 0, 0, 0, 1, 12, 252, 182, 0, 0, 0, 0, 198, 4, 169, 152, 169, 125, 0, 0, 0, 0, 62, 144, 138, 185, 0, 0, 0, 0, 200, 173, 113, 112, 0, 0, 0, 0, 216, 205, 226, 8, 0, 0, 0, 0, 198, 4, 225, 40, 122, 203, 0, 0, 0, 0, 166, 222, 198, 80, 0, 0, 0, 0, 246, 244, 11, 142, 0, 0, 0, 0, 111, 124, 125, 229, 0, 0, 0, 0, 198, 4, 80, 48, 45, 7, 0, 0, 0, 0, 117, 139, 54, 119, 0, 0, 0, 0, 118, 217, 40, 28, 0, 0, 0, 0, 112, 133, 161, 238, 0, 0, 0, 0, 198, 4, 210, 31, 228, 40, 0, 0, 0, 0, 212, 167, 136, 55, 0, 0, 0, 0, 207, 41, 198, 8, 0, 0, 0, 0, 93, 125, 101, 89, 0, 0, 0, 0, 198, 4, 239, 46, 190, 172, 0, 0, 0, 0, 118, 88, 154, 212, 0, 0, 0, 0, 29, 123, 244, 208, 0, 0, 0, 0, 117, 96, 54, 183, 0, 0, 0, 0, 198, 4, 224, 201, 163, 140, 0, 0, 0, 0, 137, 51, 253, 96, 0, 0, 0, 0, 15, 18, 118, 160, 0, 0, 0, 0, 153, 82, 74, 22, 0, 0, 0, 0, 198, 4, 20, 228, 230, 181, 0, 0, 0, 0, 44, 245, 199, 37, 0, 0, 0, 0, 16, 186, 193, 84, 0, 0, 0, 0, 221, 239, 188, 85, 0, 0, 0, 0, 198, 4, 162, 244, 110, 125, 0, 0, 0, 0, 88, 135, 61, 70, 0, 0, 0, 0, 134, 17, 122, 182, 0, 0, 0, 0, 145, 238, 208, 165, 0, 0, 0, 0, 198, 4, 171, 41, 24, 155, 0, 0, 0, 0, 47, 14, 52, 185, 0, 0, 0, 0, 217, 34, 251, 56, 0, 0, 0, 0, 91, 121, 249, 136, 0, 0, 0, 0, 198, 4, 62, 75, 183, 144, 0, 0, 0, 0, 177, 61, 1, 205, 0, 0, 0, 0, 89, 130, 230, 156, 0, 0, 0, 0, 142, 187, 168, 87, 0, 0, 0, 0, 198, 4, 83, 163, 13, 241, 0, 0, 0, 0, 187, 68, 134, 177, 0, 0, 0, 0, 138, 24, 183, 169, 0, 0, 0, 0, 187, 17, 11, 156, 0, 0, 0, 0, 198, 4, 123, 247, 52, 55, 0, 0, 0, 0, 187, 168, 4, 172, 0, 0, 0, 0, 62, 76, 178, 232, 0, 0, 0, 0, 173, 99, 0, 45, 0, 0, 0, 0, 198, 4, 132, 121, 59, 60, 0, 0, 0, 0, 25, 141, 163, 1, 0, 0, 0, 0, 16, 16, 138, 222, 0, 0, 0, 0, 139, 120, 237, 3, 0, 0, 0, 0, 198, 4, 185, 98, 100, 159, 0, 0, 0, 0, 135, 217, 148, 87, 0, 0, 0, 0, 157, 170, 190, 199, 0, 0, 0, 0, 81, 0, 71, 192, 0, 0, 0, 0, 198, 4, 233, 122, 86, 148, 0, 0, 0, 0, 68, 36, 90, 218, 0, 0, 0, 0, 122, 186, 150, 0, 0, 0, 0, 0, 15, 84, 140, 225, 0, 0, 0, 0, 198, 4, 19, 144, 200, 137, 0, 0, 0, 0, 158, 19, 82, 205, 0, 0, 0, 0, 104, 171, 161, 22, 0, 0, 0, 0, 137, 246, 82, 87, 0, 0, 0, 0, 198, 4, 134, 23, 166, 114, 0, 0, 0, 0, 238, 57, 102, 14, 0, 0, 0, 0, 181, 86, 34, 123, 0, 0, 0, 0, 34, 50, 3, 93, 0, 0, 0, 0, 198, 4, 221, 60, 184, 48, 0, 0, 0, 0, 55, 0, 26, 149, 0, 0, 0, 0, 90, 251, 248, 66, 0, 0, 0, 0, 210, 99, 124, 217, 0, 0, 0, 0, 198, 4, 62, 29, 215, 220, 0, 0, 0, 0, 94, 150, 140, 181, 0, 0, 0, 0, 230, 223, 16, 210, 0, 0, 0, 0, 245, 227, 138, 90, 0, 0, 0, 0, 198, 4, 236, 145, 105, 22, 0, 0, 0, 0, 53, 224, 244, 54, 0, 0, 0, 0, 55, 132, 187, 213, 0, 0, 0, 0, 122, 234, 45, 235, 0, 0, 0, 0, 198, 4, 24, 48, 65, 208, 0, 0, 0, 0, 72, 231, 233, 164, 0, 0, 0, 0, 80, 202, 8, 85, 0, 0, 0, 0, 114, 123, 84, 195, 0, 0, 0, 0, 198, 4, 21, 41, 191, 156, 0, 0, 0, 0, 246, 214, 117, 223, 0, 0, 0, 0, 54, 10, 131, 200, 0, 0, 0, 0, 104, 193, 200, 17, 0, 0, 0, 0, 198, 4, 194, 221, 175, 216, 0, 0, 0, 0, 156, 199, 190, 177, 0, 0, 0, 0, 240, 140, 6, 86, 0, 0, 0, 0, 183, 23, 4, 158, 0, 0, 0, 0, 198, 4, 230, 128, 166, 48, 0, 0, 0, 0, 14, 194, 73, 210, 0, 0, 0, 0, 46, 182, 78, 114, 0, 0, 0, 0, 86, 47, 123, 89, 0, 0, 0, 0, 198, 4, 45, 7, 52, 251, 0, 0, 0, 0, 158, 213, 163, 113, 0, 0, 0, 0, 37, 42, 92, 116, 0, 0, 0, 0, 105, 226, 78, 95, 0, 0, 0, 0, 198, 4, 84, 122, 62, 52, 0, 0, 0, 0, 198, 208, 174, 64, 0, 0, 0, 0, 16, 109, 177, 65, 0, 0, 0, 0, 254, 149, 55, 58, 0, 0, 0, 0, 198, 4, 115, 105, 17, 148, 0, 0, 0, 0, 155, 202, 147, 251, 0, 0, 0, 0, 207, 176, 98, 63, 0, 0, 0, 0, 68, 233, 228, 172, 0, 0, 0, 0, 198, 4, 110, 97, 8, 107, 0, 0, 0, 0, 51, 169, 129, 152, 0, 0, 0, 0, 4, 92, 148, 183, 0, 0, 0, 0, 169, 215, 202, 253, 0, 0, 0, 0, 198, 4, 194, 221, 179, 158, 0, 0, 0, 0, 29, 121, 197, 74, 0, 0, 0, 0, 253, 132, 0, 57, 0, 0, 0, 0, 42, 211, 76, 92, 0, 0, 0, 0, 198, 4, 16, 86, 76, 10, 0, 0, 0, 0, 149, 214, 46, 242, 0, 0, 0, 0, 64, 240, 181, 91, 0, 0, 0, 0, 26, 103, 174, 196, 0, 0, 0, 0, 198, 4, 184, 208, 202, 78, 0, 0, 0, 0, 74, 13, 205, 132, 0, 0, 0, 0, 156, 179, 71, 90, 0, 0, 0, 0, 247, 245, 210, 39, 0, 0, 0, 0, 198, 4, 133, 106, 126, 222, 0, 0, 0, 0, 26, 146, 170, 135, 0, 0, 0, 0, 79, 213, 54, 82, 0, 0, 0, 0, 227, 25, 46, 210, 0, 0, 0, 0, 198, 4, 192, 123, 58, 47, 0, 0, 0, 0, 88, 187, 231, 17, 0, 0, 0, 0, 94, 30, 79, 210, 0, 0, 0, 0, 52, 7, 226, 39, 0, 0, 0, 0, 198, 4, 129, 101, 168, 125, 0, 0, 0, 0, 143, 244, 249, 114, 0, 0, 0, 0, 75, 98, 5, 235, 0, 0, 0, 0, 103, 31, 215, 139, 0, 0, 0, 0, 198, 4, 180, 157, 114, 201, 0, 0, 0, 0, 94, 169, 88, 172, 0, 0, 0, 0, 231, 180, 251, 160, 0, 0, 0, 0, 99, 246, 41, 94, 0, 0, 0, 0, 198, 4, 19, 18, 170, 247, 0, 0, 0, 0, 249, 54, 133, 176, 0, 0, 0, 0, 216, 78, 49, 157, 0, 0, 0, 0, 203, 217, 67, 223, 0, 0, 0, 0, 198, 4, 80, 196, 242, 142, 0, 0, 0, 0, 113, 204, 200, 248, 0, 0, 0, 0, 254, 192, 251, 185, 0, 0, 0, 0, 165, 93, 142, 153, 0, 0, 0, 0, 198, 4, 79, 53, 199, 239, 0, 0, 0, 0, 139, 114, 71, 44, 0, 0, 0, 0, 222, 147, 137, 89, 0, 0, 0, 0, 152, 225, 68, 69, 0, 0, 0, 0, 198, 4, 219, 120, 8, 179, 0, 0, 0, 0, 20, 252, 160, 7, 0, 0, 0, 0, 181, 7, 159, 44, 0, 0, 0, 0, 168, 90, 113, 177, 0, 0, 0, 0, 198, 4, 23, 224, 196, 184, 0, 0, 0, 0, 145, 117, 225, 122, 0, 0, 0, 0, 53, 129, 74, 91, 0, 0, 0, 0, 67, 97, 98, 9, 0, 0, 0, 0, 198, 4, 203, 152, 27, 61, 0, 0, 0, 0, 9, 183, 117, 77, 0, 0, 0, 0, 103, 61, 149, 246, 0, 0, 0, 0, 30, 26, 154, 184, 0, 0, 0, 0, 198, 4, 181, 24, 137, 72, 0, 0, 0, 0, 125, 164, 90, 75, 0, 0, 0, 0, 122, 67, 193, 50, 0, 0, 0, 0, 140, 57, 175, 48, 0, 0, 0, 0, 198, 4, 179, 6, 220, 127, 0, 0, 0, 0, 145, 136, 102, 122, 0, 0, 0, 0, 250, 134, 121, 48, 0, 0, 0, 0, 121, 169, 123, 22, 0, 0, 0, 0, 198, 4, 152, 127, 54, 127, 0, 0, 0, 0, 5, 117, 118, 27, 0, 0, 0, 0, 110, 51, 73, 90, 0, 0, 0, 0, 33, 149, 2, 166, 0, 0, 0, 0, 198, 4, 95, 163, 204, 215, 0, 0, 0, 0, 211, 16, 244, 40, 0, 0, 0, 0, 139, 9, 168, 229, 0, 0, 0, 0, 114, 44, 186, 135, 0, 0, 0, 0, 198, 4, 203, 133, 176, 193, 0, 0, 0, 0, 79, 126, 151, 164, 0, 0, 0, 0, 0, 79, 137, 180, 0, 0, 0, 0, 32, 109, 20, 98, 0, 0, 0, 0, 198, 4, 87, 241, 171, 0, 0, 0, 0, 0, 25, 132, 68, 73, 0, 0, 0, 0, 195, 206, 50, 110, 0, 0, 0, 0, 104, 201, 191, 181, 0, 0, 0, 0, 198, 4, 253, 38, 72, 72, 0, 0, 0, 0, 59, 149, 86, 212, 0, 0, 0, 0, 197, 25, 97, 140, 0, 0, 0, 0, 233, 53, 95, 148, 0, 0, 0, 0, 198, 4, 106, 15, 116, 125, 0, 0, 0, 0, 201, 148, 131, 75, 0, 0, 0, 0, 44, 13, 244, 40, 0, 0, 0, 0, 244, 200, 90, 130, 0, 0, 0, 0, 198, 4, 220, 253, 232, 163, 0, 0, 0, 0, 234, 22, 245, 85, 0, 0, 0, 0, 95, 41, 138, 252, 0, 0, 0, 0, 57, 240, 248, 5, 0, 0, 0, 0, 198, 4, 36, 180, 145, 134, 0, 0, 0, 0, 245, 254, 204, 187, 0, 0, 0, 0, 101, 106, 161, 236, 0, 0, 0, 0, 171, 242, 115, 248, 0, 0, 0, 0, 198, 4, 230, 124, 73, 218, 0, 0, 0, 0, 190, 232, 21, 136, 0, 0, 0, 0, 146, 178, 93, 102, 0, 0, 0, 0, 172, 64, 126, 127, 0, 0, 0, 0, 198, 4, 40, 104, 50, 161, 0, 0, 0, 0, 244, 128, 53, 111, 0, 0, 0, 0, 235, 80, 160, 190, 0, 0, 0, 0, 223, 90, 7, 110, 0, 0, 0, 0, 198, 4, 110, 74, 15, 55, 0, 0, 0, 0, 125, 210, 178, 44, 0, 0, 0, 0, 192, 149, 202, 83, 0, 0, 0, 0, 74, 23, 157, 199, 0, 0, 0, 0, 198, 4, 250, 247, 170, 65, 0, 0, 0, 0, 53, 83, 210, 212, 0, 0, 0, 0, 232, 148, 57, 163, 0, 0, 0, 0, 233, 40, 209, 30, 0, 0, 0, 0, 198, 4, 56, 101, 99, 189, 0, 0, 0, 0, 118, 34, 132, 117, 0, 0, 0, 0, 106, 234, 115, 204, 0, 0, 0, 0, 30, 193, 123, 73, 0, 0, 0, 0, 198, 4, 98, 65, 28, 77, 0, 0, 0, 0, 223, 122, 71, 223, 0, 0, 0, 0, 220, 184, 17, 243, 0, 0, 0, 0, 246, 34, 198, 134, 0, 0, 0, 0, 198, 4, 185, 47, 54, 235, 0, 0, 0, 0, 225, 231, 251, 3, 0, 0, 0, 0, 247, 190, 139, 253, 0, 0, 0, 0, 170, 69, 205, 96, 0, 0, 0, 0, 198, 4, 91, 167, 70, 230, 0, 0, 0, 0, 66, 90, 246, 96, 0, 0, 0, 0, 39, 169, 161, 221, 0, 0, 0, 0, 133, 199, 18, 17, 0, 0, 0, 0, 198, 4, 32, 202, 29, 235, 0, 0, 0, 0, 192, 194, 56, 210, 0, 0, 0, 0, 119, 25, 234, 114, 0, 0, 0, 0, 62, 249, 147, 38, 0, 0, 0, 0, 198, 4, 61, 216, 109, 89, 0, 0, 0, 0, 147, 251, 90, 145, 0, 0, 0, 0, 113, 126, 244, 203, 0, 0, 0, 0, 178, 229, 183, 212, 0, 0, 0, 0, 198, 4, 240, 213, 215, 247, 0, 0, 0, 0, 96, 182, 17, 240, 0, 0, 0, 0, 50, 31, 54, 190, 0, 0, 0, 0, 88, 247, 182, 156, 0, 0, 0, 0, 198, 4, 247, 200, 101, 87, 0, 0, 0, 0, 49, 7, 44, 54, 0, 0, 0, 0, 163, 82, 46, 198, 0, 0, 0, 0, 36, 239, 231, 31, 0, 0, 0, 0, 198, 4, 45, 71, 194, 143, 0, 0, 0, 0, 225, 175, 232, 159, 0, 0, 0, 0, 22, 153, 11, 128, 0, 0, 0, 0, 219, 148, 93, 187, 0, 0, 0, 0, 198, 4, 38, 182, 45, 9, 0, 0, 0, 0, 253, 120, 66, 239, 0, 0, 0, 0, 0, 22, 24, 95, 0, 0, 0, 0, 237, 103, 1, 46, 0, 0, 0, 0, 198, 4, 237, 253, 51, 17, 0, 0, 0, 0, 162, 40, 163, 194, 0, 0, 0, 0, 130, 8, 119, 41, 0, 0, 0, 0, 40, 84, 209, 231, 0, 0, 0, 0, 198, 4, 163, 135, 199, 212, 0, 0, 0, 0, 20, 98, 127, 40, 0, 0, 0, 0, 136, 14, 197, 16, 0, 0, 0, 0, 13, 12, 233, 215, 0, 0, 0, 0, 198, 4, 196, 170, 148, 228, 0, 0, 0, 0, 111, 7, 138, 195, 0, 0, 0, 0, 196, 16, 86, 115, 0, 0, 0, 0, 88, 125, 98, 98, 0, 0, 0, 0, 198, 4, 124, 19, 65, 215, 0, 0, 0, 0, 19, 3, 50, 109, 0, 0, 0, 0, 111, 126, 118, 102, 0, 0, 0, 0, 35, 124, 130, 116, 0, 0, 0, 0, 198, 4, 126, 161, 0, 76, 0, 0, 0, 0, 25, 11, 205, 52, 0, 0, 0, 0, 242, 189, 146, 174, 0, 0, 0, 0, 20, 187, 5, 175, 0, 0, 0, 0, 198, 4, 96, 135, 161, 37, 0, 0, 0, 0, 254, 152, 232, 129, 0, 0, 0, 0, 216, 146, 45, 14, 0, 0, 0, 0, 122, 190, 47, 86, 0, 0, 0, 0, 198, 4, 74, 118, 202, 62, 0, 0, 0, 0, 115, 71, 73, 27, 0, 0, 0, 0, 154, 61, 67, 134, 0, 0, 0, 0, 129, 127, 117, 82, 0, 0, 0, 0, 198, 4, 230, 213, 247, 110, 0, 0, 0, 0, 59, 233, 7, 203, 0, 0, 0, 0, 254, 184, 184, 183, 0, 0, 0, 0, 61, 1, 223, 254, 0, 0, 0, 0, 198, 4, 3, 26, 132, 152, 0, 0, 0, 0, 18, 252, 24, 157, 0, 0, 0, 0, 75, 124, 35, 172, 0, 0, 0, 0, 207, 70, 101, 191, 0, 0, 0, 0, 198, 4, 177, 166, 58, 131, 0, 0, 0, 0, 84, 117, 122, 171, 0, 0, 0, 0, 182, 123, 27, 123, 0, 0, 0, 0, 214, 215, 159, 176, 0, 0, 0, 0, 198, 4, 110, 106, 163, 235, 0, 0, 0, 0, 68, 187, 77, 132, 0, 0, 0, 0, 8, 255, 205, 152, 0, 0, 0, 0, 126, 204, 199, 95, 0, 0, 0, 0, 198, 4, 249, 27, 0, 39, 0, 0, 0, 0, 115, 81, 5, 45, 0, 0, 0, 0, 108, 250, 25, 70, 0, 0, 0, 0, 140, 75, 95, 117, 0, 0, 0, 0, 198, 4, 188, 174, 39, 236, 0, 0, 0, 0, 146, 86, 189, 40, 0, 0, 0, 0, 104, 57, 111, 50, 0, 0, 0, 0, 250, 250, 75, 137, 0, 0, 0, 0, 198, 4, 14, 77, 233, 200, 0, 0, 0, 0, 88, 199, 77, 145, 0, 0, 0, 0, 238, 117, 136, 218, 0, 0, 0, 0, 40, 78, 157, 2, 0, 0, 0, 0, 198, 4, 15, 207, 62, 66, 0, 0, 0, 0, 23, 212, 106, 50, 0, 0, 0, 0, 56, 92, 169, 7, 0, 0, 0, 0, 213, 244, 61, 172, 0, 0, 0, 0, 198, 4, 66, 134, 30, 55, 0, 0, 0, 0, 81, 10, 127, 234, 0, 0, 0, 0, 76, 7, 136, 99, 0, 0, 0, 0, 240, 88, 51, 145, 0, 0, 0, 0, 198, 4, 137, 36, 120, 167, 0, 0, 0, 0, 225, 216, 237, 241, 0, 0, 0, 0, 170, 233, 169, 9, 0, 0, 0, 0, 26, 223, 192, 66, 0, 0, 0, 0, 198, 4, 106, 35, 140, 47, 0, 0, 0, 0, 10, 23, 44, 130, 0, 0, 0, 0, 56, 167, 145, 154, 0, 0, 0, 0, 220, 116, 193, 128, 0, 0, 0, 0, 198, 4, 235, 165, 144, 49, 0, 0, 0, 0, 79, 173, 175, 92, 0, 0, 0, 0, 219, 102, 131, 33, 0, 0, 0, 0, 113, 171, 10, 42, 0, 0, 0, 0, 198, 4, 139, 14, 58, 38, 0, 0, 0, 0, 72, 176, 1, 179, 0, 0, 0, 0, 51, 6, 35, 228, 0, 0, 0, 0, 177, 131, 135, 1, 0, 0, 0, 0, 198, 4, 105, 208, 184, 17, 0, 0, 0, 0, 166, 225, 77, 177, 0, 0, 0, 0, 66, 42, 227, 86, 0, 0, 0, 0, 170, 226, 213, 67, 0, 0, 0, 0, 198, 4, 160, 158, 16, 132, 0, 0, 0, 0, 197, 38, 67, 109, 0, 0, 0, 0, 85, 226, 186, 62, 0, 0, 0, 0, 147, 136, 243, 219, 0, 0, 0, 0, 198, 4, 119, 38, 246, 65, 0, 0, 0, 0, 23, 149, 225, 232, 0, 0, 0, 0, 237, 46, 248, 217, 0, 0, 0, 0, 53, 178, 194, 178, 0, 0, 0, 0, 198, 4, 12, 152, 164, 151, 0, 0, 0, 0, 222, 211, 235, 221, 0, 0, 0, 0, 131, 59, 10, 106, 0, 0, 0, 0, 247, 216, 244, 241, 0, 0, 0, 0, 198, 4, 58, 133, 27, 239, 0, 0, 0, 0, 190, 52, 104, 178, 0, 0, 0, 0, 188, 79, 34, 68, 0, 0, 0, 0, 149, 58, 199, 232, 0, 0, 0, 0, 198, 4, 245, 96, 237, 238, 0, 0, 0, 0, 229, 43, 189, 233, 0, 0, 0, 0, 18, 138, 51, 212, 0, 0, 0, 0, 135, 255, 106, 25, 0, 0, 0, 0, 198, 4, 126, 225, 130, 210, 0, 0, 0, 0, 57, 180, 146, 17, 0, 0, 0, 0, 180, 94, 149, 102, 0, 0, 0, 0, 167, 204, 133, 191, 0, 0, 0, 0, 198, 4, 237, 179, 105, 73, 0, 0, 0, 0, 195, 93, 218, 33, 0, 0, 0, 0, 21, 182, 48, 222, 0, 0, 0, 0, 244, 23, 148, 153, 0, 0, 0, 0, 198, 4, 89, 70, 149, 59, 0, 0, 0, 0, 149, 209, 237, 92, 0, 0, 0, 0, 150, 242, 193, 224, 0, 0, 0, 0, 0, 220, 126, 201, 0, 0, 0, 0, 198, 4, 136, 28, 20, 245, 0, 0, 0, 0, 248, 129, 24, 6, 0, 0, 0, 0, 38, 140, 223, 27, 0, 0, 0, 0, 38, 95, 12, 94, 0, 0, 0, 0, 198, 4, 173, 48, 252, 147, 0, 0, 0, 0, 40, 189, 48, 137, 0, 0, 0, 0, 132, 75, 30, 33, 0, 0, 0, 0, 158, 48, 14, 140, 0, 0, 0, 0, 198, 4, 245, 123, 113, 210, 0, 0, 0, 0, 141, 186, 14, 212, 0, 0, 0, 0, 88, 221, 153, 79, 0, 0, 0, 0, 117, 124, 29, 207, 0, 0, 0, 0, 198, 4, 84, 117, 64, 118, 0, 0, 0, 0, 222, 224, 187, 188, 0, 0, 0, 0, 197, 213, 75, 159, 0, 0, 0, 0, 155, 16, 15, 91, 0, 0, 0, 0, 198, 4, 186, 176, 57, 235, 0, 0, 0, 0, 15, 41, 101, 167, 0, 0, 0, 0, 174, 6, 152, 248, 0, 0, 0, 0, 120, 27, 6, 92, 0, 0, 0, 0, 198, 4, 156, 197, 15, 37, 0, 0, 0, 0, 192, 65, 113, 115, 0, 0, 0, 0, 236, 205, 36, 91, 0, 0, 0, 0, 41, 25, 170, 49, 0, 0, 0, 0, 198, 4, 111, 7, 99, 3, 0, 0, 0, 0, 172, 51, 16, 124, 0, 0, 0, 0, 150, 163, 47, 65, 0, 0, 0, 0, 123, 4, 248, 105, 0, 0, 0, 0, 198, 4, 89, 182, 21, 204, 0, 0, 0, 0, 198, 10, 236, 89, 0, 0, 0, 0, 51, 205, 48, 34, 0, 0, 0, 0, 101, 13, 182, 117, 0, 0, 0, 0, 198, 4, 208, 79, 82, 17, 0, 0, 0, 0, 61, 198, 188, 135, 0, 0, 0, 0, 65, 98, 89, 13, 0, 0, 0, 0, 202, 108, 4, 132, 0, 0, 0, 0, 198, 4, 65, 35, 30, 123, 0, 0, 0, 0, 142, 74, 227, 5, 0, 0, 0, 0, 229, 51, 7, 14, 0, 0, 0, 0, 85, 186, 42, 203, 0, 0, 0, 0, 198, 4, 149, 128, 118, 90, 0, 0, 0, 0, 147, 171, 91, 30, 0, 0, 0, 0, 97, 14, 226, 63, 0, 0, 0, 0, 229, 189, 165, 83, 0, 0, 0, 0, 198, 4, 136, 120, 165, 64, 0, 0, 0, 0, 176, 253, 219, 41, 0, 0, 0, 0, 189, 191, 54, 180, 0, 0, 0, 0, 18, 91, 204, 212, 0, 0, 0, 0, 198, 4, 233, 69, 100, 111, 0, 0, 0, 0, 237, 91, 26, 28, 0, 0, 0, 0, 48, 15, 37, 193, 0, 0, 0, 0, 48, 106, 55, 126, 0, 0, 0, 0, 198, 4, 42, 196, 71, 196, 0, 0, 0, 0, 135, 46, 147, 237, 0, 0, 0, 0, 195, 148, 72, 204, 0, 0, 0, 0, 82, 13, 156, 158, 0, 0, 0, 0, 198, 4, 137, 50, 20, 40, 0, 0, 0, 0, 33, 39, 185, 21, 0, 0, 0, 0, 115, 177, 208, 187, 0, 0, 0, 0, 124, 72, 230, 108, 0, 0, 0, 0, 198, 4, 183, 210, 92, 105, 0, 0, 0, 0, 95, 158, 246, 8, 0, 0, 0, 0, 212, 60, 185, 101, 0, 0, 0, 0, 228, 81, 168, 105, 0, 0, 0, 0, 198, 4, 174, 18, 228, 138, 0, 0, 0, 0, 37, 209, 30, 226, 0, 0, 0, 0, 229, 95, 82, 99, 0, 0, 0, 0, 157, 193, 113, 67, 0, 0, 0, 0, 198, 4, 224, 218, 79, 199, 0, 0, 0, 0, 15, 144, 246, 237, 0, 0, 0, 0, 56, 158, 224, 170, 0, 0, 0, 0, 252, 99, 228, 156, 0, 0, 0, 0, 198, 4, 65, 46, 23, 25, 0, 0, 0, 0, 152, 60, 51, 253, 0, 0, 0, 0, 172, 63, 213, 210, 0, 0, 0, 0, 226, 93, 79, 78, 0, 0, 0, 0, 198, 4, 200, 82, 92, 232, 0, 0, 0, 0, 119, 56, 99, 36, 0, 0, 0, 0, 171, 93, 215, 60, 0, 0, 0, 0, 215, 59, 85, 164, 0, 0, 0, 0, 198, 4, 85, 82, 89, 231, 0, 0, 0, 0, 213, 156, 167, 141, 0, 0, 0, 0, 179, 6, 173, 156, 0, 0, 0, 0, 82, 5, 249, 45, 0, 0, 0, 0, 198, 4, 188, 81, 164, 118, 0, 0, 0, 0, 200, 209, 70, 185, 0, 0, 0, 0, 120, 58, 224, 28, 0, 0, 0, 0, 158, 207, 209, 206, 0, 0, 0, 0, 198, 4, 46, 16, 194, 244, 0, 0, 0, 0, 24, 153, 167, 158, 0, 0, 0, 0, 16, 28, 26, 225, 0, 0, 0, 0, 125, 103, 32, 246, 0, 0, 0, 0, 198, 4, 214, 58, 11, 9, 0, 0, 0, 0, 202, 96, 135, 61, 0, 0, 0, 0, 107, 215, 48, 174, 0, 0, 0, 0, 97, 110, 68, 83, 0, 0, 0, 0, 198, 4, 209, 168, 115, 139, 0, 0, 0, 0, 25, 31, 129, 208, 0, 0, 0, 0, 41, 33, 119, 81, 0, 0, 0, 0, 200, 178, 96, 199, 0, 0, 0, 0, 198, 4, 222, 153, 97, 158, 0, 0, 0, 0, 159, 243, 57, 217, 0, 0, 0, 0, 207, 154, 51, 148, 0, 0, 0, 0, 248, 138, 194, 240, 0, 0, 0, 0, 198, 4, 73, 144, 182, 68, 0, 0, 0, 0, 129, 235, 144, 192, 0, 0, 0, 0, 82, 9, 221, 153, 0, 0, 0, 0, 60, 12, 82, 242, 0, 0, 0, 0, 198, 4, 158, 58, 250, 48, 0, 0, 0, 0, 98, 218, 184, 179, 0, 0, 0, 0, 60, 58, 213, 54, 0, 0, 0, 0, 159, 87, 223, 221, 0, 0, 0, 0, 198, 4, 158, 85, 229, 124, 0, 0, 0, 0, 223, 197, 7, 79, 0, 0, 0, 0, 108, 56, 46, 222, 0, 0, 0, 0, 87, 88, 97, 55, 0, 0, 0, 0, 198, 4, 26, 118, 202, 44, 0, 0, 0, 0, 162, 124, 141, 167, 0, 0, 0, 0, 0, 163, 152, 56, 0, 0, 0, 0, 154, 71, 34, 136, 0, 0, 0, 0, 198, 4, 96, 141, 126, 29, 0, 0, 0, 0, 45, 153, 246, 88, 0, 0, 0, 0, 52, 227, 246, 40, 0, 0, 0, 0, 203, 64, 0, 61, 0, 0, 0, 0, 198, 4, 187, 153, 3, 162, 0, 0, 0, 0, 163, 241, 98, 98, 0, 0, 0, 0, 28, 142, 183, 148, 0, 0, 0, 0, 82, 238, 151, 50, 0, 0, 0, 0, 198, 4, 104, 235, 221, 15, 0, 0, 0, 0, 132, 46, 216, 210, 0, 0, 0, 0, 41, 227, 236, 208, 0, 0, 0, 0, 80, 179, 165, 10, 0, 0, 0, 0, 198, 4, 198, 28, 74, 148, 0, 0, 0, 0, 121, 112, 91, 49, 0, 0, 0, 0, 53, 62, 124, 18, 0, 0, 0, 0, 26, 7, 111, 245, 0, 0, 0, 0, 198, 4, 87, 176, 211, 205, 0, 0, 0, 0, 247, 223, 32, 93, 0, 0, 0, 0, 226, 29, 112, 255, 0, 0, 0, 0, 185, 241, 127, 158, 0, 0, 0, 0, 198, 4, 125, 95, 94, 109, 0, 0, 0, 0, 140, 25, 7, 156, 0, 0, 0, 0, 137, 168, 215, 39, 0, 0, 0, 0, 155, 23, 11, 236, 0, 0, 0, 0, 198, 4, 172, 113, 201, 123, 0, 0, 0, 0, 0, 124, 250, 194, 0, 0, 0, 0, 232, 30, 151, 195, 0, 0, 0, 0, 187, 33, 120, 85, 0, 0, 0, 0, 198, 4, 25, 61, 220, 245, 0, 0, 0, 0, 37, 34, 82, 51, 0, 0, 0, 0, 76, 51, 59, 150, 0, 0, 0, 0, 171, 198, 45, 107, 0, 0, 0, 0, 198, 4, 114, 198, 40, 69, 0, 0, 0, 0, 95, 239, 230, 102, 0, 0, 0, 0, 127, 185, 234, 2, 0, 0, 0, 0, 43, 80, 101, 34, 0, 0, 0, 0, 198, 4, 118, 3, 5, 69, 0, 0, 0, 0, 145, 57, 207, 197, 0, 0, 0, 0, 101, 205, 247, 85, 0, 0, 0, 0, 226, 48, 147, 2, 0, 0, 0, 0, 198, 4, 89, 84, 225, 25, 0, 0, 0, 0, 87, 101, 153, 85, 0, 0, 0, 0, 164, 35, 124, 136, 0, 0, 0, 0, 96, 185, 11, 217, 0, 0, 0, 0, 198, 4, 141, 162, 75, 144, 0, 0, 0, 0, 220, 161, 72, 184, 0, 0, 0, 0, 170, 153, 154, 56, 0, 0, 0, 0, 43, 46, 119, 145, 0, 0, 0, 0, 198, 4, 183, 207, 215, 163, 0, 0, 0, 0, 81, 180, 33, 27, 0, 0, 0, 0, 216, 35, 107, 40, 0, 0, 0, 0, 35, 227, 207, 229, 0, 0, 0, 0, 198, 4, 2, 67, 47, 150, 0, 0, 0, 0, 59, 174, 78, 253, 0, 0, 0, 0, 32, 108, 183, 92, 0, 0, 0, 0, 68, 156, 22, 210, 0, 0, 0, 0, 198, 4, 195, 65, 255, 109, 0, 0, 0, 0, 90, 247, 239, 4, 0, 0, 0, 0, 249, 85, 165, 185, 0, 0, 0, 0, 211, 121, 129, 174, 0, 0, 0, 0, 198, 4, 95, 190, 109, 57, 0, 0, 0, 0, 197, 162, 28, 4, 0, 0, 0, 0, 86, 71, 57, 62, 0, 0, 0, 0, 199, 66, 35, 216, 0, 0, 0, 0, 198, 4, 7, 177, 194, 45, 0, 0, 0, 0, 36, 26, 13, 255, 0, 0, 0, 0, 248, 152, 254, 68, 0, 0, 0, 0, 241, 207, 112, 129, 0, 0, 0, 0, 198, 4, 34, 109, 71, 176, 0, 0, 0, 0, 15, 32, 19, 210, 0, 0, 0, 0, 84, 96, 146, 40, 0, 0, 0, 0, 221, 228, 136, 205, 0, 0, 0, 0, 198, 4, 69, 77, 189, 168, 0, 0, 0, 0, 229, 147, 250, 180, 0, 0, 0, 0, 120, 192, 9, 211, 0, 0, 0, 0, 156, 34, 231, 91, 0, 0, 0, 0, 198, 4, 198, 86, 20, 23, 0, 0, 0, 0, 202, 145, 161, 177, 0, 0, 0, 0, 69, 127, 72, 157, 0, 0, 0, 0, 221, 29, 6, 128, 0, 0, 0, 0, 198, 4, 161, 236, 95, 123, 0, 0, 0, 0, 97, 142, 32, 171, 0, 0, 0, 0, 192, 141, 130, 249, 0, 0, 0, 0, 6, 241, 85, 135, 0, 0, 0, 0, 198, 4, 101, 51, 162, 231, 0, 0, 0, 0, 42, 185, 184, 98, 0, 0, 0, 0, 203, 135, 43, 90, 0, 0, 0, 0, 82, 166, 29, 3, 0, 0, 0, 0, 198, 4, 183, 201, 231, 140, 0, 0, 0, 0, 100, 82, 72, 133, 0, 0, 0, 0, 133, 63, 178, 79, 0, 0, 0, 0, 144, 141, 125, 194, 0, 0, 0, 0, 198, 4, 107, 208, 177, 68, 0, 0, 0, 0, 104, 213, 241, 244, 0, 0, 0, 0, 133, 109, 68, 161, 0, 0, 0, 0, 216, 86, 251, 8, 0, 0, 0, 0, 198, 4, 221, 35, 222, 119, 0, 0, 0, 0, 92, 86, 41, 42, 0, 0, 0, 0, 88, 3, 8, 169, 0, 0, 0, 0, 188, 115, 189, 116, 0, 0, 0, 0, 198, 4, 103, 21, 19, 117, 0, 0, 0, 0, 171, 51, 185, 23, 0, 0, 0, 0, 70, 115, 46, 178, 0, 0, 0, 0, 252, 135, 148, 48, 0, 0, 0, 0, 198, 4, 60, 30, 10, 77, 0, 0, 0, 0, 221, 22, 45, 140, 0, 0, 0, 0, 56, 70, 194, 239, 0, 0, 0, 0, 39, 194, 108, 108, 0, 0, 0, 0, 198, 4, 145, 45, 9, 116, 0, 0, 0, 0, 48, 7, 139, 177, 0, 0, 0, 0, 58, 56, 125, 93, 0, 0, 0, 0, 155, 146, 27, 172, 0, 0, 0, 0, 198, 4, 207, 129, 111, 122, 0, 0, 0, 0, 148, 241, 249, 132, 0, 0, 0, 0, 224, 50, 54, 67, 0, 0, 0, 0, 4, 160, 34, 231, 0, 0, 0, 0, 198, 4, 135, 102, 142, 97, 0, 0, 0, 0, 185, 27, 54, 92, 0, 0, 0, 0, 200, 182, 47, 69, 0, 0, 0, 0, 50, 67, 91, 47, 0, 0, 0, 0, 198, 4, 22, 39, 140, 201, 0, 0, 0, 0, 47, 185, 230, 33, 0, 0, 0, 0, 201, 119, 127, 114, 0, 0, 0, 0, 16, 151, 211, 70, 0, 0, 0, 0, 198, 4, 244, 55, 5, 241, 0, 0, 0, 0, 64, 0, 89, 208, 0, 0, 0, 0, 33, 251, 160, 74, 0, 0, 0, 0, 163, 107, 137, 152, 0, 0, 0, 0, 198, 4, 43, 63, 10, 232, 0, 0, 0, 0, 253, 171, 201, 65, 0, 0, 0, 0, 68, 198, 45, 188, 0, 0, 0, 0, 182, 17, 210, 175, 0, 0, 0, 0, 198, 4, 133, 19, 6, 6, 0, 0, 0, 0, 56, 58, 110, 112, 0, 0, 0, 0, 1, 84, 124, 216, 0, 0, 0, 0, 190, 247, 85, 121, 0, 0, 0, 0, 198, 4, 117, 0, 187, 2, 0, 0, 0, 0, 66, 120, 219, 45, 0, 0, 0, 0, 73, 82, 34, 134, 0, 0, 0, 0, 179, 238, 174, 139, 0, 0, 0, 0, 198, 4, 17, 16, 91, 105, 0, 0, 0, 0, 82, 21, 240, 252, 0, 0, 0, 0, 16, 3, 178, 230, 0, 0, 0, 0, 3, 107, 23, 255, 0, 0, 0, 0, 198, 4, 29, 121, 73, 62, 0, 0, 0, 0, 105, 196, 171, 174, 0, 0, 0, 0, 199, 154, 72, 167, 0, 0, 0, 0, 105, 163, 39, 252, 0, 0, 0, 0, 198, 4, 241, 58, 185, 8, 0, 0, 0, 0, 87, 52, 150, 53, 0, 0, 0, 0, 11, 166, 183, 16, 0, 0, 0, 0, 18, 168, 232, 89, 0, 0, 0, 0, 198, 4, 44, 43, 81, 1, 0, 0, 0, 0, 162, 77, 101, 12, 0, 0, 0, 0, 76, 230, 253, 250, 0, 0, 0, 0, 6, 148, 35, 199, 0, 0, 0, 0, 198, 4, 111, 228, 152, 181, 0, 0, 0, 0, 100, 20, 55, 238, 0, 0, 0, 0, 149, 239, 26, 245, 0, 0, 0, 0, 215, 5, 247, 208, 0, 0, 0, 0, 198, 4, 81, 57, 102, 133, 0, 0, 0, 0, 37, 247, 138, 117, 0, 0, 0, 0, 5, 153, 118, 215, 0, 0, 0, 0, 61, 64, 193, 204, 0, 0, 0, 0, 198, 4, 171, 140, 179, 132, 0, 0, 0, 0, 136, 141, 153, 73, 0, 0, 0, 0, 187, 184, 224, 49, 0, 0, 0, 0, 33, 128, 11, 60, 0, 0, 0, 0, 198, 4, 230, 100, 227, 246, 0, 0, 0, 0, 226, 36, 94, 140, 0, 0, 0, 0, 140, 69, 48, 122, 0, 0, 0, 0, 40, 109, 5, 103, 0, 0, 0, 0, 198, 4, 4, 46, 218, 121, 0, 0, 0, 0, 209, 78, 247, 109, 0, 0, 0, 0, 11, 19, 247, 156, 0, 0, 0, 0, 21, 143, 116, 88, 0, 0, 0, 0, 198, 4, 18, 201, 184, 64, 0, 0, 0, 0, 109, 221, 81, 128, 0, 0, 0, 0, 223, 102, 75, 197, 0, 0, 0, 0, 179, 58, 244, 111, 0, 0, 0, 0, 198, 4, 70, 242, 226, 18, 0, 0, 0, 0, 122, 102, 101, 141, 0, 0, 0, 0, 25, 109, 23, 32, 0, 0, 0, 0, 254, 126, 160, 211, 0, 0, 0, 0, 198, 4, 209, 33, 169, 174, 0, 0, 0, 0, 123, 198, 73, 0, 0, 0, 0, 0, 131, 141, 4, 252, 0, 0, 0, 0, 106, 123, 66, 187, 0, 0, 0, 0, 198, 4, 125, 202, 117, 233, 0, 0, 0, 0, 6, 103, 110, 77, 0, 0, 0, 0, 74, 47, 87, 254, 0, 0, 0, 0, 66, 244, 112, 246, 0, 0, 0, 0, 198, 4, 111, 213, 122, 76, 0, 0, 0, 0, 58, 118, 40, 43, 0, 0, 0, 0, 213, 64, 21, 27, 0, 0, 0, 0, 151, 157, 99, 137, 0, 0, 0, 0, 198, 4, 65, 128, 146, 86, 0, 0, 0, 0, 96, 220, 3, 128, 0, 0, 0, 0, 253, 175, 119, 188, 0, 0, 0, 0, 199, 97, 206, 143, 0, 0, 0, 0, 198, 4, 216, 112, 208, 88, 0, 0, 0, 0, 203, 86, 249, 124, 0, 0, 0, 0, 144, 145, 118, 245, 0, 0, 0, 0, 39, 73, 212, 162, 0, 0, 0, 0, 198, 4, 251, 10, 66, 89, 0, 0, 0, 0, 222, 83, 251, 84, 0, 0, 0, 0, 105, 82, 70, 76, 0, 0, 0, 0, 158, 36, 133, 72, 0, 0, 0, 0, 198, 4, 229, 70, 55, 62, 0, 0, 0, 0, 80, 114, 252, 9, 0, 0, 0, 0, 1, 185, 189, 17, 0, 0, 0, 0, 118, 7, 244, 219, 0, 0, 0, 0, 198, 4, 222, 215, 244, 101, 0, 0, 0, 0, 23, 45, 142, 187, 0, 0, 0, 0, 71, 137, 196, 125, 0, 0, 0, 0, 102, 38, 237, 21, 0, 0, 0, 0, 198, 4, 133, 246, 192, 249, 0, 0, 0, 0, 205, 227, 232, 234, 0, 0, 0, 0, 80, 197, 67, 231, 0, 0, 0, 0, 139, 180, 18, 72, 0, 0, 0, 0, 198, 4, 17, 210, 245, 11, 0, 0, 0, 0, 88, 66, 10, 120, 0, 0, 0, 0, 47, 56, 43, 240, 0, 0, 0, 0, 51, 14, 170, 77, 0, 0, 0, 0, 198, 4, 8, 124, 240, 162, 0, 0, 0, 0, 36, 176, 210, 107, 0, 0, 0, 0, 176, 229, 186, 151, 0, 0, 0, 0, 19, 233, 255, 24, 0, 0, 0, 0, 198, 4, 55, 35, 114, 166, 0, 0, 0, 0, 167, 138, 58, 232, 0, 0, 0, 0, 135, 22, 17, 155, 0, 0, 0, 0, 230, 117, 91, 146, 0, 0, 0, 0, 198, 4, 31, 147, 181, 253, 0, 0, 0, 0, 54, 213, 238, 57, 0, 0, 0, 0, 66, 61, 89, 160, 0, 0, 0, 0, 231, 68, 135, 206, 0, 0, 0, 0, 198, 4, 93, 154, 87, 213, 0, 0, 0, 0, 210, 178, 181, 136, 0, 0, 0, 0, 179, 237, 123, 175, 0, 0, 0, 0, 164, 184, 86, 110, 0, 0, 0, 0, 198, 4, 56, 29, 223, 137, 0, 0, 0, 0, 157, 55, 98, 162, 0, 0, 0, 0, 254, 229, 255, 106, 0, 0, 0, 0, 86, 213, 14, 17, 0, 0, 0, 0, 198, 4, 213, 198, 221, 219, 0, 0, 0, 0, 88, 98, 140, 42, 0, 0, 0, 0, 95, 128, 0, 251, 0, 0, 0, 0, 104, 254, 8, 254, 0, 0, 0, 0, 198, 4, 148, 21, 27, 28, 0, 0, 0, 0, 74, 74, 122, 241, 0, 0, 0, 0, 167, 16, 91, 110, 0, 0, 0, 0, 72, 16, 253, 80, 0, 0, 0, 0, 198, 4, 231, 30, 41, 237, 0, 0, 0, 0, 177, 32, 246, 56, 0, 0, 0, 0, 137, 149, 58, 95, 0, 0, 0, 0, 186, 106, 122, 133, 0, 0, 0, 0, 198, 4, 4, 91, 144, 57, 0, 0, 0, 0, 172, 175, 59, 54, 0, 0, 0, 0, 232, 56, 57, 25, 0, 0, 0, 0, 99, 205, 30, 75, 0, 0, 0, 0, 198, 4, 87, 85, 175, 2, 0, 0, 0, 0, 147, 19, 130, 197, 0, 0, 0, 0, 50, 103, 78, 242, 0, 0, 0, 0, 209, 100, 37, 138, 0, 0, 0, 0, 198, 4, 198, 117, 52, 151, 0, 0, 0, 0, 135, 210, 52, 224, 0, 0, 0, 0, 143, 48, 145, 21, 0, 0, 0, 0, 76, 67, 151, 11, 0, 0, 0, 0, 198, 4, 237, 109, 93, 32, 0, 0, 0, 0, 96, 243, 187, 107, 0, 0, 0, 0, 247, 131, 122, 50, 0, 0, 0, 0, 221, 216, 62, 191, 0, 0, 0, 0, 198, 4, 84, 255, 65, 145, 0, 0, 0, 0, 72, 64, 206, 127, 0, 0, 0, 0, 88, 224, 229, 92, 0, 0, 0, 0, 133, 57, 102, 138, 0, 0, 0, 0, 198, 4, 21, 238, 66, 153, 0, 0, 0, 0, 37, 229, 29, 170, 0, 0, 0, 0, 166, 213, 226, 71, 0, 0, 0, 0, 140, 100, 222, 25, 0, 0, 0, 0, 198, 4, 36, 106, 251, 127, 0, 0, 0, 0, 113, 183, 48, 145, 0, 0, 0, 0, 22, 49, 2, 67, 0, 0, 0, 0, 40, 161, 75, 41, 0, 0, 0, 0, 198, 4, 71, 88, 220, 188, 0, 0, 0, 0, 190, 124, 91, 95, 0, 0, 0, 0, 62, 134, 196, 113, 0, 0, 0, 0, 13, 62, 133, 213, 0, 0, 0, 0, 198, 4, 175, 188, 235, 176, 0, 0, 0, 0, 53, 230, 137, 161, 0, 0, 0, 0, 196, 254, 199, 59, 0, 0, 0, 0, 4, 186, 205, 120, 0, 0, 0, 0, 198, 4, 193, 176, 0, 38, 0, 0, 0, 0, 96, 96, 255, 84, 0, 0, 0, 0, 101, 74, 183, 211, 0, 0, 0, 0, 112, 94, 232, 209, 0, 0, 0, 0, 198, 4, 217, 165, 216, 251, 0, 0, 0, 0, 4, 235, 65, 197, 0, 0, 0, 0, 138, 186, 149, 40, 0, 0, 0, 0, 32, 176, 135, 182, 0, 0, 0, 0, 198, 4, 32, 110, 93, 190, 0, 0, 0, 0, 28, 88, 206, 235, 0, 0, 0, 0, 62, 165, 18, 143, 0, 0, 0, 0, 169, 213, 160, 155, 0, 0, 0, 0, 198, 4, 60, 248, 163, 111, 0, 0, 0, 0, 127, 3, 87, 173, 0, 0, 0, 0, 109, 179, 255, 104, 0, 0, 0, 0, 30, 68, 55, 246, 0, 0, 0, 0, 198, 4, 224, 107, 92, 129, 0, 0, 0, 0, 163, 250, 125, 74, 0, 0, 0, 0, 21, 45, 249, 95, 0, 0, 0, 0, 59, 198, 154, 0, 0, 0, 0, 0, 198, 4, 17, 250, 242, 131, 0, 0, 0, 0, 204, 189, 22, 141, 0, 0, 0, 0, 243, 105, 153, 245, 0, 0, 0, 0, 173, 235, 147, 3, 0, 0, 0, 0, 198, 4, 192, 71, 138, 24, 0, 0, 0, 0, 216, 59, 226, 145, 0, 0, 0, 0, 140, 102, 183, 137, 0, 0, 0, 0, 53, 162, 98, 225, 0, 0, 0, 0, 198, 4, 220, 77, 5, 69, 0, 0, 0, 0, 72, 57, 207, 147, 0, 0, 0, 0, 66, 123, 176, 0, 0, 0, 0, 0, 225, 133, 218, 147, 0, 0, 0, 0, 198, 4, 232, 189, 75, 77, 0, 0, 0, 0, 103, 151, 152, 74, 0, 0, 0, 0, 13, 113, 156, 55, 0, 0, 0, 0, 164, 201, 71, 241, 0, 0, 0, 0, 198, 4, 206, 78, 42, 176, 0, 0, 0, 0, 117, 142, 53, 123, 0, 0, 0, 0, 8, 223, 243, 149, 0, 0, 0, 0, 198, 240, 48, 188, 0, 0, 0, 0, 198, 4, 238, 63, 74, 226, 0, 0, 0, 0, 144, 172, 74, 27, 0, 0, 0, 0, 8, 142, 67, 226, 0, 0, 0, 0, 28, 95, 243, 7, 0, 0, 0, 0, 198, 4, 153, 64, 206, 44, 0, 0, 0, 0, 202, 55, 36, 174, 0, 0, 0, 0, 45, 69, 176, 161, 0, 0, 0, 0, 15, 164, 95, 159, 0, 0, 0, 0, 198, 4, 106, 22, 65, 113, 0, 0, 0, 0, 138, 208, 195, 171, 0, 0, 0, 0, 185, 108, 130, 22, 0, 0, 0, 0, 210, 6, 1, 45, 0, 0, 0, 0, 198, 4, 148, 200, 195, 109, 0, 0, 0, 0, 114, 127, 211, 188, 0, 0, 0, 0, 107, 104, 85, 50, 0, 0, 0, 0, 96, 124, 26, 21, 0, 0, 0, 0, 198, 4, 7, 83, 17, 237, 0, 0, 0, 0, 50, 101, 32, 26, 0, 0, 0, 0, 228, 10, 246, 236, 0, 0, 0, 0, 152, 209, 89, 200, 0, 0, 0, 0, 198, 4, 210, 72, 115, 156, 0, 0, 0, 0, 224, 37, 241, 93, 0, 0, 0, 0, 16, 94, 37, 8, 0, 0, 0, 0, 37, 108, 52, 85, 0, 0, 0, 0, 198, 4, 106, 15, 112, 3, 0, 0, 0, 0, 204, 228, 48, 238, 0, 0, 0, 0, 47, 105, 166, 26, 0, 0, 0, 0, 129, 109, 57, 198, 0, 0, 0, 0, 198, 4, 203, 39, 152, 96, 0, 0, 0, 0, 206, 112, 99, 163, 0, 0, 0, 0, 229, 153, 130, 49, 0, 0, 0, 0, 130, 73, 139, 40, 0, 0, 0, 0, 198, 4, 254, 222, 195, 239, 0, 0, 0, 0, 47, 183, 56, 169, 0, 0, 0, 0, 101, 77, 245, 123, 0, 0, 0, 0, 102, 104, 153, 31, 0, 0, 0, 0, 198, 4, 29, 120, 46, 144, 0, 0, 0, 0, 37, 53, 128, 194, 0, 0, 0, 0, 64, 198, 149, 205, 0, 0, 0, 0, 99, 159, 56, 159, 0, 0, 0, 0, 198, 4, 113, 200, 114, 16, 0, 0, 0, 0, 179, 239, 69, 235, 0, 0, 0, 0, 201, 237, 105, 128, 0, 0, 0, 0, 23, 179, 186, 112, 0, 0, 0, 0, 198, 4, 53, 92, 98, 243, 0, 0, 0, 0, 177, 216, 182, 80, 0, 0, 0, 0, 28, 50, 107, 199, 0, 0, 0, 0, 170, 76, 38, 189, 0, 0, 0, 0, 198, 4, 109, 47, 234, 239, 0, 0, 0, 0, 202, 143, 239, 178, 0, 0, 0, 0, 124, 198, 159, 155, 0, 0, 0, 0, 110, 218, 185, 57, 0, 0, 0, 0, 198, 4, 202, 113, 160, 199, 0, 0, 0, 0, 133, 80, 248, 16, 0, 0, 0, 0, 40, 196, 110, 61, 0, 0, 0, 0, 241, 169, 200, 50, 0, 0, 0, 0, 198, 4, 67, 188, 244, 106, 0, 0, 0, 0, 24, 50, 37, 218, 0, 0, 0, 0, 134, 135, 78, 80, 0, 0, 0, 0, 166, 22, 213, 1, 0, 0, 0, 0, 198, 4, 251, 69, 174, 183, 0, 0, 0, 0, 177, 21, 119, 111, 0, 0, 0, 0, 104, 70, 52, 251, 0, 0, 0, 0, 53, 184, 193, 175, 0, 0, 0, 0, 198, 4, 16, 238, 77, 55, 0, 0, 0, 0, 36, 22, 204, 203, 0, 0, 0, 0, 240, 15, 69, 84, 0, 0, 0, 0, 106, 165, 72, 238, 0, 0, 0, 0, 198, 4, 178, 229, 236, 243, 0, 0, 0, 0, 232, 226, 7, 64, 0, 0, 0, 0, 138, 251, 22, 251, 0, 0, 0, 0, 222, 60, 69, 168, 0, 0, 0, 0, 198, 4, 211, 236, 117, 224, 0, 0, 0, 0, 204, 18, 109, 184, 0, 0, 0, 0, 123, 37, 98, 212, 0, 0, 0, 0, 40, 73, 145, 145, 0, 0, 0, 0, 198, 4, 92, 189, 159, 95, 0, 0, 0, 0, 86, 214, 133, 191, 0, 0, 0, 0, 147, 240, 44, 139, 0, 0, 0, 0, 184, 10, 190, 211, 0, 0, 0, 0, 198, 4, 172, 253, 245, 85, 0, 0, 0, 0, 156, 76, 15, 104, 0, 0, 0, 0, 155, 22, 54, 199, 0, 0, 0, 0, 195, 54, 235, 40, 0, 0, 0, 0, 198, 4, 14, 56, 186, 56, 0, 0, 0, 0, 193, 126, 124, 51, 0, 0, 0, 0, 89, 207, 16, 48, 0, 0, 0, 0, 180, 148, 114, 80, 0, 0, 0, 0, 198, 4, 10, 62, 198, 40, 0, 0, 0, 0, 238, 211, 3, 180, 0, 0, 0, 0, 169, 150, 135, 153, 0, 0, 0, 0, 37, 5, 106, 248, 0, 0, 0, 0, 198, 4, 205, 233, 205, 231, 0, 0, 0, 0, 70, 125, 127, 211, 0, 0, 0, 0, 94, 51, 25, 91, 0, 0, 0, 0, 0, 24, 20, 81, 0, 0, 0, 0, 198, 4, 74, 49, 121, 120, 0, 0, 0, 0, 113, 133, 179, 249, 0, 0, 0, 0, 143, 226, 88, 13, 0, 0, 0, 0, 220, 164, 213, 183, 0, 0, 0, 0, 198, 4, 167, 51, 171, 59, 0, 0, 0, 0, 215, 199, 0, 88, 0, 0, 0, 0, 202, 38, 43, 126, 0, 0, 0, 0, 122, 86, 41, 39, 0, 0, 0, 0, 198, 4, 201, 197, 187, 205, 0, 0, 0, 0, 7, 2, 98, 202, 0, 0, 0, 0, 106, 162, 214, 48, 0, 0, 0, 0, 65, 182, 189, 189, 0, 0, 0, 0, 198, 4, 217, 246, 104, 144, 0, 0, 0, 0, 28, 174, 28, 36, 0, 0, 0, 0, 186, 225, 111, 167, 0, 0, 0, 0, 12, 1, 92, 112, 0, 0, 0, 0, 198, 4, 32, 46, 191, 99, 0, 0, 0, 0, 4, 22, 128, 193, 0, 0, 0, 0, 86, 151, 181, 192, 0, 0, 0, 0, 80, 134, 57, 220, 0, 0, 0, 0, 198, 4, 30, 104, 81, 181, 0, 0, 0, 0, 212, 111, 71, 237, 0, 0, 0, 0, 123, 250, 19, 143, 0, 0, 0, 0, 63, 160, 28, 45, 0, 0, 0, 0, 198, 4, 39, 96, 32, 160, 0, 0, 0, 0, 32, 64, 245, 188, 0, 0, 0, 0, 107, 143, 45, 147, 0, 0, 0, 0, 246, 62, 136, 32, 0, 0, 0, 0, 198, 4, 4, 222, 128, 161, 0, 0, 0, 0, 32, 20, 145, 134, 0, 0, 0, 0, 112, 118, 117, 161, 0, 0, 0, 0, 109, 69, 130, 217, 0, 0, 0, 0, 198, 4, 102, 113, 151, 233, 0, 0, 0, 0, 69, 160, 106, 78, 0, 0, 0, 0, 116, 63, 6, 161, 0, 0, 0, 0, 125, 159, 115, 185, 0, 0, 0, 0, 198, 4, 66, 125, 197, 107, 0, 0, 0, 0, 189, 196, 173, 140, 0, 0, 0, 0, 182, 15, 250, 147, 0, 0, 0, 0, 168, 239, 44, 193, 0, 0, 0, 0, 198, 4, 44, 58, 138, 7, 0, 0, 0, 0, 91, 0, 99, 170, 0, 0, 0, 0, 136, 46, 128, 108, 0, 0, 0, 0, 142, 15, 154, 210, 0, 0, 0, 0, 198, 4, 21, 227, 53, 117, 0, 0, 0, 0, 10, 47, 10, 36, 0, 0, 0, 0, 188, 81, 37, 250, 0, 0, 0, 0, 165, 109, 18, 47, 0, 0, 0, 0, 198, 4, 195, 5, 174, 20, 0, 0, 0, 0, 37, 217, 63, 213, 0, 0, 0, 0, 10, 154, 54, 218, 0, 0, 0, 0, 209, 10, 213, 135, 0, 0, 0, 0, 198, 4, 211, 188, 239, 155, 0, 0, 0, 0, 79, 250, 42, 156, 0, 0, 0, 0, 150, 16, 137, 50, 0, 0, 0, 0, 217, 170, 158, 197, 0, 0, 0, 0, 198, 4, 89, 89, 36, 47, 0, 0, 0, 0, 123, 242, 54, 117, 0, 0, 0, 0, 218, 131, 52, 250, 0, 0, 0, 0, 104, 249, 81, 226, 0, 0, 0, 0, 198, 4, 200, 149, 22, 31, 0, 0, 0, 0, 114, 56, 155, 123, 0, 0, 0, 0, 77, 9, 131, 9, 0, 0, 0, 0, 61, 8, 26, 94, 0, 0, 0, 0, 198, 4, 137, 122, 184, 78, 0, 0, 0, 0, 146, 148, 73, 11, 0, 0, 0, 0, 23, 141, 192, 146, 0, 0, 0, 0, 116, 40, 191, 24, 0, 0, 0, 0, 198, 4, 247, 90, 121, 143, 0, 0, 0, 0, 3, 10, 172, 84, 0, 0, 0, 0, 93, 156, 116, 159, 0, 0, 0, 0, 215, 87, 44, 137, 0, 0, 0, 0, 198, 4, 236, 113, 160, 45, 0, 0, 0, 0, 188, 51, 152, 250, 0, 0, 0, 0, 127, 97, 21, 25, 0, 0, 0, 0, 82, 243, 231, 40, 0, 0, 0, 0, 198, 4, 235, 149, 58, 247, 0, 0, 0, 0, 242, 122, 69, 227, 0, 0, 0, 0, 124, 5, 149, 131, 0, 0, 0, 0, 38, 222, 238, 189, 0, 0, 0, 0, 198, 4, 53, 114, 222, 202, 0, 0, 0, 0, 101, 237, 133, 203, 0, 0, 0, 0, 185, 129, 153, 169, 0, 0, 0, 0, 46, 66, 52, 160, 0, 0, 0, 0, 198, 4, 227, 103, 184, 19, 0, 0, 0, 0, 172, 120, 14, 129, 0, 0, 0, 0, 186, 183, 132, 249, 0, 0, 0, 0, 64, 70, 33, 63, 0, 0, 0, 0, 198, 4, 30, 254, 225, 6, 0, 0, 0, 0, 154, 4, 6, 49, 0, 0, 0, 0, 154, 120, 230, 62, 0, 0, 0, 0, 92, 60, 165, 171, 0, 0, 0, 0, 198, 4, 138, 189, 26, 57, 0, 0, 0, 0, 71, 14, 87, 34, 0, 0, 0, 0, 55, 173, 174, 247, 0, 0, 0, 0, 128, 18, 146, 106, 0, 0, 0, 0, 198, 4, 71, 116, 143, 11, 0, 0, 0, 0, 178, 29, 8, 224, 0, 0, 0, 0, 245, 221, 239, 116, 0, 0, 0, 0, 84, 40, 212, 62, 0, 0, 0, 0, 198, 4, 183, 52, 120, 227, 0, 0, 0, 0, 92, 61, 100, 143, 0, 0, 0, 0, 208, 152, 35, 157, 0, 0, 0, 0, 70, 124, 220, 126, 0, 0, 0, 0, 198, 4, 53, 203, 142, 175, 0, 0, 0, 0, 213, 187, 46, 6, 0, 0, 0, 0, 15, 153, 87, 177, 0, 0, 0, 0, 17, 70, 3, 99, 0, 0, 0, 0, 198, 4, 34, 217, 232, 244, 0, 0, 0, 0, 9, 105, 106, 58, 0, 0, 0, 0, 57, 38, 249, 139, 0, 0, 0, 0, 169, 58, 253, 162, 0, 0, 0, 0, 198, 4, 60, 29, 80, 148, 0, 0, 0, 0, 136, 55, 39, 29, 0, 0, 0, 0, 72, 49, 179, 168, 0, 0, 0, 0, 44, 242, 153, 54, 0, 0, 0, 0, 198, 4, 204, 214, 223, 28, 0, 0, 0, 0, 213, 140, 120, 148, 0, 0, 0, 0, 238, 213, 186, 111, 0, 0, 0, 0, 160, 254, 231, 240, 0, 0, 0, 0, 198, 4, 145, 74, 63, 26, 0, 0, 0, 0, 137, 24, 177, 84, 0, 0, 0, 0, 175, 208, 9, 242, 0, 0, 0, 0, 17, 68, 53, 6, 0, 0, 0, 0, 198, 4, 132, 47, 37, 13, 0, 0, 0, 0, 242, 183, 134, 229, 0, 0, 0, 0, 122, 216, 133, 152, 0, 0, 0, 0, 85, 207, 60, 145, 0, 0, 0, 0, 198, 4, 21, 68, 42, 255, 0, 0, 0, 0, 128, 29, 163, 116, 0, 0, 0, 0, 135, 43, 242, 8, 0, 0, 0, 0, 148, 191, 118, 12, 0, 0, 0, 0, 198, 4, 132, 27, 116, 69, 0, 0, 0, 0, 146, 0, 150, 93, 0, 0, 0, 0, 122, 188, 126, 116, 0, 0, 0, 0, 247, 100, 39, 180, 0, 0, 0, 0, 198, 4, 248, 144, 162, 36, 0, 0, 0, 0, 216, 219, 44, 213, 0, 0, 0, 0, 41, 170, 166, 108, 0, 0, 0, 0, 202, 119, 10, 87, 0, 0, 0, 0, 198, 4, 6, 36, 87, 125, 0, 0, 0, 0, 57, 234, 146, 254, 0, 0, 0, 0, 168, 122, 81, 147, 0, 0, 0, 0, 150, 69, 167, 83, 0, 0, 0, 0, 198, 4, 170, 89, 87, 166, 0, 0, 0, 0, 211, 104, 56, 98, 0, 0, 0, 0, 182, 232, 194, 217, 0, 0, 0, 0, 74, 126, 177, 132, 0, 0, 0, 0, 198, 4, 175, 211, 43, 178, 0, 0, 0, 0, 219, 89, 166, 107, 0, 0, 0, 0, 69, 170, 91, 70, 0, 0, 0, 0, 135, 60, 240, 191, 0, 0, 0, 0, 198, 4, 32, 51, 42, 86, 0, 0, 0, 0, 203, 150, 42, 152, 0, 0, 0, 0, 51, 176, 66, 92, 0, 0, 0, 0, 166, 122, 202, 27, 0, 0, 0, 0, 198, 4, 197, 156, 22, 73, 0, 0, 0, 0, 200, 128, 101, 186, 0, 0, 0, 0, 29, 93, 199, 231, 0, 0, 0, 0, 206, 141, 239, 50, 0, 0, 0, 0, 198, 4, 131, 41, 247, 1, 0, 0, 0, 0, 108, 144, 81, 113, 0, 0, 0, 0, 179, 83, 122, 137, 0, 0, 0, 0, 255, 200, 188, 154, 0, 0, 0, 0, 198, 4, 121, 182, 12, 238, 0, 0, 0, 0, 66, 130, 86, 222, 0, 0, 0, 0, 74, 190, 124, 115, 0, 0, 0, 0, 68, 156, 76, 133, 0, 0, 0, 0, 198, 4, 209, 50, 218, 130, 0, 0, 0, 0, 213, 86, 176, 46, 0, 0, 0, 0, 108, 77, 112, 136, 0, 0, 0, 0, 100, 64, 1, 46, 0, 0, 0, 0, 198, 4, 54, 226, 91, 182, 0, 0, 0, 0, 89, 220, 222, 66, 0, 0, 0, 0, 124, 35, 198, 60, 0, 0, 0, 0, 62, 75, 68, 230, 0, 0, 0, 0, 198, 4, 76, 159, 143, 238, 0, 0, 0, 0, 95, 134, 112, 186, 0, 0, 0, 0, 217, 184, 207, 214, 0, 0, 0, 0, 243, 123, 29, 179, 0, 0, 0, 0, 198, 4, 163, 127, 252, 176, 0, 0, 0, 0, 106, 150, 68, 87, 0, 0, 0, 0, 153, 168, 2, 46, 0, 0, 0, 0, 63, 139, 225, 166, 0, 0, 0, 0, 198, 4, 185, 24, 232, 151, 0, 0, 0, 0, 60, 68, 55, 255, 0, 0, 0, 0, 188, 110, 226, 2, 0, 0, 0, 0, 156, 114, 85, 238, 0, 0, 0, 0, 198, 4, 31, 249, 204, 163, 0, 0, 0, 0, 80, 232, 154, 96, 0, 0, 0, 0, 37, 143, 160, 175, 0, 0, 0, 0, 146, 205, 196, 88, 0, 0, 0, 0, 198, 4, 164, 12, 95, 225, 0, 0, 0, 0, 205, 153, 196, 13, 0, 0, 0, 0, 27, 219, 146, 175, 0, 0, 0, 0, 146, 105, 157, 129, 0, 0, 0, 0, 198, 4, 115, 80, 234, 191, 0, 0, 0, 0, 118, 26, 202, 245, 0, 0, 0, 0, 5, 247, 16, 218, 0, 0, 0, 0, 30, 36, 78, 196, 0, 0, 0, 0, 198, 4, 205, 247, 175, 128, 0, 0, 0, 0, 149, 131, 58, 62, 0, 0, 0, 0, 38, 199, 202, 167, 0, 0, 0, 0, 63, 216, 70, 132, 0, 0, 0, 0, 198, 4, 44, 134, 38, 51, 0, 0, 0, 0, 30, 234, 55, 233, 0, 0, 0, 0, 174, 253, 226, 171, 0, 0, 0, 0, 27, 157, 71, 11, 0, 0, 0, 0, 198, 4, 1, 134, 181, 165, 0, 0, 0, 0, 155, 78, 188, 232, 0, 0, 0, 0, 245, 44, 158, 94, 0, 0, 0, 0, 160, 194, 30, 158, 0, 0, 0, 0, 198, 4, 209, 242, 91, 104, 0, 0, 0, 0, 0, 227, 241, 50, 0, 0, 0, 0, 251, 217, 163, 190, 0, 0, 0, 0, 23, 230, 76, 23, 0, 0, 0, 0, 198, 4, 203, 247, 123, 255, 0, 0, 0, 0, 248, 112, 137, 52, 0, 0, 0, 0, 248, 134, 200, 104, 0, 0, 0, 0, 234, 138, 143, 169, 0, 0, 0, 0, 198, 4, 248, 147, 107, 37, 0, 0, 0, 0, 119, 109, 20, 113, 0, 0, 0, 0, 40, 69, 82, 238, 0, 0, 0, 0, 173, 58, 156, 193, 0, 0, 0, 0, 198, 4, 168, 20, 37, 77, 0, 0, 0, 0, 62, 215, 195, 248, 0, 0, 0, 0, 50, 151, 231, 26, 0, 0, 0, 0, 34, 42, 240, 67, 0, 0, 0, 0, 198, 4, 11, 49, 111, 62, 0, 0, 0, 0, 148, 224, 66, 147, 0, 0, 0, 0, 65, 157, 250, 146, 0, 0, 0, 0, 195, 227, 137, 100, 0, 0, 0, 0, 198, 4, 115, 60, 224, 181, 0, 0, 0, 0, 32, 57, 107, 162, 0, 0, 0, 0, 153, 171, 178, 140, 0, 0, 0, 0, 102, 134, 102, 182, 0, 0, 0, 0, 198, 4, 189, 161, 128, 125, 0, 0, 0, 0, 178, 32, 31, 240, 0, 0, 0, 0, 159, 42, 94, 83, 0, 0, 0, 0, 111, 180, 95, 55, 0, 0, 0, 0, 198, 4, 123, 117, 241, 195, 0, 0, 0, 0, 147, 68, 126, 209, 0, 0, 0, 0, 75, 136, 177, 194, 0, 0, 0, 0, 243, 190, 118, 228, 0, 0, 0, 0, 198, 4, 12, 192, 59, 1, 0, 0, 0, 0, 121, 141, 41, 149, 0, 0, 0, 0, 17, 72, 153, 143, 0, 0, 0, 0, 178, 2, 65, 30, 0, 0, 0, 0, 198, 4, 255, 166, 7, 48, 0, 0, 0, 0, 101, 138, 224, 206, 0, 0, 0, 0, 225, 46, 59, 152, 0, 0, 0, 0, 82, 129, 89, 229, 0, 0, 0, 0, 198, 4, 155, 5, 120, 122, 0, 0, 0, 0, 70, 176, 160, 14, 0, 0, 0, 0, 212, 200, 231, 196, 0, 0, 0, 0, 69, 106, 55, 117, 0, 0, 0, 0, 198, 4, 217, 113, 223, 185, 0, 0, 0, 0, 137, 162, 104, 176, 0, 0, 0, 0, 141, 23, 252, 188, 0, 0, 0, 0, 113, 61, 5, 201, 0, 0, 0, 0, 198, 4, 20, 82, 210, 206, 0, 0, 0, 0, 155, 50, 57, 235, 0, 0, 0, 0, 31, 144, 127, 30, 0, 0, 0, 0, 239, 158, 34, 197, 0, 0, 0, 0, 198, 4, 5, 164, 3, 131, 0, 0, 0, 0, 54, 158, 190, 245, 0, 0, 0, 0, 160, 108, 35, 185, 0, 0, 0, 0, 112, 146, 71, 4, 0, 0, 0, 0, 198, 4, 162, 202, 233, 243, 0, 0, 0, 0, 135, 75, 189, 50, 0, 0, 0, 0, 19, 40, 60, 10, 0, 0, 0, 0, 56, 6, 149, 226, 0, 0, 0, 0, 198, 4, 66, 146, 1, 5, 0, 0, 0, 0, 9, 38, 87, 174, 0, 0, 0, 0, 52, 215, 148, 207, 0, 0, 0, 0, 253, 125, 229, 2, 0, 0, 0, 0, 198, 4, 82, 132, 73, 171, 0, 0, 0, 0, 241, 218, 51, 199, 0, 0, 0, 0, 247, 39, 100, 20, 0, 0, 0, 0, 53, 81, 16, 204, 0, 0, 0, 0, 198, 4, 155, 216, 244, 248, 0, 0, 0, 0, 70, 173, 227, 179, 0, 0, 0, 0, 19, 126, 240, 230, 0, 0, 0, 0, 2, 157, 172, 112, 0, 0, 0, 0, 198, 4, 163, 238, 16, 165, 0, 0, 0, 0, 223, 188, 231, 182, 0, 0, 0, 0, 143, 186, 237, 100, 0, 0, 0, 0, 200, 165, 121, 91, 0, 0, 0, 0, 198, 4, 148, 83, 76, 105, 0, 0, 0, 0, 243, 153, 123, 155, 0, 0, 0, 0, 51, 175, 181, 81, 0, 0, 0, 0, 192, 248, 181, 196, 0, 0, 0, 0, 198, 4, 9, 128, 30, 62, 0, 0, 0, 0, 55, 176, 36, 235, 0, 0, 0, 0, 248, 21, 201, 147, 0, 0, 0, 0, 167, 232, 183, 211, 0, 0, 0, 0, 198, 4, 0, 58, 235, 131, 0, 0, 0, 0, 197, 182, 248, 136, 0, 0, 0, 0, 126, 158, 213, 109, 0, 0, 0, 0, 220, 90, 211, 63, 0, 0, 0, 0, 198, 4, 147, 226, 117, 56, 0, 0, 0, 0, 103, 253, 97, 130, 0, 0, 0, 0, 121, 2, 102, 224, 0, 0, 0, 0, 188, 101, 4, 70, 0, 0, 0, 0, 198, 4, 81, 18, 167, 55, 0, 0, 0, 0, 51, 236, 99, 145, 0, 0, 0, 0, 0, 141, 226, 155, 0, 0, 0, 0, 244, 196, 120, 54, 0, 0, 0, 0, 198, 4, 137, 243, 139, 249, 0, 0, 0, 0, 190, 127, 73, 88, 0, 0, 0, 0, 169, 29, 193, 81, 0, 0, 0, 0, 42, 245, 189, 138, 0, 0, 0, 0, 198, 4, 133, 27, 70, 43, 0, 0, 0, 0, 198, 128, 143, 152, 0, 0, 0, 0, 27, 230, 48, 40, 0, 0, 0, 0, 7, 229, 208, 41, 0, 0, 0, 0, 198, 4, 78, 152, 122, 182, 0, 0, 0, 0, 47, 141, 55, 247, 0, 0, 0, 0, 239, 112, 58, 36, 0, 0, 0, 0, 227, 53, 237, 64, 0, 0, 0, 0, 198, 4, 30, 53, 17, 98, 0, 0, 0, 0, 45, 58, 113, 59, 0, 0, 0, 0, 50, 29, 206, 37, 0, 0, 0, 0, 74, 13, 46, 203, 0, 0, 0, 0, 198, 4, 169, 26, 221, 162, 0, 0, 0, 0, 255, 17, 77, 100, 0, 0, 0, 0, 137, 71, 111, 202, 0, 0, 0, 0, 125, 115, 243, 168, 0, 0, 0, 0, 198, 4, 53, 170, 123, 158, 0, 0, 0, 0, 232, 64, 225, 205, 0, 0, 0, 0, 123, 174, 90, 167, 0, 0, 0, 0, 53, 197, 199, 184, 0, 0, 0, 0, 198, 4, 237, 203, 133, 229, 0, 0, 0, 0, 39, 205, 231, 130, 0, 0, 0, 0, 119, 48, 139, 83, 0, 0, 0, 0, 219, 5, 122, 191, 0, 0, 0, 0, 198, 4, 121, 34, 95, 175, 0, 0, 0, 0, 124, 221, 206, 58, 0, 0, 0, 0, 18, 217, 166, 62, 0, 0, 0, 0, 160, 23, 80, 255, 0, 0, 0, 0, 198, 4, 124, 44, 211, 238, 0, 0, 0, 0, 107, 149, 155, 75, 0, 0, 0, 0, 201, 17, 221, 54, 0, 0, 0, 0, 100, 53, 229, 28, 0, 0, 0, 0, 198, 4, 173, 147, 184, 0, 0, 0, 0, 0, 2, 225, 227, 55, 0, 0, 0, 0, 163, 189, 167, 143, 0, 0, 0, 0, 13, 240, 11, 236, 0, 0, 0, 0, 198, 4, 115, 205, 239, 82, 0, 0, 0, 0, 231, 167, 76, 90, 0, 0, 0, 0, 53, 212, 243, 233, 0, 0, 0, 0, 9, 63, 110, 221, 0, 0, 0, 0, 198, 4, 215, 128, 239, 108, 0, 0, 0, 0, 28, 230, 168, 250, 0, 0, 0, 0, 142, 238, 216, 37, 0, 0, 0, 0, 41, 44, 124, 157, 0, 0, 0, 0, 198, 4, 160, 198, 212, 21, 0, 0, 0, 0, 188, 0, 229, 129, 0, 0, 0, 0, 50, 56, 51, 236, 0, 0, 0, 0, 232, 143, 4, 171, 0, 0, 0, 0, 198, 4, 35, 34, 117, 183, 0, 0, 0, 0, 123, 67, 227, 52, 0, 0, 0, 0, 153, 100, 221, 68, 0, 0, 0, 0, 36, 222, 122, 196, 0, 0, 0, 0, 198, 4, 169, 219, 203, 213, 0, 0, 0, 0, 155, 104, 160, 181, 0, 0, 0, 0, 107, 83, 87, 199, 0, 0, 0, 0, 237, 244, 104, 80, 0, 0, 0, 0, 198, 4, 39, 26, 4, 158, 0, 0, 0, 0, 88, 82, 182, 54, 0, 0, 0, 0, 78, 124, 142, 50, 0, 0, 0, 0, 45, 6, 243, 99, 0, 0, 0, 0, 198, 4, 116, 200, 182, 119, 0, 0, 0, 0, 15, 144, 11, 147, 0, 0, 0, 0, 210, 201, 164, 0, 0, 0, 0, 0, 191, 56, 205, 8, 0, 0, 0, 0, 198, 4, 84, 52, 171, 146, 0, 0, 0, 0, 148, 228, 143, 143, 0, 0, 0, 0, 121, 3, 125, 62, 0, 0, 0, 0, 205, 19, 144, 12, 0, 0, 0, 0, 198, 4, 80, 63, 26, 95, 0, 0, 0, 0, 202, 117, 98, 33, 0, 0, 0, 0, 136, 230, 231, 215, 0, 0, 0, 0, 23, 120, 45, 130, 0, 0, 0, 0, 198, 4, 74, 198, 241, 26, 0, 0, 0, 0, 10, 246, 171, 160, 0, 0, 0, 0, 65, 223, 179, 160, 0, 0, 0, 0, 149, 157, 48, 198, 0, 0, 0, 0, 198, 4, 13, 92, 154, 78, 0, 0, 0, 0, 226, 253, 179, 224, 0, 0, 0, 0, 199, 251, 203, 224, 0, 0, 0, 0, 175, 3, 111, 115, 0, 0, 0, 0, 198, 4, 214, 70, 173, 143, 0, 0, 0, 0, 115, 24, 73, 138, 0, 0, 0, 0, 96, 139, 211, 7, 0, 0, 0, 0, 103, 181, 56, 48, 0, 0, 0, 0, 198, 4, 77, 126, 1, 14, 0, 0, 0, 0, 241, 50, 189, 229, 0, 0, 0, 0, 202, 208, 3, 200, 0, 0, 0, 0, 52, 184, 150, 170, 0, 0, 0, 0, 198, 4, 198, 225, 54, 139, 0, 0, 0, 0, 63, 103, 66, 190, 0, 0, 0, 0, 139, 46, 141, 88, 0, 0, 0, 0, 176, 77, 55, 245, 0, 0, 0, 0, 198, 4, 24, 142, 73, 28, 0, 0, 0, 0, 250, 99, 179, 8, 0, 0, 0, 0, 78, 123, 180, 28, 0, 0, 0, 0, 200, 199, 230, 231, 0, 0, 0, 0, 198, 4, 22, 164, 105, 38, 0, 0, 0, 0, 27, 134, 145, 17, 0, 0, 0, 0, 37, 73, 15, 229, 0, 0, 0, 0, 51, 239, 37, 210, 0, 0, 0, 0, 198, 4, 252, 235, 163, 71, 0, 0, 0, 0, 74, 220, 189, 91, 0, 0, 0, 0, 29, 131, 188, 55, 0, 0, 0, 0, 78, 211, 171, 29, 0, 0, 0, 0, 198, 4, 10, 239, 201, 94, 0, 0, 0, 0, 140, 132, 97, 237, 0, 0, 0, 0, 239, 27, 199, 125, 0, 0, 0, 0, 217, 67, 54, 139, 0, 0, 0, 0, 198, 4, 83, 157, 157, 119, 0, 0, 0, 0, 177, 228, 174, 132, 0, 0, 0, 0, 183, 163, 46, 203, 0, 0, 0, 0, 251, 112, 166, 211, 0, 0, 0, 0, 198, 4, 149, 43, 157, 98, 0, 0, 0, 0, 146, 84, 94, 1, 0, 0, 0, 0, 73, 73, 130, 179, 0, 0, 0, 0, 5, 220, 38, 114, 0, 0, 0, 0, 198, 4, 112, 130, 36, 200, 0, 0, 0, 0, 243, 137, 121, 71, 0, 0, 0, 0, 253, 237, 202, 50, 0, 0, 0, 0, 116, 24, 205, 95, 0, 0, 0, 0, 198, 4, 225, 190, 136, 23, 0, 0, 0, 0, 91, 115, 56, 60, 0, 0, 0, 0, 187, 38, 43, 188, 0, 0, 0, 0, 120, 27, 191, 127, 0, 0, 0, 0, 198, 4, 235, 13, 241, 181, 0, 0, 0, 0, 196, 250, 245, 192, 0, 0, 0, 0, 226, 226, 188, 251, 0, 0, 0, 0, 200, 117, 186, 247, 0, 0, 0, 0, 198, 4, 188, 240, 122, 238, 0, 0, 0, 0, 224, 32, 158, 197, 0, 0, 0, 0, 9, 187, 106, 241, 0, 0, 0, 0, 35, 237, 181, 100, 0, 0, 0, 0, 198, 4, 62, 182, 209, 209, 0, 0, 0, 0, 248, 234, 234, 96, 0, 0, 0, 0, 241, 146, 2, 212, 0, 0, 0, 0, 2, 147, 98, 182, 0, 0, 0, 0, 198, 4, 23, 224, 103, 143, 0, 0, 0, 0, 130, 23, 129, 36, 0, 0, 0, 0, 218, 123, 107, 71, 0, 0, 0, 0, 56, 17, 234, 76, 0, 0, 0, 0, 198, 4, 63, 236, 180, 79, 0, 0, 0, 0, 194, 241, 9, 125, 0, 0, 0, 0, 85, 109, 90, 130, 0, 0, 0, 0, 71, 160, 37, 4, 0, 0, 0, 0, 198, 4, 223, 135, 144, 243, 0, 0, 0, 0, 8, 6, 212, 248, 0, 0, 0, 0, 48, 252, 31, 144, 0, 0, 0, 0, 249, 80, 140, 110, 0, 0, 0, 0, 198, 4, 190, 69, 111, 186, 0, 0, 0, 0, 149, 189, 141, 234, 0, 0, 0, 0, 50, 124, 244, 236, 0, 0, 0, 0, 1, 28, 224, 198, 0, 0, 0, 0, 198, 4, 251, 230, 253, 239, 0, 0, 0, 0, 223, 227, 59, 219, 0, 0, 0, 0, 167, 59, 177, 36, 0, 0, 0, 0, 109, 159, 6, 152, 0, 0, 0, 0, 198, 4, 127, 10, 8, 66, 0, 0, 0, 0, 172, 178, 244, 35, 0, 0, 0, 0, 196, 162, 197, 22, 0, 0, 0, 0, 180, 243, 11, 216, 0, 0, 0, 0, 198, 4, 119, 189, 209, 216, 0, 0, 0, 0, 163, 190, 248, 92, 0, 0, 0, 0, 154, 127, 117, 79, 0, 0, 0, 0, 242, 163, 6, 48, 0, 0, 0, 0, 198, 4, 203, 238, 90, 75, 0, 0, 0, 0, 61, 56, 152, 140, 0, 0, 0, 0, 140, 198, 244, 15, 0, 0, 0, 0, 176, 104, 175, 23, 0, 0, 0, 0, 198, 4, 106, 145, 20, 209, 0, 0, 0, 0, 7, 149, 138, 155, 0, 0, 0, 0, 102, 159, 186, 157, 0, 0, 0, 0, 23, 61, 51, 197, 0, 0, 0, 0, 198, 4, 129, 14, 81, 225, 0, 0, 0, 0, 80, 172, 120, 54, 0, 0, 0, 0, 18, 126, 80, 7, 0, 0, 0, 0, 242, 125, 128, 179, 0, 0, 0, 0, 198, 4, 237, 111, 144, 151, 0, 0, 0, 0, 210, 15, 192, 54, 0, 0, 0, 0, 158, 135, 37, 173, 0, 0, 0, 0, 162, 227, 64, 139, 0, 0, 0, 0, 198, 4, 65, 171, 231, 0, 0, 0, 0, 0, 111, 144, 229, 32, 0, 0, 0, 0, 8, 15, 220, 134, 0, 0, 0, 0, 215, 54, 66, 120, 0, 0, 0, 0, 198, 4, 93, 249, 39, 94, 0, 0, 0, 0, 198, 209, 106, 144, 0, 0, 0, 0, 145, 231, 104, 255, 0, 0, 0, 0, 177, 65, 250, 250, 0, 0, 0, 0, 198, 4, 233, 32, 182, 250, 0, 0, 0, 0, 90, 0, 8, 54, 0, 0, 0, 0, 216, 153, 249, 180, 0, 0, 0, 0, 150, 57, 250, 27, 0, 0, 0, 0, 198, 4, 136, 26, 62, 252, 0, 0, 0, 0, 54, 203, 220, 136, 0, 0, 0, 0, 64, 101, 180, 220, 0, 0, 0, 0, 198, 105, 230, 44, 0, 0, 0, 0, 198, 4, 248, 3, 91, 10, 0, 0, 0, 0, 201, 170, 32, 77, 0, 0, 0, 0, 181, 19, 85, 127, 0, 0, 0, 0, 211, 162, 139, 163, 0, 0, 0, 0, 198, 4, 16, 39, 164, 151, 0, 0, 0, 0, 201, 170, 155, 225, 0, 0, 0, 0, 187, 251, 206, 46, 0, 0, 0, 0, 41, 24, 145, 198, 0, 0, 0, 0, 198, 4, 144, 30, 63, 52, 0, 0, 0, 0, 255, 5, 128, 253, 0, 0, 0, 0, 222, 19, 224, 200, 0, 0, 0, 0, 169, 11, 63, 99, 0, 0, 0, 0, 198, 4, 45, 48, 211, 245, 0, 0, 0, 0, 192, 112, 112, 221, 0, 0, 0, 0, 94, 101, 175, 217, 0, 0, 0, 0, 247, 114, 122, 23, 0, 0, 0, 0, 198, 4, 243, 234, 88, 90, 0, 0, 0, 0, 241, 192, 138, 99, 0, 0, 0, 0, 37, 21, 231, 217, 0, 0, 0, 0, 230, 15, 129, 25, 0, 0, 0, 0, 198, 4, 47, 104, 180, 36, 0, 0, 0, 0, 6, 142, 154, 196, 0, 0, 0, 0, 5, 203, 164, 178, 0, 0, 0, 0, 18, 246, 208, 188, 0, 0, 0, 0, 198, 4, 158, 106, 189, 43, 0, 0, 0, 0, 191, 18, 227, 3, 0, 0, 0, 0, 193, 149, 228, 113, 0, 0, 0, 0, 134, 148, 230, 194, 0, 0, 0, 0, 198, 4, 90, 207, 67, 155, 0, 0, 0, 0, 79, 12, 80, 108, 0, 0, 0, 0, 19, 104, 94, 102, 0, 0, 0, 0, 30, 240, 79, 116, 0, 0, 0, 0, 198, 4, 43, 154, 249, 135, 0, 0, 0, 0, 88, 165, 77, 147, 0, 0, 0, 0, 162, 184, 240, 217, 0, 0, 0, 0, 213, 251, 228, 20, 0, 0, 0, 0, 198, 4, 33, 235, 40, 182, 0, 0, 0, 0, 174, 141, 19, 252, 0, 0, 0, 0, 23, 110, 252, 55, 0, 0, 0, 0, 74, 178, 15, 3, 0, 0, 0, 0, 198, 4, 228, 76, 42, 4, 0, 0, 0, 0, 148, 148, 150, 61, 0, 0, 0, 0, 65, 35, 149, 229, 0, 0, 0, 0, 175, 74, 169, 200, 0, 0, 0, 0, 198, 4, 28, 69, 11, 47, 0, 0, 0, 0, 241, 237, 92, 216, 0, 0, 0, 0, 48, 204, 48, 99, 0, 0, 0, 0, 22, 232, 21, 125, 0, 0, 0, 0, 198, 4, 82, 196, 213, 168, 0, 0, 0, 0, 51, 75, 73, 61, 0, 0, 0, 0, 184, 104, 159, 25, 0, 0, 0, 0, 53, 52, 44, 232, 0, 0, 0, 0, 198, 4, 250, 26, 66, 28, 0, 0, 0, 0, 171, 222, 185, 129, 0, 0, 0, 0, 44, 215, 160, 82, 0, 0, 0, 0, 109, 96, 48, 45, 0, 0, 0, 0, 198, 4, 151, 90, 121, 72, 0, 0, 0, 0, 37, 149, 203, 57, 0, 0, 0, 0, 164, 53, 225, 134, 0, 0, 0, 0, 24, 175, 100, 221, 0, 0, 0, 0, 198, 4, 167, 211, 178, 233, 0, 0, 0, 0, 203, 110, 199, 157, 0, 0, 0, 0, 250, 174, 205, 239, 0, 0, 0, 0, 212, 37, 48, 50, 0, 0, 0, 0, 198, 4, 180, 246, 224, 231, 0, 0, 0, 0, 109, 49, 180, 124, 0, 0, 0, 0, 184, 253, 156, 190, 0, 0, 0, 0, 178, 245, 150, 54, 0, 0, 0, 0, 198, 4, 208, 27, 40, 205, 0, 0, 0, 0, 128, 48, 63, 25, 0, 0, 0, 0, 166, 101, 228, 116, 0, 0, 0, 0, 91, 229, 127, 227, 0, 0, 0, 0, 198, 4, 64, 86, 184, 126, 0, 0, 0, 0, 118, 219, 49, 40, 0, 0, 0, 0, 136, 240, 33, 222, 0, 0, 0, 0, 129, 25, 208, 192, 0, 0, 0, 0, 198, 4, 146, 109, 4, 146, 0, 0, 0, 0, 112, 31, 185, 142, 0, 0, 0, 0, 155, 91, 255, 43, 0, 0, 0, 0, 248, 217, 134, 252, 0, 0, 0, 0, 198, 4, 42, 200, 213, 168, 0, 0, 0, 0, 78, 175, 109, 49, 0, 0, 0, 0, 146, 190, 239, 187, 0, 0, 0, 0, 96, 11, 228, 117, 0, 0, 0, 0, 198, 4, 121, 34, 170, 62, 0, 0, 0, 0, 165, 75, 209, 132, 0, 0, 0, 0, 180, 179, 252, 46, 0, 0, 0, 0, 113, 143, 170, 74, 0, 0, 0, 0, 198, 4, 161, 152, 113, 180, 0, 0, 0, 0, 70, 202, 87, 17, 0, 0, 0, 0, 204, 136, 127, 136, 0, 0, 0, 0, 157, 222, 67, 4, 0, 0, 0, 0, 198, 4, 47, 226, 13, 200, 0, 0, 0, 0, 152, 155, 148, 215, 0, 0, 0, 0, 76, 1, 145, 85, 0, 0, 0, 0, 153, 50, 7, 65, 0, 0, 0, 0, 198, 4, 36, 132, 133, 112, 0, 0, 0, 0, 236, 237, 233, 0, 0, 0, 0, 0, 122, 247, 140, 123, 0, 0, 0, 0, 191, 227, 155, 234, 0, 0, 0, 0, 198, 4, 47, 173, 42, 23, 0, 0, 0, 0, 251, 250, 7, 169, 0, 0, 0, 0, 42, 1, 151, 80, 0, 0, 0, 0, 123, 35, 130, 157, 0, 0, 0, 0, 198, 4, 188, 216, 146, 51, 0, 0, 0, 0, 35, 166, 117, 37, 0, 0, 0, 0, 88, 64, 175, 210, 0, 0, 0, 0, 124, 251, 95, 15, 0, 0, 0, 0, 198, 4, 137, 118, 100, 140, 0, 0, 0, 0, 119, 204, 144, 151, 0, 0, 0, 0, 85, 184, 116, 138, 0, 0, 0, 0, 115, 93, 223, 217, 0, 0, 0, 0, 198, 4, 21, 238, 124, 201, 0, 0, 0, 0, 139, 204, 19, 117, 0, 0, 0, 0, 16, 102, 42, 142, 0, 0, 0, 0, 185, 151, 7, 214, 0, 0, 0, 0, 198, 4, 167, 93, 124, 12, 0, 0, 0, 0, 189, 59, 102, 184, 0, 0, 0, 0, 132, 211, 128, 250, 0, 0, 0, 0, 151, 249, 223, 213, 0, 0, 0, 0, 198, 4, 64, 137, 134, 156, 0, 0, 0, 0, 131, 0, 6, 177, 0, 0, 0, 0, 184, 110, 99, 47, 0, 0, 0, 0, 179, 194, 82, 94, 0, 0, 0, 0, 198, 4, 8, 9, 172, 184, 0, 0, 0, 0, 129, 183, 150, 141, 0, 0, 0, 0, 100, 127, 24, 164, 0, 0, 0, 0, 170, 18, 144, 184, 0, 0, 0, 0, 198, 4, 202, 168, 208, 69, 0, 0, 0, 0, 88, 182, 230, 112, 0, 0, 0, 0, 189, 38, 205, 231, 0, 0, 0, 0, 37, 245, 232, 185, 0, 0, 0, 0, 198, 4, 38, 142, 77, 219, 0, 0, 0, 0, 29, 255, 151, 203, 0, 0, 0, 0, 6, 156, 183, 253, 0, 0, 0, 0, 57, 222, 213, 89, 0, 0, 0, 0, 198, 4, 200, 97, 69, 151, 0, 0, 0, 0, 46, 148, 186, 230, 0, 0, 0, 0, 119, 21, 118, 53, 0, 0, 0, 0, 117, 160, 132, 160, 0, 0, 0, 0, 198, 4, 208, 138, 230, 0, 0, 0, 0, 0, 31, 253, 40, 135, 0, 0, 0, 0, 5, 50, 243, 231, 0, 0, 0, 0, 103, 37, 205, 73, 0, 0, 0, 0, 198, 4, 239, 150, 105, 68, 0, 0, 0, 0, 37, 71, 208, 163, 0, 0, 0, 0, 171, 127, 30, 165, 0, 0, 0, 0, 147, 45, 100, 177, 0, 0, 0, 0, 198, 4, 204, 151, 211, 26, 0, 0, 0, 0, 41, 182, 137, 94, 0, 0, 0, 0, 81, 48, 13, 63, 0, 0, 0, 0, 167, 200, 175, 231, 0, 0, 0, 0, 198, 4, 123, 7, 165, 126, 0, 0, 0, 0, 52, 46, 227, 139, 0, 0, 0, 0, 155, 183, 95, 124, 0, 0, 0, 0, 215, 30, 114, 219, 0, 0, 0, 0, 198, 4, 72, 14, 7, 143, 0, 0, 0, 0, 154, 27, 222, 10, 0, 0, 0, 0, 115, 88, 239, 104, 0, 0, 0, 0, 59, 137, 166, 111, 0, 0, 0, 0, 198, 4, 196, 158, 241, 210, 0, 0, 0, 0, 246, 234, 40, 106, 0, 0, 0, 0, 105, 210, 149, 2, 0, 0, 0, 0, 128, 38, 175, 1, 0, 0, 0, 0, 198, 4, 223, 108, 72, 242, 0, 0, 0, 0, 67, 9, 248, 210, 0, 0, 0, 0, 16, 117, 237, 235, 0, 0, 0, 0, 29, 211, 49, 233, 0, 0, 0, 0, 198, 4, 231, 71, 202, 9, 0, 0, 0, 0, 237, 244, 226, 123, 0, 0, 0, 0, 40, 0, 103, 198, 0, 0, 0, 0, 3, 112, 237, 178, 0, 0, 0, 0, 198, 4, 255, 135, 147, 240, 0, 0, 0, 0, 143, 201, 90, 88, 0, 0, 0, 0, 9, 26, 197, 18, 0, 0, 0, 0, 55, 89, 54, 128, 0, 0, 0, 0, 198, 4, 145, 163, 235, 113, 0, 0, 0, 0, 82, 177, 63, 88, 0, 0, 0, 0, 91, 101, 167, 213, 0, 0, 0, 0, 56, 70, 196, 109, 0, 0, 0, 0, 198, 4, 233, 92, 177, 83, 0, 0, 0, 0, 192, 176, 157, 68, 0, 0, 0, 0, 5, 115, 188, 45, 0, 0, 0, 0, 60, 124, 18, 139, 0, 0, 0, 0, 198, 4, 54, 127, 192, 86, 0, 0, 0, 0, 55, 141, 255, 44, 0, 0, 0, 0, 227, 250, 89, 40, 0, 0, 0, 0, 251, 156, 183, 173, 0, 0, 0, 0, 198, 4, 98, 161, 249, 64, 0, 0, 0, 0, 170, 36, 224, 71, 0, 0, 0, 0, 230, 216, 1, 39, 0, 0, 0, 0, 118, 83, 72, 192, 0, 0, 0, 0, 198, 4, 27, 109, 57, 236, 0, 0, 0, 0, 169, 57, 57, 78, 0, 0, 0, 0, 114, 193, 113, 233, 0, 0, 0, 0, 119, 35, 163, 36, 0, 0, 0, 0, 198, 4, 153, 135, 250, 218, 0, 0, 0, 0, 7, 209, 123, 66, 0, 0, 0, 0, 3, 177, 6, 222, 0, 0, 0, 0, 147, 21, 218, 227, 0, 0, 0, 0, 198, 4, 42, 195, 2, 81, 0, 0, 0, 0, 111, 22, 222, 178, 0, 0, 0, 0, 149, 145, 118, 145, 0, 0, 0, 0, 209, 250, 57, 4, 0, 0, 0, 0, 198, 4, 183, 228, 194, 100, 0, 0, 0, 0, 76, 114, 15, 38, 0, 0, 0, 0, 199, 170, 105, 0, 0, 0, 0, 0, 197, 193, 3, 168, 0, 0, 0, 0, 198, 4, 168, 219, 45, 22, 0, 0, 0, 0, 211, 38, 112, 94, 0, 0, 0, 0, 196, 54, 131, 175, 0, 0, 0, 0, 205, 94, 195, 79, 0, 0, 0, 0, 198, 4, 15, 198, 36, 64, 0, 0, 0, 0, 236, 245, 105, 111, 0, 0, 0, 0, 162, 73, 67, 179, 0, 0, 0, 0, 182, 142, 194, 117, 0, 0, 0, 0, 198, 4, 85, 154, 143, 179, 0, 0, 0, 0, 176, 42, 169, 51, 0, 0, 0, 0, 176, 90, 116, 102, 0, 0, 0, 0, 38, 134, 146, 8, 0, 0, 0, 0, 198, 4, 61, 133, 174, 72, 0, 0, 0, 0, 200, 249, 245, 69, 0, 0, 0, 0, 126, 21, 187, 125, 0, 0, 0, 0, 191, 237, 121, 164, 0, 0, 0, 0, 198, 4, 32, 152, 77, 48, 0, 0, 0, 0, 126, 234, 155, 160, 0, 0, 0, 0, 241, 58, 3, 185, 0, 0, 0, 0, 68, 140, 179, 100, 0, 0, 0, 0, 198, 4, 33, 5, 32, 221, 0, 0, 0, 0, 37, 228, 49, 225, 0, 0, 0, 0, 226, 122, 161, 172, 0, 0, 0, 0, 143, 188, 126, 7, 0, 0, 0, 0, 198, 4, 146, 29, 153, 233, 0, 0, 0, 0, 223, 132, 242, 254, 0, 0, 0, 0, 69, 166, 12, 193, 0, 0, 0, 0, 39, 123, 191, 174, 0, 0, 0, 0, 198, 4, 183, 120, 73, 76, 0, 0, 0, 0, 164, 44, 32, 77, 0, 0, 0, 0, 44, 218, 68, 249, 0, 0, 0, 0, 167, 210, 130, 193, 0, 0, 0, 0, 198, 4, 165, 178, 178, 154, 0, 0, 0, 0, 65, 143, 132, 63, 0, 0, 0, 0, 94, 6, 207, 223, 0, 0, 0, 0, 238, 252, 121, 157, 0, 0, 0, 0, 198, 4, 229, 195, 93, 32, 0, 0, 0, 0, 110, 150, 99, 37, 0, 0, 0, 0, 87, 65, 247, 223, 0, 0, 0, 0, 18, 118, 160, 240, 0, 0, 0, 0, 198, 4, 158, 83, 55, 114, 0, 0, 0, 0, 138, 251, 48, 226, 0, 0, 0, 0, 210, 122, 51, 5, 0, 0, 0, 0, 154, 115, 55, 127, 0, 0, 0, 0, 198, 4, 71, 8, 76, 12, 0, 0, 0, 0, 74, 141, 101, 183, 0, 0, 0, 0, 238, 202, 192, 159, 0, 0, 0, 0, 194, 214, 106, 142, 0, 0, 0, 0, 198, 4, 43, 78, 74, 242, 0, 0, 0, 0, 170, 6, 153, 10, 0, 0, 0, 0, 14, 112, 70, 112, 0, 0, 0, 0, 143, 193, 71, 87, 0, 0, 0, 0, 198, 4, 161, 35, 84, 151, 0, 0, 0, 0, 43, 29, 219, 37, 0, 0, 0, 0, 10, 129, 188, 143, 0, 0, 0, 0, 160, 11, 238, 103, 0, 0, 0, 0, 198, 4, 165, 45, 169, 47, 0, 0, 0, 0, 6, 126, 169, 35, 0, 0, 0, 0, 198, 215, 255, 231, 0, 0, 0, 0, 148, 60, 78, 59, 0, 0, 0, 0, 198, 4, 81, 63, 125, 248, 0, 0, 0, 0, 34, 244, 140, 165, 0, 0, 0, 0, 11, 195, 169, 164, 0, 0, 0, 0, 191, 88, 223, 37, 0, 0, 0, 0, 198, 4, 254, 144, 199, 63, 0, 0, 0, 0, 19, 198, 43, 242, 0, 0, 0, 0, 116, 226, 48, 203, 0, 0, 0, 0, 20, 169, 196, 156, 0, 0, 0, 0, 198, 4, 231, 119, 75, 231, 0, 0, 0, 0, 142, 22, 16, 208, 0, 0, 0, 0, 213, 89, 242, 184, 0, 0, 0, 0, 28, 117, 219, 66, 0, 0, 0, 0, 198, 4, 204, 210, 182, 86, 0, 0, 0, 0, 179, 60, 216, 195, 0, 0, 0, 0, 230, 240, 45, 82, 0, 0, 0, 0, 80, 4, 79, 136, 0, 0, 0, 0, 198, 4, 139, 81, 9, 221, 0, 0, 0, 0, 237, 13, 114, 140, 0, 0, 0, 0, 70, 48, 238, 51, 0, 0, 0, 0, 69, 166, 149, 27, 0, 0, 0, 0, 198, 4, 9, 169, 15, 137, 0, 0, 0, 0, 211, 10, 25, 208, 0, 0, 0, 0, 166, 181, 231, 108, 0, 0, 0, 0, 128, 140, 27, 234, 0, 0, 0, 0, 198, 4, 177, 25, 37, 58, 0, 0, 0, 0, 49, 223, 91, 38, 0, 0, 0, 0, 242, 221, 140, 178, 0, 0, 0, 0, 43, 233, 223, 153, 0, 0, 0, 0, 198, 4, 55, 7, 2, 104, 0, 0, 0, 0, 65, 45, 119, 42, 0, 0, 0, 0, 85, 219, 41, 51, 0, 0, 0, 0, 209, 121, 8, 23, 0, 0, 0, 0, 198, 4, 137, 250, 251, 168, 0, 0, 0, 0, 88, 58, 130, 221, 0, 0, 0, 0, 153, 206, 40, 14, 0, 0, 0, 0, 52, 59, 142, 114, 0, 0, 0, 0, 198, 4, 217, 205, 119, 108, 0, 0, 0, 0, 120, 48, 212, 129, 0, 0, 0, 0, 92, 205, 231, 73, 0, 0, 0, 0, 28, 85, 97, 64, 0, 0, 0, 0, 198, 4, 34, 204, 231, 104, 0, 0, 0, 0, 226, 188, 75, 74, 0, 0, 0, 0, 161, 180, 159, 239, 0, 0, 0, 0, 192, 10, 3, 185, 0, 0, 0, 0, 198, 4, 96, 143, 112, 130, 0, 0, 0, 0, 171, 245, 41, 81, 0, 0, 0, 0, 58, 209, 116, 132, 0, 0, 0, 0, 159, 159, 185, 198, 0, 0, 0, 0, 198, 4, 186, 118, 210, 251, 0, 0, 0, 0, 108, 140, 181, 15, 0, 0, 0, 0, 50, 1, 202, 33, 0, 0, 0, 0, 41, 2, 2, 199, 0, 0, 0, 0, 198, 4, 110, 212, 184, 146, 0, 0, 0, 0, 75, 126, 217, 143, 0, 0, 0, 0, 92, 195, 253, 236, 0, 0, 0, 0, 218, 96, 96, 97, 0, 0, 0, 0, 198, 4, 190, 162, 204, 114, 0, 0, 0, 0, 44, 25, 221, 28, 0, 0, 0, 0, 73, 114, 191, 24, 0, 0, 0, 0, 121, 170, 56, 97, 0, 0, 0, 0, 198, 4, 42, 3, 241, 82, 0, 0, 0, 0, 105, 75, 131, 114, 0, 0, 0, 0, 158, 45, 126, 163, 0, 0, 0, 0, 42, 10, 138, 91, 0, 0, 0, 0, 198, 4, 14, 146, 194, 249, 0, 0, 0, 0, 196, 26, 18, 226, 0, 0, 0, 0, 223, 158, 213, 225, 0, 0, 0, 0, 75, 114, 237, 48, 0, 0, 0, 0, 198, 4, 212, 96, 90, 180, 0, 0, 0, 0, 172, 31, 186, 196, 0, 0, 0, 0, 171, 40, 170, 105, 0, 0, 0, 0, 84, 226, 140, 45, 0, 0, 0, 0, 198, 4, 156, 241, 243, 7, 0, 0, 0, 0, 10, 185, 83, 104, 0, 0, 0, 0, 54, 9, 56, 192, 0, 0, 0, 0, 153, 85, 75, 129, 0, 0, 0, 0, 198, 4, 253, 198, 118, 236, 0, 0, 0, 0, 116, 29, 40, 195, 0, 0, 0, 0, 147, 176, 18, 169, 0, 0, 0, 0, 98, 108, 254, 29, 0, 0, 0, 0, 198, 4, 194, 188, 182, 89, 0, 0, 0, 0, 164, 243, 51, 105, 0, 0, 0, 0, 226, 43, 219, 129, 0, 0, 0, 0, 59, 82, 115, 5, 0, 0, 0, 0, 198, 4, 101, 160, 197, 168, 0, 0, 0, 0, 149, 76, 149, 43, 0, 0, 0, 0, 184, 172, 6, 70, 0, 0, 0, 0, 35, 85, 169, 50, 0, 0, 0, 0, 198, 4, 128, 61, 26, 82, 0, 0, 0, 0, 210, 173, 154, 70, 0, 0, 0, 0, 81, 211, 178, 95, 0, 0, 0, 0, 211, 219, 65, 153, 0, 0, 0, 0, 198, 4, 228, 206, 239, 188, 0, 0, 0, 0, 20, 112, 73, 219, 0, 0, 0, 0, 145, 129, 251, 201, 0, 0, 0, 0, 46, 27, 97, 7, 0, 0, 0, 0, 198, 4, 70, 91, 33, 43, 0, 0, 0, 0, 137, 92, 35, 107, 0, 0, 0, 0, 34, 244, 0, 106, 0, 0, 0, 0, 2, 236, 108, 41, 0, 0, 0, 0, 198, 4, 254, 42, 161, 242, 0, 0, 0, 0, 230, 92, 103, 88, 0, 0, 0, 0, 136, 167, 198, 110, 0, 0, 0, 0, 244, 203, 36, 118, 0, 0, 0, 0, 198, 4, 224, 88, 209, 130, 0, 0, 0, 0, 165, 131, 205, 75, 0, 0, 0, 0, 92, 38, 67, 227, 0, 0, 0, 0, 191, 77, 32, 85, 0, 0, 0, 0, 198, 4, 4, 145, 161, 43, 0, 0, 0, 0, 157, 182, 250, 97, 0, 0, 0, 0, 67, 171, 227, 75, 0, 0, 0, 0, 40, 73, 225, 152, 0, 0, 0, 0, 198, 4, 165, 22, 103, 157, 0, 0, 0, 0, 41, 166, 229, 7, 0, 0, 0, 0, 253, 243, 168, 21, 0, 0, 0, 0, 16, 23, 238, 113, 0, 0, 0, 0, 198, 4, 248, 103, 242, 72, 0, 0, 0, 0, 154, 103, 253, 181, 0, 0, 0, 0, 102, 102, 211, 44, 0, 0, 0, 0, 131, 234, 198, 129, 0, 0, 0, 0, 198, 4, 107, 50, 56, 20, 0, 0, 0, 0, 16, 44, 26, 62, 0, 0, 0, 0, 77, 233, 147, 103, 0, 0, 0, 0, 226, 3, 107, 252, 0, 0, 0, 0, 198, 4, 60, 127, 137, 117, 0, 0, 0, 0, 141, 114, 73, 74, 0, 0, 0, 0, 125, 155, 45, 138, 0, 0, 0, 0, 241, 13, 104, 23, 0, 0, 0, 0, 198, 4, 105, 138, 72, 3, 0, 0, 0, 0, 164, 231, 75, 1, 0, 0, 0, 0, 187, 226, 1, 50, 0, 0, 0, 0, 83, 39, 174, 240, 0, 0, 0, 0, 198, 4, 177, 181, 234, 222, 0, 0, 0, 0, 221, 221, 46, 163, 0, 0, 0, 0, 163, 153, 60, 11, 0, 0, 0, 0, 163, 54, 216, 186, 0, 0, 0, 0, 198, 4, 53, 133, 193, 252, 0, 0, 0, 0, 81, 77, 227, 61, 0, 0, 0, 0, 226, 115, 187, 2, 0, 0, 0, 0, 18, 104, 34, 238, 0, 0, 0, 0, 198, 4, 66, 12, 28, 129, 0, 0, 0, 0, 93, 205, 142, 11, 0, 0, 0, 0, 237, 66, 26, 151, 0, 0, 0, 0, 31, 234, 197, 159, 0, 0, 0, 0, 198, 4, 159, 29, 29, 253, 0, 0, 0, 0, 80, 228, 152, 112, 0, 0, 0, 0, 27, 88, 175, 16, 0, 0, 0, 0, 50, 2, 234, 120, 0, 0, 0, 0, 198, 4, 47, 215, 81, 22, 0, 0, 0, 0, 50, 4, 122, 107, 0, 0, 0, 0, 24, 16, 167, 4, 0, 0, 0, 0, 173, 165, 204, 128, 0, 0, 0, 0, 198, 4, 4, 145, 233, 172, 0, 0, 0, 0, 95, 53, 153, 5, 0, 0, 0, 0, 219, 252, 206, 121, 0, 0, 0, 0, 10, 255, 61, 44, 0, 0, 0, 0, 198, 4, 196, 238, 53, 29, 0, 0, 0, 0, 103, 5, 236, 4, 0, 0, 0, 0, 40, 121, 187, 222, 0, 0, 0, 0, 59, 136, 120, 145, 0, 0, 0, 0, 198, 4, 213, 136, 119, 205, 0, 0, 0, 0, 226, 96, 83, 14, 0, 0, 0, 0, 119, 94, 208, 17, 0, 0, 0, 0, 112, 132, 35, 170, 0, 0, 0, 0, 198, 4, 67, 167, 62, 165, 0, 0, 0, 0, 237, 16, 221, 255, 0, 0, 0, 0, 7, 216, 167, 161, 0, 0, 0, 0, 224, 213, 174, 61, 0, 0, 0, 0, 198, 4, 30, 27, 172, 162, 0, 0, 0, 0, 215, 255, 118, 88, 0, 0, 0, 0, 52, 68, 86, 197, 0, 0, 0, 0, 211, 156, 244, 152, 0, 0, 0, 0, 198, 4, 152, 131, 150, 232, 0, 0, 0, 0, 25, 183, 155, 53, 0, 0, 0, 0, 247, 240, 238, 74, 0, 0, 0, 0, 88, 145, 70, 237, 0, 0, 0, 0, 198, 4, 73, 64, 135, 76, 0, 0, 0, 0, 127, 246, 77, 209, 0, 0, 0, 0, 49, 220, 235, 210, 0, 0, 0, 0, 119, 166, 172, 0, 0, 0, 0, 0, 198, 4, 125, 125, 91, 69, 0, 0, 0, 0, 182, 47, 34, 116, 0, 0, 0, 0, 49, 184, 145, 220, 0, 0, 0, 0, 83, 208, 156, 50, 0, 0, 0, 0, 198, 4, 142, 242, 6, 12, 0, 0, 0, 0, 97, 112, 2, 112, 0, 0, 0, 0, 19, 87, 214, 21, 0, 0, 0, 0, 108, 215, 181, 24, 0, 0, 0, 0, 198, 4, 97, 77, 111, 162, 0, 0, 0, 0, 65, 55, 227, 196, 0, 0, 0, 0, 97, 34, 19, 236, 0, 0, 0, 0, 121, 132, 59, 92, 0, 0, 0, 0, 198, 4, 38, 155, 165, 71, 0, 0, 0, 0, 102, 141, 38, 17, 0, 0, 0, 0, 124, 18, 20, 34, 0, 0, 0, 0, 204, 209, 169, 196, 0, 0, 0, 0, 198, 4, 113, 214, 127, 138, 0, 0, 0, 0, 174, 250, 61, 103, 0, 0, 0, 0, 51, 195, 87, 167, 0, 0, 0, 0, 140, 225, 189, 44, 0, 0, 0, 0, 198, 4, 47, 79, 72, 9, 0, 0, 0, 0, 5, 23, 39, 126, 0, 0, 0, 0, 69, 46, 199, 248, 0, 0, 0, 0, 167, 127, 134, 190, 0, 0, 0, 0, 198, 4, 166, 219, 212, 229, 0, 0, 0, 0, 220, 104, 150, 139, 0, 0, 0, 0, 39, 217, 21, 158, 0, 0, 0, 0, 203, 216, 123, 140, 0, 0, 0, 0, 198, 4, 2, 198, 181, 199, 0, 0, 0, 0, 208, 195, 169, 36, 0, 0, 0, 0, 118, 254, 171, 113, 0, 0, 0, 0, 162, 164, 13, 155, 0, 0, 0, 0, 198, 4, 187, 25, 156, 117, 0, 0, 0, 0, 35, 203, 91, 201, 0, 0, 0, 0, 141, 134, 5, 75, 0, 0, 0, 0, 30, 163, 245, 93, 0, 0, 0, 0, 198, 4, 230, 204, 246, 159, 0, 0, 0, 0, 245, 7, 10, 40, 0, 0, 0, 0, 71, 188, 100, 128, 0, 0, 0, 0, 190, 142, 166, 248, 0, 0, 0, 0, 198, 4, 0, 16, 5, 9, 0, 0, 0, 0, 138, 151, 198, 133, 0, 0, 0, 0, 14, 74, 224, 152, 0, 0, 0, 0, 139, 243, 60, 160, 0, 0, 0, 0, 198, 4, 155, 232, 185, 7, 0, 0, 0, 0, 38, 183, 59, 20, 0, 0, 0, 0, 31, 63, 149, 37, 0, 0, 0, 0, 242, 185, 209, 201, 0, 0, 0, 0, 198, 4, 134, 94, 231, 252, 0, 0, 0, 0, 183, 212, 66, 234, 0, 0, 0, 0, 132, 24, 45, 131, 0, 0, 0, 0, 67, 120, 39, 119, 0, 0, 0, 0, 198, 4, 105, 63, 158, 91, 0, 0, 0, 0, 100, 166, 187, 35, 0, 0, 0, 0, 42, 189, 6, 190, 0, 0, 0, 0, 124, 32, 150, 251, 0, 0, 0, 0, 198, 4, 19, 251, 160, 200, 0, 0, 0, 0, 150, 160, 104, 182, 0, 0, 0, 0, 139, 64, 81, 248, 0, 0, 0, 0, 86, 163, 91, 67, 0, 0, 0, 0, 198, 4, 47, 94, 98, 19, 0, 0, 0, 0, 8, 186, 8, 206, 0, 0, 0, 0, 242, 64, 14, 87, 0, 0, 0, 0, 14, 6, 107, 13, 0, 0, 0, 0, 198, 4, 195, 103, 50, 77, 0, 0, 0, 0, 57, 206, 244, 183, 0, 0, 0, 0, 163, 67, 181, 178, 0, 0, 0, 0, 132, 169, 63, 217, 0, 0, 0, 0, 198, 4, 46, 32, 49, 204, 0, 0, 0, 0, 33, 91, 168, 7, 0, 0, 0, 0, 82, 97, 224, 149, 0, 0, 0, 0, 234, 22, 152, 145, 0, 0, 0, 0, 198, 4, 139, 172, 2, 181, 0, 0, 0, 0, 177, 64, 166, 114, 0, 0, 0, 0, 32, 254, 84, 43, 0, 0, 0, 0, 105, 251, 66, 219, 0, 0, 0, 0, 198, 4, 193, 147, 153, 161, 0, 0, 0, 0, 28, 129, 217, 106, 0, 0, 0, 0, 243, 215, 133, 215, 0, 0, 0, 0, 114, 233, 232, 162, 0, 0, 0, 0, 198, 4, 206, 236, 80, 204, 0, 0, 0, 0, 249, 27, 126, 95, 0, 0, 0, 0, 215, 4, 72, 30, 0, 0, 0, 0, 121, 219, 251, 209, 0, 0, 0, 0, 198, 4, 9, 24, 212, 62, 0, 0, 0, 0, 106, 29, 47, 238, 0, 0, 0, 0, 207, 39, 199, 68, 0, 0, 0, 0, 77, 183, 1, 78, 0, 0, 0, 0, 198, 4, 76, 162, 195, 183, 0, 0, 0, 0, 39, 157, 242, 205, 0, 0, 0, 0, 68, 5, 226, 226, 0, 0, 0, 0, 123, 227, 157, 63, 0, 0, 0, 0, 198, 4, 202, 79, 52, 64, 0, 0, 0, 0, 153, 23, 97, 155, 0, 0, 0, 0, 89, 248, 139, 198, 0, 0, 0, 0, 145, 89, 124, 243, 0, 0, 0, 0, 198, 4, 221, 182, 167, 134, 0, 0, 0, 0, 60, 170, 164, 75, 0, 0, 0, 0, 212, 201, 177, 209, 0, 0, 0, 0, 186, 54, 245, 83, 0, 0, 0, 0, 198, 4, 119, 55, 21, 104, 0, 0, 0, 0, 140, 222, 6, 219, 0, 0, 0, 0, 228, 79, 128, 194, 0, 0, 0, 0, 16, 191, 97, 212, 0, 0, 0, 0, 198, 4, 132, 253, 243, 214, 0, 0, 0, 0, 142, 227, 135, 152, 0, 0, 0, 0, 237, 63, 13, 155, 0, 0, 0, 0, 6, 250, 98, 143, 0, 0, 0, 0, 198, 4, 14, 143, 29, 36, 0, 0, 0, 0, 169, 177, 55, 119, 0, 0, 0, 0, 190, 185, 34, 108, 0, 0, 0, 0, 219, 27, 106, 212, 0, 0, 0, 0, 198, 4, 141, 176, 210, 232, 0, 0, 0, 0, 213, 185, 177, 112, 0, 0, 0, 0, 139, 92, 211, 87, 0, 0, 0, 0, 77, 108, 241, 25, 0, 0, 0, 0, 198, 4, 141, 221, 16, 162, 0, 0, 0, 0, 50, 47, 217, 82, 0, 0, 0, 0, 93, 139, 215, 33, 0, 0, 0, 0, 14, 15, 207, 177, 0, 0, 0, 0, 198, 4, 227, 200, 147, 158, 0, 0, 0, 0, 91, 135, 188, 16, 0, 0, 0, 0, 170, 99, 12, 47, 0, 0, 0, 0, 78, 1, 86, 106, 0, 0, 0, 0, 198, 4, 202, 217, 194, 180, 0, 0, 0, 0, 176, 76, 35, 23, 0, 0, 0, 0, 123, 15, 228, 161, 0, 0, 0, 0, 78, 49, 179, 5, 0, 0, 0, 0, 198, 4, 110, 104, 29, 37, 0, 0, 0, 0, 93, 175, 37, 249, 0, 0, 0, 0, 177, 74, 187, 14, 0, 0, 0, 0, 24, 145, 237, 176, 0, 0, 0, 0, 198, 4, 250, 9, 126, 221, 0, 0, 0, 0, 161, 48, 133, 73, 0, 0, 0, 0, 224, 121, 61, 104, 0, 0, 0, 0, 11, 30, 224, 87, 0, 0, 0, 0, 198, 4, 98, 185, 23, 163, 0, 0, 0, 0, 75, 66, 50, 12, 0, 0, 0, 0, 68, 145, 69, 250, 0, 0, 0, 0, 24, 114, 189, 38, 0, 0, 0, 0, 198, 4, 31, 193, 165, 195, 0, 0, 0, 0, 58, 212, 95, 184, 0, 0, 0, 0, 220, 225, 252, 142, 0, 0, 0, 0, 99, 204, 189, 118, 0, 0, 0, 0, 198, 4, 71, 94, 154, 135, 0, 0, 0, 0, 37, 174, 161, 168, 0, 0, 0, 0, 171, 109, 180, 205, 0, 0, 0, 0, 250, 227, 11, 52, 0, 0, 0, 0, 198, 4, 59, 165, 58, 220, 0, 0, 0, 0, 211, 30, 229, 10, 0, 0, 0, 0, 204, 54, 64, 163, 0, 0, 0, 0, 19, 143, 2, 181, 0, 0, 0, 0, 198, 4, 198, 232, 81, 65, 0, 0, 0, 0, 136, 244, 97, 240, 0, 0, 0, 0, 91, 64, 202, 248, 0, 0, 0, 0, 151, 35, 48, 171, 0, 0, 0, 0, 198, 4, 64, 205, 50, 177, 0, 0, 0, 0, 225, 34, 146, 187, 0, 0, 0, 0, 81, 237, 102, 92, 0, 0, 0, 0, 224, 145, 127, 116, 0, 0, 0, 0, 198, 4, 110, 110, 158, 202, 0, 0, 0, 0, 194, 155, 234, 89, 0, 0, 0, 0, 51, 114, 185, 127, 0, 0, 0, 0, 2, 237, 194, 88, 0, 0, 0, 0, 198, 4, 214, 41, 223, 125, 0, 0, 0, 0, 150, 129, 113, 155, 0, 0, 0, 0, 24, 236, 180, 73, 0, 0, 0, 0, 139, 10, 33, 226, 0, 0, 0, 0, 198, 4, 106, 109, 174, 133, 0, 0, 0, 0, 241, 3, 127, 112, 0, 0, 0, 0, 50, 72, 200, 134, 0, 0, 0, 0, 88, 78, 153, 41, 0, 0, 0, 0, 198, 4, 244, 112, 253, 20, 0, 0, 0, 0, 109, 67, 14, 42, 0, 0, 0, 0, 228, 200, 6, 227, 0, 0, 0, 0, 158, 210, 188, 65, 0, 0, 0, 0, 198, 4, 66, 153, 237, 146, 0, 0, 0, 0, 146, 74, 214, 111, 0, 0, 0, 0, 239, 157, 121, 96, 0, 0, 0, 0, 254, 138, 113, 250, 0, 0, 0, 0, 198, 4, 59, 13, 160, 249, 0, 0, 0, 0, 145, 26, 189, 69, 0, 0, 0, 0, 27, 227, 200, 191, 0, 0, 0, 0, 93, 199, 224, 164, 0, 0, 0, 0, 198, 4, 101, 40, 47, 249, 0, 0, 0, 0, 205, 236, 138, 133, 0, 0, 0, 0, 244, 3, 93, 133, 0, 0, 0, 0, 248, 154, 18, 30, 0, 0, 0, 0, 198, 4, 41, 34, 60, 147, 0, 0, 0, 0, 111, 254, 53, 90, 0, 0, 0, 0, 20, 139, 239, 24, 0, 0, 0, 0, 134, 140, 188, 66, 0, 0, 0, 0, 198, 4, 110, 93, 187, 12, 0, 0, 0, 0, 192, 3, 171, 198, 0, 0, 0, 0, 175, 188, 204, 191, 0, 0, 0, 0, 55, 52, 158, 144, 0, 0, 0, 0, 198, 4, 144, 227, 74, 124, 0, 0, 0, 0, 6, 222, 86, 175, 0, 0, 0, 0, 150, 133, 255, 100, 0, 0, 0, 0, 16, 17, 205, 156, 0, 0, 0, 0, 198, 4, 163, 218, 28, 79, 0, 0, 0, 0, 72, 131, 241, 12, 0, 0, 0, 0, 92, 204, 23, 103, 0, 0, 0, 0, 56, 219, 75, 93, 0, 0, 0, 0, 198, 4, 106, 172, 59, 59, 0, 0, 0, 0, 243, 141, 254, 96, 0, 0, 0, 0, 89, 238, 173, 92, 0, 0, 0, 0, 124, 45, 133, 37, 0, 0, 0, 0, 198, 4, 211, 7, 253, 237, 0, 0, 0, 0, 29, 137, 103, 184, 0, 0, 0, 0, 87, 168, 170, 133, 0, 0, 0, 0, 77, 207, 34, 93, 0, 0, 0, 0, 198, 4, 241, 212, 69, 108, 0, 0, 0, 0, 213, 89, 159, 193, 0, 0, 0, 0, 186, 156, 72, 60, 0, 0, 0, 0, 58, 212, 106, 30, 0, 0, 0, 0, 198, 4, 202, 129, 58, 231, 0, 0, 0, 0, 19, 95, 172, 183, 0, 0, 0, 0, 118, 241, 28, 76, 0, 0, 0, 0, 240, 26, 26, 56, 0, 0, 0, 0, 198, 4, 189, 146, 164, 187, 0, 0, 0, 0, 77, 92, 82, 2, 0, 0, 0, 0, 205, 68, 15, 186, 0, 0, 0, 0, 53, 247, 93, 18, 0, 0, 0, 0, 198, 4, 213, 70, 181, 167, 0, 0, 0, 0, 42, 125, 178, 77, 0, 0, 0, 0, 175, 7, 227, 53, 0, 0, 0, 0, 243, 204, 94, 35, 0, 0, 0, 0, 198, 4, 189, 39, 219, 15, 0, 0, 0, 0, 80, 21, 149, 61, 0, 0, 0, 0, 91, 5, 163, 233, 0, 0, 0, 0, 148, 255, 131, 81, 0, 0, 0, 0, 198, 4, 160, 210, 206, 136, 0, 0, 0, 0, 247, 82, 252, 35, 0, 0, 0, 0, 164, 228, 229, 33, 0, 0, 0, 0, 84, 137, 116, 5, 0, 0, 0, 0, 198, 4, 2, 109, 208, 87, 0, 0, 0, 0, 45, 149, 205, 30, 0, 0, 0, 0, 55, 25, 182, 73, 0, 0, 0, 0, 176, 23, 46, 193, 0, 0, 0, 0, 198, 4, 128, 121, 84, 214, 0, 0, 0, 0, 230, 26, 113, 21, 0, 0, 0, 0, 180, 206, 28, 119, 0, 0, 0, 0, 167, 97, 8, 20, 0, 0, 0, 0, 198, 4, 141, 92, 175, 7, 0, 0, 0, 0, 49, 77, 221, 109, 0, 0, 0, 0, 15, 95, 113, 189, 0, 0, 0, 0, 124, 118, 70, 181, 0, 0, 0, 0, 198, 4, 186, 53, 172, 46, 0, 0, 0, 0, 209, 28, 39, 249, 0, 0, 0, 0, 168, 209, 75, 29, 0, 0, 0, 0, 89, 221, 224, 197, 0, 0, 0, 0, 198, 4, 150, 20, 9, 216, 0, 0, 0, 0, 125, 226, 254, 175, 0, 0, 0, 0, 46, 65, 34, 216, 0, 0, 0, 0, 116, 215, 203, 234, 0, 0, 0, 0, 198, 4, 142, 148, 142, 133, 0, 0, 0, 0, 183, 114, 17, 141, 0, 0, 0, 0, 136, 217, 32, 65, 0, 0, 0, 0, 11, 250, 248, 154, 0, 0, 0, 0, 198, 4, 46, 230, 184, 214, 0, 0, 0, 0, 86, 75, 80, 64, 0, 0, 0, 0, 151, 250, 17, 162, 0, 0, 0, 0, 174, 196, 50, 172, 0, 0, 0, 0, 198, 4, 89, 170, 70, 101, 0, 0, 0, 0, 133, 27, 180, 243, 0, 0, 0, 0, 239, 159, 107, 132, 0, 0, 0, 0, 148, 231, 227, 134, 0, 0, 0, 0, 198, 4, 1, 204, 2, 129, 0, 0, 0, 0, 36, 47, 246, 193, 0, 0, 0, 0, 20, 109, 218, 1, 0, 0, 0, 0, 47, 218, 98, 158, 0, 0, 0, 0, 198, 4, 242, 217, 108, 168, 0, 0, 0, 0, 16, 93, 88, 53, 0, 0, 0, 0, 231, 8, 133, 5, 0, 0, 0, 0, 138, 15, 131, 99, 0, 0, 0, 0, 198, 4, 254, 153, 5, 175, 0, 0, 0, 0, 195, 255, 58, 10, 0, 0, 0, 0, 149, 84, 136, 133, 0, 0, 0, 0, 114, 91, 84, 84, 0, 0, 0, 0, 198, 4, 233, 201, 147, 207, 0, 0, 0, 0, 186, 169, 181, 252, 0, 0, 0, 0, 97, 141, 135, 43, 0, 0, 0, 0, 10, 182, 51, 171, 0, 0, 0, 0, 198, 4, 222, 16, 59, 204, 0, 0, 0, 0, 48, 86, 205, 119, 0, 0, 0, 0, 169, 20, 28, 76, 0, 0, 0, 0, 80, 132, 152, 60, 0, 0, 0, 0, 198, 4, 143, 195, 29, 73, 0, 0, 0, 0, 139, 79, 114, 222, 0, 0, 0, 0, 173, 212, 218, 6, 0, 0, 0, 0, 176, 191, 133, 130, 0, 0, 0, 0, 198, 4, 60, 252, 130, 200, 0, 0, 0, 0, 14, 174, 220, 178, 0, 0, 0, 0, 51, 9, 237, 131, 0, 0, 0, 0, 27, 38, 222, 132, 0, 0, 0, 0, 198, 4, 116, 173, 21, 40, 0, 0, 0, 0, 73, 48, 178, 14, 0, 0, 0, 0, 141, 46, 91, 101, 0, 0, 0, 0, 111, 70, 48, 62, 0, 0, 0, 0, 198, 4, 152, 202, 17, 40, 0, 0, 0, 0, 14, 77, 110, 149, 0, 0, 0, 0, 209, 217, 67, 79, 0, 0, 0, 0, 195, 135, 6, 154, 0, 0, 0, 0, 198, 4, 38, 15, 210, 102, 0, 0, 0, 0, 167, 123, 194, 80, 0, 0, 0, 0, 152, 133, 109, 220, 0, 0, 0, 0, 208, 103, 253, 174, 0, 0, 0, 0, 198, 4, 72, 234, 81, 36, 0, 0, 0, 0, 202, 145, 150, 87, 0, 0, 0, 0, 71, 156, 199, 222, 0, 0, 0, 0, 164, 237, 75, 237, 0, 0, 0, 0, 198, 4, 16, 253, 249, 157, 0, 0, 0, 0, 107, 100, 97, 46, 0, 0, 0, 0, 151, 87, 93, 78, 0, 0, 0, 0, 45, 102, 199, 46, 0, 0, 0, 0, 198, 4, 119, 161, 74, 204, 0, 0, 0, 0, 201, 211, 134, 170, 0, 0, 0, 0, 34, 159, 232, 160, 0, 0, 0, 0, 89, 0, 183, 186, 0, 0, 0, 0, 198, 4, 130, 231, 62, 176, 0, 0, 0, 0, 10, 231, 137, 108, 0, 0, 0, 0, 179, 98, 97, 170, 0, 0, 0, 0, 229, 73, 101, 226, 0, 0, 0, 0, 198, 4, 199, 110, 161, 203, 0, 0, 0, 0, 5, 134, 108, 202, 0, 0, 0, 0, 31, 189, 128, 108, 0, 0, 0, 0, 143, 44, 133, 159, 0, 0, 0, 0, 198, 4, 134, 196, 136, 195, 0, 0, 0, 0, 153, 55, 201, 106, 0, 0, 0, 0, 46, 136, 77, 210, 0, 0, 0, 0, 6, 69, 169, 91, 0, 0, 0, 0, 198, 4, 69, 187, 230, 251, 0, 0, 0, 0, 177, 190, 108, 205, 0, 0, 0, 0, 163, 74, 30, 174, 0, 0, 0, 0, 210, 233, 42, 162, 0, 0, 0, 0, 198, 4, 208, 228, 108, 145, 0, 0, 0, 0, 187, 79, 160, 133, 0, 0, 0, 0, 233, 231, 80, 120, 0, 0, 0, 0, 188, 151, 1, 21, 0, 0, 0, 0, 198, 4, 106, 165, 119, 225, 0, 0, 0, 0, 156, 168, 60, 217, 0, 0, 0, 0, 195, 60, 124, 41, 0, 0, 0, 0, 66, 23, 147, 101, 0, 0, 0, 0, 198, 4, 104, 90, 169, 182, 0, 0, 0, 0, 189, 54, 120, 117, 0, 0, 0, 0, 46, 193, 234, 6, 0, 0, 0, 0, 16, 168, 254, 174, 0, 0, 0, 0, 198, 4, 59, 138, 167, 31, 0, 0, 0, 0, 18, 208, 236, 161, 0, 0, 0, 0, 108, 96, 139, 26, 0, 0, 0, 0, 97, 34, 111, 22, 0, 0, 0, 0, 198, 4, 160, 76, 229, 8, 0, 0, 0, 0, 213, 69, 74, 101, 0, 0, 0, 0, 12, 244, 94, 38, 0, 0, 0, 0, 24, 17, 134, 118, 0, 0, 0, 0, 198, 4, 176, 77, 16, 231, 0, 0, 0, 0, 229, 45, 141, 221, 0, 0, 0, 0, 44, 76, 208, 106, 0, 0, 0, 0, 149, 102, 11, 218, 0, 0, 0, 0, 198, 4, 181, 217, 147, 0, 0, 0, 0, 0, 110, 59, 29, 222, 0, 0, 0, 0, 130, 25, 200, 222, 0, 0, 0, 0, 166, 100, 246, 19, 0, 0, 0, 0, 198, 4, 136, 225, 187, 171, 0, 0, 0, 0, 180, 159, 35, 155, 0, 0, 0, 0, 30, 3, 33, 115, 0, 0, 0, 0, 132, 121, 104, 231, 0, 0, 0, 0, 198, 4, 212, 135, 8, 208, 0, 0, 0, 0, 137, 136, 107, 177, 0, 0, 0, 0, 181, 134, 222, 251, 0, 0, 0, 0, 1, 187, 232, 6, 0, 0, 0, 0, 198, 4, 169, 152, 38, 194, 0, 0, 0, 0, 28, 128, 14, 177, 0, 0, 0, 0, 192, 8, 83, 97, 0, 0, 0, 0, 87, 173, 38, 99, 0, 0, 0, 0, 198, 4, 223, 142, 73, 196, 0, 0, 0, 0, 240, 228, 218, 94, 0, 0, 0, 0, 132, 214, 13, 191, 0, 0, 0, 0, 20, 97, 195, 189, 0, 0, 0, 0, 198, 4, 218, 240, 31, 50, 0, 0, 0, 0, 130, 83, 4, 146, 0, 0, 0, 0, 201, 6, 62, 82, 0, 0, 0, 0, 163, 170, 58, 189, 0, 0, 0, 0, 198, 4, 147, 103, 35, 172, 0, 0, 0, 0, 160, 13, 68, 43, 0, 0, 0, 0, 31, 206, 119, 233, 0, 0, 0, 0, 117, 97, 29, 177, 0, 0, 0, 0, 198, 4, 10, 59, 174, 29, 0, 0, 0, 0, 158, 214, 102, 24, 0, 0, 0, 0, 2, 51, 134, 202, 0, 0, 0, 0, 34, 52, 62, 7, 0, 0, 0, 0, 198, 4, 132, 237, 168, 131, 0, 0, 0, 0, 161, 63, 166, 154, 0, 0, 0, 0, 193, 93, 224, 106, 0, 0, 0, 0, 46, 197, 18, 61, 0, 0, 0, 0, 198, 4, 229, 244, 139, 77, 0, 0, 0, 0, 225, 204, 225, 8, 0, 0, 0, 0, 127, 249, 149, 123, 0, 0, 0, 0, 50, 137, 181, 160, 0, 0, 0, 0, 198, 4, 152, 39, 87, 57, 0, 0, 0, 0, 118, 193, 141, 180, 0, 0, 0, 0, 50, 174, 221, 104, 0, 0, 0, 0, 238, 215, 182, 134, 0, 0, 0, 0, 198, 4, 104, 138, 31, 70, 0, 0, 0, 0, 10, 17, 52, 12, 0, 0, 0, 0, 250, 88, 191, 61, 0, 0, 0, 0, 83, 42, 57, 49, 0, 0, 0, 0, 198, 4, 15, 151, 235, 118, 0, 0, 0, 0, 45, 94, 93, 171, 0, 0, 0, 0, 122, 23, 251, 245, 0, 0, 0, 0, 77, 188, 92, 87, 0, 0, 0, 0, 198, 4, 123, 181, 217, 174, 0, 0, 0, 0, 239, 98, 151, 68, 0, 0, 0, 0, 108, 80, 56, 60, 0, 0, 0, 0, 5, 176, 100, 248, 0, 0, 0, 0, 198, 4, 8, 42, 50, 118, 0, 0, 0, 0, 128, 227, 140, 51, 0, 0, 0, 0, 29, 61, 11, 92, 0, 0, 0, 0, 171, 210, 122, 227, 0, 0, 0, 0, 198, 4, 154, 98, 189, 161, 0, 0, 0, 0, 74, 70, 185, 121, 0, 0, 0, 0, 41, 118, 175, 0, 0, 0, 0, 0, 233, 7, 26, 193, 0, 0, 0, 0, 198, 4, 142, 30, 191, 154, 0, 0, 0, 0, 3, 155, 5, 226, 0, 0, 0, 0, 170, 155, 217, 195, 0, 0, 0, 0, 212, 60, 30, 45, 0, 0, 0, 0, 198, 4, 141, 0, 235, 40, 0, 0, 0, 0, 207, 151, 20, 0, 0, 0, 0, 0, 220, 146, 84, 67, 0, 0, 0, 0, 212, 29, 150, 34, 0, 0, 0, 0, 198, 4, 194, 65, 95, 22, 0, 0, 0, 0, 230, 22, 1, 115, 0, 0, 0, 0, 78, 202, 74, 131, 0, 0, 0, 0, 46, 59, 208, 193, 0, 0, 0, 0, 198, 4, 82, 180, 150, 89, 0, 0, 0, 0, 0, 51, 75, 134, 0, 0, 0, 0, 85, 40, 67, 107, 0, 0, 0, 0, 174, 19, 138, 95, 0, 0, 0, 0, 198, 4, 69, 32, 127, 200, 0, 0, 0, 0, 128, 170, 166, 226, 0, 0, 0, 0, 235, 195, 208, 83, 0, 0, 0, 0, 223, 233, 199, 85, 0, 0, 0, 0, 198, 4, 66, 98, 176, 103, 0, 0, 0, 0, 176, 68, 42, 80, 0, 0, 0, 0, 79, 202, 211, 115, 0, 0, 0, 0, 165, 126, 126, 237, 0, 0, 0, 0, 198, 4, 156, 206, 50, 221, 0, 0, 0, 0, 150, 115, 246, 37, 0, 0, 0, 0, 34, 70, 3, 231, 0, 0, 0, 0, 2, 125, 173, 71, 0, 0, 0, 0, 198, 4, 20, 226, 71, 246, 0, 0, 0, 0, 154, 226, 194, 197, 0, 0, 0, 0, 111, 97, 199, 161, 0, 0, 0, 0, 183, 191, 83, 119, 0, 0, 0, 0, 198, 4, 51, 221, 200, 36, 0, 0, 0, 0, 219, 121, 79, 233, 0, 0, 0, 0, 104, 62, 9, 58, 0, 0, 0, 0, 21, 18, 20, 61, 0, 0, 0, 0, 198, 4, 230, 153, 0, 7, 0, 0, 0, 0, 152, 24, 43, 244, 0, 0, 0, 0, 86, 50, 105, 223, 0, 0, 0, 0, 101, 183, 81, 84, 0, 0, 0, 0, 198, 4, 183, 118, 102, 64, 0, 0, 0, 0, 228, 51, 182, 148, 0, 0, 0, 0, 113, 85, 129, 124, 0, 0, 0, 0, 169, 17, 212, 198, 0, 0, 0, 0, 198, 4, 224, 227, 10, 114, 0, 0, 0, 0, 189, 242, 130, 197, 0, 0, 0, 0, 192, 27, 187, 106, 0, 0, 0, 0, 74, 87, 54, 230, 0, 0, 0, 0, 198, 4, 221, 72, 86, 203, 0, 0, 0, 0, 138, 156, 114, 240, 0, 0, 0, 0, 103, 62, 216, 2, 0, 0, 0, 0, 169, 158, 175, 72, 0, 0, 0, 0, 198, 4, 121, 164, 126, 245, 0, 0, 0, 0, 254, 150, 178, 172, 0, 0, 0, 0, 89, 181, 203, 4, 0, 0, 0, 0, 197, 18, 226, 32, 0, 0, 0, 0, 198, 4, 217, 229, 87, 204, 0, 0, 0, 0, 148, 243, 157, 14, 0, 0, 0, 0, 214, 124, 131, 9, 0, 0, 0, 0, 89, 103, 147, 84, 0, 0, 0, 0, 198, 4, 161, 164, 226, 63, 0, 0, 0, 0, 23, 3, 40, 151, 0, 0, 0, 0, 13, 253, 250, 36, 0, 0, 0, 0, 79, 142, 107, 174, 0, 0, 0, 0, 198, 4, 48, 165, 213, 175, 0, 0, 0, 0, 93, 12, 150, 73, 0, 0, 0, 0, 252, 165, 38, 205, 0, 0, 0, 0, 4, 216, 82, 112, 0, 0, 0, 0, 198, 4, 104, 186, 45, 21, 0, 0, 0, 0, 69, 174, 151, 199, 0, 0, 0, 0, 207, 76, 152, 1, 0, 0, 0, 0, 229, 23, 144, 6, 0, 0, 0, 0, 198, 4, 184, 209, 106, 127, 0, 0, 0, 0, 51, 186, 198, 73, 0, 0, 0, 0, 139, 142, 15, 240, 0, 0, 0, 0, 52, 90, 53, 57, 0, 0, 0, 0, 198, 4, 121, 35, 151, 226, 0, 0, 0, 0, 153, 187, 43, 36, 0, 0, 0, 0, 126, 252, 170, 172, 0, 0, 0, 0, 242, 108, 126, 12, 0, 0, 0, 0, 198, 4, 74, 130, 195, 61, 0, 0, 0, 0, 234, 40, 177, 56, 0, 0, 0, 0, 130, 168, 28, 42, 0, 0, 0, 0, 134, 27, 219, 196, 0, 0, 0, 0, 198, 4, 226, 187, 61, 146, 0, 0, 0, 0, 111, 90, 172, 119, 0, 0, 0, 0, 203, 126, 45, 45, 0, 0, 0, 0, 194, 190, 191, 199, 0, 0, 0, 0, 198, 4, 253, 239, 73, 226, 0, 0, 0, 0, 184, 136, 230, 230, 0, 0, 0, 0, 55, 57, 193, 251, 0, 0, 0, 0, 199, 187, 242, 226, 0, 0, 0, 0, 198, 4, 212, 83, 214, 52, 0, 0, 0, 0, 75, 31, 238, 5, 0, 0, 0, 0, 172, 158, 242, 175, 0, 0, 0, 0, 147, 133, 214, 181, 0, 0, 0, 0, 198, 4, 49, 245, 200, 6, 0, 0, 0, 0, 107, 113, 54, 3, 0, 0, 0, 0, 238, 169, 12, 131, 0, 0, 0, 0, 20, 151, 16, 145, 0, 0, 0, 0, 198, 4, 25, 105, 252, 161, 0, 0, 0, 0, 184, 127, 4, 121, 0, 0, 0, 0, 2, 29, 46, 147, 0, 0, 0, 0, 229, 45, 239, 61, 0, 0, 0, 0, 198, 4, 182, 3, 24, 174, 0, 0, 0, 0, 70, 36, 41, 253, 0, 0, 0, 0, 39, 107, 166, 187, 0, 0, 0, 0, 250, 72, 245, 36, 0, 0, 0, 0, 198, 4, 233, 81, 26, 65, 0, 0, 0, 0, 204, 99, 1, 249, 0, 0, 0, 0, 254, 15, 189, 143, 0, 0, 0, 0, 109, 53, 79, 87, 0, 0, 0, 0, 198, 4, 246, 31, 106, 197, 0, 0, 0, 0, 189, 75, 198, 99, 0, 0, 0, 0, 11, 79, 191, 47, 0, 0, 0, 0, 21, 100, 35, 2, 0, 0, 0, 0, 198, 4, 238, 133, 213, 194, 0, 0, 0, 0, 50, 7, 178, 70, 0, 0, 0, 0, 78, 158, 144, 210, 0, 0, 0, 0, 228, 249, 141, 104, 0, 0, 0, 0, 198, 4, 235, 164, 119, 226, 0, 0, 0, 0, 118, 152, 193, 149, 0, 0, 0, 0, 241, 214, 19, 93, 0, 0, 0, 0, 82, 130, 88, 94, 0, 0, 0, 0, 198, 4, 70, 10, 234, 242, 0, 0, 0, 0, 104, 138, 142, 170, 0, 0, 0, 0, 142, 20, 128, 168, 0, 0, 0, 0, 176, 18, 212, 99, 0, 0, 0, 0, 198, 4, 231, 236, 157, 155, 0, 0, 0, 0, 54, 248, 205, 210, 0, 0, 0, 0, 179, 98, 45, 233, 0, 0, 0, 0, 41, 34, 88, 189, 0, 0, 0, 0, 198, 4, 36, 118, 2, 182, 0, 0, 0, 0, 166, 21, 78, 13, 0, 0, 0, 0, 14, 113, 66, 253, 0, 0, 0, 0, 6, 20, 109, 207, 0, 0, 0, 0, 198, 4, 100, 206, 169, 93, 0, 0, 0, 0, 219, 43, 49, 188, 0, 0, 0, 0, 216, 175, 42, 148, 0, 0, 0, 0, 44, 166, 230, 64, 0, 0, 0, 0, 198, 4, 65, 120, 82, 130, 0, 0, 0, 0, 135, 115, 224, 129, 0, 0, 0, 0, 64, 217, 161, 166, 0, 0, 0, 0, 139, 34, 249, 31, 0, 0, 0, 0, 198, 4, 182, 90, 166, 26, 0, 0, 0, 0, 40, 202, 92, 66, 0, 0, 0, 0, 6, 90, 248, 164, 0, 0, 0, 0, 59, 116, 214, 138, 0, 0, 0, 0, 198, 4, 120, 193, 85, 124, 0, 0, 0, 0, 0, 10, 104, 188, 0, 0, 0, 0, 136, 22, 184, 141, 0, 0, 0, 0, 40, 148, 154, 233, 0, 0, 0, 0, 198, 4, 115, 165, 28, 85, 0, 0, 0, 0, 57, 91, 113, 0, 0, 0, 0, 0, 111, 48, 64, 107, 0, 0, 0, 0, 144, 34, 169, 93, 0, 0, 0, 0, 198, 4, 97, 118, 169, 200, 0, 0, 0, 0, 104, 187, 185, 215, 0, 0, 0, 0, 185, 0, 56, 149, 0, 0, 0, 0, 122, 215, 112, 133, 0, 0, 0, 0, 198, 4, 193, 60, 196, 73, 0, 0, 0, 0, 117, 204, 42, 95, 0, 0, 0, 0, 115, 22, 221, 105, 0, 0, 0, 0, 43, 31, 114, 37, 0, 0, 0, 0, 198, 4, 53, 120, 54, 0, 0, 0, 0, 0, 227, 203, 95, 4, 0, 0, 0, 0, 79, 98, 166, 3, 0, 0, 0, 0, 21, 88, 63, 83, 0, 0, 0, 0, 198, 4, 89, 215, 191, 9, 0, 0, 0, 0, 48, 149, 112, 155, 0, 0, 0, 0, 50, 55, 44, 180, 0, 0, 0, 0, 243, 125, 103, 15, 0, 0, 0, 0, 198, 4, 205, 193, 188, 104, 0, 0, 0, 0, 17, 128, 40, 94, 0, 0, 0, 0, 165, 57, 21, 221, 0, 0, 0, 0, 57, 104, 114, 148, 0, 0, 0, 0, 198, 4, 71, 107, 196, 75, 0, 0, 0, 0, 88, 231, 253, 4, 0, 0, 0, 0, 214, 240, 36, 74, 0, 0, 0, 0, 28, 25, 210, 102, 0, 0, 0, 0, 198, 4, 210, 251, 112, 3, 0, 0, 0, 0, 39, 119, 109, 119, 0, 0, 0, 0, 82, 110, 93, 91, 0, 0, 0, 0, 11, 99, 75, 32, 0, 0, 0, 0, 198, 4, 219, 11, 200, 60, 0, 0, 0, 0, 114, 104, 125, 221, 0, 0, 0, 0, 95, 92, 158, 152, 0, 0, 0, 0, 131, 189, 105, 233, 0, 0, 0, 0, 198, 4, 78, 99, 78, 100, 0, 0, 0, 0, 73, 22, 254, 57, 0, 0, 0, 0, 110, 226, 82, 185, 0, 0, 0, 0, 81, 123, 170, 162, 0, 0, 0, 0, 198, 4, 131, 150, 117, 84, 0, 0, 0, 0, 170, 112, 56, 253, 0, 0, 0, 0, 76, 140, 14, 136, 0, 0, 0, 0, 3, 239, 92, 176, 0, 0, 0, 0, 198, 4, 221, 114, 107, 206, 0, 0, 0, 0, 150, 72, 64, 21, 0, 0, 0, 0, 197, 51, 65, 166, 0, 0, 0, 0, 185, 66, 150, 126, 0, 0, 0, 0, 198, 4, 111, 97, 163, 217, 0, 0, 0, 0, 24, 109, 212, 49, 0, 0, 0, 0, 231, 119, 211, 222, 0, 0, 0, 0, 103, 41, 166, 71, 0, 0, 0, 0, 198, 4, 132, 200, 245, 135, 0, 0, 0, 0, 105, 46, 8, 134, 0, 0, 0, 0, 242, 229, 118, 102, 0, 0, 0, 0, 87, 131, 19, 61, 0, 0, 0, 0, 198, 4, 27, 83, 198, 117, 0, 0, 0, 0, 44, 71, 152, 83, 0, 0, 0, 0, 248, 169, 210, 79, 0, 0, 0, 0, 104, 1, 204, 173, 0, 0, 0, 0, 198, 4, 159, 72, 100, 150, 0, 0, 0, 0, 242, 140, 226, 185, 0, 0, 0, 0, 118, 62, 215, 55, 0, 0, 0, 0, 147, 17, 122, 86, 0, 0, 0, 0, 198, 4, 84, 177, 79, 94, 0, 0, 0, 0, 199, 179, 187, 194, 0, 0, 0, 0, 39, 115, 93, 6, 0, 0, 0, 0, 169, 126, 67, 132, 0, 0, 0, 0, 198, 4, 6, 197, 191, 37, 0, 0, 0, 0, 52, 218, 53, 172, 0, 0, 0, 0, 238, 21, 23, 177, 0, 0, 0, 0, 47, 214, 6, 241, 0, 0, 0, 0, 198, 4, 13, 210, 19, 206, 0, 0, 0, 0, 77, 247, 83, 142, 0, 0, 0, 0, 59, 208, 7, 121, 0, 0, 0, 0, 14, 134, 246, 137, 0, 0, 0, 0, 198, 4, 200, 49, 187, 22, 0, 0, 0, 0, 40, 198, 106, 250, 0, 0, 0, 0, 207, 49, 54, 110, 0, 0, 0, 0, 31, 128, 66, 216, 0, 0, 0, 0, 198, 4, 138, 150, 211, 57, 0, 0, 0, 0, 61, 18, 101, 2, 0, 0, 0, 0, 67, 228, 67, 65, 0, 0, 0, 0, 60, 71, 94, 4, 0, 0, 0, 0, 198, 4, 169, 154, 124, 197, 0, 0, 0, 0, 60, 135, 17, 216, 0, 0, 0, 0, 184, 195, 80, 168, 0, 0, 0, 0, 147, 183, 205, 95, 0, 0, 0, 0, 198, 4, 160, 164, 41, 146, 0, 0, 0, 0, 18, 106, 178, 104, 0, 0, 0, 0, 126, 241, 247, 157, 0, 0, 0, 0, 28, 80, 28, 183, 0, 0, 0, 0, 198, 4, 95, 145, 184, 253, 0, 0, 0, 0, 173, 222, 86, 113, 0, 0, 0, 0, 178, 187, 201, 253, 0, 0, 0, 0, 201, 36, 145, 101, 0, 0, 0, 0, 198, 4, 74, 167, 42, 61, 0, 0, 0, 0, 69, 59, 66, 33, 0, 0, 0, 0, 60, 228, 252, 107, 0, 0, 0, 0, 101, 2, 145, 150, 0, 0, 0, 0, 198, 4, 190, 246, 183, 232, 0, 0, 0, 0, 136, 142, 221, 207, 0, 0, 0, 0, 104, 145, 173, 187, 0, 0, 0, 0, 212, 8, 70, 144, 0, 0, 0, 0, 198, 4, 160, 14, 251, 212, 0, 0, 0, 0, 117, 138, 134, 210, 0, 0, 0, 0, 31, 7, 219, 44, 0, 0, 0, 0, 237, 205, 229, 243, 0, 0, 0, 0, 198, 4, 253, 242, 131, 65, 0, 0, 0, 0, 228, 232, 90, 162, 0, 0, 0, 0, 138, 105, 177, 2, 0, 0, 0, 0, 91, 49, 24, 212, 0, 0, 0, 0, 198, 4, 44, 250, 40, 233, 0, 0, 0, 0, 165, 104, 158, 244, 0, 0, 0, 0, 9, 9, 115, 83, 0, 0, 0, 0, 134, 185, 249, 124, 0, 0, 0, 0, 198, 4, 74, 52, 64, 195, 0, 0, 0, 0, 209, 124, 215, 110, 0, 0, 0, 0, 115, 64, 159, 112, 0, 0, 0, 0, 36, 125, 172, 233, 0, 0, 0, 0, 198, 4, 155, 237, 131, 23, 0, 0, 0, 0, 99, 178, 175, 208, 0, 0, 0, 0, 75, 95, 30, 86, 0, 0, 0, 0, 178, 37, 169, 161, 0, 0, 0, 0, 198, 4, 81, 70, 64, 209, 0, 0, 0, 0, 183, 219, 237, 25, 0, 0, 0, 0, 248, 152, 238, 61, 0, 0, 0, 0, 201, 236, 30, 119, 0, 0, 0, 0, 198, 4, 88, 15, 0, 118, 0, 0, 0, 0, 214, 124, 208, 31, 0, 0, 0, 0, 239, 39, 234, 51, 0, 0, 0, 0, 107, 97, 1, 198, 0, 0, 0, 0, 198, 4, 134, 102, 243, 132, 0, 0, 0, 0, 92, 211, 80, 250, 0, 0, 0, 0, 200, 127, 136, 171, 0, 0, 0, 0, 57, 160, 184, 155, 0, 0, 0, 0, 198, 4, 199, 82, 217, 41, 0, 0, 0, 0, 131, 16, 32, 221, 0, 0, 0, 0, 197, 9, 191, 11, 0, 0, 0, 0, 76, 4, 161, 150, 0, 0, 0, 0, 198, 4, 77, 251, 10, 124, 0, 0, 0, 0, 82, 120, 233, 226, 0, 0, 0, 0, 161, 167, 252, 193, 0, 0, 0, 0, 103, 48, 255, 42, 0, 0, 0, 0, 198, 4, 221, 13, 99, 73, 0, 0, 0, 0, 156, 96, 21, 108, 0, 0, 0, 0, 145, 170, 244, 48, 0, 0, 0, 0, 29, 171, 16, 43, 0, 0, 0, 0, 198, 4, 96, 0, 220, 98, 0, 0, 0, 0, 2, 25, 60, 149, 0, 0, 0, 0, 59, 64, 12, 191, 0, 0, 0, 0, 224, 54, 193, 242, 0, 0, 0, 0, 198, 4, 75, 4, 54, 157, 0, 0, 0, 0, 47, 110, 84, 219, 0, 0, 0, 0, 130, 10, 103, 132, 0, 0, 0, 0, 65, 238, 75, 169, 0, 0, 0, 0, 198, 4, 31, 114, 229, 163, 0, 0, 0, 0, 224, 206, 25, 51, 0, 0, 0, 0, 253, 209, 251, 103, 0, 0, 0, 0, 91, 243, 103, 170, 0, 0, 0, 0, 198, 4, 6, 138, 67, 225, 0, 0, 0, 0, 230, 57, 147, 195, 0, 0, 0, 0, 117, 179, 5, 62, 0, 0, 0, 0, 81, 118, 183, 142, 0, 0, 0, 0, 198, 4, 65, 33, 103, 229, 0, 0, 0, 0, 201, 225, 72, 104, 0, 0, 0, 0, 122, 129, 17, 121, 0, 0, 0, 0, 177, 254, 144, 134, 0, 0, 0, 0, 198, 4, 203, 21, 69, 123, 0, 0, 0, 0, 243, 170, 253, 86, 0, 0, 0, 0, 136, 17, 87, 24, 0, 0, 0, 0, 239, 152, 13, 95, 0, 0, 0, 0, 198, 4, 226, 189, 155, 80, 0, 0, 0, 0, 96, 21, 104, 162, 0, 0, 0, 0, 17, 152, 38, 125, 0, 0, 0, 0, 109, 243, 52, 178, 0, 0, 0, 0, 198, 4, 210, 234, 187, 14, 0, 0, 0, 0, 216, 113, 203, 15, 0, 0, 0, 0, 112, 46, 37, 78, 0, 0, 0, 0, 91, 221, 1, 123, 0, 0, 0, 0, 198, 4, 130, 36, 170, 34, 0, 0, 0, 0, 153, 46, 32, 81, 0, 0, 0, 0, 47, 147, 218, 75, 0, 0, 0, 0, 23, 98, 36, 43, 0, 0, 0, 0, 198, 4, 115, 188, 203, 242, 0, 0, 0, 0, 254, 173, 102, 49, 0, 0, 0, 0, 89, 6, 202, 16, 0, 0, 0, 0, 112, 45, 186, 131, 0, 0, 0, 0, 198, 4, 242, 134, 217, 168, 0, 0, 0, 0, 117, 94, 208, 155, 0, 0, 0, 0, 208, 62, 97, 129, 0, 0, 0, 0, 234, 157, 78, 133, 0, 0, 0, 0, 198, 4, 206, 106, 159, 171, 0, 0, 0, 0, 163, 211, 183, 15, 0, 0, 0, 0, 4, 175, 85, 59, 0, 0, 0, 0, 162, 160, 231, 64, 0, 0, 0, 0, 198, 4, 32, 223, 144, 34, 0, 0, 0, 0, 24, 215, 40, 110, 0, 0, 0, 0, 222, 229, 131, 231, 0, 0, 0, 0, 198, 54, 44, 160, 0, 0, 0, 0, 198, 4, 225, 22, 57, 160, 0, 0, 0, 0, 16, 5, 191, 99, 0, 0, 0, 0, 140, 253, 90, 243, 0, 0, 0, 0, 1, 181, 189, 151, 0, 0, 0, 0, 198, 4, 56, 187, 222, 85, 0, 0, 0, 0, 52, 208, 74, 31, 0, 0, 0, 0, 72, 203, 39, 204, 0, 0, 0, 0, 170, 73, 100, 164, 0, 0, 0, 0, 198, 4, 253, 67, 125, 168, 0, 0, 0, 0, 75, 56, 99, 181, 0, 0, 0, 0, 56, 8, 210, 28, 0, 0, 0, 0, 159, 220, 253, 230, 0, 0, 0, 0, 198, 4, 55, 22, 202, 36, 0, 0, 0, 0, 8, 141, 72, 195, 0, 0, 0, 0, 45, 150, 2, 98, 0, 0, 0, 0, 151, 167, 208, 249, 0, 0, 0, 0, 198, 4, 66, 181, 234, 204, 0, 0, 0, 0, 242, 0, 131, 123, 0, 0, 0, 0, 55, 153, 173, 253, 0, 0, 0, 0, 194, 200, 75, 28, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 209, 3, 0, 0, 0, 0, 0, 0, 198, 4, 31, 133, 63, 207, 0, 0, 0, 0, 214, 130, 165, 212, 0, 0, 0, 0, 154, 181, 182, 112, 0, 0, 0, 0, 54, 193, 25, 172, 0, 0, 0, 0, 198, 4, 93, 93, 252, 141, 0, 0, 0, 0, 77, 198, 29, 31, 0, 0, 0, 0, 210, 166, 94, 177, 0, 0, 0, 0, 226, 171, 219, 211, 0, 0, 0, 0, 198, 4, 67, 230, 129, 153, 0, 0, 0, 0, 72, 159, 8, 233, 0, 0, 0, 0, 192, 72, 159, 151, 0, 0, 0, 0, 156, 18, 253, 51, 0, 0, 0, 0, 198, 4, 83, 41, 30, 35, 0, 0, 0, 0, 219, 102, 188, 41, 0, 0, 0, 0, 90, 46, 54, 215, 0, 0, 0, 0, 151, 32, 126, 72, 0, 0, 0, 0, 254, 125, 10, 5, 0, 254, 126, 10, 6, 0, 254, 127, 10, 10, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 18, 0, 0, 0, 0, 0, 0, 0, 107, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 68, 164, 75, 1, 196, 18, 0, 0, 0, 0, 0, 0, 0, 105, 253, 46, 0, 196, 12, 0, 0, 0, 0, 0, 0, 0, 105, 196, 13, 0, 0, 0, 0, 0, 0, 0, 105, 196, 14, 0, 0, 0, 0, 0, 0, 0, 105, 196, 15, 0, 0, 0, 0, 0, 0, 0, 105, 196, 16, 0, 0, 0, 0, 0, 0, 0, 105, 196, 17, 0, 0, 0, 0, 0, 0, 0, 105, 183, 11, 0, 0, 0, 0, 0, 0, 0, 183, 10, 0, 0, 0, 0, 0, 0, 0, 183, 9, 0, 0, 0, 0, 0, 0, 0, 183, 8, 0, 0, 0, 0, 0, 0, 0, 183, 7, 0, 0, 0, 0, 0, 0, 0, 183, 6, 0, 0, 0, 0, 0, 0, 0, 183, 17, 0, 0, 0, 0, 0, 0, 0, 183, 16, 0, 0, 0, 0, 0, 0, 0, 183, 15, 0, 0, 0, 0, 0, 0, 0, 183, 14, 0, 0, 0, 0, 0, 0, 0, 183, 13, 0, 0, 0, 0, 0, 0, 0, 183, 12, 0, 0, 0, 0, 0, 0, 0, 183, 5, 0, 0, 0, 0, 0, 0, 0, 183, 4, 0, 0, 0, 0, 0, 0, 0, 183, 3, 0, 0, 0, 0, 0, 0, 0, 183, 2, 0, 0, 0, 0, 0, 0, 0, 183, 1, 0, 0, 0, 0, 0, 0, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 207, 12, 0, 0, 0, 104, 104, 190, 6, 0, 0, 0, 0, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 196, 1, 0, 0, 0, 0, 0, 0, 0, 190, 8, 0, 0, 0, 0, 0, 0, 0, 196, 2, 0, 0, 0, 0, 0, 0, 0, 190, 9, 0, 0, 0, 0, 0, 0, 0, 196, 3, 0, 0, 0, 0, 0, 0, 0, 190, 10, 0, 0, 0, 0, 0, 0, 0, 196, 4, 0, 0, 0, 0, 0, 0, 0, 190, 11, 0, 0, 0, 0, 0, 0, 0, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 1, 0, 254, 185, 10, 1, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 18, 0, 0, 0, 0, 0, 0, 0, 163, 196, 18, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 19, 0, 0, 0, 0, 0, 0, 0, 196, 18, 0, 0, 0, 0, 0, 0, 0, 105, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 108, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 109, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 110, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 111, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 112, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 3, 109, 97, 99, 0, 0, 3, 109, 97, 99, 0, 0, 0, 5, 0, 54, 162, 38, 146, 3, 14, 112, 111, 105, 110, 116, 95, 97, 100, 100, 105, 116, 105, 111, 110, 12, 0, 14, 112, 111, 105, 110, 116, 95, 97, 100, 100, 105, 116, 105, 111, 110, 1, 16, 0, 211, 1, 113, 115, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 115, 117, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 5, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 115, 117, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 117, 119, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 5, 0, 0, 0, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 196, 3, 0, 0, 0, 0, 0, 0, 0, 105, 117, 119, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 119, 121, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 5, 0, 0, 0, 196, 4, 0, 0, 0, 0, 0, 0, 0, 105, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 109, 111, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 115, 117, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 6, 0, 0, 0, 196, 6, 0, 0, 0, 0, 0, 0, 0, 105, 196, 7, 0, 0, 0, 0, 0, 0, 0, 105, 115, 117, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 122, 122, 127, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 6, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 6, 0, 0, 0, 0, 0, 0, 0, 105, 196, 7, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 6, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 196, 6, 0, 0, 0, 0, 0, 0, 0, 105, 196, 7, 0, 0, 0, 0, 0, 0, 0, 105, 109, 111, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 119, 121, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 6, 0, 0, 0, 196, 8, 0, 0, 0, 0, 0, 0, 0, 105, 196, 9, 0, 0, 0, 0, 0, 0, 0, 105, 118, 118, 117, 119, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 152, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 9, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 8, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 8, 0, 0, 0, 0, 0, 0, 0, 105, 196, 9, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 9, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 8, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 196, 8, 0, 0, 0, 0, 0, 0, 0, 105, 196, 9, 0, 0, 0, 0, 0, 0, 0, 105, 111, 113, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 115, 117, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 6, 0, 0, 0, 196, 10, 0, 0, 0, 0, 0, 0, 0, 105, 196, 11, 0, 0, 0, 0, 0, 0, 0, 105, 117, 119, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 122, 122, 127, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 148, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 11, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 10, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 10, 0, 0, 0, 0, 0, 0, 0, 105, 196, 11, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 11, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 10, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 196, 12, 0, 0, 0, 0, 0, 0, 0, 105, 196, 13, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 124, 124, 207, 6, 0, 0, 0, 196, 10, 0, 0, 0, 0, 0, 0, 0, 142, 196, 11, 0, 0, 0, 0, 0, 0, 0, 142, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 37, 80, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 4, 0, 0, 0, 0, 0, 0, 0, 142, 196, 5, 0, 0, 0, 0, 0, 0, 0, 142, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 196, 14, 0, 0, 0, 0, 0, 0, 0, 105, 196, 15, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 196, 3, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 37, 80, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 13, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 12, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 12, 0, 0, 0, 0, 0, 0, 0, 142, 196, 13, 0, 0, 0, 0, 0, 0, 0, 142, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 9, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 8, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 10, 0, 0, 0, 0, 0, 0, 0, 105, 196, 11, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 6, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 11, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 10, 0, 0, 0, 0, 0, 0, 0, 207, 7, 0, 0, 0, 207, 6, 0, 0, 0, 196, 10, 0, 0, 0, 0, 0, 0, 0, 105, 196, 11, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 13, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 12, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 12, 0, 0, 0, 0, 0, 0, 0, 105, 196, 13, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 15, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 14, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 13, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 12, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 196, 12, 0, 0, 0, 0, 0, 0, 0, 105, 196, 13, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 6, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 105, 196, 1, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 9, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 8, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 15, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 14, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 196, 14, 0, 0, 0, 0, 0, 0, 0, 105, 196, 15, 0, 0, 0, 0, 0, 0, 0, 105, 105, 105, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 10, 0, 0, 0, 0, 0, 0, 0, 111, 194, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 11, 0, 0, 0, 0, 0, 0, 0, 112, 194, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 12, 0, 0, 0, 0, 0, 0, 0, 113, 194, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 13, 0, 0, 0, 0, 0, 0, 0, 114, 194, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 14, 0, 0, 0, 0, 0, 0, 0, 115, 194, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 15, 0, 0, 0, 0, 0, 0, 0, 116, 194, 105, 14, 112, 111, 105, 110, 116, 95, 100, 111, 117, 98, 108, 105, 110, 103, 11, 0, 14, 112, 111, 105, 110, 116, 95, 100, 111, 117, 98, 108, 105, 110, 103, 1, 12, 0, 205, 0, 110, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 113, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 124, 124, 207, 5, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 142, 196, 1, 0, 0, 0, 0, 0, 0, 0, 142, 124, 124, 207, 6, 0, 0, 0, 124, 124, 207, 6, 0, 0, 0, 124, 124, 207, 6, 0, 0, 0, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 196, 3, 0, 0, 0, 0, 0, 0, 0, 105, 112, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 115, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 118, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 121, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 5, 0, 0, 0, 196, 4, 0, 0, 0, 0, 0, 0, 0, 105, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 112, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 115, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 124, 124, 207, 5, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 37, 80, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 6, 0, 0, 0, 0, 0, 0, 0, 142, 196, 7, 0, 0, 0, 0, 0, 0, 0, 142, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 8, 0, 0, 0, 0, 0, 0, 0, 105, 196, 9, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 6, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 196, 10, 0, 0, 0, 0, 0, 0, 0, 105, 196, 11, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 5, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 4, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 196, 2, 0, 0, 0, 0, 0, 0, 0, 105, 196, 3, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 6, 0, 0, 0, 0, 0, 0, 0, 124, 124, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 7, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 6, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 8, 0, 0, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 142, 196, 1, 0, 0, 0, 0, 0, 0, 0, 142, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 11, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 10, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 9, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 8, 0, 0, 0, 0, 0, 0, 0, 207, 6, 0, 0, 0, 196, 10, 0, 0, 0, 0, 0, 0, 0, 105, 196, 11, 0, 0, 0, 0, 0, 0, 0, 105, 110, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 113, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 116, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 119, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 207, 5, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 124, 124, 207, 6, 0, 0, 0, 196, 8, 0, 0, 0, 0, 0, 0, 0, 105, 196, 9, 0, 0, 0, 0, 0, 0, 0, 105, 105, 104, 104, 107, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 8, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 108, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 9, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 109, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 10, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 110, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 11, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 111, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 2, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 112, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 3, 0, 0, 0, 0, 0, 0, 0, 148, 194, 105, 9, 112, 111, 105, 110, 116, 95, 109, 117, 108, 13, 0, 9, 112, 111, 105, 110, 116, 95, 109, 117, 108, 1, 18, 0, 53, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 1, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 2, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 3, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 4, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 6, 0, 0, 0, 0, 0, 0, 0, 196, 7, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 209, 3, 0, 0, 0, 0, 0, 0, 196, 8, 0, 0, 0, 0, 0, 0, 0, 105, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 9, 0, 0, 0, 0, 0, 0, 0, 196, 10, 0, 0, 0, 0, 0, 0, 0, 196, 11, 0, 0, 0, 0, 0, 0, 0, 105, 254, 254, 3, 2, 0, 254, 255, 3, 38, 0, 107, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 68, 253, 39, 0, 183, 17, 0, 0, 0, 0, 0, 0, 0, 183, 16, 0, 0, 0, 0, 0, 0, 0, 183, 15, 0, 0, 0, 0, 0, 0, 0, 183, 14, 0, 0, 0, 0, 0, 0, 0, 183, 13, 0, 0, 0, 0, 0, 0, 0, 183, 12, 0, 0, 0, 0, 0, 0, 0, 183, 11, 0, 0, 0, 0, 0, 0, 0, 183, 10, 0, 0, 0, 0, 0, 0, 0, 183, 9, 0, 0, 0, 0, 0, 0, 0, 183, 8, 0, 0, 0, 0, 0, 0, 0, 183, 7, 0, 0, 0, 0, 0, 0, 0, 183, 6, 0, 0, 0, 0, 0, 0, 0, 183, 5, 0, 0, 0, 0, 0, 0, 0, 183, 4, 0, 0, 0, 0, 0, 0, 0, 183, 3, 0, 0, 0, 0, 0, 0, 0, 183, 2, 0, 0, 0, 0, 0, 0, 0, 183, 1, 0, 0, 0, 0, 0, 0, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 207, 12, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 6, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 7, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 8, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 9, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 10, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 11, 0, 0, 0, 0, 0, 0, 0, 105, 0, 0, 183, 17, 0, 0, 0, 0, 0, 0, 0, 183, 16, 0, 0, 0, 0, 0, 0, 0, 183, 15, 0, 0, 0, 0, 0, 0, 0, 183, 14, 0, 0, 0, 0, 0, 0, 0, 183, 13, 0, 0, 0, 0, 0, 0, 0, 183, 12, 0, 0, 0, 0, 0, 0, 0, 183, 5, 0, 0, 0, 0, 0, 0, 0, 183, 4, 0, 0, 0, 0, 0, 0, 0, 183, 3, 0, 0, 0, 0, 0, 0, 0, 183, 2, 0, 0, 0, 0, 0, 0, 0, 183, 1, 0, 0, 0, 0, 0, 0, 0, 183, 0, 0, 0, 0, 0, 0, 0, 0, 207, 11, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 0, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 1, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 2, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 3, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 4, 0, 0, 0, 0, 0, 0, 0, 148, 187, 196, 5, 0, 0, 0, 0, 0, 0, 0, 105, 75, 1, 104, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 6, 0, 0, 0, 0, 0, 0, 0, 111, 194, 190, 7, 0, 0, 0, 0, 0, 0, 0, 112, 194, 190, 8, 0, 0, 0, 0, 0, 0, 0, 113, 194, 190, 9, 0, 0, 0, 0, 0, 0, 0, 114, 194, 190, 10, 0, 0, 0, 0, 0, 0, 0, 115, 194, 190, 11, 0, 0, 0, 0, 0, 0, 0, 116, 194, 105, 3, 115, 98, 98, 1, 0, 3, 115, 98, 98, 0, 0, 0, 3, 0, 162, 3, 46, 7, 116, 111, 95, 109, 111, 110, 116, 9, 0, 7, 116, 111, 95, 109, 111, 110, 116, 1, 0, 0, 3, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 162, 7, 0, 0, 0, 0, 0, 0, 161, 144, 14, 0, 0, 0, 0, 0, 207, 5, 0, 0, 0, 12, 117, 50, 53, 54, 95, 109, 111, 100, 95, 97, 100, 100, 6, 0, 12, 117, 50, 53, 54, 95, 109, 111, 100, 95, 97, 100, 100, 1, 0, 0, 41, 0, 160, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 149, 40, 146, 149, 40, 147, 149, 40, 148, 149, 40, 149, 153, 40, 150, 153, 40, 151, 153, 40, 152, 153, 40, 152, 108, 198, 1, 209, 3, 0, 0, 0, 0, 0, 0, 54, 104, 127, 152, 3, 146, 147, 148, 149, 150, 151, 150, 151, 12, 117, 50, 53, 54, 95, 109, 111, 100, 95, 109, 117, 108, 5, 0, 12, 117, 50, 53, 54, 95, 109, 111, 100, 95, 109, 117, 108, 1, 2, 0, 81, 0, 196, 0, 0, 0, 0, 0, 0, 0, 0, 142, 196, 1, 0, 0, 0, 0, 0, 0, 0, 142, 207, 2, 0, 0, 0, 127, 146, 147, 148, 149, 150, 151, 152, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 169, 207, 4, 0, 0, 0, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 2, 0, 0, 0, 207, 3, 0, 0, 0, 207, 4, 0, 0, 0, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 2, 0, 0, 0, 207, 3, 0, 0, 0, 207, 4, 0, 0, 0, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 2, 0, 0, 0, 207, 3, 0, 0, 0, 207, 4, 0, 0, 0, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 2, 0, 0, 0, 207, 3, 0, 0, 0, 207, 4, 0, 0, 0, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 2, 0, 0, 0, 207, 3, 0, 0, 0, 207, 4, 0, 0, 0, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 2, 0, 0, 0, 207, 3, 0, 0, 0, 207, 4, 0, 0, 0, 153, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 1, 0, 0, 0, 0, 0, 0, 0, 198, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 0, 0, 0, 0, 0, 0, 0, 0, 207, 2, 0, 0, 0, 207, 3, 0, 0, 0, 207, 4, 0, 0, 0, 152, 146, 108, 3, 146, 146, 198, 1, 209, 3, 0, 0, 0, 0, 0, 0, 54, 104, 12, 117, 50, 53, 54, 95, 109, 111, 100, 95, 110, 101, 103, 7, 0, 12, 117, 50, 53, 54, 95, 109, 111, 100, 95, 110, 101, 103, 1, 0, 0, 33, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 127, 198, 1, 47, 252, 255, 255, 0, 0, 0, 0, 207, 1, 0, 0, 0, 146, 198, 1, 254, 255, 255, 255, 0, 0, 0, 0, 207, 1, 0, 0, 0, 147, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 207, 1, 0, 0, 0, 148, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 207, 1, 0, 0, 0, 149, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 207, 1, 0, 0, 0, 150, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 207, 1, 0, 0, 0, 151, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 207, 1, 0, 0, 0, 152, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 207, 1, 0, 0, 0, 104, 127, 146, 147, 148, 149, 150, 151, 12, 117, 50, 53, 54, 95, 109, 111, 100, 95, 115, 117, 98, 8, 0, 12, 117, 50, 53, 54, 95, 109, 111, 100, 95, 115, 117, 98, 1, 0, 0, 4, 0, 161, 161, 207, 7, 0, 0, 0, 207, 6, 0, 0, 0, 8, 117, 50, 53, 54, 120, 117, 51, 50, 2, 0, 8, 117, 50, 53, 54, 120, 117, 51, 50, 0, 0, 0, 26, 0, 152, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 108, 147, 54, 109, 148, 54, 110, 149, 54, 111, 150, 54, 112, 151, 54, 113, 152, 54, 114, 153, 54, 152, 153, 54, 13, 117, 50, 56, 56, 95, 97, 100, 100, 95, 117, 50, 53, 54, 3, 0, 13, 117, 50, 56, 56, 95, 97, 100, 100, 95, 117, 50, 53, 54, 0, 0, 0, 42, 0, 142, 160, 38, 146, 151, 40, 147, 150, 40, 148, 149, 160, 146, 148, 150, 40, 149, 149, 40, 147, 148, 160, 146, 148, 150, 40, 149, 149, 40, 154, 149, 40, 148, 3, 127, 146, 147, 148, 149, 150, 151, 152, 11, 117, 50, 56, 56, 95, 114, 101, 100, 117, 99, 101, 4, 0, 11, 117, 50, 56, 56, 95, 114, 101, 100, 117, 99, 101, 0, 0, 0, 50, 0, 107, 198, 1, 49, 53, 37, 210, 0, 0, 0, 0, 50, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 146, 198, 1, 47, 252, 255, 255, 0, 0, 0, 0, 110, 207, 0, 0, 0, 0, 127, 104, 146, 198, 1, 254, 255, 255, 255, 0, 0, 0, 0, 110, 207, 0, 0, 0, 0, 147, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 111, 207, 0, 0, 0, 0, 148, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 112, 207, 0, 0, 0, 0, 149, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 113, 207, 0, 0, 0, 0, 150, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 114, 207, 0, 0, 0, 0, 151, 114, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 207, 0, 0, 0, 0, 151, 152, 127, 198, 1, 255, 255, 255, 255, 0, 0, 0, 0, 207, 0, 0, 0, 0, 153, 153, 40, 127, 146, 147, 148, 149, 150, 151, 152]),
+("std::math::ext5",vm_assembly::ProcedureId([115, 116, 100, 58, 58, 109, 97, 116, 104, 58, 58, 101, 120, 116, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0]),"#! Given two GF(p^5) elements on stack, this routine computes modular
+#! addition over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
+#!
+#! Expected stack state :
+#!
+#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
+#!
+#! After application of routine stack :
+#!
+#! [c0, c1, c2, c3, c4, ...] s.t. c = a + b
+#!
+#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
+#!
+#! For reference implementation in high level language, see 
+#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L607-L616
+export.add
+    repeat.5
+        movup.5
+        add
+        movdn.4
     end
 end
 
-export.eq_unsafe
-    swapw.3
-    eqw
-    movdn.8
-    dropw
-    dropw
-    movdn.8
-    eqw
-    movdn.8
-    dropw
-    dropw
-    and
+#! Given two GF(p^5) elements on stack, this routine subtracts second
+#! element from first one, over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
+#!
+#! Expected stack state :
+#!
+#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
+#!
+#! After application of routine stack :
+#!
+#! [c0, c1, c2, c3, c4, ...] s.t. c = a - b
+#!
+#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
+#!
+#! For reference implementation in high level language, see 
+#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L629-L638
+export.sub
+    repeat.5
+        movup.5
+        sub
+        movdn.4
+    end
 end
 
-# ===== MULTIPLICATION ============================================================================
-
-proc.mulstep
-    movdn.2
-    u32overflowing_madd
-    movdn.2
-    u32overflowing_add
-    movup.2
-    add
-end
-
-proc.mulstep4
-    movup.12
+#! Given two GF(p^5) elements on stack, this routine computes modular
+#! multiplication ( including reduction by irreducible polynomial ) 
+#! over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
+#!
+#! Expected stack state :
+#!
+#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
+#!
+#! After application of routine stack :
+#!
+#! [c0, c1, c2, c3, c4, ...] s.t. c = a * b
+#!
+#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
+#!
+#! For reference implementation in high level language, see 
+#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L676-L689
+export.mul
+    # compute {c0, c1, c2, c3, c4} - five coefficients of resulting
+    # degree-4 polynomial
+    
+    # compute c4
+    dup.9
     dup.1
+    mul
+
+    dup.9
+    dup.3
+    mul
+
+    add
+
+    dup.8
+    dup.4
+    mul
+
+    add
+
+    dup.7
+    dup.5
+    mul
+
+    add
+
+    dup.6
+    dup.6
+    mul
+    
+    add
+
+    # compute c3
+    dup.9
+    dup.2
+    mul
+
+    dup.9
+    dup.4
+    mul
+    
+    add
+
+    dup.8
+    dup.5
+    mul
+
+    add
+
+    dup.7
+    dup.6
+    mul
+
+    add
+
+    dup.11
+    dup.7
+    mul
+    mul.3
+
+    add
+
+    # compute c2
+    dup.9
+    dup.3
+    mul
+
+    dup.9
+    dup.5
+    mul
+
+    add
+
+    dup.8
+    dup.6
+    mul
+    
+    add
+
+    dup.12
+    dup.7
+    mul
+    mul.3
+
+    add
+
+    dup.11
+    dup.8
+    mul
+    mul.3
+
+    add
+
+    # compute c1
+    dup.9
+    dup.4
+    mul
+
+    dup.9
+    dup.6
+    mul
+
+    add
+
+    dup.13
+    dup.7
+    mul
+    mul.3
+
+    add
+
+    dup.12
+    dup.8
+    mul
+    mul.3
+
+    add
+
+    dup.11
+    dup.9
+    mul
+    mul.3
+
+    add
+
+    # compute c0
+    movup.9
+    movup.5
+    mul
+
+    movup.12
+    movup.6
+    mul
+    mul.3
+
+    add
+
     movup.10
-    push.0 # start k at 0
-    exec.mulstep
-    swap
-    movdn.9
-    dup.1
-    movup.9
-    movup.13
-    swap.3
-    exec.mulstep
-    swap
-    movdn.8
-    dup.1
+    movup.6
+    mul
+    mul.3
+
+    add
+
     movup.8
-    movup.12
-    swap.3
-    exec.mulstep
-    swap
-    movdn.7
-    dup.1
-    movup.7
-    movup.11
-    swap.3
-    exec.mulstep
-    swap
-    movdn.6
-end
-
-#! Performs addition of two unsigned 256 bit integers discarding the overflow.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b7, b6, b5, b4, b3, b2, b1, b0, a7, a6, a5, a4, a3, a2, a1, a0, ...] -> [c7, c6, c5, c4, c3, c2, c1, c0, ...]
-#! where c = (a * b) % 2^256, and a0, b0, and c0 are least significant 32-bit limbs of a, b, and c respectively.
-export.mul_unsafe.6
-    # Memory storing setup
-    loc_storew.0
-    dropw
-    # b[5-8] at 0
-    loc_storew.1
-    # b[0-4] at 1
-    push.0 dropw
-    # b[0] at top of stack, followed by a[0-7]
-    movdn.8
-    loc_storew.2
-    # a[0-4] at 2
-    swapw
-    loc_storew.3
-    # a[5-8] at 3
-    padw
-    loc_storew.4
-    loc_storew.5
-    # p at 4 and 5
-
-    # b[0]
-    dropw
-    swapw
-    push.0.0.0.0
-    loc_loadw.4
-    movdnw.2
-    movup.12
-
-    exec.mulstep4
-
-    movdn.9
-    movdn.9
-    swapw
-    loc_storew.4
-    dropw
-    push.0.0.0.0
-    loc_loadw.5
-    swapw
-    movup.9
-    movup.9
-
-    dup.1
     movup.6
-    movup.10
-    swap.3
-    exec.mulstep
-    swap
-    movdn.5
-    dup.1
-    movup.5
-    movup.9
-    swap.3
-    exec.mulstep
-    swap
-    movdn.4
-    dup.1
-    movup.4
-    movup.8
-    swap.3
-    exec.mulstep
-    swap
-    movdn.3
-    swap
-    movup.2
+    mul
+    mul.3
+
+    add
+
     movup.6
-    swap.3
-    exec.mulstep
-
-    drop
-    loc_storew.5
-    dropw
-
-    # b[1]
-    push.0.0.0.0
-    loc_loadw.4
-    push.0.0.0.0
-    loc_loadw.5
-    movup.7
-    dropw
-    push.0.0.0.0
-    loc_loadw.3 push.0.0.0.0
-    loc_loadw.2 # load the xs
-    push.0.0.0.0
-    loc_loadw.1
-    movup.2
-    movdn.3
-    push.0 dropw # only need b[1]
-
-    exec.mulstep4
-
-    movdn.9
-    movdn.9
-    swapw
-    movdn.3
-    push.0.0.0.0
-    loc_loadw.4
-    push.0 dropw # only need p[0]
-    movdn.3
-    # save p[0-3] to memory, not needed any more
-    loc_storew.4
-    dropw
-
-    push.0.0.0.0
-    loc_loadw.5
-    movup.3
-    drop
-    swapw
-    movup.9
-    movup.9
-
-    dup.1
     movup.6
-    movup.9
-    swap.3
-    exec.mulstep
-    swap
-    movdn.7
-    dup.1
-    movup.5
-    movup.7
-    swap.3
-    exec.mulstep
-    swap
-    movdn.5
-    swap
-    movup.3
-    movup.4
-    swap.3
-    exec.mulstep
+    mul
+    mul.3
 
-    drop
-    swap
-    drop
-    loc_storew.5
-    dropw
-
-    # b[2]
-    push.0.0.0.0
-    loc_loadw.4
-    push.0.0.0.0
-    loc_loadw.5
-    movup.7
-    movup.7
-    dropw
-    push.0.0.0.0
-    loc_loadw.3 push.0.0.0.0
-    loc_loadw.2 # load the xs
-    push.0.0.0.0
-    loc_loadw.1
-    swap
-    movdn.3
-    push.0 dropw # only need b[1]
-
-    exec.mulstep4
-
-    movdn.9
-    movdn.9
-    swapw
-    movdn.3
-    movdn.3
-    push.0.0.0.0
-    loc_loadw.4
-    drop drop
-    movdn.3
-    movdn.3
-    loc_storew.4
-    dropw
-
-    push.0.0.0.0
-    loc_loadw.5
-    movup.3
-    movup.3
-    drop
-    drop
-    swapw
-    movup.9
-    movup.9
-
-    dup.1
-    movup.6
-    movup.8
-    swap.3
-    exec.mulstep
-    swap
-    movdn.6
-    dup.1
-    movup.5
-    movup.6
-    swap.3
-    exec.mulstep
-    swap
-    swap drop
-    movdn.3
-    drop drop drop
-    loc_storew.5
-    dropw
-
-    # b[3]
-    push.0.0.0.0
-    loc_loadw.4
-    push.0.0.0.0
-    loc_loadw.5
-
-    movup.7 movup.7 movup.7
-    dropw
-    push.0.0.0.0
-    loc_loadw.3 push.0.0.0.0
-    loc_loadw.2
-
-    push.0.0.0.0
-    loc_loadw.1
-    movdn.3
-    push.0 dropw
-
-    exec.mulstep4
-
-    movdn.9
-    movdn.9
-
-    swapw
-    movup.3
-    push.0.0.0.0
-    loc_loadw.4
-    drop
-    movup.3
-
-    loc_storew.4
-    dropw
-    push.0.0.0.0
-    loc_loadw.5
-    movdn.3
-    push.0 dropw
-    swapw
-    movup.9
-    movup.9
-
-    swap
-    movup.5
-    movup.6
-    swap.3
-    exec.mulstep
-
-    drop
-    movdn.3
-    push.0 dropw
-
-    # b[4]
-    push.0.0.0.0
-    loc_loadw.3 push.0.0.0.0
-    loc_loadw.2 # load the xs
-    # OPTIM: don't need a[4-7], but can't use mulstep4 if we don't load
-
-    push.0.0.0.0
-    loc_loadw.0
-    push.0 dropw # b[4]
-
-    exec.mulstep4
-    dropw drop drop # OPTIM: don't need a[4-7], but can't use mulstep4 if we don't load
-
-    # b[5]
-    push.0.0.0.0
-    loc_loadw.3
-    push.0.0.0.0
-    loc_loadw.0
-    movup.2 movdn.3
-    push.0 dropw
-    movup.7
-    dup.1
-    movup.6
-    push.0
-    exec.mulstep
-    swap
-    movdn.7
-    movup.4
-    dup.2
-    movup.7
-    swap.3
-    exec.mulstep
-    swap
-    movdn.5
-    swap
-    movup.3
-    movup.4
-    swap.3
-    exec.mulstep
-    drop
-    swap
-    drop
-
-    # b[6]
-    push.0.0.0.0
-    loc_loadw.3
-    push.0.0.0.0
-    loc_loadw.0
-    swap
-    movdn.3
-    push.0 dropw
-    movup.6
-    dup.1
-    movup.6
-    push.0
-    exec.mulstep
-    swap
-    movdn.6
-    swap
-    movup.4
-    movup.5
-    swap.3
-    exec.mulstep
-    drop
-    movdn.2
-    drop drop
-
-    # b[7]
-    push.0.0.0.0
-    loc_loadw.3
-    push.0.0.0.0
-    loc_loadw.0
-
-    movdn.3 push.0 dropw
-    movup.4
-    movup.5
-    movdn.2
-    push.0
-    exec.mulstep
-    drop
-    movdn.3
-    drop drop drop
-
-    push.0.0.0.0
-    loc_loadw.4
-    swapw
-end"#),
-// ----- std::math::u64 ---------------------------------------------------------------------------
-("std::math::u64", r#"# ===== HELPER FUNCTIONS ==========================================================================
-
-#! Asserts that both values at the top of the stack are u64 values.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-proc.u32assert4
-    u32assert.2
-    movup.3
-    movup.3
-    u32assert.2
-    movup.3
-    movup.3
-end
-
-# ===== ADDITION ==================================================================================
-
-#! Performs addition of two unsigned 64 bit integers preserving the overflow.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [overflowing_flag, c_hi, c_lo, ...], where c = (a + b) % 2^64
-export.overflowing_add
-    swap
-    movup.3
-    u32overflowing_add
-    movup.3
-    movup.3
-    u32overflowing_add3
-end
-
-#! Performs addition of two unsigned 64 bit integers discarding the overflow.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64
-export.wrapping_add
-    exec.overflowing_add
-    drop
-end
-
-#! Performs addition of two unsigned 64 bit integers, fails when overflowing.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a + b) % 2^64
-export.checked_add
-    swap
-    movup.3
-    u32assert.2
-    u32overflowing_add
-    movup.3
-    movup.3
-    u32assert.2
-    u32overflowing_add3
-    eq.0
-    assert
-end
-
-# ===== SUBTRACTION ===============================================================================
-
-#! Performs subtraction of two unsigned 64 bit integers discarding the overflow.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a - b) % 2^64
-export.wrapping_sub
-    movup.3
-    movup.2
-    u32overflowing_sub
-    movup.3
-    movup.3
-    u32overflowing_sub
-    drop
-    swap
-    u32overflowing_sub
-    drop
-end
-
-#! Performs subtraction of two unsigned 64 bit integers, fails when underflowing.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a - b) % 2^64
-export.checked_sub
-    movup.3
-    movup.2
-    u32assert.2
-    u32overflowing_sub
-    movup.3
-    movup.3
-    u32assert.2
-    u32overflowing_sub
-    eq.0
-    assert
-    swap
-    u32overflowing_sub
-    eq.0
-    assert
-end
-
-#! Performs subtraction of two unsigned 64 bit integers preserving the overflow.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [underflowing_flag, c_hi, c_lo, ...], where c = (a - b) % 2^64
-export.overflowing_sub
-    movup.3
-    movup.2
-    u32overflowing_sub
-    movup.3
-    movup.3
-    u32overflowing_sub
-    swap
-    movup.2
-    u32overflowing_sub
-    movup.2
-    or
-end
-
-# ===== MULTIPLICATION ============================================================================
-
-#! Performs multiplication of two unsigned 64 bit integers discarding the overflow.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64
-export.wrapping_mul
-    dup.3
-    dup.2
-    u32overflowing_mul
-    movup.4
-    movup.4
-    u32overflowing_madd
-    drop
-    movup.3
-    movup.3
-    u32overflowing_madd
-    drop
-end
-
-#! Performs multiplication of two unsigned 64 bit integers preserving the overflow.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_mid_hi, c_mid_lo, c_lo, ...], where c = (a * b) % 2^64
-#! This takes 18 cycles.
-export.overflowing_mul
-    dup.3
-    dup.2
-    u32overflowing_mul
-    dup.4
-    movup.4
-    u32overflowing_madd
-    swap
-    movup.5
-    dup.4
-    u32overflowing_madd
-    movup.5
-    movup.5
-    u32overflowing_madd
-    movup.3
-    movup.2
-    u32overflowing_add
-    movup.2
     add
 end
 
-#! Performs multiplication of two unsigned 64 bit integers, fails when overflowing.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = (a * b) % 2^64
-export.checked_mul
+#! Given one GF(p^5) element on stack, this routine computes modular
+#! squaring ( including reduction by irreducible polynomial ) 
+#! over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
+#!
+#! This routine has same effect as calling mul(a, a) | a ∈ GF(p^5)
+#!
+#! Expected stack state :
+#!
+#! [a0, a1, a2, a3, a4, ...]
+#!
+#! After application of routine stack :
+#!
+#! [b0, b1, b2, b3, b4, ...] s.t. b = a * a
+#!
+#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
+#!
+#! For reference implementation in high level language, see 
+#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L709-L715
+export.square
+    # compute {b0, b1, b2, b3, b4} - five coefficients of resulting
+    # degree-4 polynomial
+
+    # compute b4
+    dup.2
     dup.3
-    dup.2
-    u32assert.2         # make sure lower limbs of operands are 32-bit
-    u32overflowing_mul
-    dup.4
-    movup.4
-    u32overflowing_madd
-    swap
-    movup.5
-    dup.4
-    u32overflowing_madd
-    movup.5
-    movup.5
-    u32assert.2         # make sure higher limbs of operands are 32-bit
-    u32overflowing_madd
-    movup.3
-    movup.2
-    u32overflowing_add
-    add
-    add
-    eq.0
-    assert
-end
+    mul
 
-# ===== COMPARISONS ===============================================================================
-
-#! Performs less-than comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise.
-export.unchecked_lt
-    movup.3
-    movup.2
-    u32overflowing_sub
-    movdn.3
-    drop
-    u32overflowing_sub
-    swap
-    eq.0
-    movup.2
-    and
-    or
-end
-
-#! Performs less-than comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a < b, and 0 otherwise.
-export.checked_lt
-    movup.3
-    movup.2
-    u32assert.2
-    u32overflowing_sub
-    movdn.3
-    drop
-    u32assert.2
-    u32overflowing_sub
-    swap
-    eq.0
-    movup.2
-    and
-    or
-end
-
-#! Performs greater-than comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise.
-#! This takes 11 cycles.
-export.unchecked_gt
-    movup.2
-    u32overflowing_sub
-    movup.2
-    movup.3
-    u32overflowing_sub
-    swap
-    drop
-    movup.2
-    eq.0
-    and
-    or
-end
-
-#! Performs greater-than comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a > b, and 0 otherwise.
-export.checked_gt
-    movup.2
-    u32assert.2
-    u32overflowing_sub
-    movup.2
-    movup.3
-    u32assert.2
-    u32overflowing_sub
-    swap
-    drop
-    movup.2
-    eq.0
-    and
-    or
-end
-
-#! Performs less-than-or-equal comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise.
-export.unchecked_lte
-    exec.unchecked_gt
-    not
-end
-
-#! Performs less-than-or-equal comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a <= b, and 0 otherwise.
-export.checked_lte
-    exec.checked_gt
-    not
-end
-
-#! Performs greater-than-or-equal comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise.
-export.unchecked_gte
-    exec.unchecked_lt
-    not
-end
-
-#! Performs greater-than-or-equal comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a >= b, and 0 otherwise.
-export.checked_gte
-    exec.checked_lt
-    not
-end
-
-#! Performs equality comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise.
-export.unchecked_eq
-    movup.2
-    u32checked_eq
-    swap
-    movup.2
-    u32checked_eq
-    and
-end
-
-#! Performs equality comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise.
-export.checked_eq
-    movup.2
-    u32checked_eq
-    swap
-    movup.2
-    u32checked_eq
-    and
-end
-
-#! Performs inequality comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a != b, and 0 otherwise.
-export.unchecked_neq
-    movup.2
-    u32checked_neq
-    swap
-    movup.2
-    u32checked_neq
-    or
-end
-
-#! Performs inequality comparison of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == b, and 0 otherwise.
-export.checked_neq
-    exec.checked_eq
-    not
-end
-
-#! Performs comparison to zero of an unsigned 64 bit integer.
-#! The input value is assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise.
-export.unchecked_eqz
-    eq.0
-    swap
-    eq.0
-    and
-end
-
-#! Performs comparison to zero of an unsigned 64 bit integer.
-#! The input value is assumed to be represented using 32 bit limbs, fails if it is not.
-#! Stack transition looks as follows:
-#! [a_hi, a_lo, ...] -> [c, ...], where c = 1 when a == 0, and 0 otherwise.
-export.checked_eqz
-    u32assert.2
-    eq.0
-    swap
-    eq.0
-    and
-end
-
-#! Compares two unsigned 64 bit integers and drop the larger one from the stack.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a when a < b, and b otherwise.
-export.unchecked_min
-    dupw
-    exec.unchecked_gt
-    movup.4
-    movup.3
-    dup.2
-    cdrop
-    movdn.3
-    cdrop
-end
-
-#! Compares two unsigned 64 bit integers and drop the larger one from the stack.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a when a < b, and b otherwise.
-export.checked_min
-    exec.u32assert4
-    exec.unchecked_min
-end
-
-#! Compares two unsigned 64 bit integers and drop the smaller one from the stack.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a when a > b, and b otherwise.
-export.unchecked_max
-    dupw
-    exec.unchecked_lt
-    movup.4
-    movup.3
-    dup.2
-    cdrop
-    movdn.3
-    cdrop
-end
-
-#! Compares two unsigned 64 bit integers and drop the smaller one from the stack.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a when a > b, and b otherwise.
-export.checked_max
-    exec.u32assert4
-    exec.unchecked_max
-end
-
-
-# ===== DIVISION ==================================================================================
-
-#! Performs division of two unsigned 64 bit integers discarding the remainder.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b
-export.unchecked_div
-    adv.u64div          # inject the quotient and the remainder into the advice tape
-
-    adv_push.2          # read the quotient from the advice tape and make sure it consists of
-    u32assert.2         # 32-bit limbs
-
-    dup.3               # multiply quotient by the divisor and make sure the resulting value
-    dup.2               # fits into 2 32-bit limbs
-    u32overflowing_mul
-    dup.4
-    dup.4
-    u32overflowing_madd
-    eq.0
-    assert
     dup.5
-    dup.3
-    u32overflowing_madd
-    eq.0
-    assert
-    dup.4
-    dup.3
+    dup.2
     mul
-    eq.0
-    assert
+    mul.2
 
-    adv_push.2          # read the remainder from the advice tape and make sure it consists of
-    u32assert.2         # 32-bit limbs
-
-    movup.7             # make sure the divisor is greater than the remainder. this also consumes
-    movup.7             # the divisor
-    dup.3
-    dup.3
-    exec.unchecked_gt
-    assert
-
-    swap                # add remainder to the previous result; this also consumes the remainder
-    movup.3
-    u32overflowing_add
-    movup.3
-    movup.3
-    u32overflowing_add3
-    eq.0
-    assert
-
-    movup.4             # make sure the result we got is equal to the dividend
-    assert_eq
-    movup.3
-    assert_eq           # quotient remains on the stack
-end
-
-#! Performs division of two unsigned 64 bit integers discarding the remainder.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b
-export.checked_div
-    exec.u32assert4
-    exec.unchecked_div
-end
-
-# ===== MODULO OPERATION ==========================================================================
-
-#! Performs modulo operation of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b
-export.unchecked_mod
-    adv.u64div          # inject the quotient and the remainder into the advice tape
-
-    adv_push.2          # read the quotient from the advice tape and make sure it consists of
-    u32assert.2         # 32-bit limbs
-
-    dup.3               # multiply quotient by the divisor and make sure the resulting value
-    dup.2               # fits into 2 32-bit limbs
-    u32overflowing_mul
-    dup.4
-    movup.4
-    u32overflowing_madd
-    eq.0
-    assert
-    dup.4
-    dup.3
-    u32overflowing_madd
-    eq.0
-    assert
-    dup.3
-    movup.3
-    mul
-    eq.0
-    assert
-
-    adv_push.2          # read the remainder from the advice tape and make sure it consists of
-    u32assert.2         # 32-bit limbs
-
-    movup.5             # make sure the divisor is greater than the remainder. this also consumes
-    movup.5             # the divisor
-    dup.3
-    dup.3
-    exec.unchecked_gt
-    assert
-
-    dup.1               # add remainder to the previous result
-    movup.4
-    u32overflowing_add
-    movup.4
-    dup.3
-    u32overflowing_add3
-    eq.0
-    assert
-
-    movup.4             # make sure the result we got is equal to the dividend
-    assert_eq
-    movup.3
-    assert_eq           # remainder remains on the stack
-end
-
-#! Performs modulo operation of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b
-export.checked_mod
-    exec.u32assert4
-    exec.unchecked_mod
-end
-
-# ===== DIVMOD OPERATION ==========================================================================
-
-#! Performs divmod operation of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [r_hi, r_lo, q_hi, q_lo ...], where r = a % b, q = a / b
-export.unchecked_divmod
-    adv.u64div          # inject the quotient and the remainder into the advice tape
-
-    adv_push.2          # read the quotient from the advice tape and make sure it consists of
-    u32assert.2         # 32-bit limbs
-
-    dup.3               # multiply quotient by the divisor and make sure the resulting value
-    dup.2               # fits into 2 32-bit limbs
-    u32overflowing_mul
-    dup.4
-    dup.4
-    u32overflowing_madd
-    eq.0
-    assert
-    dup.5
-    dup.3
-    u32overflowing_madd
-    eq.0
-    assert
-    dup.4
-    dup.3
-    mul
-    eq.0
-    assert
-
-    adv_push.2          # read the remainder from the advice tape and make sure it consists of
-    u32assert.2         # 32-bit limbs
-
-    movup.7             # make sure the divisor is greater than the remainder. this also consumes
-    movup.7             # the divisor
-    dup.3
-    dup.3
-    exec.unchecked_gt
-    assert
-
-    dup.1               # add remainder to the previous result
-    movup.4
-    u32overflowing_add
-    movup.4
-    dup.3
-    u32overflowing_add3
-    eq.0
-    assert
-
-    movup.6             # make sure the result we got is equal to the dividend
-    assert_eq
-    movup.5
-    assert_eq           # remainder remains on the stack
-end
-
-#! Performs divmod operation of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [r_hi, r_lo, q_hi, q_lo ...], where r = a % b, q = a / b
-export.checked_divmod
-    exec.u32assert4
-    exec.unchecked_divmod
-end
-
-# ===== BITWISE OPERATIONS ========================================================================
-
-#! Performs bitwise AND of two unsigned 64-bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, but this is not checked.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a AND b.
-export.checked_and
-    swap
-    movup.3
-    u32checked_and
-    swap
-    movup.2
-    u32checked_and
-end
-
-#! Performs bitwise OR of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a OR b.
-export.checked_or
-    swap
-    movup.3
-    u32checked_or
-    swap
-    movup.2
-    u32checked_or
-end
-
-#! Performs bitwise XOR of two unsigned 64 bit integers.
-#! The input values are assumed to be represented using 32 bit limbs, fails if they are not.
-#! Stack transition looks as follows:
-#! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a XOR b.
-export.checked_xor
-    swap
-    movup.3
-    u32checked_xor
-    swap
-    movup.2
-    u32checked_xor
-end
-
-#! Performs left shift of one unsigned 64-bit integer using the pow2 operation.
-#! The input value to be shifted is assumed to be represented using 32 bit limbs.
-#! The shift value should be in the range [0, 64), otherwise it will result in an
-#! error.
-#! Stack transition looks as follows:
-#! [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64.
-#! This takes 28 cycles.
-export.unchecked_shl
-    pow2
-    u32split
-    exec.wrapping_mul
-end
-
-
-#! Performs right shift of one unsigned 64-bit integer using the pow2 operation.
-#! The input value to be shifted is assumed to be represented using 32 bit limbs.
-#! The shift value should be in the range [0, 64), otherwise it will result in an
-#! error.
-#! Stack transition looks as follows:
-#! [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a >> b.
-#! This takes 44 cycles.
-export.unchecked_shr
-    pow2
-    u32split
-
-    dup.1
     add
-    movup.2
-    swap
-    u32unchecked_divmod
-    movup.3
-    movup.3
-    dup
-    eq.0
-    u32overflowing_sub
-    not
-    movdn.4
-    dup
-    movdn.4
-    u32unchecked_divmod
-    drop
-    push.4294967296
+
+    dup.4
+    dup.3
+    mul
+    mul.2
+
+    add
+
+    # compute b3
+    dup.4
+    dup.2
+    mul
+    mul.2
+
+    dup.4
+    dup.4
+    mul
+    mul.2
+
+    add
+
+    dup.6
+    dup.7
+    mul
+    mul.3
+
+    add
+
+    # compute b2
+    dup.3
+    dup.4
+    mul
+    
+    dup.5
+    dup.4
+    mul
+    mul.2
+
+    add
+
+    dup.7
+    dup.7
+    mul
+    mul.6
+
+    add
+
+    # compute b1
+    dup.4
+    dup.4
+    mul
+    mul.2
+
+    dup.7
+    dup.8
+    mul
+    mul.3
+
+    add
+
+    dup.8
+    dup.7
+    mul
+    mul.6
+
+    add
+
+    # compute b0
+    dup.4
+    movup.5
+    mul
+
+    movup.8
+    movup.6
+    mul
+    mul.6
+
+    add
+
+    movup.6
+    movup.6
+    mul
+    mul.6
+
+    add
+end
+
+#! Given an element a ∈ GF(p^5), this routine applies Frobenius operator
+#! once, raising the element to the power of p | p = 2^64 - 2^32 + 1.
+#!
+#! Expected stack state :
+#!
+#! [a0, a1, a2, a3, a4, ...]
+#!
+#! Final stack state :
+#!
+#! [b0, b1, b2, b3, b4, ...]
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L723-L737
+#! for reference implementation in high-level language.
+proc.frobenius_once
+    movup.4
+    mul.1373043270956696022
+
+    movup.4
+    mul.211587555138949697
+
+    movup.4
+    mul.15820824984080659046
+
+    movup.4
+    mul.1041288259238279555
+
+    movup.4
+end
+
+#! Given an element a ∈ GF(p^5), this routine applies Frobenius operator
+#! twice, raising the element to the power of p^2 | p = 2^64 - 2^32 + 1.
+#!
+#! Expected stack state :
+#!
+#! [a0, a1, a2, a3, a4, ...]
+#!
+#! Final stack state :
+#!
+#! [b0, b1, b2, b3, b4, ...]
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L739-L749
+#! for reference implementation in high-level language.
+proc.frobenius_twice
+    movup.4
+    mul.211587555138949697
+
+    movup.4
+    mul.1041288259238279555
+
+    movup.4
+    mul.1373043270956696022
+
+    movup.4
+    mul.15820824984080659046
+
+    movup.4
+end
+
+#! Given one GF(p^5) element on stack, this routine computes multiplicative
+#! inverse over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
+#!
+#! Expected stack state :
+#!
+#! [a0, a1, a2, a3, a4, ...]
+#!
+#! After application of routine stack :
+#!
+#! [b0, b1, b2, b3, b4, ...] s.t. b = 1 / a
+#!
+#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
+#!
+#! For reference implementation in high level language, see 
+#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L751-L775
+#!
+#! Note, this routine will not panic even when operand `a` is zero.
+export.inv
+    repeat.5
+        dup.4
+    end
+
+    exec.frobenius_once # = t0
+
+    repeat.5
+        dup.4
+    end
+
+    exec.frobenius_once # = t0.frobenius_once()
+    exec.mul            # = t1
+
+    repeat.5
+        dup.4
+    end
+
+    exec.frobenius_twice # = t1.frobenius_twice()
+    exec.mul             # = t2
+
+    movup.5
+    dup.1
+    mul
+
+    movup.6
+    dup.6
+    mul
+    mul.3
+
+    add
+
+    movup.6
     dup.5
     mul
-    movup.4
-    div
-    movup.2
+    mul.3
+
+    add
+
+    movup.6
+    dup.4
     mul
+    mul.3
+
     add
-    movup.2
-    cswap
-end
 
-#! Performs left shift of one unsigned 64-bit integer preserving the overflow and
-#! using the pow2 operation.
-#! The input value to be shifted is assumed to be represented using 32 bit limbs.
-#! The shift value should be in the range [0, 64), otherwise it will result in an
-#! error.
-#! Stack transition looks as follows:
-#! [b, a_hi, a_lo, ...] -> [d_hi, d_lo, c_hi, c_lo, ...], where (d,c) = a << b,
-#! which d contains the bits shifted out.
-#! This takes 35 cycles.
-export.overflowing_shl
-    pow2
-    u32split
-    exec.overflowing_mul
-end
-
-#! Performs right shift of one unsigned 64-bit integer preserving the overflow and
-#! using the pow2 operation.
-#! The input value to be shifted is assumed to be represented using 32 bit limbs.
-#! The shift value should be in the range [0, 64), otherwise it will result in an
-#! error.
-#! Stack transition looks as follows:
-#! [b, a_hi, a_lo, ...] -> [d_hi, d_lo, c_hi, c_lo, ...], where c = a >> b, d = a << (64 - b).
-#! This takes 94 cycles.
-export.overflowing_shr
-    push.64             # (64 - b)
-    dup.1
-    sub
-
-    dup.3               # dup [b, a_hi, a_lo]
+    movup.6
     dup.3
-    dup.3
-    exec.unchecked_shr  # c = a >> b
+    mul
+    mul.3
 
-    movdn.5             # move result [c_hi, c_lo] to be in the format [d_hi, d_lo, c_hi, c_lo, ...]
-    movdn.5
+    add                    # = t3
 
-    padw                # padding positions 0, 1, 2, 3 and 4 to be able to use cdropw
+    dup
     push.0
-
-    movup.6             # bring and b
-    eq.0
-    cdropw              # if b is 0, swap the positions 0, 1, 2 and 3 with 0, (64 - b), a_hi, a_lo
-                        # regardless of this condition, drop 0, 1, 2 and 3
-    drop                # drop the last added 0 or dup b to keep the format [b, a_hi, a_lo, ....]
-
-    exec.unchecked_shl  # d = a << (64 - b)
-end
-
-#! Performs left rotation of one unsigned 64-bit integer using the pow2 operation.
-#! The input value to be shifted is assumed to be represented using 32 bit limbs.
-#! The shift value should be in the range [0, 64), otherwise it will result in an
-#! error.
-#! Stack transition looks as follows:
-#! [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64.
-#! This takes 35 cycles.
-export.unchecked_rotl
-    push.31
-    dup.1
-    u32overflowing_sub
-    swap
-    drop
-    movdn.3
-
-    # Shift the low limb.
-    push.31
-    u32checked_and
-    pow2
-    dup
-    movup.3
-    u32overflowing_mul
-
-    # Shift the high limb.
-    movup.3
-    movup.3
-    u32overflowing_madd
-
-    # Carry the overflow shift to the low bits.
-    movup.2
+    eq
     add
-    swap
+    inv                    # = t4
 
-    # Conditionally select the limb order based on whether it's shifting by > 31 or not.
-    movup.2
-    cswap
-end
-
-#! Performs right rotation of one unsigned 64-bit integer using the pow2 operation.
-#! The input value to be shifted is assumed to be represented using 32 bit limbs.
-#! The shift value should be in the range [0, 64), otherwise it will result in an
-#! error.
-#! Stack transition looks as follows:
-#! [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64.
-#! This takes 40 cycles.
-export.unchecked_rotr
-    push.31
+    movup.5
     dup.1
-    u32overflowing_sub
-    swap
-    drop
-    movdn.3
+    mul
 
-    # Shift the low limb left by 32-b.
-    push.31
-    u32checked_and
-    push.32
-    swap
-    u32overflowing_sub
-    drop
-    pow2
-    dup
-    movup.3
-    u32overflowing_mul
+    movup.5
+    dup.2
+    mul
 
-    # Shift the high limb left by 32-b.
-    movup.3
-    movup.3
-    u32overflowing_madd
+    movup.5
+    dup.3
+    mul
 
-    # Carry the overflow shift to the low bits.
-    movup.2
-    add
-    swap
+    movup.5
+    dup.4
+    mul
 
-    # Conditionally select the limb order based on whether it's shifting by > 31 or not.
-    movup.2
-    not
-    cswap
+    movup.5
+    movup.5
+    mul
 end
-"#),
-// ----- std::sys ---------------------------------------------------------------------------------
-("std::sys", r#"#! Removes elements deep in the stack until the depth of the stack is exactly 16. The elements
-#! are removed in such a way that the top 16 elements of the stack remain unchanged. If the stack
-#! would otherwise contain more than 16 elements at the end of execution, then adding a call to this 
-#! function at the end will reduce the size of the public inputs that are shared with the verifier.
-#! Input: Stack with 16 or more elements.
-#! Output: Stack with only the original top 16 elements.
-export.truncate_stack.4
-    loc_storew.0
-    dropw
-    loc_storew.1
-    dropw
-    loc_storew.2
-    dropw
-    loc_storew.3
-    dropw
-    sdepth
-    neq.16
+
+#! Given two GF(p^5) elements ( say a, b ) on stack, this routine computes
+#! modular division over extension field GF(p^5) s.t. p = 2^64 - 2^32 + 1
+#!
+#! Expected stack state :
+#!
+#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
+#!
+#! After application of routine stack :
+#!
+#! [c0, c1, c2, c3, c4, ...] s.t. c = a / b
+#!
+#! See section 3.2 of https://eprint.iacr.org/2022/274.pdf
+#!
+#! For reference implementation in high level language, see 
+#! https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L777-L781
+export.div
+    repeat.5
+        movup.9
+    end
+
+    exec.inv
+    exec.mul
+end
+
+#! Given an element v ∈ Z_q | q = 2^64 - 2^32 + 1, and n on stack, this routine
+#! raises it to the power 2^n, by means of n successive squarings
+#!
+#! Expected stack stack
+#!
+#! [v, n, ...] | n >= 0
+#!
+#! After finishing execution stack
+#!
+#! [v', ...] s.t. v' = v ^ (2^n)
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L461-L469
+#! for reference implementation in higher level language
+proc.base_msquare
+    swap
+    dup
+    neq.0
+
     while.true
-        dropw
-        sdepth
-        neq.16
+        sub.1
+        swap
+        dup
+        mul
+
+        swap
+        dup
+        neq.0
     end
-    loc_loadw.3
-    swapw.3
-    loc_loadw.2
-    swapw.2
-    loc_loadw.1
-    swapw.1
-    loc_loadw.0
+
+    drop
 end
-"#),
+
+#! Given an element v ∈ Z_q | q = 2^64 - 2^32 + 1, this routine attempts to compute
+#! square root of v, if that number is a square.
+#!
+#! Expected stack state :
+#!
+#! [v, ...]
+#!
+#! After finishing execution stack looks like :
+#!
+#! [v', flg, ...]
+#!
+#! If flg = 1, it denotes v' is square root of v i.e. v' * v' = v ( mod q )
+#! If flg = 0, then v' = 0, denoting v doesn't have a square root
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L349-L446
+#! for reference implementation in higher level language.
+proc.base_sqrt
+    dup # = x
+
+    push.31
+    swap
+    exec.base_msquare # = u
+
+    dup
+    dup
+    mul # = u^2
+
+    movup.2
+    dup
+    eq.0
+    add
+
+    div # = v
+
+    # j = 1
+    # i = 32 - j = 31
+    dup
+    push.30
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.4614640910117430873
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.1753635133440165772
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 2
+    # i = 32 - j = 30
+    dup
+    push.29
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.9123114210336311365
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.4614640910117430873
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 3
+    # i = 32 - j = 29
+    dup
+    push.28
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.16116352524544190054
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.9123114210336311365
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 4
+    # i = 32 - j = 28
+    dup
+    push.27
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.6414415596519834757
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.16116352524544190054
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 5
+    # i = 32 - j = 27
+    dup
+    push.26
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.1213594585890690845
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.6414415596519834757
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 6
+    # i = 32 - j = 26
+    dup
+    push.25
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.17096174751763063430
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.1213594585890690845
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 7
+    # i = 32 - j = 25
+    dup
+    push.24
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.5456943929260765144
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.17096174751763063430
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 8
+    # i = 32 - j = 24
+    dup
+    push.23
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.9713644485405565297
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.5456943929260765144
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 9
+    # i = 32 - j = 23
+    dup
+    push.22
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.16905767614792059275
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.9713644485405565297
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 10
+    # i = 32 - j = 22
+    dup
+    push.21
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.5416168637041100469
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.16905767614792059275
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 11
+    # i = 32 - j = 21
+    dup
+    push.20
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.17654865857378133588
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.5416168637041100469
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 12
+    # i = 32 - j = 20
+    dup
+    push.19
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.3511170319078647661
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.17654865857378133588
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 13
+    # i = 32 - j = 19
+    dup
+    push.18
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.18146160046829613826
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.3511170319078647661
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 14
+    # i = 32 - j = 18
+    dup
+    push.17
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.9306717745644682924
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.18146160046829613826
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 15
+    # i = 32 - j = 17
+    dup
+    push.16
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.12380578893860276750
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.9306717745644682924
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 16
+    # i = 32 - j = 16
+    dup
+    push.15
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.6115771955107415310
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.12380578893860276750
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 17
+    # i = 32 - j = 15
+    dup
+    push.14
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.17776499369601055404
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.6115771955107415310
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 18
+    # i = 32 - j = 14
+    dup
+    push.13
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.16207902636198568418
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.17776499369601055404
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 19
+    # i = 32 - j = 13
+    dup
+    push.12
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.1532612707718625687
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.16207902636198568418
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 20
+    # i = 32 - j = 12
+    dup
+    push.11
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.17492915097719143606
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.1532612707718625687
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 21
+    # i = 32 - j = 11
+    dup
+    push.10
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.455906449640507599
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.17492915097719143606
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 22
+    # i = 32 - j = 10
+    dup
+    push.9
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.11353340290879379826
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.455906449640507599
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 23
+    # i = 32 - j = 9
+    dup
+    push.8
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.1803076106186727246
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.11353340290879379826
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 24
+    # i = 32 - j = 8
+    dup
+    push.7
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.13797081185216407910
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.1803076106186727246
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 25
+    # i = 32 - j = 7
+    dup
+    push.6
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.17870292113338400769
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.13797081185216407910
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 26
+    # i = 32 - j = 6
+    dup
+    push.5
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.549755813888
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.17870292113338400769
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 27
+    # i = 32 - j = 5
+    dup
+    push.4
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.70368744161280
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.549755813888
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 28
+    # i = 32 - j = 4
+    dup
+    push.3
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.17293822564807737345
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.70368744161280
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 29
+    # i = 32 - j = 3
+    dup
+    push.2
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.18446744069397807105
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.17293822564807737345
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 30
+    # i = 32 - j = 2
+    dup
+    push.1
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.281474976710656
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.18446744069397807105
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap
+
+    # j = 31
+    # i = 32 - j = 1
+    dup
+    push.0
+    swap
+    exec.base_msquare # = w
+
+    eq.18446744069414584320 # = cc
+
+    dup.1
+    mul.18446744069414584320
+    movup.2
+    swap
+    dup.2
+    cdrop # = v'
+
+    dup.2
+    mul.281474976710656
+    movup.3
+    swap
+    movup.3
+    cdrop # = u'
+
+    swap # On stack [v, u, ...]
+
+    dup
+    eq.0
+    swap
+    eq.1
+    or # = cc
+
+    swap
+    dup.1
+    mul # On stack [u * cc, cc, ...]
+end
+
+#! Given an element v ∈ Z_q | q = 2^64 - 2^32 + 1, this routine computes
+#! legendre symbol, by raising that element to the power (p-1) / 2
+#!
+#! Expected stack state :
+#!
+#! [v, ...]
+#!
+#! After finishing execution stack looks like
+#!
+#! [v', ...] s.t. v' = legendre symbol of v
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L448-L459
+#! for reference implementation in higher level language.
+proc.base_legendre
+    repeat.31
+        dup
+        mul
+    end
+
+    dup
+
+    repeat.32
+        dup
+        mul
+    end
+
+    swap
+    dup
+    eq.0
+    add
+
+    div
+end
+
+#! Given an element v ∈ GF(p^5), this routine computes its legendre symbol,
+#! which is an element ∈ GF(p) | p = 2^64 - 2^32 + 1
+#!
+#! At beginning stack looks like
+#!
+#! [a0, a1, a2, a3, a4, ...]
+#!
+#! At end stack looks like
+#!
+#! [b, ...] s.t. b = legendre symbol of a
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L857-L877
+#! for reference implementation in higher level language.
+export.legendre
+    repeat.5
+        dup.4
+    end
+
+    exec.frobenius_once
+
+    repeat.5
+        dup.4
+    end
+
+    exec.frobenius_once
+    exec.mul
+
+    repeat.5
+        dup.4
+    end
+
+    exec.frobenius_twice
+    exec.mul
+
+    movup.5
+    mul
+
+    movup.5
+    movup.5
+    mul
+    mul.3
+    
+    add
+
+    movup.4
+    movup.4
+    mul
+    mul.3
+
+    add
+
+    movup.3
+    movup.3
+    mul
+    mul.3
+
+    add
+
+    movup.2
+    movup.2
+    mul
+    mul.3
+
+    add
+
+    exec.base_legendre
+end
+
+#! Given an element v ∈ GF(p^5), this routine attempts to compute square root of v, 
+#! if that number is a square.
+#!
+#! At beginning stack looks like
+#!
+#! [a0, a1, a2, a3, a4, ...]
+#!
+#! At end stack looks like
+#!
+#! [b0, b1, b2, b3, b4, flg, ...]
+#!
+#! If flg = 1, it denotes v' = {b0, b1, b2, b3, b4} is square root of v i.e. v' * v' = v ( mod GF(p^5) )
+#! If flg = 0, then v' = {0, 0, 0, 0, 0}, denoting v doesn't have a square root
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L879-L910
+#! for reference implementation in higher level language.
+export.sqrt
+    repeat.5
+        dup.4
+    end
+
+    repeat.31
+        repeat.5
+            dup.4
+        end
+
+        exec.mul
+    end # = v
+
+    repeat.5
+        dup.4
+    end
+
+    repeat.32
+        repeat.5
+            dup.4
+        end
+
+        exec.mul
+    end
+
+    exec.div
+
+    repeat.5
+        dup.9
+    end
+
+    exec.mul # = d
+
+    repeat.5
+        dup.4
+    end
+
+    exec.frobenius_twice
+    exec.mul
+    exec.frobenius_once # = e
+
+    repeat.5
+        dup.4
+    end
+
+    exec.square # = f
+
+    movup.10
+    mul
+
+    swap
+    movup.13
+    mul
+    mul.3
+    add
+
+    swap
+    movup.11
+    mul
+    mul.3
+    add
+
+    swap
+    movup.9
+    mul
+    mul.3
+    add
+
+    swap
+    movup.7
+    mul
+    mul.3
+    add # = g
+
+    exec.base_sqrt # On stack [s, c, e0, e1, e2, e3, e4, ...]
+
+    repeat.5
+        movup.6
+    end
+
+    exec.inv # = e'
+
+    repeat.5
+        movup.4
+        dup.5
+        mul
+    end
+
+    movup.5
+    drop # On stack [e0, e1, e2, e3, e4, c, ...]
+end
+
+#! Given two elements a, b ∈ GF(p^5), this routine produces single field element r,
+#! denoting whether a == b.
+#!
+#! Expected stack state 
+#!
+#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
+#!
+#! Final stack state 
+#!
+#! [r, ...]
+#!
+#! If a == b { r = 1 } Else { r = 0 }
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L797-L806
+#! for reference implementation.
+export.eq
+    push.1
+
+    swap
+    movup.6
+    eq
+    and
+
+    swap
+    movup.5
+    eq
+    and
+
+    swap
+    movup.4
+    eq
+    and
+
+    swap
+    movup.3
+    eq
+    and
+
+    swap
+    movup.2
+    eq
+    and
+end
+
+#! Given two elements a, b ∈ GF(p^5), this routine produces single field element r,
+#! denoting whether a != b.
+#!
+#! Expected stack state 
+#!
+#! [a0, a1, a2, a3, a4, b0, b1, b2, b3, b4, ...]
+#!
+#! Final stack state 
+#!
+#! [r, ...]
+#!
+#! If a != b { r = 1 } Else { r = 0 }
+#!
+#! See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L813-L822
+#! for reference implementation.
+export.neq
+    push.0
+
+    swap
+    movup.6
+    neq
+    or
+
+    swap
+    movup.5
+    neq
+    or
+
+    swap
+    movup.4
+    neq
+    or
+
+    swap
+    movup.3
+    neq
+    or
+
+    swap
+    movup.2
+    neq
+    or
+end
+",&[15, 0, 3, 97, 100, 100, 0, 0, 3, 97, 100, 100, 1, 0, 0, 1, 0, 254, 1, 0, 3, 0, 149, 3, 164, 13, 98, 97, 115, 101, 95, 108, 101, 103, 101, 110, 100, 114, 101, 10, 0, 13, 98, 97, 115, 101, 95, 108, 101, 103, 101, 110, 100, 114, 101, 0, 0, 0, 8, 0, 254, 106, 3, 2, 0, 107, 7, 107, 254, 111, 3, 2, 0, 107, 7, 127, 107, 19, 3, 9, 12, 98, 97, 115, 101, 95, 109, 115, 113, 117, 97, 114, 101, 8, 0, 12, 98, 97, 115, 101, 95, 109, 115, 113, 117, 97, 114, 101, 0, 0, 0, 5, 0, 127, 107, 21, 255, 7, 0, 5, 127, 107, 7, 127, 107, 21, 104, 9, 98, 97, 115, 101, 95, 115, 113, 114, 116, 9, 0, 9, 98, 97, 115, 101, 95, 115, 113, 114, 116, 0, 0, 0, 66, 2, 107, 198, 1, 31, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 107, 107, 7, 146, 107, 19, 3, 9, 107, 198, 1, 30, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 29, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 28, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 27, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 26, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 25, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 24, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 23, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 22, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 21, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 20, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 19, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 18, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 17, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 16, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 15, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 14, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 13, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 12, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 11, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 10, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 9, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 8, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 7, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 6, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 5, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 4, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 3, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 2, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 127, 207, 8, 0, 0, 0, 19, 108, 7, 146, 127, 109, 180, 109, 7, 147, 127, 147, 180, 127, 107, 19, 127, 19, 17, 127, 108, 7, 3, 100, 105, 118, 7, 0, 3, 100, 105, 118, 1, 0, 0, 3, 0, 254, 16, 1, 1, 0, 153, 207, 6, 0, 0, 0, 207, 2, 0, 0, 0, 2, 101, 113, 13, 0, 2, 101, 113, 1, 0, 0, 21, 0, 198, 1, 1, 0, 0, 0, 0, 0, 0, 0, 127, 150, 19, 16, 127, 149, 19, 16, 127, 148, 19, 16, 127, 147, 19, 16, 127, 146, 19, 16, 14, 102, 114, 111, 98, 101, 110, 105, 117, 115, 95, 111, 110, 99, 101, 4, 0, 14, 102, 114, 111, 98, 101, 110, 105, 117, 115, 95, 111, 110, 99, 101, 0, 0, 0, 9, 0, 148, 7, 148, 7, 148, 7, 148, 7, 148, 15, 102, 114, 111, 98, 101, 110, 105, 117, 115, 95, 116, 119, 105, 99, 101, 5, 0, 15, 102, 114, 111, 98, 101, 110, 105, 117, 115, 95, 116, 119, 105, 99, 101, 0, 0, 0, 9, 0, 148, 7, 148, 7, 148, 7, 148, 7, 148, 3, 105, 110, 118, 6, 0, 3, 105, 110, 118, 1, 0, 0, 51, 0, 254, 213, 0, 1, 0, 111, 207, 4, 0, 0, 0, 254, 217, 0, 1, 0, 111, 207, 4, 0, 0, 0, 207, 2, 0, 0, 0, 254, 222, 0, 1, 0, 111, 207, 5, 0, 0, 0, 207, 2, 0, 0, 0, 149, 108, 7, 150, 113, 7, 7, 3, 150, 112, 7, 7, 3, 150, 111, 7, 7, 3, 150, 110, 7, 7, 3, 107, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 19, 3, 12, 149, 108, 7, 149, 109, 7, 149, 110, 7, 149, 111, 7, 149, 149, 7, 8, 108, 101, 103, 101, 110, 100, 114, 101, 11, 0, 8, 108, 101, 103, 101, 110, 100, 114, 101, 1, 0, 0, 31, 0, 254, 122, 3, 1, 0, 111, 207, 4, 0, 0, 0, 254, 126, 3, 1, 0, 111, 207, 4, 0, 0, 0, 207, 2, 0, 0, 0, 254, 131, 3, 1, 0, 111, 207, 5, 0, 0, 0, 207, 2, 0, 0, 0, 149, 7, 149, 149, 7, 7, 3, 148, 148, 7, 7, 3, 147, 147, 7, 7, 3, 146, 146, 7, 7, 3, 207, 10, 0, 0, 0, 3, 109, 117, 108, 2, 0, 3, 109, 117, 108, 1, 0, 0, 105, 0, 116, 108, 7, 116, 110, 7, 3, 115, 111, 7, 3, 114, 112, 7, 3, 113, 113, 7, 3, 116, 109, 7, 116, 111, 7, 3, 115, 112, 7, 3, 114, 113, 7, 3, 118, 114, 7, 7, 3, 116, 110, 7, 116, 112, 7, 3, 115, 113, 7, 3, 119, 114, 7, 7, 3, 118, 115, 7, 7, 3, 116, 111, 7, 116, 113, 7, 3, 120, 114, 7, 7, 3, 119, 115, 7, 7, 3, 118, 116, 7, 7, 3, 153, 149, 7, 156, 150, 7, 7, 3, 154, 150, 7, 7, 3, 152, 150, 7, 7, 3, 150, 150, 7, 7, 3, 3, 110, 101, 113, 14, 0, 3, 110, 101, 113, 1, 0, 0, 21, 0, 198, 1, 0, 0, 0, 0, 0, 0, 0, 0, 127, 150, 21, 17, 127, 149, 21, 17, 127, 148, 21, 17, 127, 147, 21, 17, 127, 146, 21, 17, 4, 115, 113, 114, 116, 12, 0, 4, 115, 113, 114, 116, 1, 0, 0, 41, 0, 254, 161, 3, 1, 0, 111, 254, 164, 3, 2, 0, 254, 165, 3, 1, 0, 111, 207, 2, 0, 0, 0, 254, 170, 3, 1, 0, 111, 254, 173, 3, 2, 0, 254, 174, 3, 1, 0, 111, 207, 2, 0, 0, 0, 207, 7, 0, 0, 0, 254, 180, 3, 1, 0, 116, 207, 2, 0, 0, 0, 254, 184, 3, 1, 0, 111, 207, 5, 0, 0, 0, 207, 2, 0, 0, 0, 207, 4, 0, 0, 0, 254, 190, 3, 1, 0, 111, 207, 3, 0, 0, 0, 154, 7, 127, 157, 7, 7, 3, 127, 155, 7, 7, 3, 127, 153, 7, 7, 3, 127, 151, 7, 7, 3, 207, 9, 0, 0, 0, 254, 217, 3, 1, 0, 150, 207, 6, 0, 0, 0, 254, 221, 3, 3, 0, 148, 112, 7, 149, 104, 6, 115, 113, 117, 97, 114, 101, 3, 0, 6, 115, 113, 117, 97, 114, 101, 1, 0, 0, 67, 0, 109, 110, 7, 112, 109, 7, 7, 3, 111, 110, 7, 7, 3, 111, 109, 7, 7, 111, 111, 7, 7, 3, 113, 114, 7, 7, 3, 110, 111, 7, 112, 111, 7, 7, 3, 114, 114, 7, 7, 3, 111, 111, 7, 7, 114, 115, 7, 7, 3, 115, 114, 7, 7, 3, 111, 149, 7, 152, 150, 7, 7, 3, 150, 150, 7, 7, 3, 3, 115, 117, 98, 1, 0, 3, 115, 117, 98, 1, 0, 0, 1, 0, 254, 8, 0, 3, 0, 149, 5, 164]),
 ];

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use vm_assembly::ModuleProvider;
+use vm_assembly::{ModuleAst, ModuleProvider, ProcedureId};
 use vm_core::{
     errors::LibraryError,
     utils::{collections::BTreeMap, string::ToString},
@@ -18,7 +18,9 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 // TYPE ALIASES
 // ================================================================================================
 
-type ModuleMap = BTreeMap<&'static str, &'static str>;
+type ModuleMap = BTreeMap<ProcedureId, ModuleAst>;
+type ModuleNamedMap = BTreeMap<&'static str, ModuleAst>;
+type ModuleSource = BTreeMap<&'static str, &'static str>;
 
 // STANDARD LIBRARY
 // ================================================================================================
@@ -26,15 +28,23 @@ type ModuleMap = BTreeMap<&'static str, &'static str>;
 /// TODO: add docs
 pub struct StdLibrary {
     modules: ModuleMap,
+    named: ModuleNamedMap,
+    sources: ModuleSource,
 }
 
 impl ModuleProvider for StdLibrary {
     fn get_source(&self, path: &str) -> Option<&str> {
-        self.get_module_source(path).ok()
+        self.sources.get(path).copied()
+    }
+
+    fn get_module(&self, id: &ProcedureId) -> Option<&ModuleAst> {
+        self.modules.get(id)
     }
 }
 
 impl Library for StdLibrary {
+    type Module = ModuleAst;
+
     /// Returns root namespace of the standard library, which is always "std".
     fn root_ns(&self) -> &str {
         "std"
@@ -50,23 +60,48 @@ impl Library for StdLibrary {
     /// # Errors
     /// Returns an error if the modules for the specified path does not exist in the standard
     /// library.
-    fn get_module_source(&self, module_path: &str) -> Result<&str, LibraryError> {
-        let source = self
-            .modules
+    fn get_module(&self, module_path: &str) -> Result<&ModuleAst, LibraryError> {
+        self.named
             .get(module_path)
-            .ok_or_else(|| LibraryError::ModuleNotFound(module_path.to_string()))?;
-        Ok(source)
+            .ok_or_else(|| LibraryError::ModuleNotFound(module_path.to_string()))
     }
 }
 
 impl Default for StdLibrary {
     /// Returns a new [StdLibrary] instance instantiated with default parameters.
     fn default() -> Self {
-        let mut modules = BTreeMap::new();
-        for (ns, source) in MODULES {
-            modules.insert(ns, source);
+        // TODO this will be trimmed in the future to `ids` as the only provider for std library
+
+        let modules = MODULES
+            .into_iter()
+            .map(|(_, id, _, bytes)| {
+                let ast = ModuleAst::from_bytes(bytes)
+                    .expect("static module deserialization should be infallible");
+
+                (id, ast)
+            })
+            .collect();
+
+        let named = MODULES
+            .into_iter()
+            .map(|(label, _, _, bytes)| {
+                let ast = ModuleAst::from_bytes(bytes)
+                    .expect("static module deserialization should be infallible");
+
+                (label, ast)
+            })
+            .collect();
+
+        let sources = MODULES
+            .into_iter()
+            .map(|(label, _, source, _)| (label, source))
+            .collect();
+
+        Self {
+            modules,
+            named,
+            sources,
         }
-        Self { modules }
     }
 }
 


### PR DESCRIPTION
This commit introduces the deserialization of precompiled modules as ModuleAst instead of strings to be parsed somewhere else.

We have two pending actions introduced by this PR

- build stdlib docs in build.rs
- The assembly module provider shouldn't return the source str. Instead, it should return a ModuleAst. However, this will cause non-negligible impact in the module parsing of the assembly.