### PR TITLE
Implement handling of advice injectors in new assembler

### DIFF
--- a/assembly/src/assembler/instruction/adv_ops.rs
+++ b/assembly/src/assembler/instruction/adv_ops.rs
@@ -1,38 +1,38 @@
-use super::super::{span_builder::SpanBuilder, AssemblerError};
+use super::{validate_param, AdviceInjector, AssemblerError, Decorator, SpanBuilder};
+use crate::ADVICE_READ_LIMIT;
 use vm_core::{code_blocks::CodeBlock, Operation::*};
-
-// CONSTANTS
-// ================================================================================================
-
-/// The maximum number of elements that can be read from the advice tape in a single `push`
-/// operation.
-const ADVICE_READ_LIMIT: u8 = 16;
 
 // NON-DETERMINISTIC (ADVICE) INPUTS
 // ================================================================================================
 
-/// Appends the number of `READ` operations specified by the operation's immediate value to the
-/// span block. This removes the specified number of items from the advice tape and pushes them
-/// onto the stack. The number of items that can be read from the advice tape is limited to 16.
+/// Appends the number of READ operations specified by the instruction's immediate value to the
+/// span. This removes the specified number of elements from the advice tape and pushes them onto
+/// the stack.
 ///
 /// # Errors
-///
-/// Returns an `AssemblyError` if the instruction is invalid, malformed, missing a required
-/// parameter, or does not match the expected operation. Returns an `invalid_param` `AssemblyError`
-/// if the parameter for `adv_push` is not a decimal value.
+/// Returns an error if the specified number of values to pushed is smaller than 1 or greater
+/// than 16.
 pub fn adv_push(span: &mut SpanBuilder, n: u8) -> Result<Option<CodeBlock>, AssemblerError> {
-    // parse and validate the parameter as the number of items to read from the advice tape
-    // it must be between 1 and ADVICE_READ_LIMIT, inclusive, since adv.push.0 is a no-op
-    if !(1..=ADVICE_READ_LIMIT).contains(&n) {
-        return Err(AssemblerError::imm_out_of_bounds(
-            n as u64,
-            1,
-            ADVICE_READ_LIMIT as u64,
-        ));
-    }
-
-    // read n items from the advice tape and push then onto the stack
+    validate_param(n, 1, ADVICE_READ_LIMIT)?;
     span.push_op_many(Read, n as usize);
-
     Ok(None)
+}
+
+// ADVICE INJECTORS
+// ================================================================================================
+
+/// Appends adv.mem.a.n advice injector to the span. This operation copies n number of words from
+/// memory the starting at address a into the advice provider's key-value map.
+///
+/// # Errors
+/// Returns an error is start_addr + num_words > u32::MAX.
+pub fn adv_mem(
+    span: &mut SpanBuilder,
+    start_addr: u32,
+    num_words: u32,
+) -> Result<Option<CodeBlock>, AssemblerError> {
+    validate_param(num_words, 0, u32::MAX - start_addr)?;
+    span.add_decorator(Decorator::Advice(AdviceInjector::Memory(
+        start_addr, num_words,
+    )))
 }

--- a/assembly/src/assembler/span_builder.rs
+++ b/assembly/src/assembler/span_builder.rs
@@ -35,7 +35,7 @@ impl SpanBuilder {
         }
     }
 
-    // STATE MUTATORS
+    // OPERATIONS
     // --------------------------------------------------------------------------------------------
 
     /// TODO: add docs
@@ -65,9 +65,21 @@ impl SpanBuilder {
         self.ops.resize(new_len, op);
     }
 
-    /// TODO: add docs
+    // DECORATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Add ths specified decorator to the list of decorators.
     pub fn push_decorator(&mut self, decorator: Decorator) {
         self.decorators.push((self.ops.len(), decorator));
+    }
+
+    /// Adds the specified decorator to the list of decorators and returns Ok(None).
+    pub fn add_decorator(
+        &mut self,
+        decorator: Decorator,
+    ) -> Result<Option<CodeBlock>, AssemblerError> {
+        self.push_decorator(decorator);
+        Ok(None)
     }
 
     /// Adds an AsmOp decorator to the decorator list.

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -401,10 +401,10 @@ impl AssemblerError {
         }
     }
 
-    pub fn imm_out_of_bounds(value: u64, min: u64, max: u64) -> Self {
+    pub fn param_out_of_bounds(value: u64, min: u64, max: u64) -> Self {
         Self {
             message: format!(
-                "immediate value must be greater than or equal to {} and less than or equal to {}, but was {}",
+                "parameter value must be greater than or equal to {} and less than or equal to {}, but was {}",
                 min, max, value
             )
         }

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -38,6 +38,10 @@ mod tests;
 
 const MODULE_PATH_DELIM: &str = "::";
 
+/// The maximum number of elements that can be read from the advice tape in a single `adv_push`
+/// instruction.
+const ADVICE_READ_LIMIT: u8 = 16;
+
 // MODULE PROVIDER
 // ================================================================================================
 


### PR DESCRIPTION
This PR implements handling of advice injectors in the new assembler structure. It also fixes a couple of bugs and contains minor refactorings of u32 operation handlers.