### PR TITLE
Compile crypto ops in the new assembler structure

### DIFF
--- a/assembly/src/parsers/ast/context.rs
+++ b/assembly/src/parsers/ast/context.rs
@@ -497,7 +497,7 @@ fn parse_op_token(op: &Token) -> Result<Node, AssemblyError> {
 
         "mtree_get" => Node::Instruction(Instruction::MTreeGet),
         "mtree_set" => Node::Instruction(Instruction::MTreeSet),
-        "mtree_cwm" => Node::Instruction(Instruction::MTreeCWM),
+        "mtree_cwm" => Node::Instruction(Instruction::MTreeCwm),
 
         // ----- catch all ------------------------------------------------------------------------
         _ => return Err(AssemblyError::invalid_op(op)),

--- a/assembly/src/parsers/ast/nodes.rs
+++ b/assembly/src/parsers/ast/nodes.rs
@@ -242,7 +242,7 @@ pub enum Instruction {
     RPPerm,
     MTreeGet,
     MTreeSet,
-    MTreeCWM,
+    MTreeCwm,
 
     // ----- exec / call ----------------------------------------------------------------------
     ExecLocal(u16),

--- a/assembly/src/parsers/ast/serde/deserialization.rs
+++ b/assembly/src/parsers/ast/serde/deserialization.rs
@@ -409,7 +409,7 @@ impl Deserializable for Instruction {
             OpCode::RPPerm => Ok(Instruction::RPPerm),
             OpCode::MTreeGet => Ok(Instruction::MTreeGet),
             OpCode::MTreeSet => Ok(Instruction::MTreeSet),
-            OpCode::MTreeCWM => Ok(Instruction::MTreeCWM),
+            OpCode::MTreeCwm => Ok(Instruction::MTreeCwm),
 
             // ----- exec / call ----------------------------------------------------------------------
             OpCode::ExecLocal => Ok(Instruction::ExecLocal(bytes.read_u16()?)),

--- a/assembly/src/parsers/ast/serde/mod.rs
+++ b/assembly/src/parsers/ast/serde/mod.rs
@@ -239,7 +239,7 @@ pub enum OpCode {
     RPPerm = 207,
     MTreeGet = 208,
     MTreeSet = 209,
-    MTreeCWM = 210,
+    MTreeCwm = 210,
 
     // ----- exec / call ----------------------------------------------------------------------
     ExecLocal = 211,

--- a/assembly/src/parsers/ast/serde/serialization.rs
+++ b/assembly/src/parsers/ast/serde/serialization.rs
@@ -492,7 +492,7 @@ impl Serializable for Instruction {
             Self::RPPerm => target.write_opcode(OpCode::RPPerm),
             Self::MTreeGet => target.write_opcode(OpCode::MTreeGet),
             Self::MTreeSet => target.write_opcode(OpCode::MTreeSet),
-            Self::MTreeCWM => target.write_opcode(OpCode::MTreeCWM),
+            Self::MTreeCwm => target.write_opcode(OpCode::MTreeCwm),
 
             // ----- exec / call ----------------------------------------------------------------------
             Self::ExecLocal(v) => {

--- a/assembly/src/todo/instruction/crypto_ops.rs
+++ b/assembly/src/todo/instruction/crypto_ops.rs
@@ -1,13 +1,184 @@
-use core::iter;
+use super::{AssemblerError, CodeBlock, Operation::*, SpanBuilder};
+use vm_core::{AdviceInjector, Decorator, Felt};
 
-use vm_core::{code_blocks::CodeBlock, AdviceInjector, Decorator, Operation::*};
+// HASHING
+// ================================================================================================
+// The number of elements to be hashed by the rphash operation
+const RPHASH_NUM_ELEMENTS: u64 = 8;
 
-use crate::{todo::span_builder::SpanBuilder, AssemblerError};
+/// Appends RPPERM and stack manipulation operations to the span block as required to compute a
+/// 2-to-1 Rescue Prime hash. The top of the stack is expected to be arranged with 2 words
+/// (8 elements) to be hashed: [B, A, ...]. The resulting stack will contain the 2-to-1 hash result
+/// [E, ...].
+///
+/// This assembly operation uses the VM operation RPPERM at its core, which permutes the top 12
+/// elements of the stack.
+///
+/// To perform the operation, we do the following:
+/// 1. Prepare the stack with 12 elements for RPPERM by pushing 4 more elements for the capacity,
+///    including the number of elements to be hashed (8), so the stack looks like [C, B, A, ...]
+///    where C is the capacity, and the number of elements is the deepest element in C.
+/// 2. Reorder the stack so the capacity is deepest in the stack [B, A, C, ...]
+/// 3. Append the RPPERM operation, which performs a Rescue Prime permutation on the top 12
+///    elements and leaves an output of [F, E, D, ...] on the stack. E is our 2-to-1 hash result.
+/// 4. Drop F and D to return our result [E, ...].
+///
+/// This operation takes 16 VM cycles.
+pub(super) fn rphash(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblerError> {
+    // Add 4 elements to the stack to prepare the capacity portion for the Rescue Prime permutation
+    // The capacity should start at stack[8], and the number of elements to be hashed should
+    // be deepest in the stack at stack[11]
+    span.push_op(Push(Felt::new(RPHASH_NUM_ELEMENTS)));
+    span.push_op_many(Pad, 3);
+    span.push_op(SwapW2);
+    // restore the order of the top 2 words to be hashed
+    span.push_op(SwapW);
+
+    // Do the Rescue Prime permutation on the top 12 elements in the stack
+    span.push_op(RpPerm);
+
+    // Drop 4 elements (the part of the rate that doesn't have our result)
+    span.push_op_many(Drop, 4);
+
+    // Move the top word (our result) down the stack
+    span.push_op(SwapW);
+
+    // Drop 4 elements (the capacity portion)
+    span.push_op_many(Drop, 4);
+
+    Ok(None)
+}
 
 // MERKLE TREES
 // ================================================================================================
 
+/// Appends the MPVERIFY op and stack manipulations to the span block as required to verify that a
+/// Merkle tree with root R opens to node V at depth d and index i. The stack is expected to be
+/// arranged as follows (from the top):
+/// - depth of the node, 1 element
+/// - index of the node, 1 element
+/// - current root of the tree, 4 elements
+///
+/// After the operations are executed, the stack will be arranged as follows:
+/// - node V, 4 elements
+/// - root of the tree, 4 elements.
+///
+/// This operation takes 9 VM cycles.
 pub(super) fn mtree_get(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblerError> {
+    // stack: [d, i, R, ...]
+    // inject the node value we're looking for at the head of the advice tape
+    read_mtree_node(span);
+
+    // verify the node V for root R with depth d and index i
+    // => [V, d, i, R, ...]
+    span.push_op(MpVerify);
+
+    // move d, i back to the top of the stack and are dropped since they are
+    // no longer needed => [V, R, ...]
+    span.push_op(MovUp4);
+    span.push_op(Drop);
+    span.push_op(MovUp4);
+    span.push_op(Drop);
+
+    Ok(None)
+}
+
+/// Appends the MRUPDATE op with a parameter of "false" and stack manipulations to the span block
+/// as required to update a node in the Merkle tree with root R at depth d and index i to value V.
+/// The stack is expected to be arranged as follows (from the top):
+/// - depth of the node, 1 element
+/// - index of the node, 1 element
+/// - current root of the tree, 4 elements
+/// - new value of the node, 4 element
+///
+/// After the operations are executed, the stack will be arranged as follows:
+/// - new root of the tree after the update, 4 elements
+/// - new value of the node, 4 elements
+///
+/// This operation takes 14 VM cycles.
+pub(super) fn mtree_set(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblerError> {
+    // Inject the old node value onto the stack for the call to MRUPDATE.
+    // [d, i, R, V_new, ...] => [V_old, d, i, R, V_new, ...]
+    read_mtree_node(span);
+
+    // Update the Merkle tree with the new value without copying the old tree. This replaces the
+    // old node value with the computed new Merkle root.
+    // => [R_new, d, i, R, V_new, ...]
+    span.push_op(MrUpdate(false));
+
+    // move d, i back to the top of the stack and are dropped since they are
+    // no longer needed => [R_new, R, V_new, ...]
+    span.push_op(MovUp4);
+    span.push_op(Drop);
+    span.push_op(MovUp4);
+    span.push_op(Drop);
+
+    // Move the old root to the top of the stack => [R, R_new, V_new, ...]
+    span.push_op(SwapW);
+
+    // Drop old root from the stack => [R_new, V_new ...]
+    span.push_op_many(Drop, 4);
+
+    Ok(None)
+}
+
+/// Appends the MRUPDATE op with a parameter of "true" and stack manipulations to the span block as
+/// required to copy a Merkle tree with root R and update the node in the copied tree at depth d
+/// and index i to value V. The stack is expected to be arranged as follows (from the top):
+/// - depth of the node, 1 element; this is expected to be the depth of the Merkle tree
+/// - index of the node, 1 element
+/// - current root of the tree, 4 elements
+/// - new value of the node, 4 element
+///
+/// After the operations are executed, the stack will be arranged as follows:
+/// - new root of the tree after the update, 4 elements
+/// - new value of the node, 4 elements
+/// - root of the old tree which was copied, 4 elements
+///
+/// This operation takes 12 VM cycles.
+pub(super) fn mtree_cwm(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblerError> {
+    // Inject the old node value onto the stack for the call to MRUPDATE.
+    // [d, i, R, V_new, ...] => [V_old, d, i, R, V_new, ...]
+    read_mtree_node(span);
+
+    // update the Merkle tree with the new value and copy the old tree. This replaces the
+    // old node value with the computed new Merkle root.
+    // => [R_new, d, i, R, V_new, ...]
+    span.push_op(MrUpdate(true));
+
+    // move d, i back to the top of the stack and are dropped since they are
+    // no longer needed => [R_new, R, V_new, ...]
+    span.push_op(MovUp4);
+    span.push_op(Drop);
+    span.push_op(MovUp4);
+    span.push_op(Drop);
+
+    // Move the new value to the top => [R_new, V_new, R ...]
+    span.push_op(SwapW);
+    span.push_op(SwapW2);
+    span.push_op(SwapW);
+
+    Ok(None)
+}
+
+/// This is a helper function for assembly operations that fetches the node value from the
+/// Merkle tree using decorators and pushes it onto the stack. It prepares the stack with the
+/// elements expected by the VM's MPVERIFY & MRUPDATE operations.
+/// The stack is expected to be arranged as follows (from the top):
+/// - depth of the node, 1 element
+/// - index of the node, 1 element
+/// - root of the Merkle tree, 4 elements
+/// - new value of the node, 4 elements (only in the case of mtree_set and mtree_cwm)
+///
+/// After the operations are executed, the stack will be arranged as follows:
+/// - old value of the node, 4 elements
+/// - depth of the node, 1 element
+/// - index of the node, 1 element
+/// - root of the Merkle tree, 4 elements
+/// - new value of the node, 4 elements (only in the case of mtree_set and mtree_cwm)
+///
+/// This operation takes 4 VM cycles.
+fn read_mtree_node(span: &mut SpanBuilder) {
     // The stack should be arranged in the following way: [d, i, R, ...] so that the decorator
     // can fetch the node value from the root. In the `mtree.get` operation we have the stack in
     // the following format: [d, i, R], whereas in the case of `mtree.set` and `mtree.cwm` we
@@ -18,17 +189,5 @@ pub(super) fn mtree_get(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, Ass
 
     // read old node value from advice tape => MPVERIFY: [V_old, d, i, R, ...]
     // MRUPDATE: [V_old, d, i, R, V_new, ...]
-    let pre = iter::repeat(Read).take(4);
-
-    let post = [
-        // verify the node V for root R with depth d and index i
-        // => [V, d, i, R, ...]
-        MpVerify,
-        // move d, i back to the top of the stack and are dropped since they are
-        // no longer needed => [V, R, ...]
-        MovUp4, Drop, MovUp4, Drop,
-    ]
-    .into_iter();
-
-    span.add_ops(pre.chain(post))
+    span.push_op_many(Read, 4);
 }

--- a/assembly/src/todo/instruction/mod.rs
+++ b/assembly/src/todo/instruction/mod.rs
@@ -50,7 +50,11 @@ impl Assembler {
             Instruction::Neq => span.add_ops([Eq, Not]),
             Instruction::NeqImm(imm) => field_ops::neq_imm(imm, span),
 
+            Instruction::RPPerm => span.add_op(RpPerm),
+            Instruction::RPHash => crypto_ops::rphash(span),
             Instruction::MTreeGet => crypto_ops::mtree_get(span),
+            Instruction::MTreeSet => crypto_ops::mtree_set(span),
+            Instruction::MTreeCwm => crypto_ops::mtree_cwm(span),
 
             Instruction::PushConstants(imms) => span.add_ops(imms.iter().copied().map(Push)),
             Instruction::ExecLocal(idx) => self.exec_local(*idx, context, callset),

--- a/assembly/src/todo/span_builder.rs
+++ b/assembly/src/todo/span_builder.rs
@@ -51,9 +51,14 @@ impl SpanBuilder {
     }
 
     /// TODO: add docs
-    #[allow(dead_code)]
     pub fn push_op(&mut self, op: Operation) {
         self.ops.push(op);
+    }
+
+    /// TODO: add docs
+    pub fn push_op_many(&mut self, op: Operation, n: usize) {
+        let new_len = self.ops.len() + n;
+        self.ops.resize(new_len, op);
     }
 
     /// TODO: add docs


### PR DESCRIPTION
This PR adds handlers for compiling cryptographic instructions in the new assembler structure.