### PR TITLE
Fix the overflow stack depth air constraint

### DIFF
--- a/air/src/stack/overflow/mod.rs
+++ b/air/src/stack/overflow/mod.rs
@@ -75,7 +75,8 @@ pub fn enforce_stack_depth_constraints<E: FieldElement>(
 ) -> usize {
     let depth = frame.stack_depth();
     let depth_next = frame.stack_depth_next();
-    let no_shift_part = (depth_next - depth) * (E::ONE - op_flag.call() - frame.is_call_end());
+    let no_shift_part =
+        (depth_next - depth) * (E::ONE - op_flag.call() - (op_flag.end() * frame.is_call_end()));
     let left_shift_part = op_flag.left_shift() * op_flag.overflow();
     let right_shift_part = op_flag.right_shift();
     let call_part = op_flag.call() * (depth_next - E::from(16u32));

--- a/air/src/stack/overflow/tests.rs
+++ b/air/src/stack/overflow/tests.rs
@@ -96,7 +96,7 @@ fn test_stack_overflow_constraints() {
 }
 
 #[test]
-fn test_stack_depth_air_fail() {
+fn test_stack_depth_air() {
     let depth = 16 + rand_value::<u32>() as u64;
     // block with a control block opcode.
     let mut frame = generate_evaluation_frame(Operation::Split.op_code().into());
@@ -111,17 +111,17 @@ fn test_stack_depth_air_fail() {
     frame.current_mut()[DECODER_TRACE_OFFSET + IS_CALL_FLAG_COL_IDX] =
         Felt::new(rand_value::<u32>() as u64);
     frame.current_mut()[B1_COL_IDX] = Felt::new(12);
-    frame.current_mut()[H0_COL_IDX] = ONE;
+    frame.current_mut()[H0_COL_IDX] = Felt::new(depth - 16).inv();
 
     frame.next_mut()[CLK_COL_IDX] = ONE;
     frame.next_mut()[B0_COL_IDX] = Felt::new(depth - 1);
-    frame.current_mut()[B1_COL_IDX] = Felt::new(12);
-    frame.current_mut()[H0_COL_IDX] = ONE;
+    frame.next_mut()[B1_COL_IDX] = Felt::new(12);
+    frame.next_mut()[H0_COL_IDX] = Felt::new(depth - 1 - 16).inv();
 
     let expected = [Felt::ZERO; NUM_CONSTRAINTS];
     let result = get_constraint_evaluation(frame);
 
-    assert_ne!(expected, result);
+    assert_eq!(expected, result);
 }
 
 // TEST HELPERS


### PR DESCRIPTION
## Describe your changes
This PR fixes #466. It also sets the next frame correctly, which was not happening in the last [PR](#473), where the current frame was updated again instead of the next. Due to this, the tests were failing because of other stack overflow constraints.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.