### PR TITLE
eq and neq parsers, u32 error message

### DIFF
--- a/assembly/src/parsers/ast/context.rs
+++ b/assembly/src/parsers/ast/context.rs
@@ -438,8 +438,8 @@ fn parse_op_token(op: &Token) -> Result<Node, AssemblyError> {
         "u32checked_rotl" => u32_ops::parse_u32_rotl(op, true),
         "u32unchecked_rotl" => u32_ops::parse_u32_rotl(op, false),
 
-        "u32checked_eq" => simple_instruction(op, U32CheckedEq),
-        "u32checked_neq" => simple_instruction(op, U32CheckedNeq),
+        "u32checked_eq" => u32_ops::parse_u32checked_eq(op),
+        "u32checked_neq" => u32_ops::parse_u32checked_neq(op),
 
         "u32checked_lt" => simple_instruction(op, U32CheckedLt),
         "u32unchecked_lt" => simple_instruction(op, U32UncheckedLt),

--- a/assembly/src/parsers/ast/u32_ops.rs
+++ b/assembly/src/parsers/ast/u32_ops.rs
@@ -389,3 +389,37 @@ pub fn parse_u32_rotl(op: &Token, checked: bool) -> Result<Node, AssemblyError> 
         _ => Err(AssemblyError::extra_param(op)),
     }
 }
+
+/// Returns `U32CheckedEq` instruction node if no immediate value is provided or
+/// `U32CheckedEqImm` instruction node otherwise.
+///
+/// # Errors
+/// Returns an error if the instruction token contains wrong number of parameters, or if the
+/// provided parameter is not a u32 value.
+pub fn parse_u32checked_eq(op: &Token) -> Result<Node, AssemblyError> {
+    match op.num_parts() {
+        1 => Ok(Instruction(U32CheckedEq)),
+        2 => {
+            let value = parse_param::<u32>(op, 1)?;
+            Ok(Instruction(U32CheckedEqImm(value)))
+        }
+        _ => Err(AssemblyError::extra_param(op)),
+    }
+}
+
+/// Returns `U32CheckedNeq` instruction node if no immediate value is provided or
+/// `U32CheckedNeqImm` instruction node otherwise.
+///
+/// # Errors
+/// Returns an error if the instruction token contains wrong number of parameters, or if the
+/// provided parameter is not a u32 value.
+pub fn parse_u32checked_neq(op: &Token) -> Result<Node, AssemblyError> {
+    match op.num_parts() {
+        1 => Ok(Instruction(U32CheckedNeq)),
+        2 => {
+            let value = parse_param::<u32>(op, 1)?;
+            Ok(Instruction(U32CheckedNeqImm(value)))
+        }
+        _ => Err(AssemblyError::extra_param(op)),
+    }
+}

--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -792,7 +792,7 @@ fn u32checked_div_b_fail() {
 
     // should fail during compilation if b = 0.
     let test = build_op_test!(build_asm_op(0).as_str());
-    test.expect_error(TestError::AssemblyError("parameter"));
+    test.expect_error(TestError::AssemblyError("division by zero"));
 }
 
 #[test]
@@ -885,7 +885,7 @@ fn u32checked_mod_b_fail() {
 
     // should fail during compilation if b = 0.
     let test = build_op_test!(build_asm_op(0).as_str());
-    test.expect_error(TestError::AssemblyError("parameter"));
+    test.expect_error(TestError::AssemblyError("division by zero"));
 }
 
 #[test]
@@ -980,7 +980,7 @@ fn u32checked_divmod_b_fail() {
 
     // should fail during compilation if b = 0.
     let test = build_op_test!(build_asm_op(0).as_str());
-    test.expect_error(TestError::AssemblyError("parameter"));
+    test.expect_error(TestError::AssemblyError("division by zero"));
 }
 
 #[test]


### PR DESCRIPTION
Fixed  `parse_u32checked_eq()` and  `parse_u32checked_neq()` parsers ― now `checked_eq` and `checked_neq` operations could be used with immediate values. 
Error messages in `u32checked_div_b_fail()`, `u32checked_mod_b_fail()` and `u32checked_divmod_b_fail()` integration tests was updated with new `AssemblerError` messages.