### PR TITLE
ExpImm and ExpBitLength assembly serialization fix

### DIFF
--- a/assembly/src/parsers/serde/serialization.rs
+++ b/assembly/src/parsers/serde/serialization.rs
@@ -162,11 +162,11 @@ impl Serializable for Instruction {
             Self::Pow2 => target.write_opcode(OpCode::Pow2),
             Self::Exp => target.write_opcode(OpCode::Exp),
             Self::ExpImm(v) => {
-                target.write_opcode(OpCode::Exp);
+                target.write_opcode(OpCode::ExpImm);
                 target.write_felt(*v);
             }
             Self::ExpBitLength(v) => {
-                target.write_opcode(OpCode::Exp);
+                target.write_opcode(OpCode::ExpBitLength);
                 target.write_u8(*v);
             }
             Self::Not => target.write_opcode(OpCode::Not),


### PR DESCRIPTION
## Describe your changes
This PR introduce a fix for #553. 

The ExpImm and ExpBitLength instructions were not using their respective opcode during serialization, causing a few tests in #553 to fail. This PR rectifies this issue, and the correct opcode is assigned to both.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.