### PR TITLE
refactor: assembly ops impls for crypto, u32 and env

### DIFF
--- a/assembly/src/assembler/instruction/env_ops.rs
+++ b/assembly/src/assembler/instruction/env_ops.rs
@@ -59,6 +59,5 @@ pub fn caller(
     if !context.is_kernel() {
         return Err(AssemblyError::caller_out_of_kernel());
     }
-
     span.add_op(Caller)
 }


### PR DESCRIPTION
This PR reorganizes some of the instructions implementations and move repeated code into helpers