### PR TITLE
Assembly parser error reporting improvements

### DIFF
--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -14,13 +14,14 @@ pub enum AssemblyError {
     ExportedProcInProgram(String),
     ImportedProcModuleNotFound(ProcedureId),
     ImportedProcNotFoundInModule(ProcedureId, String),
+    InvalidCacheLock,
     KernelProcNotFound(ProcedureId),
+    LibraryError(String),
     LocalProcNotFound(u16, String),
     ParsingError(String),
     ParamOutOfBounds(u64, u64, u64),
+    ProcedureNameError(String),
     SysCallInKernel(String),
-    InvalidCacheLock,
-    LibraryError(String),
 }
 
 impl AssemblyError {
@@ -92,6 +93,12 @@ impl From<LibraryError> for AssemblyError {
     }
 }
 
+impl From<ProcedureNameError> for AssemblyError {
+    fn from(err: ProcedureNameError) -> Self {
+        Self::ProcedureNameError(format!("invalid procedure name: {err}"))
+    }
+}
+
 impl fmt::Display for AssemblyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use AssemblyError::*;
@@ -104,12 +111,12 @@ impl fmt::Display for AssemblyError {
             ExportedProcInProgram(proc_name) => write!(f, "exported procedure '{proc_name}' in executable program"),
             ImportedProcModuleNotFound(proc_id) => write!(f, "module for imported procedure {proc_id} not found"),
             ImportedProcNotFoundInModule(proc_id, module_path) => write!(f, "imported procedure {proc_id} not found in module {module_path}"),
+            InvalidCacheLock => write!(f, "an attempt was made to lock a borrowed procedures cache"),
             KernelProcNotFound(proc_id) => write!(f, "procedure {proc_id} not found in kernel"),
             LocalProcNotFound(proc_idx, module_path) => write!(f, "procedure at index {proc_idx} not found in module {module_path}"),
-            LibraryError(err) | ParsingError(err) => write!(f, "{err}"),
             ParamOutOfBounds(value, min, max) => write!(f, "parameter value must be greater than or equal to {min} and less than or equal to {max}, but was {value}"),
             SysCallInKernel(proc_name) => write!(f, "syscall instruction used in kernel procedure '{proc_name}'"),
-            InvalidCacheLock => write!(f, "an attempt was made to lock a borrowed procedures cache"),
+            LibraryError(err) | ParsingError(err) | ProcedureNameError(err) => write!(f, "{err}"),
         }
     }
 }
@@ -307,9 +314,9 @@ impl ParsingError {
         }
     }
 
