### PR TITLE
refactor(assembly): library trait to provide ast modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,27 @@ on:
     types: [opened, repoened, synchronize]
 
 jobs:
+  check:
+    name: Check Rust ${{matrix.toolchain}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@main
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+      - name: Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-targets
+
   test:
     name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
     runs-on: ${{matrix.os}}-latest

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -1,12 +1,16 @@
 use super::{
     parsers::{self, Instruction, Node, ProcedureAst, ProgramAst},
-    AssemblyError, BTreeMap, Box, CallSet, CodeBlock, CodeBlockTable, Felt, Kernel, ModuleAst,
-    ModuleProvider, Operation, Procedure, ProcedureId, Program, String, ToString, Vec, ONE, ZERO,
+    AbsolutePath, AssemblyError, BTreeMap, CallSet, CodeBlock, CodeBlockTable, Felt, Kernel,
+    Library, LibraryError, Module, ModuleAst, Operation, Procedure, ProcedureId, Program, String,
+    ToString, Vec, ONE, ZERO,
 };
 use core::{borrow::Borrow, cell::RefCell};
 use vm_core::{utils::group_vector_elements, Decorator, DecoratorList};
 
 mod instruction;
+
+mod module_provider;
+use module_provider::ModuleProvider;
 
 mod span_builder;
 use span_builder::SpanBuilder;
@@ -30,12 +34,9 @@ type ProcedureCache = BTreeMap<ProcedureId, Procedure>;
 /// - If `with_kernel()` or `with_kernel_module()` methods are not used, the assembler will be
 ///   instantiated with a default empty kernel. Programs compiled using such assembler
 ///   cannot make calls to kernel procedures via `syscall` instruction.
-/// - If `with_module_provider()` method is not used, the assembler will be instantiated without
-///   access to external libraries. Programs compiled with such assembler must be self-contained
-///   (i.e., they cannot invoke procedures from external libraries).
 pub struct Assembler {
     kernel: Kernel,
-    module_provider: Box<dyn ModuleProvider>,
+    module_provider: ModuleProvider,
     proc_cache: RefCell<ProcedureCache>,
     in_debug_mode: bool,
 }
@@ -47,7 +48,7 @@ impl Assembler {
     pub fn new() -> Self {
         Self {
             kernel: Kernel::default(),
-            module_provider: Box::new(()),
+            module_provider: Default::default(),
             proc_cache: Default::default(),
             in_debug_mode: false,
         }
@@ -59,13 +60,23 @@ impl Assembler {
         self
     }
 
-    /// Adds the specified [ModuleProvider] to the assembler.
-    pub fn with_module_provider<P>(mut self, provider: P) -> Self
+    /// Adds the library to provide modules for the compilation.
+    pub fn with_library<L>(mut self, library: &L) -> Result<Self, AssemblyError>
     where
-        P: ModuleProvider + 'static,
+        L: Library,
     {
-        self.module_provider = Box::new(provider);
-        self
+        self.module_provider.add_library(library)?;
+        Ok(self)
+    }
+
+    /// Adds a library bundle to provide modules for the compilation.
+    pub fn with_libraries<I, L, LB>(self, mut libraries: I) -> Result<Self, AssemblyError>
+    where
+        L: Library,
+        LB: Borrow<L>,
+        I: Iterator<Item = L>,
+    {
+        libraries.try_fold(self, |slf, library| slf.with_library(library.borrow()))
     }
 
     /// Sets the kernel for the assembler to the kernel defined by the provided source.
@@ -77,17 +88,18 @@ impl Assembler {
     /// Panics if the assembler has already been used to compile programs.
     pub fn with_kernel(self, kernel_source: &str) -> Result<Self, AssemblyError> {
         let kernel_ast = parsers::parse_module(kernel_source)?;
-        self.with_kernel_module(&kernel_ast)
+        self.with_kernel_module(kernel_ast)
     }
 
     /// Sets the kernel for the assembler to the kernel defined by the provided module.
     ///
     /// # Errors
     /// Returns an error if compiling kernel source results in an error.
-    pub fn with_kernel_module(mut self, module: &ModuleAst) -> Result<Self, AssemblyError> {
+    pub fn with_kernel_module(mut self, module: ModuleAst) -> Result<Self, AssemblyError> {
         // compile the kernel; this adds all exported kernel procedures to the procedure cache
         let mut context = AssemblyContext::new(true);
-        self.compile_module(module, ProcedureId::KERNEL_PATH, &mut context)?;
+        let kernel = Module::kernel(module);
+        self.compile_module(&kernel, &mut context)?;
 
         // convert the context into Kernel; this builds the kernel from hashes of procedures
         // exported form the kernel module
@@ -155,14 +167,13 @@ impl Assembler {
     /// Compiles all procedures in the specified module and adds them to the procedure cache.
     fn compile_module(
         &self,
-        module: &ModuleAst,
-        module_path: &str,
+        module: &Module,
         context: &mut AssemblyContext,
     ) -> Result<(), AssemblyError> {
         // compile all procedures in the module; once the compilation is complete, we get all
         // compiled procedures (and their combined callset) from the context
-        context.begin_module(module_path)?;
-        for proc_ast in module.local_procs.iter() {
+        context.begin_module(&module.path)?;
+        for proc_ast in module.ast.local_procs.iter() {
             self.compile_procedure(proc_ast, context)?;
         }
         let (module_procs, module_callset) = context.complete_module();
@@ -310,13 +321,13 @@ impl Assembler {
                 .module_provider
                 .get_module(proc_id)
                 .ok_or_else(|| AssemblyError::imported_proc_module_not_found(proc_id))?;
-            self.compile_module(&module, module.path(), context)?;
+            self.compile_module(module, context)?;
 
             // if the procedure is still not in cache, then there was some error
             if !self.proc_cache.borrow().contains_key(proc_id) {
                 return Err(AssemblyError::imported_proc_not_found_in_module(
                     proc_id,
-                    module.path(),
+                    &module.path,
                 ));
             }
         }
@@ -408,10 +419,7 @@ pub fn combine_spans(spans: &mut Vec<CodeBlock>) -> CodeBlock {
                 ops.extend_from_slice(batch.ops());
             }
         } else {
-            panic!(
-                "Codeblock was expected to be a Span Block, got {:?}.",
-                block
-            );
+            panic!("Codeblock was expected to be a Span Block, got {block:?}.",);
         }
     });
     CodeBlock::new_span_with_decorators(ops, decorators)

--- a/assembly/src/assembler/module_provider.rs
+++ b/assembly/src/assembler/module_provider.rs
@@ -1,0 +1,62 @@
+use super::{BTreeMap, Library, LibraryError, Module, ProcedureId, Vec};
+
+// MODULE PROVIDER
+// ================================================================================================
+
+/// A module provider contains all modules from libraries available to a given assembler. It is
+/// used during compilation to resolve references to imported procedures.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ModuleProvider {
+    modules: Vec<Module>,
+    /// Map from procedure id to the index of a module in which the procedure is defined.
+    procedures: BTreeMap<ProcedureId, usize>,
+}
+
+impl ModuleProvider {
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Fetch a module that contains the provided procedure id.
+    pub fn get_module(&self, id: &ProcedureId) -> Option<&Module> {
+        // this will panic only if there is a bug in `Self::add_module`.
+        self.procedures.get(id).map(|i| &self.modules[*i])
+    }
+
+    // MODULE AND LIBRARY MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Adds the provided module to this module provider.
+    ///
+    /// # Errors
+    ///
+    /// Will error if there is a duplicated module path.
+    fn add_module(&mut self, module: Module) -> Result<(), LibraryError> {
+        if self.modules.iter().any(|m| module.path == m.path) {
+            return Err(LibraryError::duplicate_module_path(&module.path));
+        }
+        let module_idx = self.modules.len();
+        module.ast.local_procs.iter().for_each(|proc| {
+            let proc_name = proc.name.to_absolute(&module.path);
+            let proc_id = ProcedureId::from(&proc_name);
+            self.procedures.insert(proc_id, module_idx);
+        });
+        self.modules.push(module);
+        Ok(())
+    }
+
+    /// Adds all modules from the provided library to this module provider.
+    ///
+    /// # Errors
+    ///
+    /// Will error if there is a duplicated module path.
+    pub fn add_library<L>(&mut self, library: &L) -> Result<(), LibraryError>
+    where
+        L: Library,
+    {
+        let namespace = library.root_ns();
+        library.modules().try_for_each(|module| {
+            module.check_namespace(namespace)?;
+            self.add_module(module.clone())
+        })
+    }
+}

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -4,24 +4,22 @@
 #[macro_use]
 extern crate alloc;
 
+use core::{cmp::Ordering, ops::Deref};
 use vm_core::{
     code_blocks::CodeBlock,
     utils::{
         collections::{BTreeMap, BTreeSet, Vec},
         string::{String, ToString},
-        Box,
     },
     CodeBlockTable, Felt, Kernel, Operation, Program, StarkField, ONE, ZERO,
 };
 
 mod procedures;
-pub use procedures::ProcedureId;
 use procedures::{CallSet, Procedure};
+pub use procedures::{ProcedureId, ProcedureName};
 
 mod parsers;
-pub use parsers::{
-    parse_module, parse_program, ModuleAst, NamedModuleAst, ProcedureAst, ProgramAst,
-};
+pub use parsers::{parse_module, parse_program, ModuleAst, ProcedureAst, ProgramAst};
 
 mod tokens;
 use tokens::{Token, TokenStream};
@@ -68,39 +66,244 @@ const MAX_PROC_NAME_LEN: u8 = 100;
 /// input is provided to `push` masm operation without period separators.
 const HEX_CHUNK_SIZE: usize = 16;
 
-// MODULE PROVIDER
+// TYPE-SAFE PATHS
 // ================================================================================================
 
-/// The module provider is now a simplified version of a module cache. It is expected to evolve to
-/// a general solution for the module lookup.
-pub trait ModuleProvider {
-    /// Fetch a module AST from its ID
-    fn get_module(&self, id: &ProcedureId) -> Option<NamedModuleAst<'_>>;
+/// Absolute path of a module or a procedure.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AbsolutePath {
+    path: String,
 }
 
-// A default provider that won't resolve modules
-impl ModuleProvider for () {
-    fn get_module(&self, _id: &ProcedureId) -> Option<NamedModuleAst<'_>> {
-        None
+impl AbsolutePath {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+
+    /// Base kernel path
+    // TODO better use `MODULE_PATH_DELIM`. maybe require `const_format` crate?
+    pub const KERNEL_PATH: &str = "::sys";
+
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Create a new absolute path without checking its integrity.
+    pub(crate) fn new_unchecked(path: String) -> Self {
+        Self { path }
+    }
+
+    pub fn kernel_path() -> Self {
+        Self {
+            path: Self::KERNEL_PATH.into(),
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Label of the path.
+    ///
+    /// Will be the rightmost token separated by [`MODULE_PATH_DELIM`].
+    pub fn label(&self) -> &str {
+        self.path
+            .rsplit_once(MODULE_PATH_DELIM)
+            .expect("a valid absolute path should always have a namespace separator")
+            .1
+    }
+
+    /// Namespace of the path.
+    ///
+    /// Will be the leftmost token separated by [`MODULE_PATH_DELIM`].
+    pub fn namespace(&self) -> &str {
+        self.path
+            .split_once(MODULE_PATH_DELIM)
+            .expect("a valid absolute path should always have a namespace separator")
+            .0
+    }
+}
+
+impl From<&AbsolutePath> for ProcedureId {
+    fn from(path: &AbsolutePath) -> Self {
+        ProcedureId::new(path)
+    }
+}
+
+impl Deref for AbsolutePath {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
+    }
+}
+
+impl AsRef<str> for AbsolutePath {
+    fn as_ref(&self) -> &str {
+        &self.path
+    }
+}
+
+/// Library namespace.
+///
+/// Will be `std` in the absolute procedure name `std::foo::bar::baz`.
+///
+/// # Type-safety
+///
+/// It is achieved as any instance of this type can be created only via the checked
+/// [`Self::try_from`]. A valid library namespace cannot contain a [`MODULE_PATH_DELIM`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LibraryNamespace {
+    name: String,
+}
+
+impl TryFrom<String> for LibraryNamespace {
+    type Error = LibraryError;
+
+    fn try_from(name: String) -> Result<Self, Self::Error> {
+        if name.contains(MODULE_PATH_DELIM) {
+            return Err(LibraryError::library_name_with_delimiter(&name));
+        }
+        Ok(Self { name })
+    }
+}
+
+impl Deref for LibraryNamespace {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.name
+    }
+}
+
+impl AsRef<str> for LibraryNamespace {
+    fn as_ref(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Module path relative to a namespace.
+///
+/// Will be `foo::bar` in the absolute procedure name `std::foo::bar::baz`.
+///
+/// # Type-safety
+///
+/// It is achieved as any instance of this type can be created only via the checked
+/// [`Self::try_from`]. A valid module path cannot start or end with [`MODULE_PATH_DELIM`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ModulePath {
+    path: String,
+}
+
+impl ModulePath {
+    // TYPE-SAFE TRANSFORMATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Append the module path to a library namespace.
+    pub fn to_absolute(&self, library: &LibraryNamespace) -> AbsolutePath {
+        let delimiter = if self.path.is_empty() {
+            ""
+        } else {
+            MODULE_PATH_DELIM
+        };
+        AbsolutePath::new_unchecked(format!("{}{delimiter}{}", library.as_str(), &self.path))
+    }
+}
+
+impl TryFrom<String> for ModulePath {
+    type Error = LibraryError;
+
+    fn try_from(path: String) -> Result<Self, Self::Error> {
+        if path.starts_with(MODULE_PATH_DELIM) {
+            return Err(LibraryError::module_path_starts_with_delimiter(&path));
+        } else if path.ends_with(MODULE_PATH_DELIM) {
+            return Err(LibraryError::module_path_ends_with_delimiter(&path));
+        }
+        Ok(Self { path })
+    }
+}
+
+impl Deref for ModulePath {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.path
+    }
+}
+
+impl AsRef<str> for ModulePath {
+    fn as_ref(&self) -> &str {
+        &self.path
     }
 }
 
 // LIBRARY
 // ================================================================================================
 
-/// TODO: add docs
+/// A library definition that provides AST modules for the compilation process.
+///
+/// Its `IntoIterator` implementation will be used to provide the modules to the assembler.
 pub trait Library {
-    type Module;
+    type ModuleIterator<'a>: Iterator<Item = &'a Module>
+    where
+        Self: 'a;
 
     /// Returns the root namespace of this library.
-    fn root_ns(&self) -> &str;
+    fn root_ns(&self) -> &LibraryNamespace;
 
     /// Returns the version number of this library.
+    // TODO should have a SEMVER well-formed struct instead of raw string.
     fn version(&self) -> &str;
 
-    /// Returns the module located at the specified path.
-    ///
-    /// # Errors
-    /// Returns an error if the modules for the specified path does not exist in this library.
-    fn get_module(&self, module_path: &str) -> Result<&Self::Module, LibraryError>;
+    /// Iterate the modules available in the library.
+    fn modules(&self) -> Self::ModuleIterator<'_>;
+}
+
+// MODULE
+// ================================================================================================
+
+/// A module containing its absolute path and parsed AST.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Module {
+    /// Absolute path of the module.
+    pub path: AbsolutePath,
+    /// Parsed AST of the module.
+    pub ast: ModuleAst,
+}
+
+impl Module {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Create a new module from a path and ast.
+    pub const fn new(path: AbsolutePath, ast: ModuleAst) -> Self {
+        Self { path, ast }
+    }
+
+    /// Create a new kernel module from a AST using the constant [`AbsolutePath::kernel_path`].
+    pub fn kernel(ast: ModuleAst) -> Self {
+        Self {
+            path: AbsolutePath::kernel_path(),
+            ast,
+        }
+    }
+
+    // VALIDATIONS
+    // --------------------------------------------------------------------------------------------
+
+    /// Validate if the module belongs to the provided namespace.
+    pub fn check_namespace(&self, namespace: &LibraryNamespace) -> Result<(), LibraryError> {
+        (self.path.namespace() == namespace.as_str())
+            .then_some(())
+            .ok_or(LibraryError::EmptyProcedureName)
+    }
+}
+
+impl PartialOrd for Module {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.path.partial_cmp(&other.path)
+    }
+}
+
+impl Ord for Module {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.path.cmp(&other.path)
+    }
 }

--- a/assembly/src/parsers/context.rs
+++ b/assembly/src/parsers/context.rs
@@ -214,7 +214,7 @@ impl ParserContext {
                         return Err(ParsingError::proc_export_not_allowed(token, &label));
                     }
 
-                    if self.local_procs.contains_key(&label) {
+                    if self.local_procs.contains_key(label.as_ref()) {
                         return Err(ParsingError::duplicate_proc_label(token, &label));
                     }
 

--- a/assembly/src/parsers/field_ops.rs
+++ b/assembly/src/parsers/field_ops.rs
@@ -108,7 +108,7 @@ pub fn parse_exp(op: &Token) -> Result<Node, ParsingError> {
                     return Err(ParsingError::invalid_param_with_reason(
                         op,
                         1,
-                        format!("parameter can at max be a u64 but found u{}", bits_len).as_str(),
+                        format!("parameter can at max be a u64 but found u{bits_len}").as_str(),
                     ));
                 }
 

--- a/assembly/src/parsers/nodes.rs
+++ b/assembly/src/parsers/nodes.rs
@@ -520,7 +520,7 @@ impl fmt::Display for Instruction {
 fn display_push_vec<T: fmt::Display>(f: &mut fmt::Formatter<'_>, values: &[T]) -> fmt::Result {
     write!(f, "push")?;
     for elem in values {
-        write!(f, ".{}", elem)?;
+        write!(f, ".{elem}")?;
     }
     Ok(())
 }

--- a/assembly/src/parsers/tests.rs
+++ b/assembly/src/parsers/tests.rs
@@ -106,7 +106,7 @@ fn test_ast_parsing_program_proc() {
         (
             0,
             ProcedureAst {
-                name: String::from("foo"),
+                name: String::from("foo").try_into().unwrap(),
                 docs: None,
                 is_export: false,
                 num_locals: 1,
@@ -120,7 +120,7 @@ fn test_ast_parsing_program_proc() {
         (
             1,
             ProcedureAst {
-                name: String::from("bar"),
+                name: String::from("bar").try_into().unwrap(),
                 docs: None,
                 is_export: false,
                 num_locals: 2,
@@ -148,7 +148,7 @@ fn test_ast_parsing_module() {
         (
             0,
             ProcedureAst {
-                name: String::from("foo"),
+                name: String::from("foo").try_into().unwrap(),
                 docs: None,
                 is_export: true,
                 num_locals: 1,
@@ -255,7 +255,7 @@ fn test_ast_parsing_module_nested_if() {
         (
             0,
             ProcedureAst {
-                name: String::from("foo"),
+                name: String::from("foo").try_into().unwrap(),
                 docs: None,
                 is_export: false,
                 num_locals: 0,
@@ -324,7 +324,7 @@ fn test_ast_parsing_module_sequential_if() {
         (
             0,
             ProcedureAst {
-                name: String::from("foo"),
+                name: String::from("foo").try_into().unwrap(),
                 docs: None,
                 is_export: false,
                 num_locals: 0,
@@ -357,7 +357,7 @@ fn test_ast_parsing_simple_docs() {
     let proc_body_foo: Vec<Node> = vec![Node::Instruction(Instruction::LocLoad(0))];
     let docs_foo = "proc doc".to_string();
     let procedure = ProcedureAst {
-        name: String::from("foo"),
+        name: String::from("foo").try_into().unwrap(),
         docs: Some(docs_foo),
         is_export: true,
         num_locals: 1,
@@ -413,7 +413,7 @@ of the comments is correctly parsed. There was a bug here earlier."
         (
             0,
             ProcedureAst {
-                name: String::from("foo"),
+                name: String::from("foo").try_into().unwrap(),
                 docs: Some(docs_foo),
                 is_export: true,
                 num_locals: 1,
@@ -428,7 +428,7 @@ of the comments is correctly parsed. There was a bug here earlier."
         (
             1,
             ProcedureAst {
-                name: String::from("bar"),
+                name: String::from("bar").try_into().unwrap(),
                 docs: None,
                 is_export: false,
                 num_locals: 2,
@@ -451,7 +451,7 @@ aliqua."
         (
             2,
             ProcedureAst {
-                name: String::from("baz"),
+                name: String::from("baz").try_into().unwrap(),
                 docs: Some(docs_baz),
                 is_export: true,
                 num_locals: 3,

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -1,4 +1,5 @@
-use crate::{parse_module, Assembler, ModuleAst, ModuleProvider, NamedModuleAst, ProcedureId};
+use crate::{parse_module, Assembler, Library, LibraryNamespace, Module, ModulePath};
+use core::slice::Iter;
 
 // SIMPLE PROGRAMS
 // ================================================================================================
@@ -178,7 +179,9 @@ fn program_with_exported_procedure() {
 
 #[test]
 fn program_with_one_import() {
-    const MODULE: &str = "dummy::math::u256";
+    const NAMESPACE: &str = "dummy";
+    const VERSION: &str = "0.1.0";
+    const MODULE: &str = "math::u256";
     const PROCEDURE: &str = r#"
         export.iszero_unsafe
             eq.0
@@ -189,40 +192,52 @@ fn program_with_one_import() {
             end
         end"#;
 
-    struct DummyProvider {
-        module: ModuleAst,
+    pub struct DummyLibrary {
+        namespace: LibraryNamespace,
+        modules: Vec<Module>,
     }
 
-    impl Default for DummyProvider {
+    impl Default for DummyLibrary {
         fn default() -> Self {
+            let namespace = LibraryNamespace::try_from(NAMESPACE.to_string()).unwrap();
+            let path = ModulePath::try_from(MODULE.to_string())
+                .unwrap()
+                .to_absolute(&namespace);
+            let ast = parse_module(PROCEDURE).unwrap();
             Self {
-                module: parse_module(PROCEDURE).unwrap(),
+                namespace,
+                modules: vec![Module { path, ast }],
             }
         }
     }
 
-    impl ModuleProvider for DummyProvider {
-        fn get_module(&self, id: &ProcedureId) -> Option<NamedModuleAst<'_>> {
-            self.module
-                .local_procs
-                .iter()
-                .any(|proc| {
-                    let proc_id = ProcedureId::from_name(&proc.name, MODULE);
-                    &proc_id == id
-                })
-                .then_some(NamedModuleAst::new(MODULE, &self.module))
+    impl Library for DummyLibrary {
+        type ModuleIterator<'a> = Iter<'a, Module>;
+
+        fn root_ns(&self) -> &LibraryNamespace {
+            &self.namespace
+        }
+
+        fn version(&self) -> &str {
+            VERSION
+        }
+
+        fn modules(&self) -> Self::ModuleIterator<'_> {
+            self.modules.iter()
         }
     }
 
-    let assembler = super::Assembler::new().with_module_provider(DummyProvider::default());
+    let assembler = super::Assembler::new()
+        .with_library(&DummyLibrary::default())
+        .unwrap();
     let source = format!(
         r#"
-        use.{}
+        use.{}::{}
         begin
             push.4 push.3
             exec.u256::iszero_unsafe
         end"#,
-        MODULE
+        NAMESPACE, MODULE
     );
     let program = assembler.compile(&source).unwrap();
     let expected = "\

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -1,4 +1,4 @@
-use super::{BTreeMap, ParsingError, String, ToString, Vec};
+use super::{BTreeMap, ParsingError, ProcedureName, String, ToString, Vec};
 use core::fmt;
 
 mod stream;
@@ -116,7 +116,7 @@ impl<'a> Token<'a> {
         }
     }
 
-    pub fn parse_proc(&self) -> Result<(String, u16, bool), ParsingError> {
+    pub fn parse_proc(&self) -> Result<(ProcedureName, u16, bool), ParsingError> {
         assert!(
             self.parts[0] == Self::PROC || self.parts[0] == Self::EXPORT,
             "invalid procedure declaration"
@@ -236,7 +236,10 @@ impl<'a> fmt::Display for Token<'a> {
 /// Label of a declared procedure must comply with the following rules:
 /// - It must start with an ascii letter.
 /// - It can contain only ascii letters, numbers, or underscores.
-fn validate_proc_declaration_label(label: &str, token: &Token) -> Result<String, ParsingError> {
+fn validate_proc_declaration_label(
+    label: &str,
+    token: &Token,
+) -> Result<ProcedureName, ParsingError> {
     // a label must start with a letter
     if label.is_empty() || !label.chars().next().unwrap().is_ascii_alphabetic() {
         return Err(ParsingError::invalid_proc_label(token, label));
@@ -247,7 +250,8 @@ fn validate_proc_declaration_label(label: &str, token: &Token) -> Result<String,
         return Err(ParsingError::invalid_proc_label(token, label));
     }
 
-    Ok(label.to_string())
+    ProcedureName::try_from(label.to_string())
+        .map_err(|e| ParsingError::invalid_library_path(token, e))
 }
 
 /// A label of an invoked procedure must comply with the following rules:

--- a/core/src/operations/decorators/advice.rs
+++ b/core/src/operations/decorators/advice.rs
@@ -34,7 +34,7 @@ impl fmt::Display for AdviceInjector {
             Self::MerkleNode => write!(f, "merkle_node"),
             Self::DivResultU64 => write!(f, "div_result_u64"),
             Self::MapValue => write!(f, "map_value"),
-            Self::Memory(start_addr, num_words) => write!(f, "mem({}, {})", start_addr, num_words),
+            Self::Memory(start_addr, num_words) => write!(f, "mem({start_addr}, {num_words})"),
         }
     }
 }

--- a/miden/benches/program_compilation.rs
+++ b/miden/benches/program_compilation.rs
@@ -15,7 +15,9 @@ fn program_compilation(c: &mut Criterion) {
                 exec.sha256::hash
             end";
         bench.iter(|| {
-            let assembler = Assembler::new().with_module_provider(StdLibrary::default());
+            let assembler = Assembler::new()
+                .with_library(&StdLibrary::default())
+                .expect("failed to load stdlib");
             assembler
                 .compile(source)
                 .expect("Failed to compile test source.")

--- a/miden/benches/program_execution.rs
+++ b/miden/benches/program_execution.rs
@@ -14,7 +14,9 @@ fn program_execution(c: &mut Criterion) {
             begin
                 exec.sha256::hash
             end";
-        let assembler = Assembler::new().with_module_provider(StdLibrary::default());
+        let assembler = Assembler::new()
+            .with_library(&StdLibrary::default())
+            .expect("failed to load stdlib");
         let program = assembler
             .compile(source)
             .expect("Failed to compile test source.");

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -184,7 +184,8 @@ impl ProgramFile {
 
         // compile program
         let program = Assembler::new()
-            .with_module_provider(StdLibrary::default())
+            .with_library(StdLibrary::default())
+            .map_err(|err| format!("Failed to load stdlib - {}", err))?
             .compile(&program_file)
             .map_err(|err| format!("Failed to compile program - {}", err))?;
 

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -141,7 +141,8 @@ impl fmt::Display for ProgramInfo {
 pub fn analyze(program: &str, inputs: ProgramInputs) -> Result<ProgramInfo, ProgramError> {
     let program = Assembler::new()
         .with_debug_mode(true)
-        .with_module_provider(StdLibrary::default())
+        .with_library(StdLibrary::default())
+        .map_err(ProgramError::AssemblyError)?
         .compile(program)
         .map_err(ProgramError::AssemblyError)?;
     let vm_state_iterator = processor::execute_iter(&program, &inputs);

--- a/miden/tests/integration/helpers/mod.rs
+++ b/miden/tests/integration/helpers/mod.rs
@@ -140,7 +140,8 @@ impl Test {
     pub fn compile(&self) -> Program {
         let assembler = assembly::Assembler::new()
             .with_debug_mode(self.in_debug_mode)
-            .with_module_provider(StdLibrary::default());
+            .with_library(&StdLibrary::default())
+            .expect("failed to load stdlib");
 
         match self.kernel.as_ref() {
             Some(kernel) => assembler

--- a/processor/src/decoder/trace.rs
+++ b/processor/src/decoder/trace.rs
@@ -543,8 +543,7 @@ fn get_op_batch_flags(num_groups_left: Felt) -> [Felt; NUM_OP_BATCH_FLAGS] {
         2 => OP_BATCH_2_GROUPS,
         1 => OP_BATCH_1_GROUPS,
         _ => panic!(
-            "invalid number of groups in a batch: {}, group count: {}",
-            num_groups, num_groups_left
+            "invalid number of groups in a batch: {num_groups}, group count: {num_groups_left}"
         ),
     }
 }

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -301,9 +301,7 @@ fn finalize_trace(process: Process, mut rng: RandomCoin) -> (Vec<Vec<Felt>>, Aux
     let trace_len = (max_len + NUM_RAND_ROWS).next_power_of_two();
     assert!(
         trace_len >= MIN_TRACE_LEN,
-        "trace length must be at least {}, but was {}",
-        MIN_TRACE_LEN,
-        trace_len
+        "trace length must be at least {MIN_TRACE_LEN}, but was {trace_len}"
     );
 
     // combine all trace segments into the main trace

--- a/stdlib/md_renderer.rs
+++ b/stdlib/md_renderer.rs
@@ -13,10 +13,8 @@ pub struct MarkdownRenderer {}
 
 impl MarkdownRenderer {
     fn write_docs_header(mut writer: &File, ns: &str) {
-        let header = format!(
-            "\n## {}\n| Procedure | Description |\n| ----------- | ------------- |\n",
-            ns
-        );
+        let header =
+            format!("\n## {ns}\n| Procedure | Description |\n| ----------- | ------------- |\n");
         writer
             .write_all(header.as_bytes())
             .expect("unable to write header to writer");
@@ -28,7 +26,7 @@ impl MarkdownRenderer {
         }
         let func_output = format!(
             "| {} | {} |\n",
-            proc.name,
+            proc.name.as_str(),
             proc.docs
                 .clone()
                 .unwrap()

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -1,12 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use assembly::{
-    utils::{
-        collections::{BTreeMap, Vec},
-        string::{String, ToString},
-    },
-    Library, LibraryError, ModuleAst, ModuleProvider, NamedModuleAst, ProcedureId,
+    utils::{collections::Vec, string::ToString},
+    Library, LibraryNamespace, Module, ModuleAst, ModulePath,
 };
+use core::slice::Iter;
 
 pub mod asm;
 use asm::MODULES;
@@ -14,6 +12,7 @@ use asm::MODULES;
 // CONSTANTS
 // ================================================================================================
 
+const NAMESPACE: &str = "std";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // STANDARD LIBRARY
@@ -21,72 +20,47 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// TODO: add docs
 pub struct StdLibrary {
-    modules: Vec<(String, ModuleAst)>,
-    proc_to_module: BTreeMap<ProcedureId, usize>,
-}
-
-impl ModuleProvider for StdLibrary {
-    fn get_module(&self, proc_id: &ProcedureId) -> Option<NamedModuleAst<'_>> {
-        self.proc_to_module
-            .get(proc_id)
-            .map(|&module_idx| &self.modules[module_idx])
-            .map(|(path, ast)| ast.named_ref(path))
-    }
+    namespace: LibraryNamespace,
+    modules: Vec<Module>,
 }
 
 impl Library for StdLibrary {
-    type Module = ModuleAst;
+    type ModuleIterator<'a> = Iter<'a, Module>;
 
-    /// Returns root namespace of the standard library, which is always "std".
-    fn root_ns(&self) -> &str {
-        "std"
+    fn root_ns(&self) -> &LibraryNamespace {
+        &self.namespace
     }
 
-    /// Returns the current version of the standard library.
     fn version(&self) -> &str {
         VERSION
     }
 
-    /// Returns the source code of the module located at the specified path.
-    ///
-    /// # Errors
-    /// Returns an error if the modules for the specified path does not exist in the standard
-    /// library.
-    fn get_module(&self, module_path: &str) -> Result<&ModuleAst, LibraryError> {
-        self.modules
-            .iter()
-            .find(|(path, _)| path == module_path)
-            .map(|(_, ast)| ast)
-            .ok_or_else(|| LibraryError::ModuleNotFound(module_path.to_string()))
+    fn modules(&self) -> Self::ModuleIterator<'_> {
+        self.modules.iter()
     }
 }
 
 impl Default for StdLibrary {
     /// Returns a new [StdLibrary] instance instantiated with default parameters.
     fn default() -> Self {
-        let mut modules = Vec::with_capacity(MODULES.len());
-        let mut proc_to_module = BTreeMap::new();
+        let namespace =
+            LibraryNamespace::try_from(NAMESPACE.to_string()).expect("malformed library namespace");
+        let modules = MODULES
+            .iter()
+            .map(|(path, bytes)| {
+                let (ns, path) = path.split_once("::").expect("malformed module path");
+                let path = ModulePath::try_from(path.to_string()).expect("malformed module path");
+                let path = path.to_absolute(&namespace);
+                assert_eq!(namespace.as_str(), ns, "invalid namespace");
 
-        for (i, (module_path, module_bytes)) in MODULES.iter().enumerate() {
-            // deserialize module AST
-            let module_ast = ModuleAst::from_bytes(module_bytes)
-                .expect("static module deserialization should be infallible");
+                // deserialize module AST
+                let ast = ModuleAst::from_bytes(bytes)
+                    .expect("static module deserialization should be infallible");
 
-            // for each procedure in the module, compute its ID and create a map between procedure
-            // ID and its module
-            for proc_ast in module_ast.local_procs.iter() {
-                let proc_id = ProcedureId::from_name(&proc_ast.name, module_path);
-                proc_to_module.insert(proc_id, i);
-            }
-
-            // add the module together with its path to the module list
-            modules.push((module_path.to_string(), module_ast));
-        }
-
-        Self {
-            modules,
-            proc_to_module,
-        }
+                Module::new(path, ast)
+            })
+            .collect();
+        Self { namespace, modules }
     }
 }
 


### PR DESCRIPTION
This commit changes the Library trait of assembly to provide AST modules to the compilation process.

It also introduces a type-safe path for library namespace, module path (relative), procedure name, and absolute path. Prior to this commit, there was no distinction between these different states and they were treated as raw strings. It was a context-heavy task to define when a path is absolute and when is relative to a module.

The procedure ID, used to compile AST into MAST, is calculated always with the absolute path of a procedure. Having only strings was error-prone to compute the procedure ID correctly. With this commit, the absolute path, used to compute a procedure ID, can only be obtained from a sequence of validations in the namespace, module path, and procedure name.

This commit also moves `ModuleProvider` to the private scope of the
assembly since now it is used only during the compilation context
creation and won't interact with the consumers of the library.

It will also fix a couple of new lints introduced in clippy for 1.67.

closes #552 