### PR TITLE
Fix: u32add and upper bits agg constraint

### DIFF
--- a/air/src/stack/u32_ops/tests.rs
+++ b/air/src/stack/u32_ops/tests.rs
@@ -87,6 +87,51 @@ proptest! {
     }
 }
 
+#[test]
+fn test_u32add_fail() {
+    let a = 3445447666_u32;
+    let b = 1013904242_u32;
+    let mut frame = generate_evaluation_frame(Operation::U32add.op_code() as usize);
+
+    // the sum of a and b is splitted into two 32-bit limbs.
+    let (hi, lo) = split_element(Felt::new(a.into()) + Felt::new(b.into()));
+
+    // Set the output. First and second element in the next frame should be the
+    // upper and lower 32-bit limb of the sum of the first two elements in the current trace.
+    frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(a.into());
+    frame.current_mut()[STACK_TRACE_OFFSET + 1] = Felt::new(b.into());
+    frame.next_mut()[STACK_TRACE_OFFSET] = hi;
+    frame.next_mut()[STACK_TRACE_OFFSET + 1] = lo;
+
+    let (t1, t0) = split_u32_into_u16(lo.as_int());
+
+    // set the helper registers in the decoder.
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET] = Felt::new(t0 as u64);
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 1] = Felt::new(t1 as u64);
+    // ZERO is being passed as `hi` while doing range check and setting the value of upper 32-bit helper registers.
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 2] = ZERO;
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 3] = ZERO;
+    frame.current_mut()[DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + 4] = ZERO;
+
+    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+
+    let result = get_constraint_evaluation(frame);
+
+    // The aggregation of the upper 16-bits should not match when the sum overflows a 32-bit number.
+    assert_ne!(expected[2], result[2]);
+
+    // The aggregation of the least three significant limbs from the helper registers should should satisfy
+    // u32add air constraint as the 3rd least significant limb coefficient is set to 0.
+    assert_ne!(expected[4], result[4]);
+
+    // Rest all constraints should be good.
+    for i in 0..NUM_CONSTRAINTS {
+        if i != 2 && i != 4 {
+            assert_eq!(expected[i], result[i]);
+        }
+    }
+}
+
 // TEST HELPERS
 // ================================================================================================
 

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -16,6 +16,9 @@ use vm_core::{
 mod trace;
 use trace::DecoderTrace;
 
+#[cfg(test)]
+use vm_core::decoder::NUM_USER_OP_HELPERS;
+
 mod block_stack;
 use block_stack::{BlockInfo, BlockStack, BlockType, ExecutionContextInfo};
 
@@ -753,6 +756,12 @@ impl Decoder {
     #[cfg(test)]
     pub fn add_dummy_trace_row(&mut self) {
         self.trace.add_dummy_row();
+    }
+
+    /// Returns a list of all the helper registers set during an operation.
+    #[cfg(test)]
+    pub fn get_user_op_helpers(&self) -> [Felt; NUM_USER_OP_HELPERS] {
+        self.trace.get_user_op_helpers()
     }
 }
 

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -7,6 +7,9 @@ use crate::utils::get_trace_len;
 use core::ops::Range;
 use vm_core::utils::new_array_vec;
 
+#[cfg(test)]
+use vm_core::decoder::NUM_USER_OP_HELPERS;
+
 // CONSTANTS
 // ================================================================================================
 
@@ -512,6 +515,18 @@ impl DecoderTrace {
         }
         self.group_count_trace.push(ZERO);
         self.op_idx_trace.push(ZERO);
+    }
+
+    /// Fetches all the helper registers from the trace.
+    #[cfg(test)]
+    pub fn get_user_op_helpers(&self) -> [Felt; NUM_USER_OP_HELPERS] {
+        let mut result = [ZERO; NUM_USER_OP_HELPERS];
+        for (idx, helper) in result.iter_mut().enumerate() {
+            *helper = *self.hasher_trace[USER_OP_HELPERS.start + idx]
+                .last()
+                .expect("no last helper value");
+        }
+        result
     }
 }
 


### PR DESCRIPTION
## Describe your changes
This PR addresses #510. I've tried to reproduce the error by writing a failed unit test. The issue seems to be how the upper bits are aggregated and updated in helper registers in the `u32add` operation. Here is a brief explanation of why we are having this issue:
The processor splits the sum of the top two elements into two 32-bit limbs and sents both for range check. In the case of `u32add`, instead of sending the `hi` 32-bit limb, it sends a ZERO, due to which the top two most significant bits in the user helper register are being set to ZERO. When the sum of the two top elements of the stack overflows an u32, we will have the issue. 
The unit tests used the `hi` as the second most significant in the helper register, due to which they were not failing. If we set the second most significant helper register to ZERO, we will see the same error.

We can make the processor send the value of `hi` for range check, which will fix this issue. I'll send it in the next PR once the current one gets merged. 

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.