### PR TITLE
Refactor AssemblyError and fix Miden executable

### DIFF
--- a/assembly/src/assembler/instruction/adv_ops.rs
+++ b/assembly/src/assembler/instruction/adv_ops.rs
@@ -1,4 +1,4 @@
-use super::{validate_param, AdviceInjector, AssemblerError, Decorator, SpanBuilder};
+use super::{validate_param, AdviceInjector, AssemblyError, Decorator, SpanBuilder};
 use crate::ADVICE_READ_LIMIT;
 use vm_core::{code_blocks::CodeBlock, Operation::*};
 
@@ -12,7 +12,7 @@ use vm_core::{code_blocks::CodeBlock, Operation::*};
 /// # Errors
 /// Returns an error if the specified number of values to pushed is smaller than 1 or greater
 /// than 16.
-pub fn adv_push(span: &mut SpanBuilder, n: u8) -> Result<Option<CodeBlock>, AssemblerError> {
+pub fn adv_push(span: &mut SpanBuilder, n: u8) -> Result<Option<CodeBlock>, AssemblyError> {
     validate_param(n, 1, ADVICE_READ_LIMIT)?;
     span.push_op_many(Read, n as usize);
     Ok(None)
@@ -30,7 +30,7 @@ pub fn adv_mem(
     span: &mut SpanBuilder,
     start_addr: u32,
     num_words: u32,
-) -> Result<Option<CodeBlock>, AssemblerError> {
+) -> Result<Option<CodeBlock>, AssemblyError> {
     validate_param(num_words, 0, u32::MAX - start_addr)?;
     span.add_decorator(Decorator::Advice(AdviceInjector::Memory(
         start_addr, num_words,

--- a/assembly/src/assembler/instruction/crypto_ops.rs
+++ b/assembly/src/assembler/instruction/crypto_ops.rs
@@ -1,4 +1,4 @@
-use super::{AssemblerError, CodeBlock, Operation::*, SpanBuilder};
+use super::{AssemblyError, CodeBlock, Operation::*, SpanBuilder};
 use vm_core::{AdviceInjector, Decorator, Felt};
 
 // HASHING
@@ -24,7 +24,7 @@ const RPHASH_NUM_ELEMENTS: u64 = 8;
 /// 4. Drop F and D to return our result [E, ...].
 ///
 /// This operation takes 16 VM cycles.
-pub(super) fn rphash(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblerError> {
+pub(super) fn rphash(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
     // Add 4 elements to the stack to prepare the capacity portion for the Rescue Prime permutation
     // The capacity should start at stack[8], and the number of elements to be hashed should
     // be deepest in the stack at stack[11]
@@ -64,7 +64,7 @@ pub(super) fn rphash(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, Assemb
 /// - root of the tree, 4 elements.
 ///
 /// This operation takes 9 VM cycles.
-pub(super) fn mtree_get(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblerError> {
+pub(super) fn mtree_get(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
     // stack: [d, i, R, ...]
     // inject the node value we're looking for at the head of the advice tape
     read_mtree_node(span);
@@ -96,7 +96,7 @@ pub(super) fn mtree_get(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, Ass
 /// - new value of the node, 4 elements
 ///
 /// This operation takes 14 VM cycles.
-pub(super) fn mtree_set(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblerError> {
+pub(super) fn mtree_set(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
     // Inject the old node value onto the stack for the call to MRUPDATE.
     // [d, i, R, V_new, ...] => [V_old, d, i, R, V_new, ...]
     read_mtree_node(span);
@@ -136,7 +136,7 @@ pub(super) fn mtree_set(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, Ass
 /// - root of the old tree which was copied, 4 elements
 ///
 /// This operation takes 12 VM cycles.
-pub(super) fn mtree_cwm(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblerError> {
+pub(super) fn mtree_cwm(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
     // Inject the old node value onto the stack for the call to MRUPDATE.
     // [d, i, R, V_new, ...] => [V_old, d, i, R, V_new, ...]
     read_mtree_node(span);

--- a/assembly/src/assembler/instruction/env_ops.rs
+++ b/assembly/src/assembler/instruction/env_ops.rs
@@ -1,5 +1,5 @@
 use super::{
-    mem_ops::local_to_absolute_addr, push_felt, AssemblerError, AssemblyContext, CodeBlock, Felt,
+    mem_ops::local_to_absolute_addr, push_felt, AssemblyContext, AssemblyError, CodeBlock, Felt,
     Operation::*, SpanBuilder,
 };
 
@@ -25,7 +25,7 @@ use super::{
 /// It will return an error if no immediate value is provided or if any of parameter formats are
 /// invalid. It will also return an error if the op token is malformed or doesn't match the expected
 /// instruction.
-pub fn push(imms: &[Felt], span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblerError> {
+pub fn push(imms: &[Felt], span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
     imms.iter().copied().for_each(|imm| push_felt(span, imm));
     Ok(None)
 }
@@ -42,7 +42,7 @@ pub fn locaddr(
     span: &mut SpanBuilder,
     index: u16,
     context: &AssemblyContext,
-) -> Result<Option<CodeBlock>, AssemblerError> {
+) -> Result<Option<CodeBlock>, AssemblyError> {
     local_to_absolute_addr(span, index, context.num_proc_locals())?;
     Ok(None)
 }
@@ -55,9 +55,9 @@ pub fn locaddr(
 pub fn caller(
     span: &mut SpanBuilder,
     context: &AssemblyContext,
-) -> Result<Option<CodeBlock>, AssemblerError> {
+) -> Result<Option<CodeBlock>, AssemblyError> {
     if !context.is_kernel() {
-        return Err(AssemblerError::caller_out_of_kernel());
+        return Err(AssemblyError::caller_out_of_kernel());
     }
 
     span.add_op(Caller)

--- a/assembly/src/assembler/instruction/mem_ops.rs
+++ b/assembly/src/assembler/instruction/mem_ops.rs
@@ -1,5 +1,5 @@
 use super::{
-    push_felt, push_u32_value, validate_param, AssemblerError, AssemblyContext, CodeBlock, Felt,
+    push_felt, push_u32_value, validate_param, AssemblyContext, AssemblyError, CodeBlock, Felt,
     Operation::*, SpanBuilder,
 };
 
@@ -26,7 +26,7 @@ pub fn mem_read(
     addr: Option<u32>,
     is_local: bool,
     is_single: bool,
-) -> Result<Option<CodeBlock>, AssemblerError> {
+) -> Result<Option<CodeBlock>, AssemblyError> {
     // if the address was provided as an immediate value, put it onto the stack
     if let Some(addr) = addr {
         if is_local {
@@ -68,7 +68,7 @@ pub fn mem_write(
     addr: Option<u32>,
     is_local: bool,
     is_single: bool,
-) -> Result<Option<CodeBlock>, AssemblerError> {
+) -> Result<Option<CodeBlock>, AssemblyError> {
     // if the address was provided as an immediate value, put it onto the stack
     if let Some(addr) = addr {
         if is_local {
@@ -106,7 +106,7 @@ pub fn local_to_absolute_addr(
     span: &mut SpanBuilder,
     index: u16,
     num_proc_locals: u16,
-) -> Result<(), AssemblerError> {
+) -> Result<(), AssemblyError> {
     let max = num_proc_locals - 1;
     validate_param(index, 0, max)?;
 

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    Assembler, AssemblerError, AssemblyContext, CodeBlock, Decorator, Felt, Instruction, Operation,
+    Assembler, AssemblyContext, AssemblyError, CodeBlock, Decorator, Felt, Instruction, Operation,
     ProcedureId, SpanBuilder, ONE, ZERO,
 };
 use vm_core::{AdviceInjector, FieldElement, StarkField};
@@ -23,7 +23,7 @@ impl Assembler {
         instruction: &Instruction,
         span: &mut SpanBuilder,
         ctx: &mut AssemblyContext,
-    ) -> Result<Option<CodeBlock>, AssemblerError> {
+    ) -> Result<Option<CodeBlock>, AssemblyError> {
         use AdviceInjector::*;
         use Operation::*;
 
@@ -326,9 +326,9 @@ fn push_felt(span: &mut SpanBuilder, value: Felt) {
 
 /// Returns an error if the specified value is smaller than or equal to min or greater than or
 /// equal to max. Otherwise, returns Ok(()).
-fn validate_param<I: Ord + Into<u64>>(value: I, min: I, max: I) -> Result<(), AssemblerError> {
+fn validate_param<I: Ord + Into<u64>>(value: I, min: I, max: I) -> Result<(), AssemblyError> {
     if value < min || value > max {
-        Err(AssemblerError::param_out_of_bounds(
+        Err(AssemblyError::param_out_of_bounds(
             value.into(),
             min.into(),
             max.into(),

--- a/assembly/src/assembler/instruction/procedures.rs
+++ b/assembly/src/assembler/instruction/procedures.rs
@@ -1,4 +1,4 @@
-use super::{Assembler, AssemblerError, AssemblyContext, CodeBlock, ProcedureId};
+use super::{Assembler, AssemblyContext, AssemblyError, CodeBlock, ProcedureId};
 
 // PROCEDURE INVOCATIONS
 // ================================================================================================
@@ -8,7 +8,7 @@ impl Assembler {
         &self,
         proc_idx: u16,
         context: &mut AssemblyContext,
-    ) -> Result<Option<CodeBlock>, AssemblerError> {
+    ) -> Result<Option<CodeBlock>, AssemblyError> {
         // register an "inlined" call to the procedure at the specified index in the module
         // currently being complied; this updates the callset of the procedure currently being
         // compiled
@@ -25,7 +25,7 @@ impl Assembler {
         &self,
         proc_id: &ProcedureId,
         context: &mut AssemblyContext,
-    ) -> Result<Option<CodeBlock>, AssemblerError> {
+    ) -> Result<Option<CodeBlock>, AssemblyError> {
         // get the procedure from the assembler
         let proc = self.get_imported_proc(proc_id, context)?;
         debug_assert!(proc.is_export(), "not imported procedure");
@@ -45,7 +45,7 @@ impl Assembler {
         &self,
         index: u16,
         context: &mut AssemblyContext,
-    ) -> Result<Option<CodeBlock>, AssemblerError> {
+    ) -> Result<Option<CodeBlock>, AssemblyError> {
         // register an "non-inlined" call to the procedure at the specified index in the module
         // currently being complied; this updates the callset of the procedure currently being
         // compiled
@@ -60,7 +60,7 @@ impl Assembler {
         &self,
         proc_id: &ProcedureId,
         context: &mut AssemblyContext,
-    ) -> Result<Option<CodeBlock>, AssemblerError> {
+    ) -> Result<Option<CodeBlock>, AssemblyError> {
         // get the procedure from the assembler
         let proc = self.get_imported_proc(proc_id, context)?;
         debug_assert!(proc.is_export(), "not imported procedure");
@@ -78,14 +78,14 @@ impl Assembler {
         &self,
         proc_id: &ProcedureId,
         context: &mut AssemblyContext,
-    ) -> Result<Option<CodeBlock>, AssemblerError> {
+    ) -> Result<Option<CodeBlock>, AssemblyError> {
         // fetch from proc cache and check if its a kernel procedure
         // note: the assembler is expected to have all kernel procedures properly inserted in the
         // proc cache upon initialization, with their correct procedure ids
         let proc = self
             .proc_cache
             .get(proc_id)
-            .ok_or_else(|| AssemblerError::undefined_syscall(proc_id))?;
+            .ok_or_else(|| AssemblyError::kernel_proc_not_found(proc_id))?;
 
         // since call and syscall instructions cannot be executed inside a kernel, a callset for
         // a kernel procedure must be empty.

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -24,8 +24,15 @@ type ProcedureCache = BTreeMap<ProcedureId, Procedure>;
 
 // ASSEMBLER
 // ================================================================================================
-
-/// TODO: add comments
+/// Miden Assembler which can be used to convert Miden assembly source code into program MAST (
+/// represented by the [Program] struct). The assembler can be instantiated in several ways using
+/// a "builder" patter. Specifically:
+/// - If `with_kernel()` or `with_kernel_module()` methods are not used, the assembler will be
+///   instantiated with a default empty kernel. Programs compiled using such assembler
+///   cannot make calls to kernel procedures via `syscall` instruction.
+/// - If `with_module_provider()` method is not used, the assembler will be instantiated without
+///   access to external libraries. Programs compiled with such assembler must be self-contained
+///   (i.e., they cannot invoke procedures from external libraries).
 pub struct Assembler {
     kernel: Kernel,
     module_provider: Box<dyn ModuleProvider>,

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     parsers::{self, Instruction, Node, ProcedureAst, ProgramAst},
-    AssemblerError, BTreeMap, Box, CallSet, CodeBlock, CodeBlockTable, Felt, Kernel, ModuleAst,
+    AssemblyError, BTreeMap, Box, CallSet, CodeBlock, CodeBlockTable, Felt, Kernel, ModuleAst,
     ModuleProvider, Operation, Procedure, ProcedureId, Program, String, ToString, Vec, ONE, ZERO,
 };
 use core::{borrow::Borrow, pin::Pin};
@@ -68,7 +68,7 @@ impl Assembler {
     ///
     /// # Panics
     /// Panics if the assembler has already been used to compile programs.
-    pub fn with_kernel(self, kernel_source: &str) -> Result<Self, AssemblerError> {
+    pub fn with_kernel(self, kernel_source: &str) -> Result<Self, AssemblyError> {
         let kernel_ast = parsers::parse_module(kernel_source)?;
         self.with_kernel_module(&kernel_ast)
     }
@@ -77,7 +77,7 @@ impl Assembler {
     ///
     /// # Errors
     /// Returns an error if compiling kernel source results in an error.
-    pub fn with_kernel_module(mut self, module: &ModuleAst) -> Result<Self, AssemblerError> {
+    pub fn with_kernel_module(mut self, module: &ModuleAst) -> Result<Self, AssemblyError> {
         // compile the kernel; this adds all exported kernel procedures to the procedure cache
         let mut context = AssemblyContext::new(true);
         self.compile_module(module, ProcedureId::KERNEL_PATH, &mut context)?;
@@ -111,7 +111,7 @@ impl Assembler {
     ///
     /// # Errors
     /// Returns an error if parsing or compilation of the specified program fails.
-    pub fn compile<S>(&self, source: S) -> Result<Program, AssemblerError>
+    pub fn compile<S>(&self, source: S) -> Result<Program, AssemblyError>
     where
         S: AsRef<str>,
     {
@@ -123,7 +123,7 @@ impl Assembler {
         let mut context = AssemblyContext::new(false);
         for proc_ast in local_procs.iter() {
             if proc_ast.is_export {
-                return Err(AssemblerError::proc_export_in_program(&proc_ast.name));
+                return Err(AssemblyError::exported_proc_in_program(&proc_ast.name));
             }
             self.compile_procedure(proc_ast, &mut context)?;
         }
@@ -152,7 +152,7 @@ impl Assembler {
         module: &ModuleAst,
         module_path: &str,
         context: &mut AssemblyContext,
-    ) -> Result<(), AssemblerError> {
+    ) -> Result<(), AssemblyError> {
         // compile all procedures in the module; once the compilation is complete, we get all
         // compiled procedures (and their combined callset) from the context
         context.begin_module(module_path)?;
@@ -187,7 +187,7 @@ impl Assembler {
         &self,
         proc: &ProcedureAst,
         context: &mut AssemblyContext,
-    ) -> Result<(), AssemblerError> {
+    ) -> Result<(), AssemblyError> {
         context.begin_proc(&proc.name, proc.is_export, proc.num_locals as u16)?;
 
         let code_root = if proc.num_locals > 0 {
@@ -219,7 +219,7 @@ impl Assembler {
         body: A,
         context: &mut AssemblyContext,
         wrapper: Option<BodyWrapper>,
-    ) -> Result<CodeBlock, AssemblerError>
+    ) -> Result<CodeBlock, AssemblyError>
     where
         A: Iterator<Item = N>,
         N: Borrow<Node>,
@@ -293,7 +293,7 @@ impl Assembler {
         &self,
         proc_id: &ProcedureId,
         context: &mut AssemblyContext,
-    ) -> Result<&Procedure, AssemblerError> {
+    ) -> Result<&Procedure, AssemblyError> {
         // if the procedure is already in the procedure cache, return it
         if let Some(p) = self.proc_cache.get(proc_id) {
             return Ok(p);
@@ -304,14 +304,15 @@ impl Assembler {
         let module = self
             .module_provider
             .get_module(proc_id)
-            .ok_or_else(|| AssemblerError::undefined_imported_proc(proc_id))?;
+            .ok_or_else(|| AssemblyError::imported_proc_module_not_found(proc_id))?;
         self.compile_module(&module, module.path(), context)?;
 
-        // then, get the procedure out of the procedure cache and return
-        let proc = self
-            .proc_cache
-            .get(proc_id)
-            .expect("compiled imported procedure not in procedure cache");
+        // then, get the procedure out of the procedure cache and return; if the procedure
+        // cannot be found in the cache, it is possible that the procedure was not in the
+        // module returned from the module provider
+        let proc = self.proc_cache.get(proc_id).ok_or_else(|| {
+            AssemblyError::imported_proc_not_found_in_module(proc_id, module.path())
+        })?;
         Ok(proc)
     }
 }

--- a/assembly/src/assembler/span_builder.rs
+++ b/assembly/src/assembler/span_builder.rs
@@ -1,5 +1,5 @@
 use super::{
-    AssemblerError, BodyWrapper, Borrow, CodeBlock, Decorator, DecoratorList, Instruction,
+    AssemblyError, BodyWrapper, Borrow, CodeBlock, Decorator, DecoratorList, Instruction,
     Operation, ToString, Vec,
 };
 use vm_core::AssemblyOp;
@@ -46,13 +46,13 @@ impl SpanBuilder {
     // --------------------------------------------------------------------------------------------
 
     /// Adds the specified operation to the list of span operations and returns Ok(None).
-    pub fn add_op(&mut self, op: Operation) -> Result<Option<CodeBlock>, AssemblerError> {
+    pub fn add_op(&mut self, op: Operation) -> Result<Option<CodeBlock>, AssemblyError> {
         self.ops.push(op);
         Ok(None)
     }
 
     /// Adds the specified sequence operations to the list of span operations and returns Ok(None).
-    pub fn add_ops<I, O>(&mut self, ops: I) -> Result<Option<CodeBlock>, AssemblerError>
+    pub fn add_ops<I, O>(&mut self, ops: I) -> Result<Option<CodeBlock>, AssemblyError>
     where
         I: IntoIterator<Item = O>,
         O: Borrow<Operation>,
@@ -93,7 +93,7 @@ impl SpanBuilder {
     pub fn add_decorator(
         &mut self,
         decorator: Decorator,
-    ) -> Result<Option<CodeBlock>, AssemblerError> {
+    ) -> Result<Option<CodeBlock>, AssemblyError> {
         self.push_decorator(decorator);
         Ok(None)
     }

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -1,4 +1,4 @@
-use super::{ProcedureId, String, ToString, Token};
+use super::{ProcedureId, String, ToString, Token, Vec};
 use core::fmt;
 
 // ASSEMBLY ERROR

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -25,7 +25,7 @@ mod tokens;
 use tokens::{Token, TokenStream};
 
 mod errors;
-pub use errors::{AssemblerError, LibraryError, ParsingError};
+pub use errors::{AssemblyError, LibraryError, ParsingError};
 
 mod assembler;
 pub use assembler::Assembler;

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -346,14 +346,14 @@ fn invalid_program() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "source code cannot be an empty string");
+        assert_eq!(error.to_string(), "source code cannot be an empty string");
     }
 
     let source = " ";
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "source code cannot be an empty string");
+        assert_eq!(error.to_string(), "source code cannot be an empty string");
     }
 
     let source = "none";
@@ -361,7 +361,7 @@ fn invalid_program() {
     assert!(program.is_err());
     if let Err(error) = program {
         assert_eq!(
-            error.message(),
+            error.to_string(),
             "unexpected token: expected 'begin' but was 'none'"
         );
     }
@@ -370,7 +370,7 @@ fn invalid_program() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "begin without matching end");
+        assert_eq!(error.to_string(), "begin without matching end");
     }
 
     let source = "begin end";
@@ -378,7 +378,7 @@ fn invalid_program() {
     assert!(program.is_err());
     if let Err(error) = program {
         assert_eq!(
-            error.message(),
+            error.to_string(),
             "a code block must contain at least one instruction"
         );
     }
@@ -387,7 +387,7 @@ fn invalid_program() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "dangling instructions after program end");
+        assert_eq!(error.to_string(), "dangling instructions after program end");
     }
 }
 
@@ -400,7 +400,7 @@ fn invalid_proc() {
     assert!(program.is_err());
     if let Err(error) = program {
         assert_eq!(
-            error.message(),
+            error.to_string(),
             "unexpected body termination: invalid token 'begin'"
         );
     }
@@ -410,7 +410,7 @@ fn invalid_proc() {
     assert!(program.is_err());
     if let Err(error) = program {
         assert_eq!(
-            error.message(),
+            error.to_string(),
             "unexpected body termination: invalid token 'proc.bar'"
         );
     }
@@ -419,21 +419,21 @@ fn invalid_proc() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "undefined procedure: bar");
+        assert_eq!(error.to_string(), "undefined procedure: bar");
     }
 
     let source = "proc.123 add mul end begin push.1 exec.123 end";
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "invalid procedure label: 123");
+        assert_eq!(error.to_string(), "invalid procedure label: 123");
     }
 
     let source = "proc.foo add mul end proc.foo push.3 end begin push.1 end";
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "duplicate procedure label: foo");
+        assert_eq!(error.to_string(), "duplicate procedure label: foo");
     }
 }
 
@@ -446,7 +446,7 @@ fn invalid_if_else() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "if without matching else/end");
+        assert_eq!(error.to_string(), "if without matching else/end");
     }
 
     // --- unmatched else -------------------------------------------------------------------------
@@ -454,28 +454,28 @@ fn invalid_if_else() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "else without matching if");
+        assert_eq!(error.to_string(), "else without matching if");
     }
 
     let source = "begin push.1 while.true add else mul end end";
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "else without matching if");
+        assert_eq!(error.to_string(), "else without matching if");
     }
 
     let source = "begin push.1 if.true add else mul else push.1 end end end";
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "else without matching if");
+        assert_eq!(error.to_string(), "else without matching if");
     }
 
     let source = "begin push.1 add if.true mul else add";
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "else without matching end");
+        assert_eq!(error.to_string(), "else without matching end");
     }
 }
 
@@ -488,7 +488,7 @@ fn invalid_repeat() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "repeat without matching end");
+        assert_eq!(error.to_string(), "repeat without matching end");
     }
 
     // invalid iter count
@@ -497,7 +497,7 @@ fn invalid_repeat() {
     assert!(program.is_err());
     if let Err(error) = program {
         assert_eq!(
-            error.message(),
+            error.to_string(),
             "malformed instruction `repeat.23x3`: parameter '23x3' is invalid"
         );
     }
@@ -512,7 +512,7 @@ fn invalid_while() {
     assert!(program.is_err());
     if let Err(error) = program {
         assert_eq!(
-            error.message(),
+            error.to_string(),
             "malformed instruction 'while': missing required parameter"
         );
     }
@@ -522,7 +522,7 @@ fn invalid_while() {
     assert!(program.is_err());
     if let Err(error) = program {
         assert_eq!(
-            error.message(),
+            error.to_string(),
             "malformed instruction `while.abc`: parameter 'abc' is invalid"
         );
     }
@@ -531,6 +531,6 @@ fn invalid_while() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.message(), "while without matching end");
+        assert_eq!(error.to_string(), "while without matching end");
     }
 }

--- a/miden/src/lib.rs
+++ b/miden/src/lib.rs
@@ -4,7 +4,7 @@
 // ================================================================================================
 
 pub use air::{FieldExtension, HashFunction, ProofOptions};
-pub use assembly::{Assembler, AssemblerError, ParsingError};
+pub use assembly::{Assembler, AssemblyError, ParsingError};
 pub use processor::{
     execute, execute_iter, AsmOpInfo, ExecutionError, ExecutionTrace, VmState, VmStateIterator,
 };

--- a/miden/src/main.rs
+++ b/miden/src/main.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+use miden::{AssemblyError, ExecutionError};
 use structopt::StructOpt;
 
 mod cli;
@@ -50,5 +52,24 @@ pub fn main() {
     // execute cli action
     if let Err(error) = cli.execute() {
         println!("{}", error);
+    }
+}
+
+// PROGRAM ERROR
+// ================================================================================================
+
+/// This is used to specify the error type returned from analyze.
+#[derive(Debug)]
+pub enum ProgramError {
+    AssemblyError(AssemblyError),
+    ExecutionError(ExecutionError),
+}
+
+impl fmt::Display for ProgramError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProgramError::AssemblyError(e) => write!(f, "Assembly Error: {:?}", e),
+            ProgramError::ExecutionError(e) => write!(f, "Execution Error: {:?}", e),
+        }
     }
 }

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -1,7 +1,7 @@
-use air::StarkField;
-use processor::{ExecutionError, Process};
+use super::ProgramError;
+use processor::Process;
 use rustyline::{error::ReadlineError, Editor};
-use vm_core::{Felt, ProgramInputs, Word};
+use vm_core::{Felt, ProgramInputs, StarkField, Word};
 
 /// This work is in continuation to the amazing work done by team `Scribe`
 /// [here](https://github.com/ControlCplusControlV/Scribe/blob/main/transpiler/src/repl.rs#L8)
@@ -259,17 +259,17 @@ pub fn start_repl() {
 /// Compiles and executes a compiled Miden program, returning the stack, memory and any Miden errors.
 /// The program is passed in as a String, passed to the Miden Assembler, and then passed into the Miden
 /// Processor to be executed.
-fn execute(program: String) -> Result<(Vec<(u64, Word)>, Vec<Felt>), MidenError> {
+fn execute(program: String) -> Result<(Vec<(u64, Word)>, Vec<Felt>), ProgramError> {
     let program = assembly::Assembler::new()
         .compile(&program)
-        .map_err(MidenError::AssemblyError)?;
+        .map_err(ProgramError::AssemblyError)?;
 
     let pub_inputs = vec![];
     let inputs = ProgramInputs::new(&pub_inputs, &[], vec![]).unwrap();
     let mut process = Process::new_debug(program.kernel(), inputs);
     let _program_outputs = process
         .execute(&program)
-        .map_err(MidenError::ExecutionError);
+        .map_err(ProgramError::ExecutionError);
 
     let (sys, _, stack, _, chiplets) = process.to_components();
 
@@ -280,13 +280,6 @@ fn execute(program: String) -> Result<(Vec<(u64, Word)>, Vec<Felt>), MidenError>
     let stack_state = stack.get_state_at(sys.clk());
 
     Ok((mem, stack_state))
-}
-
-/// Errors that are returned from the Miden processor during execution.
-#[derive(Debug)]
-pub enum MidenError {
-    AssemblyError(assembly::ParsingError),
-    ExecutionError(ExecutionError),
 }
 
 /// Parses the address in integer form from "!mem[addr]" command, otherwise throws an error.

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -1,8 +1,7 @@
-use super::cli::InputFile;
-use assembly::ParsingError;
+use super::{cli::InputFile, ProgramError};
 use core::fmt;
 use miden::Assembler;
-use processor::{AsmOpInfo, ExecutionError};
+use processor::AsmOpInfo;
 use std::path::PathBuf;
 use stdlib::StdLibrary;
 use structopt::StructOpt;
@@ -161,25 +160,6 @@ pub fn analyze(program: &str, inputs: ProgramInputs) -> Result<ProgramInfo, Prog
     }
 
     Ok(program_info)
-}
-
-// PROGRAM ERROR
-// ================================================================================================
-
-/// This is used to specify the error type returned from analyze.
-#[derive(Debug)]
-pub enum ProgramError {
-    AssemblyError(ParsingError),
-    ExecutionError(ExecutionError),
-}
-
-impl fmt::Display for ProgramError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ProgramError::AssemblyError(e) => write!(f, "Assembly Error: {:?}", e),
-            ProgramError::ExecutionError(e) => write!(f, "Execution Error: {:?}", e),
-        }
-    }
 }
 
 // ASMOP STATS

--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -792,7 +792,7 @@ fn u32checked_div_b_fail() {
 
     // should fail during compilation if b = 0.
     let test = build_op_test!(build_asm_op(0).as_str());
-    test.expect_error(TestError::AssemblyError("division by zero"));
+    test.expect_error(TestError::AssemblyError("DivisionByZero"));
 }
 
 #[test]
@@ -885,7 +885,7 @@ fn u32checked_mod_b_fail() {
 
     // should fail during compilation if b = 0.
     let test = build_op_test!(build_asm_op(0).as_str());
-    test.expect_error(TestError::AssemblyError("division by zero"));
+    test.expect_error(TestError::AssemblyError("DivisionByZero"));
 }
 
 #[test]
@@ -980,7 +980,7 @@ fn u32checked_divmod_b_fail() {
 
     // should fail during compilation if b = 0.
     let test = build_op_test!(build_asm_op(0).as_str());
-    test.expect_error(TestError::AssemblyError("division by zero"));
+    test.expect_error(TestError::AssemblyError("DivisionByZero"));
 }
 
 #[test]


### PR DESCRIPTION
This PR refactors `AssemblerError` as follows:

- Change `AssemblerError` from struct into an enum.
- Rename `AssemblerError` into `AssemblyError`.
- Add more info to some error variants.

This PR also fixes a couple of small errors in Miden executable to make it compile and run.