-    pub fn invalid_proc_name(token: &Token, label: &str) -> Self {
+    pub fn invalid_proc_name(token: &Token, err: ProcedureNameError) -> Self {
         ParsingError {
-            message: format!("invalid procedure name: {label}"),
+            message: format!("invalid procedure name: {err}"),
             step: token.pos(),
             op: token.to_string(),
         }
@@ -458,6 +465,53 @@ impl fmt::Display for ParsingError {
 #[cfg(feature = "std")]
 impl std::error::Error for ParsingError {}
 
+// PROCEDURE NAME ERROR
+// ================================================================================================
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ProcedureNameError {
+    EmptyProcedureName,
+    InvalidFirstLetter(String),
+    InvalidProcedureName(String),
+    ProcedureNameTooLong(String, u8),
+}
+
+impl ProcedureNameError {
+    pub const fn empty_procedure_name() -> Self {
+        Self::EmptyProcedureName
+    }
+
+    pub fn invalid_procedure_name(proc_name: &str) -> Self {
+        Self::InvalidProcedureName(proc_name.to_string())
+    }
+
+    pub fn invalid_fist_letter(proc_name: &str) -> Self {
+        Self::InvalidFirstLetter(proc_name.to_string())
+    }
+
+    pub fn procedure_name_too_long(proc_name: &str, max_len: u8) -> Self {
+        Self::ProcedureNameTooLong(proc_name.to_string(), max_len)
+    }
+}
+
+impl fmt::Display for ProcedureNameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ProcedureNameError::*;
+        match self {
+            EmptyProcedureName => write!(f, "procedure name cannot be empty"),
+            InvalidFirstLetter(proc_name) => {
+                write!(f, "'{proc_name}' does not start with a letter")
+            }
+            InvalidProcedureName(proc_name) => {
+                write!(f, "'{proc_name}' contains invalid characters")
+            }
+            ProcedureNameTooLong(proc_name, max_len) => {
+                write!(f, "'{proc_name}' is over {max_len} characters long")
+            }
+        }
+    }
+}
+
 // SERIALIZATION ERROR
 // ================================================================================================
 
@@ -478,8 +532,6 @@ pub enum SerializationError {
 pub enum LibraryError {
     ModuleNotFound(String),
     DuplicateModulePath(String),
-    EmptyProcedureName,
-    ProcedureNameWithDelimiter(String),
     ModulePathStartsWithDelimiter(String),
     ModulePathEndsWithDelimiter(String),
     LibraryNameWithDelimiter(String),
@@ -490,16 +542,8 @@ impl LibraryError {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    pub const fn empty_procedure_name() -> Self {
-        Self::EmptyProcedureName
-    }
-
     pub fn duplicate_module_path(path: &str) -> Self {
         Self::DuplicateModulePath(path.to_string())
-    }
-
-    pub fn procedure_name_with_delimiter(name: &str) -> Self {
-        Self::ProcedureNameWithDelimiter(name.to_string())
     }
 
     pub fn module_path_starts_with_delimiter(path: &str) -> Self {
@@ -528,10 +572,6 @@ impl fmt::Display for LibraryError {
         match self {
             ModuleNotFound(path) => write!(f, "module '{path}' not found"),
             DuplicateModulePath(path) => write!(f, "duplciate module path '{path}'"),
-            EmptyProcedureName => write!(f, "the procedure name cannot be empty"),
-            ProcedureNameWithDelimiter(name) => {
-                write!(f, "'{name}' cannot contain a module delimiter")
-            }
             ModulePathStartsWithDelimiter(path) => {
                 write!(f, "'{path}' cannot start with a module delimiter")
             }

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -155,14 +155,6 @@ impl ParsingError {
         }
     }
 
-    pub fn unexpected_body_end(token: &Token) -> Self {
-        ParsingError {
-            message: format!("unexpected body termination: invalid token '{token}'"),
-            step: token.pos(),
-            op: token.to_string(),
-        }
-    }
-
     pub fn empty_block(token: &Token) -> Self {
         ParsingError {
             message: "a code block must contain at least one instruction".to_string(),
@@ -350,9 +342,9 @@ impl ParsingError {
         }
     }
 
-    pub fn unmatched_proc(token: &Token) -> Self {
+    pub fn unmatched_proc(token: &Token, proc_name: &str) -> Self {
         ParsingError {
-            message: "proc without matching end".to_string(),
+            message: format!("procedure '{proc_name}' has no matching end"),
             step: token.pos(),
             op: token.to_string(),
         }

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -25,7 +25,7 @@ mod tokens;
 use tokens::{Token, TokenStream};
 
 mod errors;
-pub use errors::{AssemblyError, LibraryError, ParsingError};
+pub use errors::{AssemblyError, LibraryError, ParsingError, ProcedureNameError};
 
 mod assembler;
 pub use assembler::Assembler;
@@ -292,7 +292,7 @@ impl Module {
     pub fn check_namespace(&self, namespace: &LibraryNamespace) -> Result<(), LibraryError> {
         (self.path.namespace() == namespace.as_str())
             .then_some(())
-            .ok_or(LibraryError::EmptyProcedureName)
+            .ok_or_else(|| LibraryError::namespace_violation(self.path.namespace(), namespace))
     }
 }
 

--- a/assembly/src/parsers/context.rs
+++ b/assembly/src/parsers/context.rs
@@ -1,6 +1,6 @@
 use super::{
-    field_ops, io_ops, stack_ops, u32_ops, Instruction, LocalProcMap, Node, ParsingError,
-    ProcedureAst, ProcedureId, Token, TokenStream, MODULE_PATH_DELIM,
+    field_ops, io_ops, stack_ops, u32_ops, AbsolutePath, Instruction, LocalProcMap, Node,
+    ParsingError, ProcedureAst, ProcedureId, Token, TokenStream,
 };
 use vm_core::utils::{
     collections::{BTreeMap, Vec},
@@ -13,7 +13,7 @@ use vm_core::utils::{
 /// AST Parser context that holds internal state to generate correct ASTs.
 #[derive(Default)]
 pub struct ParserContext {
-    pub imports: BTreeMap<String, String>,
+    pub imports: BTreeMap<String, AbsolutePath>,
     pub local_procs: LocalProcMap,
 }
 
@@ -25,6 +25,7 @@ impl ParserContext {
     fn parse_if(&self, tokens: &mut TokenStream) -> Result<Node, ParsingError> {
         // record start of the if-else block and consume the 'if' token
         let if_start = tokens.pos();
+        tokens.read().expect("no if token").validate_if()?;
         tokens.advance();
 
         let mut t_branch = Vec::<Node>::new();
@@ -71,15 +72,13 @@ impl ParserContext {
                     Vec::new()
                 }
                 _ => {
-                    return Err(ParsingError::unmatched_if(
-                        tokens.read_at(if_start).expect("no if token"),
-                    ))
+                    let token = tokens.read_at(if_start).expect("no if token");
+                    return Err(ParsingError::unmatched_if(token));
                 }
             },
             None => {
-                return Err(ParsingError::unmatched_if(
-                    tokens.read_at(if_start).expect("no if token"),
-                ))
+                let token = tokens.read_at(if_start).expect("no if token");
+                return Err(ParsingError::unmatched_if(token));
             }
         };
 
@@ -90,6 +89,7 @@ impl ParserContext {
     fn parse_while(&self, tokens: &mut TokenStream) -> Result<Node, ParsingError> {
         // record start of the while block and consume the 'while' token
         let while_start = tokens.pos();
+        tokens.read().expect("no while token").validate_while()?;
         tokens.advance();
 
         let mut loop_body = Vec::<Node>::new();
@@ -118,14 +118,7 @@ impl ParserContext {
     fn parse_repeat(&self, tokens: &mut TokenStream) -> Result<Node, ParsingError> {
         // record start of the repeat block and consume the 'repeat' token
         let repeat_start = tokens.pos();
-        let count = match tokens.read() {
-            Some(token) => token.parse_repeat()? as usize,
-            None => {
-                return Err(ParsingError::missing_param(
-                    tokens.read_at(repeat_start).expect("no repeat token"),
-                ))
-            }
-        };
+        let count = tokens.read().expect("no repeat token").parse_repeat()? as usize;
         tokens.advance();
 
         let mut loop_body = Vec::<Node>::new();
@@ -154,46 +147,39 @@ impl ParserContext {
     // --------------------------------------------------------------------------------------------
 
     /// Parse exec token into AST nodes.
-    fn parse_exec(&self, label: String, tokens: &mut TokenStream) -> Result<Node, ParsingError> {
-        tokens.advance();
+    fn parse_exec(&self, token: &Token) -> Result<Node, ParsingError> {
+        // get the label of the invoked procedure and consume the `exec` token
+        let (proc_name, module_name) = token.parse_exec()?;
 
-        if label.contains(MODULE_PATH_DELIM) {
-            let full_proc_name = self.get_full_imported_proc_name(label);
-            let proc_id = ProcedureId::new(full_proc_name);
+        if let Some(module_name) = module_name {
+            let proc_id = self.get_imported_proc_id(proc_name, module_name, token)?;
             Ok(Node::Instruction(Instruction::ExecImported(proc_id)))
         } else {
-            let index = self
-                .local_procs
-                .get(&label)
-                .ok_or_else(|| ParsingError::undefined_proc(tokens.read().unwrap(), &label))?
-                .0;
-
+            let index = self.get_local_proc_index(proc_name, token)?;
             Ok(Node::Instruction(Instruction::ExecLocal(index)))
         }
     }
 
     /// Parse call token into AST nodes.
-    fn parse_call(&self, label: String, tokens: &mut TokenStream) -> Result<Node, ParsingError> {
-        tokens.advance();
-        if label.contains(MODULE_PATH_DELIM) {
-            let full_proc_name = self.get_full_imported_proc_name(label);
-            let proc_id = ProcedureId::new(full_proc_name);
+    fn parse_call(&self, token: &Token) -> Result<Node, ParsingError> {
+        // get the label of the invoked procedure and consume the `call` token
+        let (proc_name, module_name) = token.parse_call()?;
+
+        if let Some(module_name) = module_name {
+            let proc_id = self.get_imported_proc_id(proc_name, module_name, token)?;
             Ok(Node::Instruction(Instruction::CallImported(proc_id)))
         } else {
-            let index = self
-                .local_procs
-                .get(&label)
-                .ok_or_else(|| ParsingError::undefined_proc(tokens.read().unwrap(), &label))?
-                .0;
-
+            let index = self.get_local_proc_index(proc_name, token)?;
             Ok(Node::Instruction(Instruction::CallLocal(index)))
         }
     }
 
     /// Parse syscall token into AST nodes.
-    fn parse_syscall(&self, label: String, tokens: &mut TokenStream) -> Result<Node, ParsingError> {
-        tokens.advance();
-        let proc_id = ProcedureId::from_kernel_name(label.as_str());
+    fn parse_syscall(&self, token: &Token) -> Result<Node, ParsingError> {
+        // get the label of the invoked procedure and consume the `syscall` token
+        let label = token.parse_syscall()?;
+
+        let proc_id = ProcedureId::from_kernel_name(label);
         Ok(Node::Instruction(Instruction::SysCall(proc_id)))
     }
 
@@ -215,7 +201,7 @@ impl ParserContext {
                     }
 
                     if self.local_procs.contains_key(label.as_ref()) {
-                        return Err(ParsingError::duplicate_proc_label(token, &label));
+                        return Err(ParsingError::duplicate_proc_name(token, &label));
                     }
 
                     let proc = self.parse_procedure(tokens)?;
@@ -235,7 +221,7 @@ impl ParserContext {
 
         // read procedure name and consume the procedure header token
         let header = tokens.read().expect("missing procedure header");
-        let (label, num_locals, is_export) = header.parse_proc()?;
+        let (name, num_locals, is_export) = header.parse_proc()?;
         let docs = if is_export {
             tokens.take_doc_comment_at(proc_start)
         } else {
@@ -244,8 +230,8 @@ impl ParserContext {
 
         tokens.advance();
 
-        let mut body = Vec::<Node>::new();
         // parse procedure body
+        let mut body = Vec::<Node>::new();
         self.parse_body(tokens, &mut body, false)?;
 
         // consume the 'end' token
@@ -264,7 +250,7 @@ impl ParserContext {
 
         // build and return the procedure
         let proc = ProcedureAst {
-            name: label,
+            name,
             docs,
             num_locals,
             is_export,
@@ -285,6 +271,7 @@ impl ParserContext {
     ) -> Result<(), ParsingError> {
         while let Some(token) = tokens.read() {
             match token.parts()[0] {
+                Token::IF => nodes.push(self.parse_if(tokens)?),
                 Token::ELSE => {
                     token.validate_else()?;
                     if break_on_else {
@@ -292,45 +279,23 @@ impl ParserContext {
                     }
                     return Err(ParsingError::dangling_else(token));
                 }
-                Token::IF => {
-                    token.validate_if()?;
-                    nodes.push(self.parse_if(tokens)?);
-                }
-                Token::WHILE => {
-                    token.validate_while()?;
-                    nodes.push(self.parse_while(tokens)?);
-                }
+                Token::WHILE => nodes.push(self.parse_while(tokens)?),
                 Token::REPEAT => nodes.push(self.parse_repeat(tokens)?),
-                Token::EXEC => {
-                    let label = token.parse_exec()?;
-                    nodes.push(self.parse_exec(label, tokens)?);
-                }
-                Token::CALL => {
-                    let label = token.parse_call()?;
-                    nodes.push(self.parse_call(label, tokens)?);
-                }
-                Token::SYSCALL => {
-                    let label = token.parse_syscall()?;
-                    nodes.push(self.parse_syscall(label, tokens)?);
-                }
                 Token::END => {
                     token.validate_end()?;
                     break;
                 }
-                Token::USE | Token::EXPORT | Token::PROC | Token::BEGIN => {
+                Token::USE => {
+                    return Err(ParsingError::import_inside_body(token));
+                }
+                Token::EXPORT | Token::PROC | Token::BEGIN => {
                     // TODO improve the error with the originating block
                     // https://github.com/maticnetwork/miden/issues/514
                     return Err(ParsingError::unexpected_body_end(token));
                 }
                 _ => {
-                    // Process non control tokens.
-                    while let Some(op) = tokens.read() {
-                        if op.is_control_token() {
-                            break;
-                        }
-                        nodes.push(parse_op_token(op)?);
-                        tokens.advance();
-                    }
+                    nodes.push(self.parse_op_token(token)?);
+                    tokens.advance();
                 }
             }
         }
@@ -338,181 +303,213 @@ impl ParserContext {
         Ok(())
     }
 
-    // HELPER FUNCTIONS
-    // ================================================================================================
+    // HELPER METHODS
+    // --------------------------------------------------------------------------------------------
 
-    fn get_full_imported_proc_name(&self, short_name: String) -> String {
-        let (module_name, proc_name) = short_name.rsplit_once(MODULE_PATH_DELIM).unwrap();
-        let full_module_name = self.imports.get(module_name).unwrap();
-        ProcedureId::path(proc_name, full_module_name)
+    /// Parses a Token into a node instruction.
+    fn parse_op_token(&self, op: &Token) -> Result<Node, ParsingError> {
+        use Instruction::*;
+
+        // based on the instruction, invoke the correct parser for the operation
+        match op.parts()[0] {
+            // ----- field operations -------------------------------------------------------------
+            "assert" => simple_instruction(op, Assert),
+            "assertz" => simple_instruction(op, Assertz),
+            "assert_eq" => simple_instruction(op, AssertEq),
+
+            "add" => field_ops::parse_add(op),
+            "sub" => field_ops::parse_sub(op),
+            "mul" => field_ops::parse_mul(op),
+            "div" => field_ops::parse_div(op),
+            "neg" => simple_instruction(op, Neg),
+            "inv" => simple_instruction(op, Inv),
+
+            "pow2" => simple_instruction(op, Pow2),
+            "exp" => field_ops::parse_exp(op),
+
+            "not" => simple_instruction(op, Not),
+            "and" => simple_instruction(op, And),
+            "or" => simple_instruction(op, Or),
+            "xor" => simple_instruction(op, Xor),
+
+            "eq" => field_ops::parse_eq(op),
+            "neq" => field_ops::parse_neq(op),
+            "lt" => simple_instruction(op, Lt),
+            "lte" => simple_instruction(op, Lte),
+            "gt" => simple_instruction(op, Gt),
+            "gte" => simple_instruction(op, Gte),
+            "eqw" => simple_instruction(op, Eqw),
+
+            // ----- u32 operations ---------------------------------------------------------------
+            "u32test" => simple_instruction(op, U32Test),
+            "u32testw" => simple_instruction(op, U32TestW),
+            "u32assert" => u32_ops::parse_u32assert(op),
+            "u32assertw" => simple_instruction(op, U32AssertW),
+            "u32cast" => simple_instruction(op, U32Cast),
+            "u32split" => simple_instruction(op, U32Split),
+
+            "u32checked_add" => u32_ops::parse_u32checked_add(op),
+            "u32wrapping_add" => u32_ops::parse_u32wrapping_add(op),
+            "u32overflowing_add" => u32_ops::parse_u32overflowing_add(op),
+
+            "u32overflowing_add3" => simple_instruction(op, U32OverflowingAdd3),
+            "u32wrapping_add3" => simple_instruction(op, U32WrappingAdd3),
+
+            "u32checked_sub" => u32_ops::parse_u32checked_sub(op),
+            "u32wrapping_sub" => u32_ops::parse_u32wrapping_sub(op),
+            "u32overflowing_sub" => u32_ops::parse_u32overflowing_sub(op),
+
+            "u32checked_mul" => u32_ops::parse_u32checked_mul(op),
+            "u32wrapping_mul" => u32_ops::parse_u32wrapping_mul(op),
+            "u32overflowing_mul" => u32_ops::parse_u32overflowing_mul(op),
+
+            "u32overflowing_madd" => simple_instruction(op, U32OverflowingMadd),
+            "u32wrapping_madd" => simple_instruction(op, U32WrappingMadd),
+
+            "u32checked_div" => u32_ops::parse_u32_div(op, true),
+            "u32unchecked_div" => u32_ops::parse_u32_div(op, false),
+
+            "u32checked_mod" => u32_ops::parse_u32_mod(op, true),
+            "u32unchecked_mod" => u32_ops::parse_u32_mod(op, false),
+
+            "u32checked_divmod" => u32_ops::parse_u32_divmod(op, true),
+            "u32unchecked_divmod" => u32_ops::parse_u32_divmod(op, false),
+
+            "u32checked_and" => simple_instruction(op, U32CheckedAnd),
+            "u32checked_or" => simple_instruction(op, U32CheckedOr),
+            "u32checked_xor" => simple_instruction(op, U32CheckedXor),
+            "u32checked_not" => simple_instruction(op, U32CheckedNot),
+
+            "u32checked_shr" => u32_ops::parse_u32_shr(op, true),
+            "u32unchecked_shr" => u32_ops::parse_u32_shr(op, false),
+
+            "u32checked_shl" => u32_ops::parse_u32_shl(op, true),
+            "u32unchecked_shl" => u32_ops::parse_u32_shl(op, false),
+
+            "u32checked_rotr" => u32_ops::parse_u32_rotr(op, true),
+            "u32unchecked_rotr" => u32_ops::parse_u32_rotr(op, false),
+
+            "u32checked_rotl" => u32_ops::parse_u32_rotl(op, true),
+            "u32unchecked_rotl" => u32_ops::parse_u32_rotl(op, false),
+
+            "u32checked_eq" => u32_ops::parse_u32checked_eq(op),
+            "u32checked_neq" => u32_ops::parse_u32checked_neq(op),
+
+            "u32checked_lt" => simple_instruction(op, U32CheckedLt),
+            "u32unchecked_lt" => simple_instruction(op, U32UncheckedLt),
+
+            "u32checked_lte" => simple_instruction(op, U32CheckedLte),
+            "u32unchecked_lte" => simple_instruction(op, U32UncheckedLte),
+
+            "u32checked_gt" => simple_instruction(op, U32CheckedGt),
+            "u32unchecked_gt" => simple_instruction(op, U32UncheckedGt),
+
+            "u32checked_gte" => simple_instruction(op, U32CheckedGte),
+            "u32unchecked_gte" => simple_instruction(op, U32UncheckedGte),
+
+            "u32checked_min" => simple_instruction(op, U32CheckedMin),
+            "u32unchecked_min" => simple_instruction(op, U32UncheckedMin),
+
+            "u32checked_max" => simple_instruction(op, U32CheckedMax),
+            "u32unchecked_max" => simple_instruction(op, U32UncheckedMax),
+
+            // ----- stack manipulation -----------------------------------------------------------
+            "drop" => simple_instruction(op, Drop),
+            "dropw" => simple_instruction(op, DropW),
+            "padw" => simple_instruction(op, PadW),
+            "dup" => stack_ops::parse_dup(op),
+            "dupw" => stack_ops::parse_dupw(op),
+            "swap" => stack_ops::parse_swap(op),
+            "swapw" => stack_ops::parse_swapw(op),
+            "swapdw" => simple_instruction(op, SwapDw),
+            "movup" => stack_ops::parse_movup(op),
+            "movupw" => stack_ops::parse_movupw(op),
+            "movdn" => stack_ops::parse_movdn(op),
+            "movdnw" => stack_ops::parse_movdnw(op),
+
+            "cswap" => simple_instruction(op, CSwap),
+            "cswapw" => simple_instruction(op, CSwapW),
+            "cdrop" => simple_instruction(op, CDrop),
+            "cdropw" => simple_instruction(op, CDropW),
+
+            // ----- input / output operations ----------------------------------------------------
+            "push" => io_ops::parse_push(op),
+
+            "sdepth" => simple_instruction(op, Sdepth),
+            "locaddr" => io_ops::parse_locaddr(op),
+            "caller" => io_ops::parse_caller(op), // TODO: error if not in SYSCALL
+
+            "mem_load" => io_ops::parse_mem_load(op),
+            "loc_load" => io_ops::parse_loc_load(op),
+
+            "mem_loadw" => io_ops::parse_mem_loadw(op),
+            "loc_loadw" => io_ops::parse_loc_loadw(op),
+
+            "mem_store" => io_ops::parse_mem_store(op),
+            "loc_store" => io_ops::parse_loc_store(op),
+
+            "mem_storew" => io_ops::parse_mem_storew(op),
+            "loc_storew" => io_ops::parse_loc_storew(op),
+
+            "mem_stream" => simple_instruction(op, MemStream),
+            "adv_pipe" => simple_instruction(op, AdvPipe),
+
+            "adv_push" => io_ops::parse_adv_push(op),
+            "adv_loadw" => simple_instruction(op, AdvLoadW),
+
+            "adv" => io_ops::parse_adv_inject(op),
+
+            // ----- cryptographic operations -----------------------------------------------------
+            "rphash" => simple_instruction(op, RpHash),
+            "rpperm" => simple_instruction(op, RpPerm),
+
+            "mtree_get" => simple_instruction(op, MTreeGet),
+            "mtree_set" => simple_instruction(op, MTreeSet),
+            "mtree_cwm" => simple_instruction(op, MTreeCwm),
+
+            // ----- procedure invocations --------------------------------------------------------
+            "exec" => self.parse_exec(op),
+            "call" => self.parse_call(op),
+            "syscall" => self.parse_syscall(op),
+
+            // ----- catch all --------------------------------------------------------------------
+            _ => Err(ParsingError::invalid_op(op)),
+        }
+    }
+
+    /// Returns an index of a local procedure for the specified procedure name.
+    ///
+    /// # Errors
+    /// Returns an error if a local procedure with the specified name has not been parsed ye.
+    fn get_local_proc_index(&self, proc_name: &str, token: &Token) -> Result<u16, ParsingError> {
+        self.local_procs
+            .get(proc_name)
+            .ok_or_else(|| ParsingError::undefined_local_proc(token, proc_name))
+            .map(|(index, _)| *index)
+    }
+
+    /// Returns procedure ID of a procedure imported from the specified module.
+    /// 
+    /// # Errors
+    /// Return an error if the module with the specified name has not been imported via the `use`
+    /// statement.
+    fn get_imported_proc_id(
+        &self,
+        proc_name: &str,
+        module_name: &str,
+        token: &Token,
+    ) -> Result<ProcedureId, ParsingError> {
+        let module_path = self
+            .imports
+            .get(module_name)
+            .ok_or_else(|| ParsingError::procedure_module_not_imported(token, module_name))?;
+        let proc_id = ProcedureId::from_name(proc_name, module_path.as_str());
+        Ok(proc_id)
     }
 }
 
-/// Parses a Token into a node instruction.
-fn parse_op_token(op: &Token) -> Result<Node, ParsingError> {
-    use Instruction::*;
-
-    // based on the instruction, invoke the correct parser for the operation
-    match op.parts()[0] {
-        // ----- field operations -----------------------------------------------------------------
-        "assert" => simple_instruction(op, Assert),
-        "assertz" => simple_instruction(op, Assertz),
-        "assert_eq" => simple_instruction(op, AssertEq),
-
-        "add" => field_ops::parse_add(op),
-        "sub" => field_ops::parse_sub(op),
-        "mul" => field_ops::parse_mul(op),
-        "div" => field_ops::parse_div(op),
-        "neg" => simple_instruction(op, Neg),
-        "inv" => simple_instruction(op, Inv),
-
-        "pow2" => simple_instruction(op, Pow2),
-        "exp" => field_ops::parse_exp(op),
-
-        "not" => simple_instruction(op, Not),
-        "and" => simple_instruction(op, And),
-        "or" => simple_instruction(op, Or),
-        "xor" => simple_instruction(op, Xor),
-
-        "eq" => field_ops::parse_eq(op),
-        "neq" => field_ops::parse_neq(op),
-        "lt" => simple_instruction(op, Lt),
-        "lte" => simple_instruction(op, Lte),
-        "gt" => simple_instruction(op, Gt),
-        "gte" => simple_instruction(op, Gte),
-        "eqw" => simple_instruction(op, Eqw),
-
-        // ----- u32 operations -------------------------------------------------------------------
-        "u32test" => simple_instruction(op, U32Test),
-        "u32testw" => simple_instruction(op, U32TestW),
-        "u32assert" => u32_ops::parse_u32assert(op),
-        "u32assertw" => simple_instruction(op, U32AssertW),
-        "u32cast" => simple_instruction(op, U32Cast),
-        "u32split" => simple_instruction(op, U32Split),
-
-        "u32checked_add" => u32_ops::parse_u32checked_add(op),
-        "u32wrapping_add" => u32_ops::parse_u32wrapping_add(op),
-        "u32overflowing_add" => u32_ops::parse_u32overflowing_add(op),
-
-        "u32overflowing_add3" => simple_instruction(op, U32OverflowingAdd3),
-        "u32wrapping_add3" => simple_instruction(op, U32WrappingAdd3),
-
-        "u32checked_sub" => u32_ops::parse_u32checked_sub(op),
-        "u32wrapping_sub" => u32_ops::parse_u32wrapping_sub(op),
-        "u32overflowing_sub" => u32_ops::parse_u32overflowing_sub(op),
-
-        "u32checked_mul" => u32_ops::parse_u32checked_mul(op),
-        "u32wrapping_mul" => u32_ops::parse_u32wrapping_mul(op),
-        "u32overflowing_mul" => u32_ops::parse_u32overflowing_mul(op),
-
-        "u32overflowing_madd" => simple_instruction(op, U32OverflowingMadd),
-        "u32wrapping_madd" => simple_instruction(op, U32WrappingMadd),
-
-        "u32checked_div" => u32_ops::parse_u32_div(op, true),
-        "u32unchecked_div" => u32_ops::parse_u32_div(op, false),
-
-        "u32checked_mod" => u32_ops::parse_u32_mod(op, true),
-        "u32unchecked_mod" => u32_ops::parse_u32_mod(op, false),
-
-        "u32checked_divmod" => u32_ops::parse_u32_divmod(op, true),
-        "u32unchecked_divmod" => u32_ops::parse_u32_divmod(op, false),
-
-        "u32checked_and" => simple_instruction(op, U32CheckedAnd),
-        "u32checked_or" => simple_instruction(op, U32CheckedOr),
-        "u32checked_xor" => simple_instruction(op, U32CheckedXor),
-        "u32checked_not" => simple_instruction(op, U32CheckedNot),
-
-        "u32checked_shr" => u32_ops::parse_u32_shr(op, true),
-        "u32unchecked_shr" => u32_ops::parse_u32_shr(op, false),
-
-        "u32checked_shl" => u32_ops::parse_u32_shl(op, true),
-        "u32unchecked_shl" => u32_ops::parse_u32_shl(op, false),
-
-        "u32checked_rotr" => u32_ops::parse_u32_rotr(op, true),
-        "u32unchecked_rotr" => u32_ops::parse_u32_rotr(op, false),
-
-        "u32checked_rotl" => u32_ops::parse_u32_rotl(op, true),
-        "u32unchecked_rotl" => u32_ops::parse_u32_rotl(op, false),
-
-        "u32checked_eq" => u32_ops::parse_u32checked_eq(op),
-        "u32checked_neq" => u32_ops::parse_u32checked_neq(op),
-
-        "u32checked_lt" => simple_instruction(op, U32CheckedLt),
-        "u32unchecked_lt" => simple_instruction(op, U32UncheckedLt),
-
-        "u32checked_lte" => simple_instruction(op, U32CheckedLte),
-        "u32unchecked_lte" => simple_instruction(op, U32UncheckedLte),
-
-        "u32checked_gt" => simple_instruction(op, U32CheckedGt),
-        "u32unchecked_gt" => simple_instruction(op, U32UncheckedGt),
-
-        "u32checked_gte" => simple_instruction(op, U32CheckedGte),
-        "u32unchecked_gte" => simple_instruction(op, U32UncheckedGte),
-
-        "u32checked_min" => simple_instruction(op, U32CheckedMin),
-        "u32unchecked_min" => simple_instruction(op, U32UncheckedMin),
-
-        "u32checked_max" => simple_instruction(op, U32CheckedMax),
-        "u32unchecked_max" => simple_instruction(op, U32UncheckedMax),
-
-        // ----- stack manipulation ---------------------------------------------------------------
-        "drop" => simple_instruction(op, Drop),
-        "dropw" => simple_instruction(op, DropW),
-        "padw" => simple_instruction(op, PadW),
-        "dup" => stack_ops::parse_dup(op),
-        "dupw" => stack_ops::parse_dupw(op),
-        "swap" => stack_ops::parse_swap(op),
-        "swapw" => stack_ops::parse_swapw(op),
-        "swapdw" => simple_instruction(op, SwapDw),
-        "movup" => stack_ops::parse_movup(op),
-        "movupw" => stack_ops::parse_movupw(op),
-        "movdn" => stack_ops::parse_movdn(op),
-        "movdnw" => stack_ops::parse_movdnw(op),
-
-        "cswap" => simple_instruction(op, CSwap),
-        "cswapw" => simple_instruction(op, CSwapW),
-        "cdrop" => simple_instruction(op, CDrop),
-        "cdropw" => simple_instruction(op, CDropW),
-
-        // ----- input / output operations --------------------------------------------------------
-        "push" => io_ops::parse_push(op),
-
-        "sdepth" => simple_instruction(op, Sdepth),
-        "locaddr" => io_ops::parse_locaddr(op),
-        "caller" => io_ops::parse_caller(op), // TODO: error if not in SYSCALL
-
-        "mem_load" => io_ops::parse_mem_load(op),
-        "loc_load" => io_ops::parse_loc_load(op),
-
-        "mem_loadw" => io_ops::parse_mem_loadw(op),
-        "loc_loadw" => io_ops::parse_loc_loadw(op),
-
-        "mem_store" => io_ops::parse_mem_store(op),
-        "loc_store" => io_ops::parse_loc_store(op),
-
-        "mem_storew" => io_ops::parse_mem_storew(op),
-        "loc_storew" => io_ops::parse_loc_storew(op),
-
-        "mem_stream" => simple_instruction(op, MemStream),
-        "adv_pipe" => simple_instruction(op, AdvPipe),
-
-        "adv_push" => io_ops::parse_adv_push(op),
-        "adv_loadw" => simple_instruction(op, AdvLoadW),
-
-        "adv" => io_ops::parse_adv_inject(op),
-
-        // ----- cryptographic operations ---------------------------------------------------------
-        "rphash" => simple_instruction(op, RpHash),
-        "rpperm" => simple_instruction(op, RpPerm),
-
-        "mtree_get" => simple_instruction(op, MTreeGet),
-        "mtree_set" => simple_instruction(op, MTreeSet),
-        "mtree_cwm" => simple_instruction(op, MTreeCwm),
-
-        // ----- catch all ------------------------------------------------------------------------
-        _ => Err(ParsingError::invalid_op(op)),
-    }
-}
+// HELPER FUNCTIONS
+// ================================================================================================
 
 /// Validates that the provided token does not contain any immediate parameters and returns a node
 /// for the specified instruction.

--- a/assembly/src/parsers/nodes.rs
+++ b/assembly/src/parsers/nodes.rs
@@ -9,7 +9,7 @@ use core::fmt;
 pub enum Node {
     Instruction(Instruction),
     IfElse(Vec<Node>, Vec<Node>),
-    Repeat(usize, Vec<Node>),
+    Repeat(u16, Vec<Node>),
     While(Vec<Node>),
 }
 

--- a/assembly/src/parsers/serde/deserialization.rs
+++ b/assembly/src/parsers/serde/deserialization.rs
@@ -159,7 +159,7 @@ impl Deserializable for Node {
             REPEAT_OPCODE => {
                 bytes.read_u8()?;
                 Ok(Node::Repeat(
-                    bytes.read_u16()?.into(),
+                    bytes.read_u16()?,
                     Deserializable::read_from(bytes)?,
                 ))
             }

--- a/assembly/src/parsers/serde/serialization.rs
+++ b/assembly/src/parsers/serde/serialization.rs
@@ -110,21 +110,16 @@ impl Serializable for Node {
             }
             Self::IfElse(if_clause, else_clause) => {
                 target.write_u8(IF_ELSE_OPCODE);
-
                 if_clause.write_into(target);
-
                 else_clause.write_into(target);
             }
             Self::Repeat(times, nodes) => {
                 target.write_u8(REPEAT_OPCODE);
-
-                target.write_u16(*times as u16);
-
+                target.write_u16(*times);
                 nodes.write_into(target);
             }
             Self::While(nodes) => {
                 target.write_u8(WHILE_OPCODE);
-
                 nodes.write_into(target);
             }
         };

--- a/assembly/src/parsers/tests.rs
+++ b/assembly/src/parsers/tests.rs
@@ -381,7 +381,6 @@ fn test_use_in_proc_body() {
     }
 }
 
-/*
 #[test]
 fn test_unterminated_proc() {
     let source = "proc.foo add mul begin push.1 end";
@@ -389,13 +388,22 @@ fn test_unterminated_proc() {
     let result = parse_module(source);
     match result {
         Ok(_) => assert!(false),
-        Err(err) => {
-            println!("err: {err}");
-            assert!(err.to_string().contains("import in procedure body"))
-        }
+        Err(err) => assert!(err
+            .to_string()
+            .contains("procedure 'foo' has no matching end")),
     }
 }
-*/
+
+#[test]
+fn test_unterminated_if() {
+    let source = "proc.foo add mul if.true add.2 begin push.1 end";
+
+    let result = parse_module(source);
+    match result {
+        Ok(_) => assert!(false),
+        Err(err) => assert!(err.to_string().contains("if without matching else/end")),
+    }
+}
 
 // DOCUMENTATION PARSING TESTS
 // ================================================================================================

--- a/assembly/src/parsers/tests.rs
+++ b/assembly/src/parsers/tests.rs
@@ -346,6 +346,60 @@ fn test_ast_parsing_module_sequential_if() {
     }
 }
 
+// PROCEDURE IMPORTS
+// ================================================================================================
+
+#[test]
+fn test_missing_import() {
+    let source = "\
+    begin
+        exec.u64::add
+    end";
+
+    let result = parse_program(source);
+    match result {
+        Ok(_) => assert!(false),
+        Err(err) => assert!(err.to_string().contains("module 'u64' was not imported")),
+    }
+}
+
+// INVALID BODY TESTS
+// ================================================================================================
+
+#[test]
+fn test_use_in_proc_body() {
+    let source = "\
+    export.foo.1
+        loc_load.0
+        use
+    end";
+
+    let result = parse_module(source);
+    match result {
+        Ok(_) => assert!(false),
+        Err(err) => assert!(err.to_string().contains("import in procedure body")),
+    }
+}
+
+/*
+#[test]
+fn test_unterminated_proc() {
+    let source = "proc.foo add mul begin push.1 end";
+
+    let result = parse_module(source);
+    match result {
+        Ok(_) => assert!(false),
+        Err(err) => {
+            println!("err: {err}");
+            assert!(err.to_string().contains("import in procedure body"))
+        }
+    }
+}
+*/
+
+// DOCUMENTATION PARSING TESTS
+// ================================================================================================
+
 #[test]
 fn test_ast_parsing_simple_docs() {
     let source = "\

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -433,21 +433,21 @@ fn invalid_proc() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.to_string(), "undefined procedure: bar");
+        assert_eq!(error.to_string(), "undefined local procedure: bar");
     }
 
     let source = "proc.123 add mul end begin push.1 exec.123 end";
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.to_string(), "invalid procedure label: 123");
+        assert_eq!(error.to_string(), "invalid procedure name: 123");
     }
 
     let source = "proc.foo add mul end proc.foo push.3 end begin push.1 end";
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.to_string(), "duplicate procedure label: foo");
+        assert_eq!(error.to_string(), "duplicate procedure name: foo");
     }
 }
 

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -413,20 +413,14 @@ fn invalid_proc() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(
-            error.to_string(),
-            "unexpected body termination: invalid token 'begin'"
-        );
+        assert_eq!(error.to_string(), "procedure 'foo' has no matching end");
     }
 
     let source = "proc.foo add mul proc.bar push.3 end begin push.1 end";
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(
-            error.to_string(),
-            "unexpected body termination: invalid token 'proc.bar'"
-        );
+        assert_eq!(error.to_string(), "procedure 'foo' has no matching end");
     }
 
     let source = "proc.foo add mul end begin push.1 exec.bar end";

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -434,7 +434,10 @@ fn invalid_proc() {
     let program = assembler.compile(source);
     assert!(program.is_err());
     if let Err(error) = program {
-        assert_eq!(error.to_string(), "invalid procedure name: 123");
+        assert_eq!(
+            error.to_string(),
+            "invalid procedure name: '123' does not start with a letter"
+        );
     }
 
     let source = "proc.foo add mul end proc.foo push.3 end begin push.1 end";

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -165,13 +165,13 @@ impl<'a> Token<'a> {
         }
     }
 
-    pub fn parse_repeat(&self) -> Result<u32, ParsingError> {
+    pub fn parse_repeat(&self) -> Result<u16, ParsingError> {
         assert_eq!(Self::REPEAT, self.parts[0], "not a repeat");
         match self.num_parts() {
             0 => unreachable!(),
             1 => Err(ParsingError::missing_param(self)),
             2 => self.parts[1]
-                .parse::<u32>()
+                .parse::<u16>()
                 .map_err(|_| ParsingError::invalid_param(self, 1)),
             _ => Err(ParsingError::extra_param(self)),
         }

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -184,7 +184,7 @@ impl ProgramFile {
 
         // compile program
         let program = Assembler::new()
-            .with_library(StdLibrary::default())
+            .with_library(&StdLibrary::default())
             .map_err(|err| format!("Failed to load stdlib - {}", err))?
             .compile(&program_file)
             .map_err(|err| format!("Failed to compile program - {}", err))?;

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -141,7 +141,7 @@ impl fmt::Display for ProgramInfo {
 pub fn analyze(program: &str, inputs: ProgramInputs) -> Result<ProgramInfo, ProgramError> {
     let program = Assembler::new()
         .with_debug_mode(true)
-        .with_library(StdLibrary::default())
+        .with_library(&StdLibrary::default())
         .map_err(ProgramError::AssemblyError)?
         .compile(program)
         .map_err(ProgramError::AssemblyError)?;


### PR DESCRIPTION
This PR improves error handling in the assembly parser and cleans up parser structure. Specifically:

- Addresses #514. This was actually much simpler than I thought as the logic was already there - we just need to break out of the loop instead of returning an error.
- Streamlines parsing of control flow blocks. There is no longer a need for check `is_control_token()` during parsing.
- Improves error reporting for invoking procedures - e.g., invalid invocation strings, un-imported modules etc.
- Moves validation of procedure names into `ProcedureName` struct.

Refactoring of validation of import paths and procedure invocation labels are left to future PRs.