### PR TITLE
Remove index field from ProcedureAst struct

### DIFF
--- a/assembly/src/parsers/ast/mod.rs
+++ b/assembly/src/parsers/ast/mod.rs
@@ -23,14 +23,14 @@ const PROC_DIGEST_SIZE: usize = 24;
 
 // TYPE ALIASES
 // ================================================================================================
-type ProcMap = BTreeMap<String, ProcedureAst>;
+type LocalProcMap = BTreeMap<String, (u16, ProcedureAst)>;
 
 /// Represents a parsed program AST.
 /// This AST can then be furthur processed to generate MAST.
 /// A program has to have a body and no exported procedures.
 #[derive(Debug, Eq, PartialEq)]
 pub struct ProgramAst {
-    pub procedures: ProcMap,
+    pub procedures: LocalProcMap,
     pub body: Vec<Node>,
 }
 
@@ -41,11 +41,9 @@ impl ProgramAst {
 
         // procedures
         byte_writer.write_u16(self.procedures.len() as u16);
-        for (key, value) in self.procedures.iter() {
-            byte_writer
-                .write_string(key)
-                .expect("String serialization failure");
-            value.write_into(&mut byte_writer);
+
+        for (_, proc) in sort_procs_by_index(&self.procedures) {
+            proc.write_into(&mut byte_writer);
         }
 
         // body
@@ -58,14 +56,13 @@ impl ProgramAst {
     pub fn from_bytes(bytes: &mut &[u8]) -> Result<Self, SerializationError> {
         let mut byte_reader = ByteReader::new(bytes.to_vec());
 
-        let mut procedures = ProcMap::new();
+        let mut procedures = LocalProcMap::new();
 
         let num_procedures = byte_reader.read_u16()?;
-        for _ in 0..num_procedures {
-            let proc_name = byte_reader.read_string()?;
+        for i in 0..num_procedures {
             let proc_ast = ProcedureAst::read_from(&mut byte_reader)?;
 
-            procedures.insert(proc_name, proc_ast);
+            procedures.insert(proc_ast.name.clone(), (i, proc_ast));
         }
 
         let body = Deserializable::read_from(&mut byte_reader)?;
@@ -78,39 +75,36 @@ impl ProgramAst {
 /// A module can only have exported and local procedures, but no body.
 #[derive(Debug, Eq, PartialEq)]
 pub struct ModuleAst {
-    pub procedures: ProcMap,
+    pub procedures: LocalProcMap,
 }
 
 impl ModuleAst {
     /// Returns byte representation of the `ModuleAst.
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut module_ast_bytes = ByteWriter::new();
+        let mut byte_writer = ByteWriter::new();
 
         // procedures
-        module_ast_bytes.write_u16(self.procedures.len() as u16);
-        for (key, value) in self.procedures.iter() {
-            module_ast_bytes
-                .write_string(key)
-                .expect("String serialization failure");
-            value.write_into(&mut module_ast_bytes);
+        byte_writer.write_u16(self.procedures.len() as u16);
+
+        for (_, proc) in sort_procs_by_index(&self.procedures) {
+            proc.write_into(&mut byte_writer);
         }
 
-        module_ast_bytes.into_bytes()
+        byte_writer.into_bytes()
     }
 
     /// Returns a `ModuleAst` struct by its byte representation.
     pub fn from_bytes(bytes: &mut &[u8]) -> Result<Self, SerializationError> {
         let mut byte_reader = ByteReader::new(bytes.to_vec());
 
-        let mut procedures = ProcMap::new();
+        let mut procedures = LocalProcMap::new();
 
         let procedures_len = byte_reader.read_u16()?;
 
-        for _ in 0..procedures_len {
-            let proc_name = byte_reader.read_string()?;
+        for i in 0..procedures_len {
             let proc_ast = ProcedureAst::read_from(&mut byte_reader)?;
 
-            procedures.insert(proc_name, proc_ast);
+            procedures.insert(proc_ast.name.clone(), (i, proc_ast));
         }
 
         Ok(ModuleAst { procedures })
@@ -124,13 +118,11 @@ pub struct ProcedureAst {
     pub num_locals: u32,
     pub body: Vec<Node>,
     pub is_export: bool,
-    pub index: u32,
 }
 
 impl Serializable for ProcedureAst {
     /// Writes byte representation of the `ProcedureAst` into the provided `ByteWriter` struct.
     fn write_into(&self, target: &mut ByteWriter) {
-        target.write_u16(self.index as u16);
         target
             .write_string(&self.name)
             .expect("String serialization failure");
@@ -143,7 +135,6 @@ impl Serializable for ProcedureAst {
 impl Deserializable for ProcedureAst {
     /// Returns a `ProcedureAst` from its byte representation stored in provided `ByteReader` struct.
     fn read_from(bytes: &mut ByteReader) -> Result<Self, SerializationError> {
-        let index = bytes.read_u16()?.into();
         let name = bytes.read_string()?;
         let is_export = bytes.read_bool()?;
         let num_locals = bytes.read_u16()?.into();
@@ -153,7 +144,6 @@ impl Deserializable for ProcedureAst {
             num_locals,
             body,
             is_export,
-            index,
         })
     }
 }
@@ -233,7 +223,7 @@ pub fn parse_program(source: &str) -> Result<ProgramAst, AssemblyError> {
 
     let program = ProgramAst {
         body,
-        procedures: context.procedures,
+        procedures: context.local_procs,
     };
 
     Ok(program)
@@ -257,7 +247,7 @@ pub fn parse_module(source: &str) -> Result<ModuleAst, AssemblyError> {
     }
 
     let module = ModuleAst {
-        procedures: context.procedures,
+        procedures: context.local_procs,
     };
 
     Ok(module)
@@ -301,4 +291,19 @@ fn parse_param<I: core::str::FromStr>(op: &Token, param_idx: usize) -> Result<I,
     };
 
     Ok(result)
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Sorts `ProcMap` by procedure index (`0`th value element) and returns sorted map as
+/// `BTreeMap<index, procedure>`
+fn sort_procs_by_index(proc_map: &LocalProcMap) -> BTreeMap<u16, ProcedureAst> {
+    let mut result = BTreeMap::new();
+
+    for (_, value) in proc_map.iter() {
+        result.insert(value.0, value.1.clone());
+    }
+
+    result
 }

--- a/assembly/src/parsers/ast/nodes.rs
+++ b/assembly/src/parsers/ast/nodes.rs
@@ -236,8 +236,8 @@ pub enum Instruction {
     MTreeCWM,
 
     // ----- exec / call ----------------------------------------------------------------------
-    ExecLocal(u32),
+    ExecLocal(u16),
     ExecImported([u8; 24]),
-    CallLocal(u32),
+    CallLocal(u16),
     CallImported([u8; 24]),
 }

--- a/assembly/src/parsers/ast/serde/deserialization.rs
+++ b/assembly/src/parsers/ast/serde/deserialization.rs
@@ -398,9 +398,9 @@ impl Deserializable for Instruction {
             OpCode::MTreeCWM => Ok(Instruction::MTreeCWM),
 
             // ----- exec / call ----------------------------------------------------------------------
-            OpCode::ExecLocal => Ok(Instruction::ExecLocal(bytes.read_u32()?)),
+            OpCode::ExecLocal => Ok(Instruction::ExecLocal(bytes.read_u16()?)),
             OpCode::ExecImported => Ok(Instruction::ExecImported(bytes.read_proc_hash()?)),
-            OpCode::CallLocal => Ok(Instruction::CallLocal(bytes.read_u32()?)),
+            OpCode::CallLocal => Ok(Instruction::CallLocal(bytes.read_u16()?)),
             OpCode::CallImported => Ok(Instruction::CallImported(bytes.read_proc_hash()?)),
         }
     }

--- a/assembly/src/parsers/ast/serde/serialization.rs
+++ b/assembly/src/parsers/ast/serde/serialization.rs
@@ -474,7 +474,7 @@ impl Serializable for Instruction {
             // ----- exec / call ----------------------------------------------------------------------
             Self::ExecLocal(v) => {
                 target.write_opcode(OpCode::ExecLocal);
-                target.write_u32(*v);
+                target.write_u16(*v);
             }
             Self::ExecImported(imported) => {
                 target.write_opcode(OpCode::ExecImported);
@@ -482,7 +482,7 @@ impl Serializable for Instruction {
             }
             Self::CallLocal(v) => {
                 target.write_opcode(OpCode::CallLocal);
-                target.write_u32(*v);
+                target.write_u16(*v);
             }
             Self::CallImported(imported) => {
                 target.write_opcode(OpCode::CallImported);

--- a/assembly/src/parsers/ast/tests.rs
+++ b/assembly/src/parsers/ast/tests.rs
@@ -1,4 +1,4 @@
-use super::{parse_module, parse_program, BTreeMap, Instruction, Node, ProcMap, ProcedureAst};
+use super::{parse_module, parse_program, BTreeMap, Instruction, LocalProcMap, Node, ProcedureAst};
 use crate::parsers::ast::{ModuleAst, ProgramAst};
 use crypto::{hashers::Blake3_192, Digest, Hasher};
 use vm_core::{Felt, FieldElement};
@@ -68,27 +68,31 @@ fn test_ast_parsing_program_proc() {
         exec.bar
     end";
     let proc_body1: Vec<Node> = vec![Node::Instruction(Instruction::LocLoad(Felt::ZERO))];
-    let mut procedures: ProcMap = BTreeMap::new();
+    let mut procedures: LocalProcMap = BTreeMap::new();
     procedures.insert(
         String::from("foo"),
-        ProcedureAst {
-            name: String::from("foo"),
-            is_export: false,
-            num_locals: 1,
-            index: 0,
-            body: proc_body1,
-        },
+        (
+            0,
+            ProcedureAst {
+                name: String::from("foo"),
+                is_export: false,
+                num_locals: 1,
+                body: proc_body1,
+            },
+        ),
     );
     let proc_body2: Vec<Node> = vec![Node::Instruction(Instruction::PadW)];
     procedures.insert(
         String::from("bar"),
-        ProcedureAst {
-            name: String::from("bar"),
-            is_export: false,
-            num_locals: 2,
-            index: 1,
-            body: proc_body2,
-        },
+        (
+            1,
+            ProcedureAst {
+                name: String::from("bar"),
+                is_export: false,
+                num_locals: 2,
+                body: proc_body2,
+            },
+        ),
     );
     let nodes: Vec<Node> = vec![
         Node::Instruction(Instruction::ExecLocal(0)),
@@ -103,17 +107,19 @@ fn test_ast_parsing_module() {
     export.foo.1 
         loc_load.0
     end";
-    let mut procedures: ProcMap = BTreeMap::new();
+    let mut procedures: LocalProcMap = BTreeMap::new();
     let proc_body: Vec<Node> = vec![Node::Instruction(Instruction::LocLoad(Felt::ZERO))];
     procedures.insert(
         String::from("foo"),
-        ProcedureAst {
-            name: String::from("foo"),
-            is_export: true,
-            num_locals: 1,
-            index: 0,
-            body: proc_body,
-        },
+        (
+            0,
+            ProcedureAst {
+                name: String::from("foo"),
+                is_export: true,
+                num_locals: 1,
+                body: proc_body,
+            },
+        ),
     );
     parse_program(source).expect_err("Program should contain body and no export");
     let module = parse_module(source).unwrap();
@@ -131,7 +137,7 @@ fn test_ast_parsing_use() {
     begin
         exec.foo::bar
     end";
-    let procedures: ProcMap = BTreeMap::new();
+    let procedures: LocalProcMap = BTreeMap::new();
     let proc_name_digest = Blake3_192::<Felt>::hash(String::from("std::abc::foo::bar").as_bytes());
     let mut proc_name_hash = [0; 24];
     proc_name_hash.copy_from_slice(&proc_name_digest.as_bytes()[..24]);
@@ -140,7 +146,7 @@ fn test_ast_parsing_use() {
 }
 
 #[test]
-fn test_ast_parsing_module_multiple_if() {
+fn test_ast_parsing_module_nested_if() {
     let source = "\
     proc.foo
         push.1
@@ -157,7 +163,7 @@ fn test_ast_parsing_module_multiple_if() {
         end
     end";
 
-    let mut procedures: ProcMap = BTreeMap::new();
+    let mut procedures: LocalProcMap = BTreeMap::new();
     let proc_body: Vec<Node> = vec![
         Node::Instruction(Instruction::PushConstants([Felt::ONE].to_vec())),
         Node::IfElse(
@@ -183,13 +189,15 @@ fn test_ast_parsing_module_multiple_if() {
     ];
     procedures.insert(
         String::from("foo"),
-        ProcedureAst {
-            name: String::from("foo"),
-            is_export: false,
-            num_locals: 0,
-            index: 0,
-            body: proc_body,
-        },
+        (
+            0,
+            ProcedureAst {
+                name: String::from("foo"),
+                is_export: false,
+                num_locals: 0,
+                body: proc_body,
+            },
+        ),
     );
     parse_program(source).expect_err("Program should contain body and no export");
     let module = parse_module(source).unwrap();
@@ -218,7 +226,7 @@ fn test_ast_parsing_module_sequential_if() {
         end
     end";
 
-    let mut procedures: ProcMap = BTreeMap::new();
+    let mut procedures: LocalProcMap = BTreeMap::new();
     let proc_body: Vec<Node> = vec![
         Node::Instruction(Instruction::PushConstants([Felt::ONE].to_vec())),
         Node::IfElse(
@@ -244,13 +252,15 @@ fn test_ast_parsing_module_sequential_if() {
     ];
     procedures.insert(
         String::from("foo"),
-        ProcedureAst {
-            name: String::from("foo"),
-            is_export: false,
-            num_locals: 0,
-            index: 0,
-            body: proc_body,
-        },
+        (
+            0,
+            ProcedureAst {
+                name: String::from("foo"),
+                is_export: false,
+                num_locals: 0,
+                body: proc_body,
+            },
+        ),
     );
     parse_program(source).expect_err("Program should contain body and no export");
     let module = parse_module(source).unwrap();
@@ -347,7 +357,7 @@ fn test_ast_program_serde_control_flow() {
     assert_eq!(program, program_deserialized);
 }
 
-fn assert_program_output(source: &str, procedures: ProcMap, body: Vec<Node>) {
+fn assert_program_output(source: &str, procedures: LocalProcMap, body: Vec<Node>) {
     let program = parse_program(source).unwrap();
     assert_eq!(program.body, body);
     assert_eq!(program.procedures.len(), procedures.len());


### PR DESCRIPTION
`index` field in `ProcedureAst` structure was pulled out to `ProcMap`. Thus this field is not serializing anymore 